### PR TITLE
Add initial-load states to Costs, Automation & Storage tabs

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -198,6 +198,9 @@ function dashboard() {
     // Traces
     traces: [],
     tracesLoading: false,
+    costsLoading: false,
+    cronLoading: false,
+    storageLoading: false,
 
     // Activity view
     activityView: 'traces',
@@ -5929,6 +5932,7 @@ function dashboard() {
     },
 
     async fetchCosts() {
+      this.costsLoading = true;
       try {
         const resp = await fetch(`${window.__config.apiBase}/costs?period=${this.costPeriod}`);
         if (resp.ok) {
@@ -5936,6 +5940,7 @@ function dashboard() {
           this.$nextTick(() => { this.renderCostChart(); this.renderModelChart(); });
         }
       } catch (e) { console.warn('fetchCosts failed:', e); }
+      this.costsLoading = false;
     },
 
     async fetchTraces() {
@@ -6866,10 +6871,12 @@ function dashboard() {
     // ── Cron fetchers ───────────────────────────────────
 
     async fetchCronJobs() {
+      this.cronLoading = true;
       try {
         const resp = await fetch(`${window.__config.apiBase}/cron`);
         if (resp.ok) this.cronJobs = (await resp.json()).jobs;
       } catch (e) { console.warn('fetchCronJobs failed:', e); }
+      this.cronLoading = false;
     },
 
     async runCronJob(jobId) {
@@ -7688,10 +7695,12 @@ function dashboard() {
     },
 
     async fetchStorage() {
+      this.storageLoading = true;
       try {
         const resp = await fetch(`${window.__config.apiBase}/storage`);
         if (resp.ok) this.storageData = await resp.json();
       } catch (e) { console.warn('fetchStorage failed:', e); }
+      this.storageLoading = false;
     },
 
     formatBytes(bytes) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4602,6 +4602,13 @@
         <!-- Costs sub-tab -->
         <div x-show="systemTab === 'costs'">
 
+        <!-- Initial-load spinner (avoids flashing $0.00 before data arrives) -->
+        <div x-show="costsLoading && costData.agents === undefined" class="text-center py-16 text-gray-500 text-sm">
+          <svg class="animate-spin h-5 w-5 mx-auto mb-2 text-gray-600" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+          Loading costs&hellip;
+        </div>
+        <div x-show="!costsLoading || costData.agents !== undefined">
+
         <!-- Stat Cards -->
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5 chat-grid">
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
@@ -4735,6 +4742,7 @@
             </div>
           </div>
         </details>
+        </div><!-- /costs content -->
         </div><!-- /costs sub-tab -->
 
         <!-- Automation sub-tab -->
@@ -4872,7 +4880,11 @@
                 </tbody>
               </table>
             </div>
-            <div x-show="cronJobs.length === 0" class="text-center py-12">
+            <div x-show="cronLoading && cronJobs.length === 0" class="text-center py-12 text-gray-500 text-sm">
+              <svg class="animate-spin h-5 w-5 mx-auto mb-2 text-gray-600" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+              Loading schedules&hellip;
+            </div>
+            <div x-show="!cronLoading && cronJobs.length === 0" class="text-center py-12">
               <svg class="empty-state-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
               </svg>
@@ -4933,7 +4945,11 @@
                 </div>
               </template>
             </div>
-            <div x-show="workflows.length === 0" class="text-center py-8">
+            <div x-show="workflowsLoading && workflows.length === 0" class="text-center py-8 text-gray-500 text-sm">
+              <svg class="animate-spin h-5 w-5 mx-auto mb-2 text-gray-600" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+              Loading workflows&hellip;
+            </div>
+            <div x-show="!workflowsLoading && workflows.length === 0" class="text-center py-8">
               <div class="text-gray-400 text-sm">No workflows configured</div>
               <div class="text-gray-500 text-xs mt-1">Add workflows in your mesh.yaml config</div>
             </div>
@@ -6141,6 +6157,10 @@
           </div>
         </div>
         <!-- Disk & Engine Data -->
+        <div class="mt-6 text-center py-12 text-gray-500 text-sm" x-show="storageLoading && !storageData">
+          <svg class="animate-spin h-5 w-5 mx-auto mb-2 text-gray-600" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+          Loading disk usage&hellip;
+        </div>
         <div class="mt-6" x-show="storageData">
           <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Disk Usage<span class="setting-hint setting-hint-sm ml-1" tabindex="0">?<span class="setting-hint-text">Storage utilization across the server. Includes agent workspaces, uploaded files, and engine databases.</span></span></div>
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 chat-grid">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4784,7 +4784,7 @@
         </div>
         <div class="mb-6">
           <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
-            <div class="overflow-x-auto">
+            <div class="overflow-x-auto" x-show="cronJobs.length > 0">
               <table class="w-full text-sm">
                 <thead>
                   <tr class="text-gray-400 text-left text-xs uppercase tracking-wider border-b border-gray-800">


### PR DESCRIPTION
First of three follow-up PRs from the Settings design review.

**Problem:** these tabs rendered their empty/zero state *during* the in-flight fetch, so first paint showed real-looking but false data:
- **Costs** flashed `$0.00` / `0 tokens` / "All within budget" before `/costs` resolved.
- **Automation** showed "No scheduled jobs configured" / "No workflows configured" while the lists were still loading.
- **Storage** Disk Usage popped in with no feedback.

**Fix:** adopt the loading-flag + spinner pattern already used by Activity (`tracesLoading`) and Workflows. Added `costsLoading` / `cronLoading` / `storageLoading`, toggled in `fetchCosts` / `fetchCronJobs` / `fetchStorage`, and gated the empty/zero UI behind the flag so a spinner shows on first load instead.

**Behavior preserved:**
- Genuinely-empty accounts still see their empty states (gated on `!loading && length === 0`).
- Period switches / refreshes keep showing current data — no full-tab spinner flash (the Costs guard keys off `costData.agents !== undefined`, not the loading flag alone).
- Load *failures* fall through to the empty state exactly as before — consistent with the codebase convention (background-load errors → `console.warn`; toasts reserved for user actions). No new error-banner pattern introduced.

**Verification:** `pytest tests/test_dashboard_ui.py` → 179 passed, 4 skipped. `node --check` clean; `<div>` balance identical to `main`.

Scope note: General's loading issue (empty card frames) is deliberately deferred to the consistency PR, where its header/padding/loading problems can be fixed together rather than piecemeal.