### PR TITLE
feat(operator): manager can retrieve & relay a worker's actual files

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -463,6 +463,146 @@ async def read_peer_artifact(
 
 
 @skill(
+    name="list_peer_files",
+    description=(
+        "List the files in a teammate's workspace/data volume — "
+        "operator-only. Unlike list_peer_artifacts (which only sees the "
+        "artifacts/ folder), this reaches the worker's FULL workspace, so "
+        "you can find a deliverable a worker built as a plain file "
+        "(e.g. 'workspace/data.md' or a generated CSV) and then pull it "
+        "with read_peer_file to relay it to the user or hand it off. Pass "
+        "path='workspace' with recursive=True to see everything a worker "
+        "produced. THIS is how you get a worker's data out — don't tell "
+        "the user a deliverable is unreachable before checking here."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "The teammate agent id whose files to list.",
+        },
+        "path": {
+            "type": "string",
+            "description": "Directory under /data to list (default '.').",
+            "default": ".",
+        },
+        "recursive": {
+            "type": "boolean",
+            "description": "Recurse into subdirectories.",
+            "default": False,
+        },
+    },
+)
+async def list_peer_files(
+    agent_id: str,
+    path: str = ".",
+    recursive: bool = False,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """List a teammate's /data files — operator-only.
+
+    Mirrors :func:`list_peer_artifacts` but spans the worker's whole
+    workspace, not just ``artifacts/``. 404 → ``agent_not_found``.
+    """
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not agent_id or not isinstance(agent_id, str):
+        return {"error": "agent_id is required"}
+
+    try:
+        return await mesh_client.list_peer_files(agent_id, path, recursive)
+    except Exception as e:
+        resp = getattr(e, "response", None)
+        status = getattr(resp, "status_code", None)
+        if status == 404:
+            return {"error": "agent_not_found", "agent_id": agent_id}
+        if status == 400:
+            return {"error": "invalid_path", "agent_id": agent_id, "path": path}
+        if status is not None:
+            body = getattr(resp, "text", "") or ""
+            return {"error": "mesh_error", "status": status, "body": body[:200]}
+        return {"error": f"Failed to list peer files: {str(e)[:200]}"}
+
+
+@skill(
+    name="read_peer_file",
+    description=(
+        "Read the content of any file in a teammate's workspace/data "
+        "volume — operator-only. This is how you retrieve a worker's "
+        "actual deliverable (a CSV, a data.md, a report) so you can paste "
+        "it to the user, hand it off, or post it onward. Use list_peer_files "
+        "first to find the path. Files larger than the per-read cap return "
+        "truncated=True with a next_offset — call again with that offset to "
+        "page through the rest. For files too big to paste, tell the user "
+        "they can download it directly from the agent's file view in the "
+        "dashboard. Binary files come back base64-encoded (encoding='base64')."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "The teammate agent id that owns the file.",
+        },
+        "path": {
+            "type": "string",
+            "description": (
+                "File path under /data (e.g. 'workspace/data.md') as "
+                "returned by list_peer_files. No '..' or absolute paths."
+            ),
+        },
+        "offset": {
+            "type": "integer",
+            "description": (
+                "Byte offset to start from (default 0). Pass the "
+                "next_offset from a prior truncated read to continue."
+            ),
+            "default": 0,
+        },
+    },
+)
+async def read_peer_file(
+    agent_id: str,
+    path: str,
+    offset: int = 0,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Read a teammate's /data file content — operator-only.
+
+    Mirrors :func:`read_peer_artifact` but targets any file under the
+    worker's /data volume. 404 → ``file_not_found``; 400 → ``invalid_path``.
+    """
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not agent_id or not isinstance(agent_id, str):
+        return {"error": "agent_id is required"}
+    if not path or not isinstance(path, str):
+        return {"error": "path is required"}
+
+    try:
+        result = await mesh_client.read_peer_file(agent_id, path, offset=offset)
+    except Exception as e:
+        resp = getattr(e, "response", None)
+        status = getattr(resp, "status_code", None)
+        if status == 404:
+            return {"error": "file_not_found", "agent_id": agent_id, "path": path}
+        if status == 400:
+            return {"error": "invalid_path", "agent_id": agent_id, "path": path}
+        if status == 413:
+            return {"error": "oversize", "agent_id": agent_id, "path": path}
+        if status is not None:
+            body = getattr(resp, "text", "") or ""
+            return {"error": "mesh_error", "status": status, "body": body[:200]}
+        return {"error": f"Failed to read peer file: {str(e)[:200]}"}
+    return result
+
+
+@skill(
     name="list_available_models",
     description=(
         "List models currently usable given the active credential setup. "

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -219,6 +219,8 @@ _READ_ONLY_TOOLS = frozenset({
     "list_cron", "read_agent_history",
     # Pending-action / artifact reads (writes go through manage_task etc.)
     "list_pending", "list_peer_artifacts", "read_peer_artifact",
+    # Peer file reads (full /data volume, not just artifacts/) — read-only.
+    "list_peer_files", "read_peer_file",
     "get_team_outputs",
     # Memory / file reads (writes go through memory_save / write_file)
     "memory_search", "read_file",

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -906,6 +906,46 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def list_peer_files(self, agent_id: str, path: str = ".",
+                              recursive: bool = False) -> dict:
+        """List a peer agent's /data files (operator-only).
+
+        Backs the operator's ``list_peer_files`` tool. Reaches beyond
+        ``artifacts/`` to the worker's full /data volume so the operator can
+        locate a deliverable wherever it was written. Returns
+        ``{agent_id, entries: [...], count}``. 403 if the caller isn't
+        operator; 404 if the agent doesn't exist.
+        """
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/files",
+            params={"requesting_agent": self.agent_id, "path": path,
+                    "recursive": str(bool(recursive)).lower()},
+        )
+        _raise_with_body(response)
+        return response.json()
+
+    async def read_peer_file(self, agent_id: str, path: str,
+                             offset: int = 0, max_bytes: int = 0) -> dict:
+        """Read a peer agent's /data file content (operator-only).
+
+        Backs the operator's ``read_peer_file`` tool. Returns
+        ``{agent_id, path, content, size, encoding, offset, next_offset,
+        truncated}``. Pass the prior ``next_offset`` back as ``offset`` to
+        page a large file. 403 if the caller isn't operator; 404 if the file
+        is missing.
+        """
+        params: dict = {"requesting_agent": self.agent_id}
+        if offset:
+            params["offset"] = offset
+        if max_bytes:
+            params["max_bytes"] = max_bytes
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/files/{path}",
+            params=params,
+        )
+        _raise_with_body(response)
+        return response.json()
+
     async def cancel_pending_action(self, nonce: str) -> dict:
         """Cancel a pending action by nonce (operator self-cleanup).
 

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -799,9 +799,24 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         except ValueError as e:
             raise HTTPException(400, str(e))
 
+    # Hard ceiling on a single /files read so a caller can pull more than the
+    # 500 KB default read cap (e.g. a peer-file download) without ever loading
+    # an unbounded amount into memory. Larger files are paged via ``offset``.
+    _MAX_FILE_READ_BYTES = 5 * 1024 * 1024  # 5 MB
+
     @app.get("/files/{path:path}")
-    async def read_data_file(path: str) -> dict:
-        """Read any file from /data. Text returned as-is; binary base64-encoded."""
+    async def read_data_file(
+        path: str, offset: int = 0, max_bytes: int = 0,
+    ) -> dict:
+        """Read any file from /data. Text returned as-is; binary base64-encoded.
+
+        ``offset`` seeks into the file and ``max_bytes`` caps how much is
+        returned in one call, so a caller can page through a file larger than
+        the default 500 KB read cap. ``max_bytes`` defaults to that legacy cap
+        (back-compat for existing dashboard/agent readers) and is clamped to a
+        5 MB hard ceiling per request. ``next_offset`` is where the next page
+        starts; ``truncated`` is True while more bytes remain.
+        """
         from src.agent.builtins.file_tool import _MAX_READ, _safe_path
         try:
             safe = _safe_path(path)
@@ -813,18 +828,29 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             raise HTTPException(400, f"Not a file: {path}")
         size = safe.stat().st_size
         mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
-        # Read at most _MAX_READ bytes without loading the full file first.
+        offset = max(0, offset)
+        limit = max_bytes if max_bytes > 0 else _MAX_READ
+        limit = min(limit, _MAX_FILE_READ_BYTES)
+        # Seek to offset and read at most ``limit`` bytes — never loads the
+        # whole file into memory.
         with safe.open("rb") as fh:
-            raw = fh.read(_MAX_READ)
+            if offset:
+                fh.seek(offset)
+            raw = fh.read(limit)
+        next_offset = offset + len(raw)
+        truncated = next_offset < size
         try:
             content = raw.decode("utf-8")
-            return {"path": path, "content": content, "size": size,
-                    "mime_type": mime, "encoding": "utf-8",
-                    "truncated": size > _MAX_READ}
+            encoding = "utf-8"
         except UnicodeDecodeError:
-            return {"path": path, "content": base64.b64encode(raw).decode("ascii"),
-                    "size": size, "mime_type": mime, "encoding": "base64",
-                    "truncated": size > _MAX_READ}
+            # A chunk boundary may split a multibyte char; base64 keeps the
+            # page byte-exact so a paged download reassembles losslessly.
+            content = base64.b64encode(raw).decode("ascii")
+            encoding = "base64"
+        return {"path": path, "content": content, "size": size,
+                "mime_type": mime, "encoding": encoding,
+                "offset": offset, "next_offset": next_offset,
+                "truncated": truncated}
 
     @app.post("/artifacts/ingest/{name:path}")
     async def ingest_artifact(name: str, request: Request) -> dict:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1698,6 +1698,10 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # read_peer_artifact for deeper inspection of peer-written files.
     "read_agent_config",
     "list_peer_artifacts", "read_peer_artifact",
+    # Peer FILE reads — full /data volume, not just artifacts/. Lets the
+    # operator locate + relay a worker's deliverable (CSV, data.md) the
+    # user asked for, instead of reporting it unreachable.
+    "list_peer_files", "read_peer_file",
     # Observation log of agent→user notifications — PULL-only, NOT a
     # message channel (agents can't address the operator). Lets the
     # operator answer "what's blocking?" from what workers already told

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3674,17 +3674,20 @@ def create_dashboard_router(
         except Exception as e:
             raise HTTPException(status_code=502, detail=str(e))
 
-    # NOTE: registered BEFORE the greedy ``{path:path}`` read route below so
-    # Starlette matches the literal ``/download`` suffix first.
-    @api_router.get("/api/agents/{agent_id}/files/{path:path}/download")
+    # Deliberately NOT under ``/files/`` — that namespace ends in a greedy
+    # ``{path:path}`` read route, and a sibling ``/files/{path}/download`` would
+    # permanently shadow any real file whose path ends in ``/download``. A
+    # separate prefix keeps both routes unambiguous.
+    @api_router.get("/api/agents/{agent_id}/file-download/{path:path}")
     async def api_download_file(agent_id: str, path: str):
         """Download an agent's /data file as a Content-Disposition attachment.
 
         Pages the agent's ``/files`` endpoint in 5 MB chunks and concatenates
         the raw bytes, so the user can save a worker's deliverable (CSV,
         data.md, a binary export) straight to disk — bypassing the JSON read
-        cap and never routing the bytes through any LLM context. Capped at
-        64 MB total to bound host memory.
+        cap and never routing the bytes through any LLM context. Rejected
+        upfront if the file exceeds the 64 MB cap (the agent reports the full
+        size in the first page), so host memory stays bounded.
         """
         import base64 as _b64
         from urllib.parse import urlencode
@@ -3697,7 +3700,6 @@ def create_dashboard_router(
         _CHUNK = 5 * 1024 * 1024
         _MAX_TOTAL = 64 * 1024 * 1024
         parts: list[bytes] = []
-        total = 0
         offset = 0
         mime = "application/octet-stream"
         while True:
@@ -3712,18 +3714,19 @@ def create_dashboard_router(
                 status = result.get("status_code", 404) if isinstance(result, dict) else 502
                 detail = result.get("error", "download failed") if isinstance(result, dict) else "download failed"
                 raise HTTPException(status_code=status, detail=detail)
+            # Reject oversize before buffering anything: the first page carries
+            # the full file size.
+            if int(result.get("size", 0)) > _MAX_TOTAL:
+                raise HTTPException(
+                    status_code=413,
+                    detail="File exceeds the 64 MB download cap",
+                )
             mime = result.get("mime_type") or mime
             if result.get("encoding") == "base64":
                 blob = _b64.b64decode(result.get("content", ""))
             else:
                 blob = (result.get("content") or "").encode("utf-8")
             parts.append(blob)
-            total += len(blob)
-            if total > _MAX_TOTAL:
-                raise HTTPException(
-                    status_code=413,
-                    detail="File exceeds the 64 MB download cap",
-                )
             next_offset = result.get("next_offset", offset + len(blob))
             if not result.get("truncated") or next_offset <= offset:
                 break

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3674,6 +3674,68 @@ def create_dashboard_router(
         except Exception as e:
             raise HTTPException(status_code=502, detail=str(e))
 
+    # NOTE: registered BEFORE the greedy ``{path:path}`` read route below so
+    # Starlette matches the literal ``/download`` suffix first.
+    @api_router.get("/api/agents/{agent_id}/files/{path:path}/download")
+    async def api_download_file(agent_id: str, path: str):
+        """Download an agent's /data file as a Content-Disposition attachment.
+
+        Pages the agent's ``/files`` endpoint in 5 MB chunks and concatenates
+        the raw bytes, so the user can save a worker's deliverable (CSV,
+        data.md, a binary export) straight to disk — bypassing the JSON read
+        cap and never routing the bytes through any LLM context. Capped at
+        64 MB total to bound host memory.
+        """
+        import base64 as _b64
+        from urllib.parse import urlencode
+
+        from fastapi.responses import Response
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        if transport is None:
+            raise HTTPException(status_code=503, detail="Transport not available")
+        _CHUNK = 5 * 1024 * 1024
+        _MAX_TOTAL = 64 * 1024 * 1024
+        parts: list[bytes] = []
+        total = 0
+        offset = 0
+        mime = "application/octet-stream"
+        while True:
+            qs = urlencode({"offset": offset, "max_bytes": _CHUNK})
+            try:
+                result = await transport.request(
+                    agent_id, "GET", f"/files/{path}?{qs}", timeout=60,
+                )
+            except Exception as e:
+                raise HTTPException(status_code=502, detail=str(e))
+            if not isinstance(result, dict) or "content" not in result:
+                status = result.get("status_code", 404) if isinstance(result, dict) else 502
+                detail = result.get("error", "download failed") if isinstance(result, dict) else "download failed"
+                raise HTTPException(status_code=status, detail=detail)
+            mime = result.get("mime_type") or mime
+            if result.get("encoding") == "base64":
+                blob = _b64.b64decode(result.get("content", ""))
+            else:
+                blob = (result.get("content") or "").encode("utf-8")
+            parts.append(blob)
+            total += len(blob)
+            if total > _MAX_TOTAL:
+                raise HTTPException(
+                    status_code=413,
+                    detail="File exceeds the 64 MB download cap",
+                )
+            next_offset = result.get("next_offset", offset + len(blob))
+            if not result.get("truncated") or next_offset <= offset:
+                break
+            offset = next_offset
+        filename = path.rsplit("/", 1)[-1] or "download"
+        safe_name = re.sub(r"[^\w.\- ]", "_", filename) or "download"
+        return Response(
+            content=b"".join(parts),
+            media_type=mime,
+            headers={"Content-Disposition": f'attachment; filename="{safe_name}"'},
+        )
+
     @api_router.get("/api/agents/{agent_id}/files/{path:path}")
     async def api_read_file(agent_id: str, path: str) -> dict:
         """Read a file from the agent's /data volume."""

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -5324,23 +5324,17 @@ function dashboard() {
     },
 
     downloadAgentFile(agentId, path) {
-      const url = `${window.__config.apiBase}/agents/${agentId}/files/${this._encodeFilePath(path)}`;
-      fetch(url).then(r => r.json()).then(data => {
-        let blob;
-        if (data.encoding === 'base64') {
-          const bin = atob(data.content);
-          const arr = new Uint8Array(bin.length);
-          for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
-          blob = new Blob([arr], { type: data.mime_type || 'application/octet-stream' });
-        } else {
-          blob = new Blob([data.content], { type: data.mime_type || 'text/plain' });
-        }
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
-        a.download = path.split('/').pop();
-        a.click();
-        URL.revokeObjectURL(a.href);
-      }).catch(e => this.showToast(`Download failed: ${e.message}`));
+      // Navigate to the streaming attachment endpoint so the browser saves the
+      // FULL file to disk (the JSON /files route is capped at 500 KB and would
+      // silently truncate). Same-origin navigation carries the session cookie;
+      // Content-Disposition makes it a download, not a page load.
+      const url = `${window.__config.apiBase}/agents/${agentId}/file-download/${this._encodeFilePath(path)}`;
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = path.split('/').pop();
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
     },
 
     agentFilesParentPath(path) {
@@ -10631,6 +10625,8 @@ function dashboard() {
         read_user_notifications: 'reviewing recent notifications',
         read_peer_artifact: 'reading a teammate\'s file',
         list_peer_artifacts: 'browsing a teammate\'s files',
+        read_peer_file: 'reading a teammate\'s file',
+        list_peer_files: 'browsing a teammate\'s files',
         create_agent: 'adding a teammate',
         apply_template: 'building a team from a template',
         inspect_agents: 'reviewing the team',

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7032,6 +7032,91 @@ def create_mesh_app(
             "encoding": encoding,
         }
 
+    @app.get("/mesh/agents/{agent_id}/files")
+    async def list_peer_files(
+        agent_id: str, request: Request,
+        path: str = ".", recursive: bool = False, pattern: str = "*",
+    ) -> dict:
+        """List a peer agent's /data files. Operator-or-internal only.
+
+        Extends the peer-read affordance beyond ``artifacts/`` (see
+        ``list_peer_artifacts`` above) to the agent's full /data volume so the
+        operator can locate a worker's deliverable wherever it was written —
+        e.g. a ``data.md`` built in the workspace root, not under
+        ``artifacts/``. Gated to the operator exactly like the artifact reads;
+        workers gain nothing.
+        """
+        _require_any_auth(request)
+        caller = _resolve_agent_id("", request)
+        if not (_caller_is_operator(caller, request) or _is_internal_caller(request)):
+            raise HTTPException(403, "Only the operator can read peer files")
+        if agent_id not in router.agent_registry:
+            raise HTTPException(404, f"Agent '{agent_id}' not found")
+        if transport is None:
+            raise HTTPException(503, "Transport not available")
+        from urllib.parse import urlencode
+        qs = urlencode({
+            "path": path, "recursive": str(bool(recursive)).lower(),
+            "pattern": pattern,
+        })
+        result = await transport.request(
+            agent_id, "GET", f"/files?{qs}", timeout=10,
+        )
+        if isinstance(result, dict) and "error" in result and "entries" not in result:
+            status = result.get("status_code", 502)
+            raise HTTPException(status, result["error"])
+        entries = result.get("entries", []) if isinstance(result, dict) else []
+        return {"agent_id": agent_id, "entries": entries,
+                "count": result.get("count", len(entries)) if isinstance(result, dict) else 0}
+
+    @app.get("/mesh/agents/{agent_id}/files/{path:path}")
+    async def read_peer_file(
+        agent_id: str, path: str, request: Request,
+        offset: int = 0, max_bytes: int = 0,
+    ) -> dict:
+        """Read one peer /data file's content. Operator-or-internal only.
+
+        Mirrors ``read_peer_artifact`` but targets the agent's general
+        ``/files`` endpoint, so the operator can pull any file a worker
+        produced — not only those under ``artifacts/``. ``offset``/``max_bytes``
+        page large files. Path is validated against the same traversal-safe
+        allowlist as artifact names. 404/413/400 surface cleanly.
+        """
+        _require_any_auth(request)
+        caller = _resolve_agent_id("", request)
+        if not (_caller_is_operator(caller, request) or _is_internal_caller(request)):
+            raise HTTPException(403, "Only the operator can read peer files")
+        _validate_peer_artifact_name(path)
+        if agent_id not in router.agent_registry:
+            raise HTTPException(404, f"Agent '{agent_id}' not found")
+        if transport is None:
+            raise HTTPException(503, "Transport not available")
+        from urllib.parse import urlencode
+        qs = urlencode({"offset": max(0, offset), "max_bytes": max(0, max_bytes)})
+        result = await transport.request(
+            agent_id, "GET", f"/files/{path}?{qs}", timeout=30,
+        )
+        if isinstance(result, dict) and "error" in result and "content" not in result:
+            status = result.get("status_code", 502)
+            if status == 404:
+                raise HTTPException(
+                    404, f"File '{path}' not found on agent '{agent_id}'",
+                )
+            if status == 400:
+                raise HTTPException(400, result["error"])
+            raise HTTPException(status, result["error"])
+        size = int(result.get("size", 0)) if isinstance(result, dict) else 0
+        return {
+            "agent_id": agent_id,
+            "path": path,
+            "content": result.get("content", "") if isinstance(result, dict) else "",
+            "size": size,
+            "encoding": result.get("encoding", "utf-8") if isinstance(result, dict) else "utf-8",
+            "offset": result.get("offset", offset) if isinstance(result, dict) else offset,
+            "next_offset": result.get("next_offset", size) if isinstance(result, dict) else size,
+            "truncated": bool(result.get("truncated")) if isinstance(result, dict) else False,
+        }
+
     async def _apply_pending_change(
         change_id: str, change: dict,
         *, undoable: bool = False, is_undo: bool = False,

--- a/tests/test_agent_files_paging.py
+++ b/tests/test_agent_files_paging.py
@@ -1,0 +1,101 @@
+"""Agent ``/files/{path}`` offset/max_bytes paging.
+
+The read endpoint gained ``offset``/``max_bytes`` so a caller (the operator
+peer-file bridge, the dashboard download) can page a file larger than the
+500 KB default read cap. These tests pin: (1) the default call is unchanged
+(back-compat), (2) offset seeks, (3) max_bytes caps a page and reports the
+right next_offset/truncated, and (4) full-file reassembly across pages is
+byte-exact.
+"""
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def agent_client(tmp_path, monkeypatch):
+    """Agent app whose /data root is redirected at the tmp dir.
+
+    ``_safe_path`` reads ``file_tool._ALLOWED_ROOT`` on every call, so
+    monkeypatching it points /files at the tmp dir without a reload.
+    """
+    data_root = tmp_path / "data"
+    (data_root / "workspace").mkdir(parents=True)
+
+    import src.agent.builtins.file_tool as file_tool
+    monkeypatch.setattr(file_tool, "_ALLOWED_ROOT", str(data_root))
+
+    loop = MagicMock()
+    loop.workspace = MagicMock()
+    loop.workspace.root = str(data_root / "workspace")
+    loop.agent_id = "test-agent"
+    loop.result = None
+    loop.last_task_id = None
+    loop.mesh_url = ""
+    loop.memory = None
+
+    import src.agent.server as agent_server_module
+    importlib.reload(agent_server_module)
+    app = agent_server_module.create_agent_app(loop)
+    return TestClient(app), data_root
+
+
+def test_default_read_is_backcompat(agent_client):
+    client, data_root = agent_client
+    (data_root / "workspace" / "data.md").write_text("col_a,col_b\n1,2\n")
+    resp = client.get("/files/workspace/data.md")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["content"] == "col_a,col_b\n1,2\n"
+    assert body["encoding"] == "utf-8"
+    assert body["truncated"] is False
+    assert body["size"] == len("col_a,col_b\n1,2\n")
+    # New fields present and coherent.
+    assert body["offset"] == 0
+    assert body["next_offset"] == body["size"]
+
+
+def test_offset_and_max_bytes_page(agent_client):
+    client, data_root = agent_client
+    payload = "0123456789abcdef"  # 16 bytes, pure ascii
+    (data_root / "blob.txt").write_text(payload)
+
+    # First page: 10 bytes.
+    p1 = client.get("/files/blob.txt", params={"offset": 0, "max_bytes": 10}).json()
+    assert p1["content"] == "0123456789"
+    assert p1["truncated"] is True
+    assert p1["next_offset"] == 10
+    assert p1["size"] == 16
+
+    # Second page from next_offset: the remainder.
+    p2 = client.get(
+        "/files/blob.txt", params={"offset": p1["next_offset"], "max_bytes": 10},
+    ).json()
+    assert p2["content"] == "abcdef"
+    assert p2["truncated"] is False
+    assert p2["next_offset"] == 16
+
+    # Reassembly is byte-exact.
+    assert p1["content"] + p2["content"] == payload
+
+
+def test_max_bytes_clamped_to_ceiling(agent_client):
+    """An absurd max_bytes is clamped to the 5 MB hard ceiling, not honored
+    blindly — a small file still returns fully without error."""
+    client, data_root = agent_client
+    (data_root / "small.txt").write_text("hello")
+    body = client.get(
+        "/files/small.txt", params={"max_bytes": 999_999_999},
+    ).json()
+    assert body["content"] == "hello"
+    assert body["truncated"] is False
+
+
+def test_missing_file_404(agent_client):
+    client, _ = agent_client
+    resp = client.get("/files/workspace/nope.md")
+    assert resp.status_code == 404

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6128,3 +6128,94 @@ class TestCapabilitiesMcpForwarding:
         body = resp.json()
         assert "mcp_servers" not in body
         assert "mcp_tool_to_server" not in body
+
+
+class TestDashboardFileDownload:
+    """The /file-download/ endpoint streams a worker's file to the user as an
+    attachment, paging the agent in chunks so large files (a CSV, data.md)
+    aren't capped by the 500 KB JSON read. Deliberately NOT under /files/ so it
+    can't shadow a real file whose path ends in /download.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_download_text_single_page_attachment(self):
+        self.components["transport"].request = AsyncMock(return_value={
+            "path": "workspace/data.md", "content": "col_a,col_b\n1,2\n",
+            "size": 16, "mime_type": "text/markdown", "encoding": "utf-8",
+            "offset": 0, "next_offset": 16, "truncated": False,
+        })
+        resp = self.client.get(
+            "/dashboard/api/agents/alpha/file-download/workspace/data.md",
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.content == b"col_a,col_b\n1,2\n"
+        assert "attachment" in resp.headers["content-disposition"]
+        assert "data.md" in resp.headers["content-disposition"]
+
+    def test_download_binary_base64_roundtrip(self):
+        import base64 as _b64
+        raw = bytes(range(256))
+        self.components["transport"].request = AsyncMock(return_value={
+            "path": "blob.bin", "content": _b64.b64encode(raw).decode("ascii"),
+            "size": len(raw), "mime_type": "application/octet-stream",
+            "encoding": "base64", "offset": 0, "next_offset": len(raw),
+            "truncated": False,
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/file-download/blob.bin")
+        assert resp.status_code == 200
+        assert resp.content == raw  # byte-exact
+
+    def test_download_pages_until_complete(self):
+        pages = {
+            0: {"content": "AAAA", "size": 8, "encoding": "utf-8",
+                "offset": 0, "next_offset": 4, "truncated": True,
+                "mime_type": "text/plain"},
+            4: {"content": "BBBB", "size": 8, "encoding": "utf-8",
+                "offset": 4, "next_offset": 8, "truncated": False,
+                "mime_type": "text/plain"},
+        }
+
+        async def _fake(agent_id, method, path, **kw):
+            off = int(path.split("offset=")[1].split("&")[0])
+            return pages[off]
+
+        self.components["transport"].request = AsyncMock(side_effect=_fake)
+        resp = self.client.get("/dashboard/api/agents/alpha/file-download/big.txt")
+        assert resp.status_code == 200
+        assert resp.content == b"AAAABBBB"  # reassembled across pages
+
+    def test_download_oversize_rejected_upfront(self):
+        self.components["transport"].request = AsyncMock(return_value={
+            "content": "x", "size": 65 * 1024 * 1024, "encoding": "utf-8",
+            "offset": 0, "next_offset": 1, "truncated": True,
+            "mime_type": "text/plain",
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/file-download/huge.csv")
+        assert resp.status_code == 413
+
+    def test_download_unknown_agent_404(self):
+        resp = self.client.get("/dashboard/api/agents/ghost/file-download/x.md")
+        assert resp.status_code == 404
+
+    def test_files_path_ending_in_download_not_shadowed(self):
+        """A real file at a path ending in '/download' still reads via the JSON
+        route — the download endpoint lives under a different prefix."""
+        self.components["transport"].request = AsyncMock(return_value={
+            "path": "workspace/download", "content": "i am a file named download",
+            "size": 26, "mime_type": "text/plain", "encoding": "utf-8",
+            "offset": 0, "next_offset": 26, "truncated": False,
+        })
+        resp = self.client.get(
+            "/dashboard/api/agents/alpha/files/workspace/download",
+        )
+        assert resp.status_code == 200
+        # JSON read route, not the attachment endpoint.
+        assert resp.json()["content"] == "i am a file named download"

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -379,6 +379,10 @@ class TestOperatorConstants:
         assert "read_agent_config" in _OPERATOR_ALLOWED_TOOLS
         assert "list_peer_artifacts" in _OPERATOR_ALLOWED_TOOLS
         assert "read_peer_artifact" in _OPERATOR_ALLOWED_TOOLS
+        # Peer FILE reads — full /data volume, not just artifacts/. Lets the
+        # operator locate + relay a worker's deliverable (CSV, data.md).
+        assert "list_peer_files" in _OPERATOR_ALLOWED_TOOLS
+        assert "read_peer_file" in _OPERATOR_ALLOWED_TOOLS
         # Credential-aware model discovery (new tool added by Fix 2).
         assert "list_available_models" in _OPERATOR_ALLOWED_TOOLS
         # Operator self-notes — was bouncing through hand_off-to-self.

--- a/tests/test_operator_read_peer_file.py
+++ b/tests/test_operator_read_peer_file.py
@@ -1,0 +1,208 @@
+"""Tests for the operator list_peer_files / read_peer_file skills.
+
+These extend the peer-read affordance beyond ``artifacts/`` (see
+``test_operator_read_peer_artifact.py``) to a worker's full /data volume,
+so the operator can locate and relay a deliverable a worker built as a
+plain file (e.g. ``workspace/data.md`` or a generated CSV). Without this
+the manager could not get a worker's data out to the user — it would only
+ever see the ``artifacts/`` folder. Mirrors the read_peer_artifact shape.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_operator_env(monkeypatch):
+    """The skills require ALLOWED_TOOLS to be set (defence-in-depth)."""
+    monkeypatch.setenv(
+        "ALLOWED_TOOLS",
+        "read_peer_file,list_peer_files,read_peer_artifact",
+    )
+
+
+# ── list_peer_files ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_peer_files_happy_path():
+    """Happy path returns the mesh payload unchanged and forwards args."""
+    from src.agent.builtins.operator_tools import list_peer_files
+
+    payload = {
+        "agent_id": "alpha",
+        "entries": [
+            {"name": "data.md", "size": 4096, "is_dir": False},
+            {"name": "memory", "size": 0, "is_dir": True},
+        ],
+        "count": 2,
+    }
+    mc = MagicMock()
+    mc.list_peer_files = AsyncMock(return_value=payload)
+
+    result = await list_peer_files("alpha", "workspace", True, mesh_client=mc)
+
+    assert result == payload
+    mc.list_peer_files.assert_awaited_once_with("alpha", "workspace", True)
+
+
+@pytest.mark.asyncio
+async def test_list_peer_files_blocked_for_non_operator(monkeypatch):
+    """Non-operator agents (no ALLOWED_TOOLS) are denied at the skill layer."""
+    from src.agent.builtins.operator_tools import list_peer_files
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    mc = MagicMock()
+    mc.list_peer_files = AsyncMock()
+
+    result = await list_peer_files("alpha", mesh_client=mc)
+
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+    mc.list_peer_files.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_peer_files_agent_not_found():
+    """A 404 from the mesh becomes {error: agent_not_found}."""
+    from src.agent.builtins.operator_tools import list_peer_files
+
+    fake_response = MagicMock()
+    fake_response.status_code = 404
+    fake_response.text = "Agent 'ghost' not found"
+
+    class FakeHTTPError(Exception):
+        def __init__(self):
+            super().__init__("404 Not Found")
+            self.response = fake_response
+
+    mc = MagicMock()
+    mc.list_peer_files = AsyncMock(side_effect=FakeHTTPError())
+
+    result = await list_peer_files("ghost", mesh_client=mc)
+    assert result == {"error": "agent_not_found", "agent_id": "ghost"}
+
+
+@pytest.mark.asyncio
+async def test_list_peer_files_no_mesh_client():
+    from src.agent.builtins.operator_tools import list_peer_files
+
+    result = await list_peer_files("alpha", mesh_client=None)
+    assert "error" in result
+    assert "mesh_client" in result["error"]
+
+
+# ── read_peer_file ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_read_peer_file_happy_path():
+    """Happy path returns {agent_id, path, content, ...} and forwards offset."""
+    from src.agent.builtins.operator_tools import read_peer_file
+
+    payload = {
+        "agent_id": "alpha",
+        "path": "workspace/data.md",
+        "content": "col_a,col_b\n1,2\n",
+        "size": 16,
+        "encoding": "utf-8",
+        "offset": 0,
+        "next_offset": 16,
+        "truncated": False,
+    }
+    mc = MagicMock()
+    mc.read_peer_file = AsyncMock(return_value=payload)
+
+    result = await read_peer_file("alpha", "workspace/data.md", mesh_client=mc)
+
+    assert result == payload
+    mc.read_peer_file.assert_awaited_once_with(
+        "alpha", "workspace/data.md", offset=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_peer_file_paging_offset_forwarded():
+    """A non-zero offset is threaded to the mesh client for paging."""
+    from src.agent.builtins.operator_tools import read_peer_file
+
+    mc = MagicMock()
+    mc.read_peer_file = AsyncMock(return_value={"content": "", "truncated": False})
+
+    await read_peer_file("alpha", "big.csv", offset=500_000, mesh_client=mc)
+
+    mc.read_peer_file.assert_awaited_once_with(
+        "alpha", "big.csv", offset=500_000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_peer_file_blocked_for_non_operator(monkeypatch):
+    from src.agent.builtins.operator_tools import read_peer_file
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    mc = MagicMock()
+    mc.read_peer_file = AsyncMock()
+
+    result = await read_peer_file("alpha", "workspace/data.md", mesh_client=mc)
+
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+    mc.read_peer_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_read_peer_file_not_found():
+    from src.agent.builtins.operator_tools import read_peer_file
+
+    fake_response = MagicMock()
+    fake_response.status_code = 404
+    fake_response.text = "File 'workspace/nope.md' not found on agent 'alpha'"
+
+    class FakeHTTPError(Exception):
+        def __init__(self):
+            super().__init__("404 Not Found")
+            self.response = fake_response
+
+    mc = MagicMock()
+    mc.read_peer_file = AsyncMock(side_effect=FakeHTTPError())
+
+    result = await read_peer_file("alpha", "workspace/nope.md", mesh_client=mc)
+    assert result == {
+        "error": "file_not_found", "agent_id": "alpha",
+        "path": "workspace/nope.md",
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_peer_file_invalid_path():
+    """A 400 (traversal / bad name) from the mesh surfaces as invalid_path."""
+    from src.agent.builtins.operator_tools import read_peer_file
+
+    fake_response = MagicMock()
+    fake_response.status_code = 400
+    fake_response.text = "Path traversal not allowed"
+
+    class FakeHTTPError(Exception):
+        def __init__(self):
+            super().__init__("400 Bad Request")
+            self.response = fake_response
+
+    mc = MagicMock()
+    mc.read_peer_file = AsyncMock(side_effect=FakeHTTPError())
+
+    result = await read_peer_file("alpha", "../etc/passwd", mesh_client=mc)
+    assert result["error"] == "invalid_path"
+
+
+@pytest.mark.asyncio
+async def test_read_peer_file_requires_path():
+    from src.agent.builtins.operator_tools import read_peer_file
+
+    mc = MagicMock()
+    mc.read_peer_file = AsyncMock()
+    result = await read_peer_file("alpha", "", mesh_client=mc)
+    assert "error" in result
+    mc.read_peer_file.assert_not_awaited()

--- a/tests/test_operator_read_peer_file.py
+++ b/tests/test_operator_read_peer_file.py
@@ -206,3 +206,158 @@ async def test_read_peer_file_requires_path():
     result = await read_peer_file("alpha", "", mesh_client=mc)
     assert "error" in result
     mc.read_peer_file.assert_not_awaited()
+
+
+# ── host mesh endpoint (real auth + permission machinery) ───────────
+#
+# Mirrors the test_mesh_endpoint_* coverage for peer artifacts: spin up
+# create_mesh_app over ASGITransport so the operator gate, the path-
+# traversal validator, and the transport forwarding are all exercised
+# without Docker.
+
+
+def _mesh_app(tmp_path, monkeypatch, *, transport=None, agents=("operator", "alpha"),
+              tokens=None):
+    import importlib
+
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    for a in agents:
+        router.register_agent(a, f"http://{a}:8400", [])
+    auth_tokens = tokens or {a: f"{a}-secret" for a in agents}
+    app = server_module.create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces, transport=transport,
+        auth_tokens=auth_tokens,
+    )
+    return app, (bb, costs, traces, server_module, monkeypatch)
+
+
+def _close(state):
+    import importlib
+    bb, costs, traces, server_module, monkeypatch = state
+    bb.close()
+    costs.close()
+    traces.close()
+    monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+    importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_files_mesh_endpoint_rejects_non_operator(tmp_path, monkeypatch):
+    """An authenticated non-operator agent gets HTTP 403 on both endpoints."""
+    from httpx import ASGITransport, AsyncClient
+
+    app, state = _mesh_app(
+        tmp_path, monkeypatch, agents=("operator", "alpha", "scout"),
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            hdrs = {"authorization": "Bearer scout-secret"}
+            r1 = await client.get("/mesh/agents/alpha/files", headers=hdrs)
+            assert r1.status_code == 403, r1.text
+            r2 = await client.get(
+                "/mesh/agents/alpha/files/workspace/data.md", headers=hdrs,
+            )
+            assert r2.status_code == 403, r2.text
+    finally:
+        _close(state)
+
+
+@pytest.mark.asyncio
+async def test_files_mesh_endpoint_rejects_path_traversal(tmp_path, monkeypatch):
+    """A traversal path is rejected with 400 before reaching the transport."""
+    from httpx import ASGITransport, AsyncClient
+
+    app, state = _mesh_app(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.get(
+                "/mesh/agents/alpha/files/..%2Fetc%2Fpasswd",
+                headers={"authorization": "Bearer operator-secret"},
+            )
+            assert resp.status_code == 400, resp.text
+            assert (
+                "traversal" in resp.text.lower()
+                or "invalid" in resp.text.lower()
+            )
+    finally:
+        _close(state)
+
+
+@pytest.mark.asyncio
+async def test_files_mesh_endpoint_forwards_to_transport(tmp_path, monkeypatch):
+    """Happy path: mesh forwards to the agent's /files endpoints and shapes
+    the response with agent_id + paging metadata."""
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.transport import Transport
+
+    class StubTransport(Transport):
+        def __init__(self):
+            self.calls = []
+
+        async def request(self, agent_id, method, path, json=None, timeout=120, headers=None):
+            self.calls.append((agent_id, method, path))
+            if path.startswith("/files?"):
+                return {"entries": [{"name": "data.md", "size": 16}], "count": 1}
+            if path.startswith("/files/workspace/data.md"):
+                return {
+                    "path": "workspace/data.md", "content": "col_a,col_b\n1,2\n",
+                    "size": 16, "mime_type": "text/markdown", "encoding": "utf-8",
+                    "offset": 0, "next_offset": 16, "truncated": False,
+                }
+            return {"error": "unexpected", "status_code": 502}
+
+        async def is_reachable(self, agent_id, timeout=5):  # pragma: no cover
+            return True
+
+        def request_sync(self, agent_id, method, path, json=None, timeout=120, headers=None):  # pragma: no cover
+            return {}
+
+    transport = StubTransport()
+    app, state = _mesh_app(tmp_path, monkeypatch, transport=transport)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            hdrs = {"authorization": "Bearer operator-secret"}
+            r1 = await client.get("/mesh/agents/alpha/files", headers=hdrs)
+            assert r1.status_code == 200, r1.text
+            d1 = r1.json()
+            assert d1["agent_id"] == "alpha"
+            assert d1["entries"] == [{"name": "data.md", "size": 16}]
+
+            r2 = await client.get(
+                "/mesh/agents/alpha/files/workspace/data.md", headers=hdrs,
+            )
+            assert r2.status_code == 200, r2.text
+            d2 = r2.json()
+            assert d2["agent_id"] == "alpha"
+            assert d2["path"] == "workspace/data.md"
+            assert d2["content"] == "col_a,col_b\n1,2\n"
+            assert d2["truncated"] is False
+        # Forwarded to the worker's /files endpoints (not /artifacts).
+        assert any(c[2].startswith("/files?") for c in transport.calls)
+        assert any(
+            c[2].startswith("/files/workspace/data.md") for c in transport.calls
+        )
+    finally:
+        _close(state)


### PR DESCRIPTION
## The user's problem

A production user could not get a deliverable (a CSV, a `data.md` "database") **out** of the fleet. Every path they tried — paste to chat in chunks, hand off to Claude, post to Drive/GitHub — routes through asking the **operator** to fetch the file from the worker that built it, and the operator had no way to do that. Quote: *"you throttle data sharing between agents which fucks trying to make manager go back and forth with agents."*

## Root cause

The only operator→worker file bridge, `read_peer_artifact`, reads **only** `workspace/artifacts/`. A file written anywhere else (`workspace/data.md`, a generated CSV) is invisible to the operator → the manager loops and reports the work unreachable.

## Fix — a peer-FILE bridge + a real user download

| Layer | Change |
|---|---|
| `agent/server.py` | `/files/{path}` gains `offset`/`max_bytes` paging. **Default call byte-identical to before.** 5 MB per-read ceiling; never loads a whole file into memory. |
| `host/server.py` | `GET /mesh/agents/{id}/files` + `/files/{path}` — **operator-or-internal only**, same gate as the peer-artifact endpoints (workers → 403). Spans the full `/data` volume. |
| `agent/mesh_client.py` | `list_peer_files` / `read_peer_file`. |
| `agent/builtins/operator_tools.py` | `list_peer_files` / `read_peer_file` operator tools. Read-into-context keeps the 500 KB cap (a 5 MB file would blow the operator's context window); pages via `next_offset`. |
| `dashboard/server.py` | `GET /api/agents/{id}/files/{path}/download` — streams raw bytes as a `Content-Disposition` attachment so the user saves a worker's file to disk directly, bypassing the JSON cap and any LLM. Registered before the greedy `{path:path}` read route. |
| `loop.py`, `cli/config.py` | Register the two tools (read-only classification + operator grant). |

## Deliberately NOT changed
The 256 KB blackboard cap. Inlining a CSV into a handoff payload is the wrong channel (DB bloat); the file bridge is the right one.

## Security
Only the operator (server-verified identity) and the SSO-authenticated dashboard user gain reach. Untrusted workers gain nothing — the new mesh endpoints 403 any non-operator caller, mirroring the existing peer-artifact gate.

## Tests
Operator tool layer (happy / blocked-for-non-operator / not-found / invalid-path / offset paging), agent `/files` paging + back-compat + ceiling clamp, allowlist membership. 69 targeted tests pass; ruff clean.