### PR TITLE
Rename Integrations 'API Keys' section to 'Programmatic Access'

### DIFF
--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -5305,8 +5305,8 @@
           </div>
         </details>
 
-        <!-- API Keys -->
-        <div class="text-xs text-gray-400 uppercase tracking-wider mb-3 flex items-center gap-1.5 mt-6">API Keys</div>
+        <!-- Programmatic Access (server-to-server API keys) -->
+        <div class="text-xs text-gray-400 uppercase tracking-wider mb-3 flex items-center gap-1.5 mt-6">Programmatic Access<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Keys for calling the mesh API from your own backend (server-to-server), sent as the X-API-Key header. Distinct from the credential vault under the "API Keys" tab, which holds the secrets your agents use.</span></span></div>
         <div class="mb-6">
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
             <div class="text-xs text-gray-400 leading-relaxed mb-3">


### PR DESCRIPTION
Copy-only follow-up to #1035.

The Integrations tab's server-to-server X-API-Key section shared the literal name **"API Keys"** with the credential-vault sub-tab — confusing now that connections live under Integrations. Renames the section to **"Programmatic Access"** and adds a hint that explicitly contrasts it with the vault tab.

- One-line visible change (`index.html`), plus comment + tooltip. No JS, no logic, no endpoints touched.
- The vault sub-tab header ("API Keys") is unchanged.