### PR TITLE
feat(skills): per-agent + fleet-wide skill assignment (PR 5)

### DIFF
--- a/src/agent/builtins/skill_admin_tool.py
+++ b/src/agent/builtins/skill_admin_tool.py
@@ -80,3 +80,112 @@ async def remove_skill(name: str, *, mesh_client=None, _messages=None, **_kw) ->
             "detail": "User confirmation required to remove a skill.",
         }
     return await mesh_client.remove_skill(name)
+
+
+@tool(
+    name="list_skill_assignments",
+    description=(
+        "Show which skill packs are assigned where: the fleet-wide list (every "
+        "agent sees these) and each agent's per-agent list. Operator-only. Read "
+        "this before assigning so you edit the right list."
+    ),
+    parameters={},
+)
+async def list_skill_assignments(*, mesh_client=None, **_kw) -> dict:
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    return await mesh_client.get_skill_assignments()
+
+
+@tool(
+    name="assign_skill",
+    description=(
+        "Give or take away a skill pack for an agent (or the whole fleet). "
+        "Skills are scoped per agent so each agent only sees the procedures it "
+        "needs — assigning one makes it visible to that agent's skills_list. "
+        "Set fleet=true to assign to EVERY agent; otherwise pass agent_id for a "
+        "single agent. action='add' grants, action='remove' revokes. "
+        "Operator-only; requires the user to have asked for it."
+    ),
+    parameters={
+        "skill": {"type": "string", "description": "Skill pack name (see skills_list / list_skill_assignments)."},
+        "agent_id": {
+            "type": "string",
+            "description": "Agent to assign to. Ignored when fleet=true.",
+            "default": "",
+        },
+        "fleet": {
+            "type": "boolean",
+            "description": "Assign fleet-wide (every agent) instead of to one agent.",
+            "default": False,
+        },
+        "action": {
+            "type": "string",
+            "description": "'add' to grant, 'remove' to revoke.",
+            "default": "add",
+        },
+    },
+)
+async def assign_skill(
+    skill: str,
+    agent_id: str = "",
+    fleet: bool = False,
+    action: str = "add",
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
+) -> dict:
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    from src.agent.loop import _last_message_is_user_origin
+    if _messages is None or not _last_message_is_user_origin(_messages):
+        return {
+            "error": "provenance_check_failed",
+            "detail": "User confirmation required to change skill assignments.",
+        }
+    skill = (skill or "").strip()
+    if not skill:
+        return {"error": "skill is required"}
+    if action not in ("add", "remove"):
+        return {"error": "action must be 'add' or 'remove'"}
+    agent_id = (agent_id or "").strip()
+    if not fleet and not agent_id:
+        return {"error": "Pass agent_id, or set fleet=true to assign to every agent."}
+
+    # Read current assignment, mutate the relevant list, write it back. The
+    # mesh endpoints set the full list, so we compute the new full list here.
+    assignments = await mesh_client.get_skill_assignments()
+    if fleet:
+        current = list(assignments.get("fleet_skills", []))
+    else:
+        current = list(assignments.get("per_agent", {}).get(agent_id, []))
+
+    names = set(current)
+    if action == "add":
+        names.add(skill)
+    else:
+        names.discard(skill)
+    new_list = sorted(names)
+
+    if fleet:
+        result = await mesh_client.set_fleet_skills(new_list)
+    else:
+        result = await mesh_client.assign_skills(agent_id, new_list)
+
+    # Surface the no-op-removal case: removing a skill from one agent has no
+    # effect while it's still assigned fleet-wide.
+    if (
+        action == "remove"
+        and not fleet
+        and skill in set(assignments.get("fleet_skills", []))
+    ):
+        result["note"] = (
+            f"'{skill}' is still assigned fleet-wide, so {agent_id} continues to "
+            "see it. Remove it from the fleet (fleet=true) to fully revoke."
+        )
+    return result

--- a/src/agent/builtins/skill_admin_tool.py
+++ b/src/agent/builtins/skill_admin_tool.py
@@ -127,6 +127,10 @@ async def list_skill_assignments(*, mesh_client=None, **_kw) -> dict:
             "default": "add",
         },
     },
+    # Read-modify-write against the full-list assign endpoints — must not run
+    # concurrently with another assign_skill or a parallel pair would compute
+    # from the same baseline and the later write would drop the earlier change.
+    parallel_safe=False,
 )
 async def assign_skill(
     skill: str,

--- a/src/agent/builtins/skills_tool.py
+++ b/src/agent/builtins/skills_tool.py
@@ -9,8 +9,36 @@ orchestrate Tools the agent is already allowed to call. See
 
 from __future__ import annotations
 
+import os
+
 from src.agent.skills import SkillStore, render_text
 from src.agent.tools import tool
+from src.shared.utils import setup_logging
+
+logger = setup_logging("agent.skills_tool")
+
+
+def _is_operator() -> bool:
+    """Defence-in-depth: only the operator agent has ALLOWED_TOOLS set."""
+    return os.environ.get("ALLOWED_TOOLS", "") != ""
+
+
+async def _allowed_skill_names(mesh_client) -> set[str] | None:
+    """Names this agent may see, or ``None`` to mean 'no filter — full catalog'.
+
+    The operator (fleet manager) and standalone single-agent runs see the whole
+    catalog; everyone else sees only their effective assignment (fleet-wide ∪
+    per-agent), fetched fresh from the mesh so operator edits take effect with
+    no restart. A fetch error fails CLOSED (empty set, skills hidden) rather
+    than open — the whole point is to keep agents from seeing skills not theirs.
+    """
+    if mesh_client is None or getattr(mesh_client, "is_standalone", False) or _is_operator():
+        return None
+    try:
+        return set(await mesh_client.list_my_skills())
+    except Exception as e:
+        logger.warning("Could not fetch assigned skills (%s); hiding skills this call", e)
+        return set()
 
 
 def _declared_requirements(metadata: dict) -> dict:
@@ -45,8 +73,11 @@ def _declared_requirements(metadata: dict) -> dict:
     ),
     parameters={},
 )
-def skills_list() -> dict:
+async def skills_list(*, mesh_client=None) -> dict:
+    allowed = await _allowed_skill_names(mesh_client)
     skills = SkillStore().list()
+    if allowed is not None:
+        skills = [s for s in skills if s.name in allowed]
     return {
         "skills": [{"name": s.name, "description": s.description} for s in skills],
         "count": len(skills),
@@ -77,7 +108,16 @@ def skills_list() -> dict:
         },
     },
 )
-def skill_view(name: str, path: str = "") -> dict:
+async def skill_view(name: str, path: str = "", *, mesh_client=None) -> dict:
+    allowed = await _allowed_skill_names(mesh_client)
+    if allowed is not None and name not in allowed:
+        # Don't leak existence of skills the agent isn't assigned — same message
+        # whether the pack is unassigned or absent.
+        return {
+            "error": (
+                f"Skill '{name}' not found. Call skills_list to see available skills."
+            ),
+        }
     store = SkillStore()
     skill = store.get(name)
     if skill is None:

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -846,6 +846,41 @@ class MeshClient:
         _raise_with_body(response)
         return response.json().get("skills", [])
 
+    async def get_skill_assignments(self) -> dict:
+        """Current fleet + per-agent skill assignment (operator-gated read)."""
+        client = await self._get_client()
+        response = await client.get(
+            f"{self.mesh_url}/mesh/skills/assignments",
+            timeout=10,
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json()
+
+    async def assign_skills(self, agent_id: str, skills: list[str]) -> dict:
+        """Replace an agent's per-agent skill allowlist (operator-gated)."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/skills/assign",
+            json={"agent_id": agent_id, "skills": skills},
+            timeout=30,
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json()
+
+    async def set_fleet_skills(self, skills: list[str]) -> dict:
+        """Replace the fleet-wide skill allowlist (operator-gated)."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/skills/fleet",
+            json={"skills": skills},
+            timeout=30,
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json()
+
     # === Browser (shared browser service via mesh proxy) ===
 
     # === Operator agent config management ===

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -830,6 +830,22 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def list_my_skills(self) -> list[str]:
+        """Skill-pack names assigned to THIS agent (effective: fleet ∪ per-agent).
+
+        The mesh resolves the caller from the request's agent identity, so an
+        agent only ever learns its own assignment. Used by skills_list /
+        skill_view to scope discovery per agent.
+        """
+        client = await self._get_client()
+        response = await client.get(
+            f"{self.mesh_url}/mesh/skills/mine",
+            timeout=10,
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json().get("skills", [])
+
     # === Browser (shared browser service via mesh proxy) ===
 
     # === Operator agent config management ===

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1713,6 +1713,7 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # operator can see which skills its workers can draw on. install_skill /
     # remove_skill are operator-gated + user-origin-gated mutations.
     "skills_list", "skill_view", "install_skill", "remove_skill",
+    "list_skill_assignments", "assign_skill",
     # Workflow awareness — operator-only chain inspection + single-task
     # blocking primitive (see _HEARTBEAT_TOOLS in src/agent/loop.py for
     # the heartbeat surface; both tools self-reject for non-operators).

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3325,7 +3325,14 @@ def create_dashboard_router(
         body = await request.json()
         from src.cli.config import _load_permissions, _save_permissions
         perms_data = _load_permissions()
-        agent_perms = perms_data.get("permissions", {}).get(agent_id, {})
+        agents = perms_data.setdefault("permissions", {})
+        # Materialize full effective permissions before a partial write, so an
+        # agent that had no explicit entry (was using the "default" template)
+        # doesn't get dropped to a sparse record that strips its other grants
+        # (Codex review). No-op for agents that already have an entry.
+        if agent_id not in agents:
+            agents[agent_id] = permissions.get_permissions(agent_id).model_dump(exclude={"agent_id"})
+        agent_perms = agents[agent_id]
 
         updated = []
         if "allowed_credentials" in body:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2152,9 +2152,35 @@ def create_dashboard_router(
             })
         return {"templates": result}
 
+    def _clean_skill_names(value) -> list[str]:
+        """Validate + normalise a skill-name list (sorted, deduped, path-safe)."""
+        if not isinstance(value, list):
+            raise HTTPException(400, "skills must be a list of names")
+        cleaned: set[str] = set()
+        for s in value:
+            if not isinstance(s, str):
+                raise HTTPException(400, "skill names must be strings")
+            s = s.strip()
+            if not s:
+                continue
+            if not all((c.isascii() and c.isalnum()) or c in "_-" for c in s):
+                raise HTTPException(400, f"Invalid skill name: {s!r}")
+            cleaned.add(s)
+        return sorted(cleaned)
+
+    def _skills_installed_dir():
+        root = getattr(runtime, "project_root", None) if runtime else None
+        return (root / "skills_installed") if root else None
+
     @api_router.get("/api/skills")
-    async def api_skills(request: Request) -> dict:
-        """List available SKILL.md packs (bundled + installed) with provenance."""
+    async def api_skills(request: Request, agent_id: str = "") -> dict:
+        """List SKILL.md packs (bundled + installed) with provenance + assignment.
+
+        ``fleet_assigned`` — assigned fleet-wide (every agent sees it). When
+        ``agent_id`` is given, ``agent_assigned`` reports the skill's presence on
+        that agent's per-agent allowlist. The Skills tab renders fleet-assigned
+        packs as inherited (on for all agents, not per-agent toggleable).
+        """
         from src.agent.skills import SkillStore
         root = getattr(runtime, "project_root", None) if runtime else None
         store = (
@@ -2162,16 +2188,82 @@ def create_dashboard_router(
             if root
             else SkillStore()
         )
-        result = [
-            {
+        fleet = set(getattr(permissions, "fleet_skills", []) or []) if permissions else set()
+        per_agent: set[str] = set()
+        if agent_id and permissions is not None:
+            per_agent = set(permissions.get_permissions(agent_id).allowed_skills)
+        result = []
+        for s in store.list():
+            entry = {
                 "name": s.name,
                 "description": s.description,
                 "version": s.version,
                 "provenance": s.source or "bundled",
+                "fleet_assigned": s.name in fleet,
             }
-            for s in store.list()
-        ]
+            if agent_id:
+                entry["agent_assigned"] = s.name in per_agent
+            result.append(entry)
         return {"skills": result}
+
+    @api_router.get("/api/fleet/skills")
+    async def api_fleet_skills(request: Request) -> dict:
+        """Current fleet-wide skill assignment (applies to every agent)."""
+        return {"fleet_skills": list(getattr(permissions, "fleet_skills", []) or [])}
+
+    @api_router.post("/api/fleet/skills")
+    async def api_set_fleet_skills(request: Request) -> dict:
+        """Set the fleet-wide skill allowlist. Body: {skills: [...]}."""
+        if permissions is None:
+            raise HTTPException(503, "Permissions not available")
+        body = await request.json()
+        skills = _clean_skill_names(body.get("skills", []))
+        from src.cli.config import _load_permissions, _save_permissions
+        perms = _load_permissions()
+        perms["fleet_skills"] = skills
+        _save_permissions(perms)
+        permissions.reload()
+        return {"fleet_skills": skills}
+
+    @api_router.post("/api/skills/install")
+    async def api_install_skill(request: Request) -> dict:
+        """Install a SKILL.md pack from a git repo. Body: {repo_url, ref?}."""
+        import asyncio as _asyncio
+
+        from src import marketplace
+        body = await request.json()
+        repo_url = str(body.get("repo_url", "")).strip()
+        if not repo_url:
+            raise HTTPException(400, "repo_url is required")
+        skills_installed = _skills_installed_dir()
+        if skills_installed is None:
+            raise HTTPException(503, "Skills directory not available")
+        result = await _asyncio.to_thread(
+            marketplace.install_skill, repo_url, skills_installed,
+            str(body.get("ref", "")).strip(),
+        )
+        if "error" in result:
+            raise HTTPException(400, result["error"])
+        return result
+
+    @api_router.post("/api/skills/remove")
+    async def api_remove_skill(request: Request) -> dict:
+        """Remove an installed skill pack. Body: {name}."""
+        import asyncio as _asyncio
+
+        from src import marketplace
+        body = await request.json()
+        name = str(body.get("name", "")).strip()
+        if not name:
+            raise HTTPException(400, "name is required")
+        skills_installed = _skills_installed_dir()
+        if skills_installed is None:
+            raise HTTPException(503, "Skills directory not available")
+        result = await _asyncio.to_thread(marketplace.remove_skill, name, skills_installed)
+        if "error" in result:
+            status = 404 if "not found" in result["error"].lower() else 400
+            raise HTTPException(status, result["error"])
+        return result
 
     @api_router.post("/api/agents")
     async def api_add_agent(request: Request) -> dict:
@@ -3220,6 +3312,7 @@ def create_dashboard_router(
             "agent_id": agent_id,
             "allowed_credentials": perms.allowed_credentials,
             "allowed_apis": perms.allowed_apis,
+            "allowed_skills": perms.allowed_skills,
             "available_credentials": available_creds,
             "can_use_browser": perms.can_use_browser,
             "can_use_internet": perms.can_use_internet,
@@ -3252,6 +3345,22 @@ def create_dashboard_router(
                 raise HTTPException(status_code=400, detail="allowed_apis must be a list of strings")
             agent_perms["allowed_apis"] = val
             updated.append("allowed_apis")
+        if "allowed_skills" in body:
+            # Per-agent skill-pack allowlist. Validate path-safe names so a
+            # value can't smuggle anything into the catalog lookup.
+            val = body["allowed_skills"]
+            if not isinstance(val, list) or not all(isinstance(v, str) for v in val):
+                raise HTTPException(status_code=400, detail="allowed_skills must be a list of strings")
+            cleaned: set[str] = set()
+            for s in val:
+                s = s.strip()
+                if not s:
+                    continue
+                if not all((c.isascii() and c.isalnum()) or c in "_-" for c in s):
+                    raise HTTPException(status_code=400, detail=f"Invalid skill name: {s!r}")
+                cleaned.add(s)
+            agent_perms["allowed_skills"] = sorted(cleaned)
+            updated.append("allowed_skills")
         for flag in ("can_use_browser", "can_use_internet", "can_spawn", "can_manage_cron", "can_use_wallet"):
             if flag in body:
                 agent_perms[flag] = bool(body[flag])

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2206,11 +2206,6 @@ def create_dashboard_router(
             result.append(entry)
         return {"skills": result}
 
-    @api_router.get("/api/fleet/skills")
-    async def api_fleet_skills(request: Request) -> dict:
-        """Current fleet-wide skill assignment (applies to every agent)."""
-        return {"fleet_skills": list(getattr(permissions, "fleet_skills", []) or [])}
-
     @api_router.post("/api/fleet/skills")
     async def api_set_fleet_skills(request: Request) -> dict:
         """Set the fleet-wide skill allowlist. Body: {skills: [...]}."""
@@ -3346,20 +3341,8 @@ def create_dashboard_router(
             agent_perms["allowed_apis"] = val
             updated.append("allowed_apis")
         if "allowed_skills" in body:
-            # Per-agent skill-pack allowlist. Validate path-safe names so a
-            # value can't smuggle anything into the catalog lookup.
-            val = body["allowed_skills"]
-            if not isinstance(val, list) or not all(isinstance(v, str) for v in val):
-                raise HTTPException(status_code=400, detail="allowed_skills must be a list of strings")
-            cleaned: set[str] = set()
-            for s in val:
-                s = s.strip()
-                if not s:
-                    continue
-                if not all((c.isascii() and c.isalnum()) or c in "_-" for c in s):
-                    raise HTTPException(status_code=400, detail=f"Invalid skill name: {s!r}")
-                cleaned.add(s)
-            agent_perms["allowed_skills"] = sorted(cleaned)
+            # Per-agent skill-pack allowlist (path-safe-validated, sorted/deduped).
+            agent_perms["allowed_skills"] = _clean_skill_names(body["allowed_skills"])
             updated.append("allowed_skills")
         for flag in ("can_use_browser", "can_use_internet", "can_spawn", "can_manage_cron", "can_use_wallet"):
             if flag in body:

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10844,6 +10844,8 @@ function dashboard() {
         skill_view: 'reading a skill',
         install_skill: 'installing a skill',
         remove_skill: 'removing a skill',
+        list_skill_assignments: 'reviewing skill assignments',
+        assign_skill: 'assigning a skill',
       };
       if (map[toolName]) return map[toolName];
       // Fallback: humanise the snake_case tool name.

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -26,6 +26,7 @@ const _IDENTITY_TABS = [
   { id: 'activity', label: 'Activity', file: null, access: 'auto' },
   { id: 'logs', label: 'Logs', file: null, access: 'auto' },
   { id: 'capabilities', label: 'Tools', file: null, access: 'auto' },
+  { id: 'skills', label: 'Skills', file: null, access: 'auto' },
   { id: 'files', label: 'Files', file: null, access: 'auto' },
 ];
 
@@ -489,6 +490,7 @@ function dashboard() {
       { id: 'costs', label: 'Costs' },
       { id: 'activity', label: 'Activity' },
       { id: 'integrations', label: 'Integrations' },
+      { id: 'skills', label: 'Skills' },
       { id: 'apikeys', label: 'API Keys' },
       { id: 'automation', label: 'Automation' },
       { id: 'browser', label: 'Browser' },
@@ -496,6 +498,23 @@ function dashboard() {
       { id: 'network', label: 'Network' },
       { id: 'storage', label: 'Storage' },
     ],
+
+    // Skills — per-agent assignment tab + fleet catalog (System → Skills).
+    // agentSkills: rows for the selected agent (carry agent_assigned +
+    // fleet_assigned); fleetSkillsCatalog: the admin/catalog view (no
+    // agent_id); fleetSkills: names assigned fleet-wide. null = not yet
+    // loaded (spinner), [] = loaded-but-empty (empty state).
+    agentSkills: null,
+    agentSkillsLoading: false,
+    agentSkillsSaving: false,
+    fleetSkillsCatalog: null,
+    fleetSkillsCatalogLoading: false,
+    fleetSkills: [],
+    fleetSkillsSaving: false,
+    skillInstallRepo: '',
+    skillInstallRef: '',
+    skillInstalling: false,
+    skillRemoving: '',
 
     // Audit sub-tab
     auditLog: [],
@@ -818,7 +837,7 @@ function dashboard() {
         // Backward compat for old URLs
         const _tabAliases = { schedules: 'automation', connections: 'integrations', uploads: 'storage' };
         const resolved = _tabAliases[sub] || sub;
-        if (resolved && ['activity', 'costs', 'automation', 'integrations', 'apikeys', 'wallet', 'network', 'storage', 'operator', 'browser', 'settings'].includes(resolved)) {
+        if (resolved && ['activity', 'costs', 'automation', 'skills', 'integrations', 'apikeys', 'wallet', 'network', 'storage', 'operator', 'browser', 'settings'].includes(resolved)) {
           route.systemTab = resolved;
           if (resolved === 'activity') {
             const view = clean.split('/')[2];
@@ -885,6 +904,9 @@ function dashboard() {
               }
               if (route.systemTab === 'storage') {
                 this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails();
+              }
+              if (route.systemTab === 'skills') {
+                this.loadSkillsCatalog(); this.loadFleetSkills();
               }
               if (route.systemTab === 'operator') {
                 this.fetchAuditLog();
@@ -2414,6 +2436,10 @@ function dashboard() {
         if (this.systemTab === 'network') {
           this.loadNetworkProxy();
         }
+        if (this.systemTab === 'skills') {
+          this.loadSkillsCatalog();
+          this.loadFleetSkills();
+        }
         if (this.systemTab === 'settings') {
           this.fetchBrowserSettings();
           this.fetchSystemSettings();
@@ -2443,6 +2469,7 @@ function dashboard() {
       if (tabId === 'integrations') { this.fetchChannels(); this.fetchWebhooks(); this.fetchApiKeys(); this.loadIntegrations(); }
       if (tabId === 'apikeys') { this.fetchSettings(); }
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
+      if (tabId === 'skills') { this.loadSkillsCatalog(); this.loadFleetSkills(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
       if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); this.startPlatformSuccessRefresh(); }
@@ -5252,6 +5279,9 @@ function dashboard() {
       if (tab.id === 'capabilities') {
         await this.fetchAgentCapabilities(agentId);
       }
+      if (tab.id === 'skills') {
+        await this.loadAgentSkills(agentId);
+      }
       if (tab.id === 'files') {
         await this.fetchAgentFiles(agentId, '.');
       }
@@ -5289,6 +5319,172 @@ function dashboard() {
             ? data.mcp_tool_to_server : {};
         }
       } catch (e) { console.warn('fetchAgentCapabilities failed:', e); }
+    },
+
+    // ── Skills: per-agent assignment (identity Skills tab) ──────────────
+    async loadAgentSkills(agentId) {
+      this.agentSkills = null;
+      this.agentSkillsLoading = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/skills?agent_id=${encodeURIComponent(agentId)}`);
+        if (resp.ok) {
+          const data = await resp.json();
+          // Guard against a stale fetch landing after the user switched
+          // agents (mirrors fetchAgentCapabilities).
+          if (this.selectedAgent !== agentId) return;
+          this.agentSkills = Array.isArray(data.skills) ? data.skills : [];
+        } else {
+          this.agentSkills = [];
+        }
+      } catch (e) {
+        console.warn('loadAgentSkills failed:', e);
+        this.agentSkills = [];
+      } finally {
+        this.agentSkillsLoading = false;
+      }
+    },
+
+    async toggleAgentSkill(agentId, skill) {
+      // Fleet-assigned skills are always-on; the toggle is locked.
+      if (skill.fleet_assigned || this.agentSkillsSaving) return;
+      const current = (this.agentSkills || [])
+        .filter(s => s.agent_assigned)
+        .map(s => s.name);
+      const set = new Set(current);
+      if (skill.agent_assigned) set.delete(skill.name);
+      else set.add(skill.name);
+      this.agentSkillsSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/permissions`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ allowed_skills: Array.from(set) }),
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Skill update failed: ${data.detail || data.error || resp.status}`);
+        }
+      } catch (e) {
+        this.showToast(`Skill update failed: ${e.message || e}`);
+      } finally {
+        this.agentSkillsSaving = false;
+        // Re-fetch to reflect server truth (fleet ∪ per-agent).
+        await this.loadAgentSkills(agentId);
+      }
+    },
+
+    // ── Skills: fleet catalog (System → Skills) ─────────────────────────
+    async loadSkillsCatalog() {
+      this.fleetSkillsCatalog = null;
+      this.fleetSkillsCatalogLoading = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/skills`);
+        if (resp.ok) {
+          const data = await resp.json();
+          this.fleetSkillsCatalog = Array.isArray(data.skills) ? data.skills : [];
+        } else {
+          this.fleetSkillsCatalog = [];
+        }
+      } catch (e) {
+        console.warn('loadSkillsCatalog failed:', e);
+        this.fleetSkillsCatalog = [];
+      } finally {
+        this.fleetSkillsCatalogLoading = false;
+      }
+    },
+
+    async loadFleetSkills() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/fleet/skills`);
+        if (resp.ok) {
+          const data = await resp.json();
+          this.fleetSkills = Array.isArray(data.fleet_skills) ? data.fleet_skills : [];
+        }
+      } catch (e) { console.warn('loadFleetSkills failed:', e); }
+    },
+
+    async toggleFleetSkill(skill) {
+      if (this.fleetSkillsSaving) return;
+      const current = (this.fleetSkillsCatalog || [])
+        .filter(s => s.fleet_assigned)
+        .map(s => s.name);
+      const set = new Set(current);
+      if (skill.fleet_assigned) set.delete(skill.name);
+      else set.add(skill.name);
+      this.fleetSkillsSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/fleet/skills`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ skills: Array.from(set) }),
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Fleet skill update failed: ${data.detail || data.error || resp.status}`);
+        }
+      } catch (e) {
+        this.showToast(`Fleet skill update failed: ${e.message || e}`);
+      } finally {
+        this.fleetSkillsSaving = false;
+        await this.loadSkillsCatalog();
+        await this.loadFleetSkills();
+      }
+    },
+
+    async installSkill() {
+      const repo = (this.skillInstallRepo || '').trim();
+      if (!repo || this.skillInstalling) return;
+      const ref = (this.skillInstallRef || '').trim();
+      this.skillInstalling = true;
+      try {
+        const body = { repo_url: repo };
+        if (ref) body.ref = ref;
+        const resp = await fetch(`${window.__config.apiBase}/skills/install`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (resp.ok && !data.error) {
+          this.showToast(`Installed skill: ${data.name || repo}`);
+          this.skillInstallRepo = '';
+          this.skillInstallRef = '';
+          await this.loadSkillsCatalog();
+          await this.loadFleetSkills();
+        } else {
+          this.showToast(`Install failed: ${data.error || data.detail || resp.status}`);
+        }
+      } catch (e) {
+        this.showToast(`Install failed: ${e.message || e}`);
+      } finally {
+        this.skillInstalling = false;
+      }
+    },
+
+    async removeSkill(name) {
+      if (!name || this.skillRemoving) return;
+      this.showConfirm('Remove skill?', `This removes the installed pack "${name}" from the fleet catalog.`, async () => {
+        this.skillRemoving = name;
+        try {
+          const resp = await fetch(`${window.__config.apiBase}/skills/remove`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name }),
+          });
+          if (resp.ok) {
+            this.showToast(`Removed skill: ${name}`);
+            await this.loadSkillsCatalog();
+            await this.loadFleetSkills();
+          } else {
+            const data = await resp.json().catch(() => ({}));
+            this.showToast(`Remove failed: ${data.error || data.detail || resp.status}`);
+          }
+        } catch (e) {
+          this.showToast(`Remove failed: ${e.message || e}`);
+        } finally {
+          this.skillRemoving = '';
+        }
+      }, true);
     },
 
     async fetchAgentFiles(agentId, path) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -502,14 +502,13 @@ function dashboard() {
     // Skills — per-agent assignment tab + fleet catalog (System → Skills).
     // agentSkills: rows for the selected agent (carry agent_assigned +
     // fleet_assigned); fleetSkillsCatalog: the admin/catalog view (no
-    // agent_id); fleetSkills: names assigned fleet-wide. null = not yet
-    // loaded (spinner), [] = loaded-but-empty (empty state).
+    // agent_id) whose rows carry fleet_assigned. null = not yet loaded
+    // (spinner), [] = loaded-but-empty (empty state).
     agentSkills: null,
     agentSkillsLoading: false,
     agentSkillsSaving: false,
     fleetSkillsCatalog: null,
     fleetSkillsCatalogLoading: false,
-    fleetSkills: [],
     fleetSkillsSaving: false,
     skillInstallRepo: '',
     skillInstallRef: '',
@@ -906,7 +905,7 @@ function dashboard() {
                 this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails();
               }
               if (route.systemTab === 'skills') {
-                this.loadSkillsCatalog(); this.loadFleetSkills();
+                this.loadSkillsCatalog();
               }
               if (route.systemTab === 'operator') {
                 this.fetchAuditLog();
@@ -2438,7 +2437,6 @@ function dashboard() {
         }
         if (this.systemTab === 'skills') {
           this.loadSkillsCatalog();
-          this.loadFleetSkills();
         }
         if (this.systemTab === 'settings') {
           this.fetchBrowserSettings();
@@ -2469,7 +2467,7 @@ function dashboard() {
       if (tabId === 'integrations') { this.fetchChannels(); this.fetchWebhooks(); this.fetchApiKeys(); this.loadIntegrations(); }
       if (tabId === 'apikeys') { this.fetchSettings(); }
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
-      if (tabId === 'skills') { this.loadSkillsCatalog(); this.loadFleetSkills(); }
+      if (tabId === 'skills') { this.loadSkillsCatalog(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
       if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); this.startPlatformSuccessRefresh(); }
@@ -5393,16 +5391,6 @@ function dashboard() {
       }
     },
 
-    async loadFleetSkills() {
-      try {
-        const resp = await fetch(`${window.__config.apiBase}/fleet/skills`);
-        if (resp.ok) {
-          const data = await resp.json();
-          this.fleetSkills = Array.isArray(data.fleet_skills) ? data.fleet_skills : [];
-        }
-      } catch (e) { console.warn('loadFleetSkills failed:', e); }
-    },
-
     async toggleFleetSkill(skill) {
       if (this.fleetSkillsSaving) return;
       const current = (this.fleetSkillsCatalog || [])
@@ -5427,7 +5415,6 @@ function dashboard() {
       } finally {
         this.fleetSkillsSaving = false;
         await this.loadSkillsCatalog();
-        await this.loadFleetSkills();
       }
     },
 
@@ -5450,7 +5437,6 @@ function dashboard() {
           this.skillInstallRepo = '';
           this.skillInstallRef = '';
           await this.loadSkillsCatalog();
-          await this.loadFleetSkills();
         } else {
           this.showToast(`Install failed: ${data.error || data.detail || resp.status}`);
         }
@@ -5474,7 +5460,6 @@ function dashboard() {
           if (resp.ok) {
             this.showToast(`Removed skill: ${name}`);
             await this.loadSkillsCatalog();
-            await this.loadFleetSkills();
           } else {
             const data = await resp.json().catch(() => ({}));
             this.showToast(`Remove failed: ${data.error || data.detail || resp.status}`);

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3774,6 +3774,60 @@
                   </div>
                   <!-- END FILES TAB -->
 
+                  <!-- ═══ SKILLS TAB (per-agent assignment) ═══ -->
+                  <div x-show="identityTab === 'skills'">
+                    <div x-show="agentSkills === null || agentSkillsLoading" class="py-6 text-center text-gray-500 text-sm">
+                      <svg class="animate-spin h-4 w-4 inline mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+                      Loading skills...
+                    </div>
+                    <!-- Empty catalog -->
+                    <div x-show="agentSkills !== null && !agentSkillsLoading && agentSkills.length === 0" class="py-6 text-center text-gray-500 text-sm">
+                      No skills installed. Add skills in Settings &rarr; Skills.
+                    </div>
+                    <div x-show="agentSkills !== null && !agentSkillsLoading && agentSkills.length > 0">
+                      <div class="flex items-center justify-between mb-2">
+                        <span class="text-[11px] text-gray-500" x-text="(agentSkills || []).length + ' skills in catalog'"></span>
+                        <div class="flex items-center gap-2 text-[11px] text-gray-500">
+                          <span class="flex items-center gap-1"><span class="inline-block w-1.5 h-1.5 rounded-full bg-indigo-500"></span>bundled</span>
+                          <span class="flex items-center gap-1"><span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500"></span>installed</span>
+                        </div>
+                      </div>
+                      <div class="space-y-1.5">
+                        <template x-for="skill in (agentSkills || [])" :key="skill.name">
+                          <div class="bg-gray-800/50 rounded px-3 py-2 border border-gray-800">
+                            <div class="flex items-center gap-2">
+                              <span class="text-xs font-mono text-indigo-400 flex-1 min-w-0 truncate" x-text="skill.name"></span>
+                              <!-- Fleet badge -->
+                              <span x-show="skill.fleet_assigned"
+                                class="flex-shrink-0 text-[11px] px-1.5 py-0.5 rounded font-medium leading-none bg-sky-900/50 text-sky-400 border border-sky-800/50"
+                                title="Assigned fleet-wide in Settings → Skills.">all agents</span>
+                              <!-- Provenance badge -->
+                              <span class="flex-shrink-0 text-[11px] px-1.5 py-0.5 rounded font-medium leading-none"
+                                :class="{
+                                  'bg-indigo-900/50 text-indigo-400 border border-indigo-800/50': skill.provenance === 'bundled',
+                                  'bg-emerald-900/50 text-emerald-400 border border-emerald-800/50': skill.provenance === 'installed',
+                                }"
+                                x-text="skill.provenance || 'bundled'"></span>
+                              <!-- Per-agent toggle -->
+                              <label class="flex-shrink-0 inline-flex items-center cursor-pointer"
+                                :class="(skill.fleet_assigned || agentSkillsSaving) && 'opacity-60 cursor-not-allowed'"
+                                :title="skill.fleet_assigned ? 'Assigned fleet-wide in Settings → Skills.' : ''">
+                                <input type="checkbox"
+                                  class="sr-only peer"
+                                  :checked="skill.fleet_assigned || skill.agent_assigned"
+                                  :disabled="skill.fleet_assigned || agentSkillsSaving"
+                                  @change="toggleAgentSkill(selectedAgent, skill)">
+                                <div class="relative w-8 h-4 bg-gray-700 rounded-full peer-checked:bg-indigo-600 transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-4"></div>
+                              </label>
+                            </div>
+                            <div x-show="skill.description" class="text-[11px] text-gray-400 mt-0.5" x-text="skill.description"></div>
+                          </div>
+                        </template>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- END SKILLS TAB -->
+
                   </div><!-- /workspace tabs container (operator + non-operator) -->
                 </div>
               </div>
@@ -4956,6 +5010,79 @@
           </div>
         </div>
         </div><!-- /automation sub-tab -->
+
+        <!-- Skills sub-tab (fleet catalog + install) -->
+        <div x-show="systemTab === 'skills'" class="space-y-4">
+          <!-- Install from repo -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Install from repo</div>
+            <div class="flex flex-col sm:flex-row gap-2">
+              <input type="text" x-model="skillInstallRepo" placeholder="https://github.com/owner/repo"
+                class="flex-1 bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-indigo-600"
+                @keydown.enter="installSkill()">
+              <input type="text" x-model="skillInstallRef" placeholder="ref (optional)"
+                class="sm:w-40 bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-indigo-600"
+                @keydown.enter="installSkill()">
+              <button @click="installSkill()"
+                :disabled="skillInstalling || !skillInstallRepo.trim()"
+                class="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                x-text="skillInstalling ? 'Installing…' : 'Install'"></button>
+            </div>
+            <div class="text-[11px] text-gray-500 mt-2">Install a SKILL.md pack from a git repository. It becomes available in the catalog below.</div>
+          </div>
+
+          <!-- Catalog -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <div class="text-xs text-gray-400 uppercase tracking-wider">Skills catalog</div>
+              <div class="flex items-center gap-2 text-[11px] text-gray-500">
+                <span class="flex items-center gap-1"><span class="inline-block w-1.5 h-1.5 rounded-full bg-indigo-500"></span>bundled</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500"></span>installed</span>
+              </div>
+            </div>
+            <div x-show="fleetSkillsCatalog === null || fleetSkillsCatalogLoading" class="py-6 text-center text-gray-500 text-sm">
+              <svg class="animate-spin h-4 w-4 inline mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+              Loading catalog...
+            </div>
+            <div x-show="fleetSkillsCatalog !== null && !fleetSkillsCatalogLoading && fleetSkillsCatalog.length === 0" class="py-6 text-center text-gray-500 text-sm">
+              No skills installed yet. Install one from a repo above.
+            </div>
+            <div x-show="fleetSkillsCatalog !== null && !fleetSkillsCatalogLoading && fleetSkillsCatalog.length > 0" class="space-y-1.5">
+              <template x-for="skill in (fleetSkillsCatalog || [])" :key="skill.name">
+                <div class="bg-gray-800/50 rounded px-3 py-2 border border-gray-800">
+                  <div class="flex items-center gap-2">
+                    <span class="text-xs font-mono text-indigo-400 flex-1 min-w-0 truncate" x-text="skill.name"></span>
+                    <span x-show="skill.version" class="flex-shrink-0 text-[11px] text-gray-500 font-mono" x-text="'v' + skill.version"></span>
+                    <span class="flex-shrink-0 text-[11px] px-1.5 py-0.5 rounded font-medium leading-none"
+                      :class="{
+                        'bg-indigo-900/50 text-indigo-400 border border-indigo-800/50': skill.provenance === 'bundled',
+                        'bg-emerald-900/50 text-emerald-400 border border-emerald-800/50': skill.provenance === 'installed',
+                      }"
+                      x-text="skill.provenance || 'bundled'"></span>
+                    <!-- Fleet-wide toggle -->
+                    <label class="flex-shrink-0 inline-flex items-center gap-1.5 cursor-pointer"
+                      :class="fleetSkillsSaving && 'opacity-60 cursor-not-allowed'"
+                      title="Assign fleet-wide (every agent)">
+                      <span class="text-[11px] text-gray-400">Fleet-wide</span>
+                      <input type="checkbox" class="sr-only peer"
+                        :checked="skill.fleet_assigned"
+                        :disabled="fleetSkillsSaving"
+                        @change="toggleFleetSkill(skill)">
+                      <div class="relative w-8 h-4 bg-gray-700 rounded-full peer-checked:bg-indigo-600 transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-4"></div>
+                    </label>
+                    <!-- Remove (installed only) -->
+                    <button x-show="skill.provenance === 'installed'"
+                      @click="removeSkill(skill.name)"
+                      :disabled="skillRemoving === skill.name"
+                      class="flex-shrink-0 text-[11px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                      x-text="skillRemoving === skill.name ? 'Removing…' : 'Remove'"></button>
+                  </div>
+                  <div x-show="skill.description" class="text-[11px] text-gray-400 mt-0.5" x-text="skill.description"></div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div><!-- /skills sub-tab -->
 
         <!-- Integrations sub-tab (Connected services + Channels + Developer/API) -->
         <div x-show="systemTab === 'integrations'">

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -87,6 +87,11 @@ class PermissionMatrix:
 
     def __init__(self, config_path: str = "config/permissions.json"):
         self.permissions: dict[str, AgentPermissions] = {}
+        # Fleet-wide skill-pack assignment (names) — applies to EVERY agent,
+        # unioned with each agent's per-agent ``allowed_skills``. Stored as a
+        # top-level ``fleet_skills`` key in permissions.json. Empty by default
+        # (no skill is fleet-wide until explicitly assigned).
+        self.fleet_skills: list[str] = []
         self._config_path = config_path
         # L10: names of credentials that loaded under the SYSTEM_* tier.
         # Injected post-construction by the runtime via
@@ -113,6 +118,9 @@ class PermissionMatrix:
 
     def _load(self, config_path: str) -> None:
         path = Path(config_path)
+        # Reset fleet-wide skills; the success path repopulates it. Both failure
+        # branches (missing / corrupt) thus fail closed to no fleet skills.
+        self.fleet_skills = []
         if not path.exists():
             logger.warning(f"Permissions file not found: {config_path}, using deny-all defaults")
             # Clear so stale permissions don't persist (fail closed)
@@ -136,6 +144,7 @@ class PermissionMatrix:
         self.permissions.clear()
         for agent_id, perms in data.get("permissions", {}).items():
             self.permissions[agent_id] = AgentPermissions(agent_id=agent_id, **perms)
+        self.fleet_skills = list(data.get("fleet_skills", []) or [])
 
     def get_permissions(self, agent_id: str) -> AgentPermissions:
         """Get permissions for an agent. Falls back to 'default' template, then deny-all."""
@@ -152,6 +161,7 @@ class PermissionMatrix:
                 blackboard_write=default.blackboard_write,
                 allowed_apis=default.allowed_apis,
                 allowed_credentials=default.allowed_credentials,
+                allowed_skills=default.allowed_skills,
                 can_use_browser=default.can_use_browser,
                 browser_actions=default.browser_actions,
                 can_use_internet=default.can_use_internet,
@@ -172,6 +182,18 @@ class PermissionMatrix:
                 wallet_allowed_contracts=default.wallet_allowed_contracts,
             )
         return AgentPermissions(agent_id=agent_id)
+
+    def get_effective_skills(self, agent_id: str) -> list[str]:
+        """Skill-pack names this agent may discover: fleet-wide ∪ per-agent.
+
+        Not a security gate — skills are data, not a capability. This only
+        scopes what ``skills_list`` / ``skill_view`` surface to the agent, so
+        each agent's context stays relevant. Names are returned sorted and
+        de-duplicated; intersection with the actually-installed catalog happens
+        at view time (an assigned-but-uninstalled name simply yields nothing).
+        """
+        per_agent = self.get_permissions(agent_id).allowed_skills
+        return sorted(set(self.fleet_skills) | set(per_agent))
 
     @staticmethod
     def _is_trusted(agent_id: str) -> bool:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3830,11 +3830,21 @@ def create_mesh_app(
         agent_id = str(data.get("agent_id", "")).strip()
         if not agent_id:
             raise HTTPException(400, "agent_id is required")
+        if agent_id == "default":
+            raise HTTPException(400, "Use /mesh/skills/fleet for fleet-wide assignment; 'default' is reserved.")
+        agent_id = _validate_agent_id(agent_id)
         skills = _clean_skill_names(data.get("skills", []))
 
         from src.cli.config import _load_permissions, _save_permissions
         perms = _load_permissions()
-        perms.setdefault("permissions", {}).setdefault(agent_id, {})["allowed_skills"] = skills
+        agents = perms.setdefault("permissions", {})
+        # Materialize the agent's full effective permissions before this partial
+        # write. Writing a bare {"allowed_skills": ...} for an agent that had no
+        # explicit entry would drop it out of the "default" template fallback in
+        # get_permissions and silently strip every other grant (Codex review).
+        if agent_id not in agents:
+            agents[agent_id] = permissions.get_permissions(agent_id).model_dump(exclude={"agent_id"})
+        agents[agent_id]["allowed_skills"] = skills
         _save_permissions(perms)
         permissions.reload()
         return {"assigned": True, "agent_id": agent_id, "skills": skills}

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3793,6 +3793,66 @@ def create_mesh_app(
             raise HTTPException(status, result["error"])
         return result
 
+    # === Skill assignment (per-agent + fleet-wide) ===
+
+    def _clean_skill_names(value) -> list[str]:
+        """Validate + normalise a skill-name list (sorted, de-duped, path-safe)."""
+        if not isinstance(value, list):
+            raise HTTPException(400, "skills must be a list of names")
+        cleaned: set[str] = set()
+        for s in value:
+            if not isinstance(s, str):
+                raise HTTPException(400, "skill names must be strings")
+            s = s.strip()
+            if not s:
+                continue
+            if not all((c.isascii() and c.isalnum()) or c in "_-" for c in s):
+                raise HTTPException(400, f"Invalid skill name: {s!r}")
+            cleaned.add(s)
+        return sorted(cleaned)
+
+    @app.get("/mesh/skills/mine")
+    async def my_skills(request: Request) -> dict:
+        """Effective skill-pack names for the calling agent (fleet ∪ per-agent).
+
+        Caller is resolved from the request identity, so an agent only ever
+        sees its own assignment. Used by skills_list / skill_view to scope
+        discovery per agent.
+        """
+        caller = _resolve_agent_id("unknown", request)
+        return {"skills": permissions.get_effective_skills(caller)}
+
+    @app.post("/mesh/skills/assign")
+    async def assign_agent_skills(data: dict, request: Request) -> dict:
+        """Set an agent's per-agent skill allowlist. Body: {agent_id, skills[], caller?}"""
+        caller = _require_skill_admin(request, data, "skills.assign:can_manage_fleet")
+        await _check_rate_limit("skill_install", caller)
+        agent_id = str(data.get("agent_id", "")).strip()
+        if not agent_id:
+            raise HTTPException(400, "agent_id is required")
+        skills = _clean_skill_names(data.get("skills", []))
+
+        from src.cli.config import _load_permissions, _save_permissions
+        perms = _load_permissions()
+        perms.setdefault("permissions", {}).setdefault(agent_id, {})["allowed_skills"] = skills
+        _save_permissions(perms)
+        permissions.reload()
+        return {"assigned": True, "agent_id": agent_id, "skills": skills}
+
+    @app.post("/mesh/skills/fleet")
+    async def set_fleet_skills(data: dict, request: Request) -> dict:
+        """Set the fleet-wide skill allowlist (applies to every agent). Body: {skills[], caller?}"""
+        caller = _require_skill_admin(request, data, "skills.fleet:can_manage_fleet")
+        await _check_rate_limit("skill_install", caller)
+        skills = _clean_skill_names(data.get("skills", []))
+
+        from src.cli.config import _load_permissions, _save_permissions
+        perms = _load_permissions()
+        perms["fleet_skills"] = skills
+        _save_permissions(perms)
+        permissions.reload()
+        return {"fleet_skills": skills}
+
     # === Create Custom Agent ===
 
     @app.post("/mesh/agents/create")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3853,6 +3853,24 @@ def create_mesh_app(
         permissions.reload()
         return {"fleet_skills": skills}
 
+    @app.get("/mesh/skills/assignments")
+    async def skill_assignments(request: Request) -> dict:
+        """Current fleet + per-agent skill assignment (operator/can_manage_fleet).
+
+        Lets the operator inspect who has what before changing it. ``per_agent``
+        only lists agents that have an explicit allowlist set.
+        """
+        _require_skill_admin(request, {}, "skills.read:can_manage_fleet")
+        per_agent = {
+            aid: list(perms.allowed_skills)
+            for aid, perms in permissions.permissions.items()
+            if perms.allowed_skills
+        }
+        return {
+            "fleet_skills": list(getattr(permissions, "fleet_skills", []) or []),
+            "per_agent": per_agent,
+        }
+
     # === Create Custom Agent ===
 
     @app.post("/mesh/agents/create")

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -340,6 +340,14 @@ class AgentPermissions(BaseModel):
     blackboard_write: list[str] = []
     allowed_apis: list[str] = []
     allowed_credentials: list[str] = []
+    # Per-agent SKILL.md pack allowlist (names). A skill is *data*, not a
+    # capability — this only controls which packs the agent can DISCOVER via
+    # skills_list / skill_view, to keep context lean and relevant. The agent's
+    # effective set is the union of this list and the fleet-wide ``fleet_skills``
+    # (a top-level key in permissions.json), resolved by
+    # ``PermissionMatrix.get_effective_skills``. Empty = no skills until
+    # assigned (the operator + standalone agents see the full catalog).
+    allowed_skills: list[str] = []
     can_use_browser: bool = False
     browser_actions: list[str] | None = None  # None = all known actions
                                                # (default-allow UX).

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -251,10 +251,10 @@ def tool_store(tmp_path, monkeypatch):
     return bundled
 
 
-def test_skills_list_tool_level0(tool_store):
+async def test_skills_list_tool_level0(tool_store):
     _write_skill(tool_store, "research", description="Research a competitor",
                  body="LONG BODY " * 100)
-    result = skills_tool.skills_list()
+    result = await skills_tool.skills_list()
     assert result["count"] == 1
     entry = result["skills"][0]
     assert entry == {"name": "research", "description": "Research a competitor"}
@@ -262,31 +262,31 @@ def test_skills_list_tool_level0(tool_store):
     assert "LONG BODY" not in str(result)
 
 
-def test_skill_view_tool_level1(tool_store):
+async def test_skill_view_tool_level1(tool_store):
     _write_skill(tool_store, "research", description="d", body="# Procedure\nDo it.")
-    result = skills_tool.skill_view("research")
+    result = await skills_tool.skill_view("research")
     assert result["name"] == "research"
     assert result["body"] == "# Procedure\nDo it."
     assert "error" not in result
 
 
-def test_skill_view_tool_unknown(tool_store):
-    result = skills_tool.skill_view("nope")
+async def test_skill_view_tool_unknown(tool_store):
+    result = await skills_tool.skill_view("nope")
     assert "error" in result and "not found" in result["error"]
 
 
-def test_skill_view_tool_reference(tool_store):
+async def test_skill_view_tool_reference(tool_store):
     _write_skill(tool_store, "research")
     (tool_store / "research" / "references").mkdir()
     (tool_store / "research" / "references" / "tpl.md").write_text("TEMPLATE", encoding="utf-8")
-    result = skills_tool.skill_view("research", "references/tpl.md")
+    result = await skills_tool.skill_view("research", "references/tpl.md")
     assert result["content"] == "TEMPLATE"
     assert result["path"] == "references/tpl.md"
 
 
-def test_skill_view_tool_bad_reference(tool_store):
+async def test_skill_view_tool_bad_reference(tool_store):
     _write_skill(tool_store, "research")
-    result = skills_tool.skill_view("research", "../escape.md")
+    result = await skills_tool.skill_view("research", "../escape.md")
     assert "error" in result
 
 
@@ -321,24 +321,24 @@ def test_render_text_noop_without_token(tmp_path):
     assert render_text(skill.body, skill) == "no tokens here"
 
 
-def test_skill_view_substitutes_skill_dir(tool_store):
+async def test_skill_view_substitutes_skill_dir(tool_store):
     pack = _write_skill(tool_store, "research", body="exec ${SKILL_DIR}/scripts/x.py").parent
-    result = skills_tool.skill_view("research")
+    result = await skills_tool.skill_view("research")
     assert "${SKILL_DIR}" not in result["body"]
     assert str(pack) in result["body"]
 
 
-def test_skill_view_substitutes_in_reference(tool_store):
+async def test_skill_view_substitutes_in_reference(tool_store):
     _write_skill(tool_store, "research")
     refs = tool_store / "research" / "references"
     refs.mkdir()
     (refs / "r.md").write_text("see ${SKILL_DIR}/scripts/x.py", encoding="utf-8")
-    result = skills_tool.skill_view("research", "references/r.md")
+    result = await skills_tool.skill_view("research", "references/r.md")
     assert "${SKILL_DIR}" not in result["content"]
     assert str(tool_store / "research") in result["content"]
 
 
-def test_skill_view_surfaces_declared_requirements(tool_store):
+async def test_skill_view_surfaces_declared_requirements(tool_store):
     _write_skill(
         tool_store, "research",
         extra_frontmatter=(
@@ -350,14 +350,14 @@ def test_skill_view_surfaces_declared_requirements(tool_store):
             "      - {key: max_sources, default: '10'}\n"
         ),
     )
-    result = skills_tool.skill_view("research")
+    result = await skills_tool.skill_view("research")
     assert result["required_environment_variables"][0]["name"] == "API_KEY"
     assert result["config"][0]["key"] == "max_sources"
 
 
-def test_skill_view_plain_skill_has_no_requirements(tool_store):
+async def test_skill_view_plain_skill_has_no_requirements(tool_store):
     _write_skill(tool_store, "plain")
-    result = skills_tool.skill_view("plain")
+    result = await skills_tool.skill_view("plain")
     assert "required_environment_variables" not in result
     assert "config" not in result
 

--- a/tests/test_skills_assignment.py
+++ b/tests/test_skills_assignment.py
@@ -70,6 +70,35 @@ def test_fleet_skills_fail_closed_on_missing_file(tmp_path):
     assert pm.get_effective_skills("a") == []
 
 
+def test_assign_preserves_default_template_grants(tmp_path):
+    """Materializing effective perms before a partial skill write must NOT strip
+    grants an agent inherited from the 'default' template (Codex review must-fix:
+    a bare {allowed_skills} write would drop the agent out of default fallback)."""
+    import json as _json
+
+    cfg = _perms_file(tmp_path, {
+        "permissions": {"default": {"allowed_apis": ["svc"], "can_use_browser": True}},
+    })
+    pm = PermissionMatrix(config_path=cfg)
+    # 'worker' has no explicit entry → inherits the default template.
+    assert pm.get_permissions("worker").allowed_apis == ["svc"]
+    assert pm.get_permissions("worker").can_use_browser is True
+
+    # Replicate the endpoint's materialize-then-write.
+    data = _json.loads((tmp_path / "permissions.json").read_text())
+    agents = data.setdefault("permissions", {})
+    if "worker" not in agents:
+        agents["worker"] = pm.get_permissions("worker").model_dump(exclude={"agent_id"})
+    agents["worker"]["allowed_skills"] = ["alpha"]
+    (tmp_path / "permissions.json").write_text(_json.dumps(data))
+    pm.reload()
+
+    # Skill assigned AND the inherited grants survive.
+    assert pm.get_permissions("worker").allowed_skills == ["alpha"]
+    assert pm.get_permissions("worker").allowed_apis == ["svc"]
+    assert pm.get_permissions("worker").can_use_browser is True
+
+
 def test_reload_picks_up_new_assignment(tmp_path):
     cfg = _perms_file(tmp_path, {"permissions": {"a": {}}})
     pm = PermissionMatrix(config_path=cfg)

--- a/tests/test_skills_assignment.py
+++ b/tests/test_skills_assignment.py
@@ -1,0 +1,165 @@
+"""Per-agent + fleet-wide skill assignment (PR 5).
+
+Covers ``PermissionMatrix.get_effective_skills`` (fleet ∪ per-agent) and the
+per-agent filtering in the skills_list / skill_view tools (operator + standalone
+see the full catalog; everyone else only their assignment; fetch errors fail
+closed).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.agent.builtins import skills_tool
+from src.host.permissions import PermissionMatrix
+
+
+def _write_skill(directory, name, description="d", body="Body."):
+    pack = directory / name
+    pack.mkdir(parents=True, exist_ok=True)
+    (pack / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _perms_file(tmp_path, data) -> str:
+    p = tmp_path / "permissions.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return str(p)
+
+
+# ── PermissionMatrix.get_effective_skills ─────────────────────────────────
+
+def test_effective_skills_union_fleet_and_per_agent(tmp_path):
+    cfg = _perms_file(tmp_path, {
+        "fleet_skills": ["common"],
+        "permissions": {"alice": {"allowed_skills": ["alpha", "beta"]}},
+    })
+    pm = PermissionMatrix(config_path=cfg)
+    assert pm.get_effective_skills("alice") == ["alpha", "beta", "common"]
+
+
+def test_effective_skills_default_empty(tmp_path):
+    cfg = _perms_file(tmp_path, {"permissions": {"bob": {}}})
+    pm = PermissionMatrix(config_path=cfg)
+    assert pm.get_effective_skills("bob") == []
+
+
+def test_fleet_skills_apply_to_every_agent(tmp_path):
+    cfg = _perms_file(tmp_path, {"fleet_skills": ["common"], "permissions": {}})
+    pm = PermissionMatrix(config_path=cfg)
+    # An agent with no explicit entry still gets the fleet-wide skill.
+    assert pm.get_effective_skills("anyone") == ["common"]
+
+
+def test_effective_skills_dedup_and_sorted(tmp_path):
+    cfg = _perms_file(tmp_path, {
+        "fleet_skills": ["dup"],
+        "permissions": {"a": {"allowed_skills": ["dup", "x"]}},
+    })
+    pm = PermissionMatrix(config_path=cfg)
+    assert pm.get_effective_skills("a") == ["dup", "x"]
+
+
+def test_fleet_skills_fail_closed_on_missing_file(tmp_path):
+    pm = PermissionMatrix(config_path=str(tmp_path / "nope.json"))
+    assert pm.fleet_skills == []
+    assert pm.get_effective_skills("a") == []
+
+
+def test_reload_picks_up_new_assignment(tmp_path):
+    cfg = _perms_file(tmp_path, {"permissions": {"a": {}}})
+    pm = PermissionMatrix(config_path=cfg)
+    assert pm.get_effective_skills("a") == []
+    # Operator assigns a skill on disk, then the mesh reloads the matrix.
+    (tmp_path / "permissions.json").write_text(
+        json.dumps({"permissions": {"a": {"allowed_skills": ["alpha"]}}}),
+        encoding="utf-8",
+    )
+    pm.reload()
+    assert pm.get_effective_skills("a") == ["alpha"]
+
+
+# ── skills_list / skill_view per-agent filtering ──────────────────────────
+
+class _FakeMesh:
+    is_standalone = False
+
+    def __init__(self, names):
+        self._names = names
+
+    async def list_my_skills(self):
+        return self._names
+
+
+@pytest.fixture
+def store_with_three(tmp_path, monkeypatch):
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    for n in ("alpha", "beta", "gamma"):
+        _write_skill(bundled, n)
+    monkeypatch.setenv("SKILLS_DIR", str(bundled))
+    monkeypatch.setenv("SKILLS_INSTALLED_DIR", str(tmp_path / "none"))
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)  # not the operator
+    return bundled
+
+
+async def test_skills_list_filters_to_assigned(store_with_three):
+    result = await skills_tool.skills_list(mesh_client=_FakeMesh(["alpha", "gamma"]))
+    assert {s["name"] for s in result["skills"]} == {"alpha", "gamma"}
+    assert result["count"] == 2
+
+
+async def test_skills_list_empty_when_none_assigned(store_with_three):
+    result = await skills_tool.skills_list(mesh_client=_FakeMesh([]))
+    assert result["skills"] == []
+    assert result["count"] == 0
+
+
+async def test_skill_view_blocks_unassigned(store_with_three):
+    result = await skills_tool.skill_view("beta", mesh_client=_FakeMesh(["alpha"]))
+    assert "error" in result and "not found" in result["error"]
+
+
+async def test_skill_view_allows_assigned(store_with_three):
+    result = await skills_tool.skill_view("beta", mesh_client=_FakeMesh(["beta"]))
+    assert result["name"] == "beta"
+    assert "error" not in result
+
+
+async def test_operator_sees_full_catalog(store_with_three, monkeypatch):
+    # The operator (fleet manager) bypasses assignment — ALLOWED_TOOLS marks it.
+    monkeypatch.setenv("ALLOWED_TOOLS", "skills_list,edit_agent")
+    result = await skills_tool.skills_list(mesh_client=_FakeMesh([]))
+    assert result["count"] == 3
+
+
+async def test_standalone_sees_full_catalog(store_with_three):
+    class Standalone:
+        is_standalone = True
+
+        async def list_my_skills(self):
+            raise AssertionError("standalone must not fetch assignment")
+
+    result = await skills_tool.skills_list(mesh_client=Standalone())
+    assert result["count"] == 3
+
+
+async def test_no_mesh_client_sees_full_catalog(store_with_three):
+    result = await skills_tool.skills_list(mesh_client=None)
+    assert result["count"] == 3
+
+
+async def test_fetch_error_fails_closed(store_with_three):
+    class Boom:
+        is_standalone = False
+
+        async def list_my_skills(self):
+            raise RuntimeError("mesh down")
+
+    # A fetch error hides skills rather than flooding the agent with all of them.
+    result = await skills_tool.skills_list(mesh_client=Boom())
+    assert result["count"] == 0

--- a/tests/test_skills_install.py
+++ b/tests/test_skills_install.py
@@ -129,9 +129,12 @@ def test_install_skill_leaves_no_staging_dir(tmp_path):
 # ── operator tools: gating ───────────────────────────────────────────────────
 
 class _FakeMesh:
-    def __init__(self):
+    def __init__(self, assignments=None):
         self.installed = None
         self.removed = None
+        self.assigned = None
+        self.fleet = None
+        self._assignments = assignments or {"fleet_skills": [], "per_agent": {}}
 
     async def install_skill(self, repo_url, ref=""):
         self.installed = (repo_url, ref)
@@ -140,6 +143,17 @@ class _FakeMesh:
     async def remove_skill(self, name):
         self.removed = name
         return {"removed": True, "name": name}
+
+    async def get_skill_assignments(self):
+        return self._assignments
+
+    async def assign_skills(self, agent_id, skills):
+        self.assigned = (agent_id, skills)
+        return {"assigned": True, "agent_id": agent_id, "skills": skills}
+
+    async def set_fleet_skills(self, skills):
+        self.fleet = skills
+        return {"fleet_skills": skills}
 
 
 async def test_install_tool_requires_operator(monkeypatch):
@@ -177,6 +191,99 @@ async def test_remove_tool_forwards_to_mesh(monkeypatch):
     )
     assert result["removed"] is True
     assert mesh.removed == "demo-skill"
+
+
+# ── operator tools: assign_skill / list_skill_assignments ────────────────────
+
+async def test_assign_skill_requires_operator(monkeypatch):
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    result = await skill_admin_tool.assign_skill("alpha", agent_id="a", mesh_client=_FakeMesh())
+    assert "only available to the operator" in result["error"]
+
+
+async def test_assign_skill_requires_user_origin(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: False)
+    result = await skill_admin_tool.assign_skill(
+        "alpha", agent_id="a", mesh_client=_FakeMesh(), _messages=[{"role": "user"}],
+    )
+    assert result["error"] == "provenance_check_failed"
+
+
+async def test_assign_skill_requires_target(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: True)
+    result = await skill_admin_tool.assign_skill(
+        "alpha", mesh_client=_FakeMesh(), _messages=[{"role": "user"}],
+    )
+    assert "agent_id" in result["error"]
+
+
+async def test_assign_skill_add_per_agent_merges(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: True)
+    mesh = _FakeMesh({"fleet_skills": [], "per_agent": {"alice": ["alpha"]}})
+    result = await skill_admin_tool.assign_skill(
+        "beta", agent_id="alice", action="add", mesh_client=mesh, _messages=[{"role": "user"}],
+    )
+    # Merges onto the existing per-agent list (full-list set semantics).
+    assert mesh.assigned == ("alice", ["alpha", "beta"])
+    assert result["assigned"] is True
+
+
+async def test_assign_skill_remove_per_agent(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: True)
+    mesh = _FakeMesh({"fleet_skills": [], "per_agent": {"alice": ["alpha", "beta"]}})
+    await skill_admin_tool.assign_skill(
+        "beta", agent_id="alice", action="remove", mesh_client=mesh, _messages=[{"role": "user"}],
+    )
+    assert mesh.assigned == ("alice", ["alpha"])
+
+
+async def test_assign_skill_fleet(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: True)
+    mesh = _FakeMesh({"fleet_skills": ["common"], "per_agent": {}})
+    await skill_admin_tool.assign_skill(
+        "extra", fleet=True, action="add", mesh_client=mesh, _messages=[{"role": "user"}],
+    )
+    assert mesh.fleet == ["common", "extra"]
+    assert mesh.assigned is None  # per-agent path untouched
+
+
+async def test_assign_skill_remove_notes_fleet_override(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: True)
+    # 'shared' is fleet-wide; removing it from one agent has no real effect.
+    mesh = _FakeMesh({"fleet_skills": ["shared"], "per_agent": {"alice": ["shared"]}})
+    result = await skill_admin_tool.assign_skill(
+        "shared", agent_id="alice", action="remove", mesh_client=mesh, _messages=[{"role": "user"}],
+    )
+    assert "fleet-wide" in result.get("note", "")
+
+
+async def test_assign_skill_rejects_bad_action(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "assign_skill")
+    monkeypatch.setattr("src.agent.loop._last_message_is_user_origin", lambda m: True)
+    result = await skill_admin_tool.assign_skill(
+        "alpha", agent_id="a", action="toggle", mesh_client=_FakeMesh(), _messages=[{"role": "user"}],
+    )
+    assert "action must be" in result["error"]
+
+
+async def test_list_skill_assignments_requires_operator(monkeypatch):
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    result = await skill_admin_tool.list_skill_assignments(mesh_client=_FakeMesh())
+    assert "only available to the operator" in result["error"]
+
+
+async def test_list_skill_assignments_forwards(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "list_skill_assignments")
+    mesh = _FakeMesh({"fleet_skills": ["common"], "per_agent": {"alice": ["alpha"]}})
+    result = await skill_admin_tool.list_skill_assignments(mesh_client=mesh)
+    assert result["fleet_skills"] == ["common"]
+    assert result["per_agent"] == {"alice": ["alpha"]}
 
 
 # ── mesh endpoint smoke (wiring + success through the route) ─────────────────


### PR DESCRIPTION
**Stacked on PR 4 (#1020).** Do NOT merge until the base stack (#1014 → #1018 → #1019 → #1020) lands first — this branches off `feat/skills-demote-authoring`, so its diff shows only the PR-5 commits once the base merges.

## Why
Skills were a global catalog: `skills_list` returned *every* pack to *every* agent. As the catalog grows that floods each agent's context and degrades skill selection. This scopes skills to the agent — an agent only discovers the packs it's been assigned.

## Model
- **Per-agent** `AgentPermissions.allowed_skills` (permissions.json) + a top-level **`fleet_skills`** (applies to every agent).
- Effective set = `fleet ∪ per-agent`, via `PermissionMatrix.get_effective_skills`.
- **Default empty** — an agent sees no skills until assigned. Fails closed to no fleet skills on a missing/corrupt permissions file.

## Delivery (single source of truth, always live)
- `skills_list` / `skill_view` (now async) fetch the calling agent's effective set from the mesh (`GET /mesh/skills/mine`, caller resolved from identity) and filter the catalog to it. No env seeding, no `/config` plumbing, no agent-loop changes — operator edits take effect with no restart.
- **Operator** (fleet manager) and **standalone** runs bypass filtering and see the full catalog. A mesh fetch error **fails closed** (skills hidden, not flooded).

## Surfaces
- Mesh: `GET /mesh/skills/mine`, `POST /mesh/skills/assign`, `POST /mesh/skills/fleet` (operator-or-`can_manage_fleet`, rate-limited, path-safe names).
- Dashboard API: `GET /api/skills` enriched (`fleet_assigned`, `agent_assigned` when `?agent_id`), `GET/POST /api/fleet/skills`, `POST /api/skills/install` + `/remove`, and `allowed_skills` on `GET/PUT /api/agents/{id}/permissions`.
- Dashboard UI: **per-agent Skills tab** beside Tools (fleet-assigned packs shown locked-on), and **System → Skills** sub-tab (install-from-repo, catalog, fleet-wide toggle, remove).

## Tests
`get_effective_skills` union/default/fail-closed/reload; per-agent tool filtering (assigned/empty/operator/standalone/no-mesh/fetch-error); existing tool tests made async. Full targeted sweep: **573 passed**.

## Note
Per-agent assignment is currently a dashboard surface (operator can still install/remove via chat). No backend behavior change for existing users beyond the stack's own.