### PR TITLE
fix(file-bridge): harden download vs lying agent + quote special filenames

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3685,28 +3685,35 @@ def create_dashboard_router(
         Pages the agent's ``/files`` endpoint in 5 MB chunks and concatenates
         the raw bytes, so the user can save a worker's deliverable (CSV,
         data.md, a binary export) straight to disk — bypassing the JSON read
-        cap and never routing the bytes through any LLM context. Rejected
-        upfront if the file exceeds the 64 MB cap (the agent reports the full
-        size in the first page), so host memory stays bounded.
+        cap and never routing the bytes through any LLM context. Memory stays
+        bounded two ways: a fast reject on the agent-reported size, AND a
+        running byte counter that does NOT trust that size (the agent is an
+        untrusted component — a lying ``size`` must not OOM the host).
         """
         import base64 as _b64
-        from urllib.parse import urlencode
+        from urllib.parse import quote, urlencode
 
         from fastapi.responses import Response
         if agent_id not in agent_registry:
             raise HTTPException(status_code=404, detail="Agent not found")
         if transport is None:
             raise HTTPException(status_code=503, detail="Transport not available")
+        # Quote the filename portion so spaces / '?' / '#' / '%' in a real
+        # filename survive interpolation into the agent URL (httpx splits on a
+        # raw '?'; the sandbox-backend curl rejects a raw space). The query
+        # string is appended AFTER, so only the path segment is quoted.
+        safe_path = quote(path, safe="/")
         _CHUNK = 5 * 1024 * 1024
         _MAX_TOTAL = 64 * 1024 * 1024
         parts: list[bytes] = []
+        total = 0
         offset = 0
         mime = "application/octet-stream"
         while True:
             qs = urlencode({"offset": offset, "max_bytes": _CHUNK})
             try:
                 result = await transport.request(
-                    agent_id, "GET", f"/files/{path}?{qs}", timeout=60,
+                    agent_id, "GET", f"/files/{safe_path}?{qs}", timeout=60,
                 )
             except Exception as e:
                 raise HTTPException(status_code=502, detail=str(e))
@@ -3714,8 +3721,7 @@ def create_dashboard_router(
                 status = result.get("status_code", 404) if isinstance(result, dict) else 502
                 detail = result.get("error", "download failed") if isinstance(result, dict) else "download failed"
                 raise HTTPException(status_code=status, detail=detail)
-            # Reject oversize before buffering anything: the first page carries
-            # the full file size.
+            # Fast reject on the agent-reported size (first page carries it).
             if int(result.get("size", 0)) > _MAX_TOTAL:
                 raise HTTPException(
                     status_code=413,
@@ -3726,6 +3732,15 @@ def create_dashboard_router(
                 blob = _b64.b64decode(result.get("content", ""))
             else:
                 blob = (result.get("content") or "").encode("utf-8")
+            # Truth, not trust: enforce the cap on actual bytes received so a
+            # malformed/lying agent (size=0, truncated=true, advancing offset)
+            # can't loop the host into unbounded memory growth.
+            total += len(blob)
+            if total > _MAX_TOTAL:
+                raise HTTPException(
+                    status_code=413,
+                    detail="File exceeds the 64 MB download cap",
+                )
             parts.append(blob)
             next_offset = result.get("next_offset", offset + len(blob))
             if not result.get("truncated") or next_offset <= offset:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7091,10 +7091,13 @@ def create_mesh_app(
             raise HTTPException(404, f"Agent '{agent_id}' not found")
         if transport is None:
             raise HTTPException(503, "Transport not available")
-        from urllib.parse import urlencode
+        from urllib.parse import quote, urlencode
         qs = urlencode({"offset": max(0, offset), "max_bytes": max(0, max_bytes)})
+        # Quote the path segment — the validated name may contain spaces, which
+        # break a raw interpolation into the agent URL (curl on the sandbox
+        # backend). The query string is appended after the quoted path.
         result = await transport.request(
-            agent_id, "GET", f"/files/{path}?{qs}", timeout=30,
+            agent_id, "GET", f"/files/{quote(path, safe='/')}?{qs}", timeout=30,
         )
         if isinstance(result, dict) and "error" in result and "content" not in result:
             status = result.get("status_code", 502)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6219,3 +6219,45 @@ class TestDashboardFileDownload:
         assert resp.status_code == 200
         # JSON read route, not the attachment endpoint.
         assert resp.json()["content"] == "i am a file named download"
+
+    def test_download_quotes_spaces_in_filename(self):
+        """A filename with a space is percent-quoted before being forwarded to
+        the agent — a raw space breaks the agent URL (curl on the sandbox
+        backend; httpx). The browser sends it pre-encoded; we re-quote after
+        FastAPI decodes the dashboard route."""
+        seen = {}
+
+        async def _fake(agent_id, method, path, **kw):
+            seen["path"] = path
+            return {
+                "content": "x,y\n1,2\n", "size": 8, "encoding": "utf-8",
+                "mime_type": "text/csv", "offset": 0, "next_offset": 8,
+                "truncated": False,
+            }
+
+        self.components["transport"].request = AsyncMock(side_effect=_fake)
+        # FastAPI decodes the dashboard {path:path}, so the endpoint sees the
+        # raw space and must re-quote it for the agent hop.
+        resp = self.client.get(
+            "/dashboard/api/agents/alpha/file-download/Q3%20Report.csv",
+        )
+        assert resp.status_code == 200
+        assert resp.content == b"x,y\n1,2\n"
+        # The forwarded agent path is quoted, query appended after.
+        assert seen["path"].startswith("/files/Q3%20Report.csv?")
+
+    def test_download_lying_agent_does_not_loop(self):
+        """A misbehaving agent that returns truncated=True forever without
+        advancing next_offset must not loop the host — the next_offset<=offset
+        guard breaks it. (The byte cap is the other backstop against a lying
+        size.)"""
+        self.components["transport"].request = AsyncMock(return_value={
+            "content": "stuck", "size": 0, "encoding": "utf-8",
+            "mime_type": "text/plain", "offset": 0, "next_offset": 0,
+            "truncated": True,
+        })
+        resp = self.client.get(
+            "/dashboard/api/agents/alpha/file-download/loop.txt",
+        )
+        assert resp.status_code == 200
+        assert resp.content == b"stuck"  # exactly one page, loop terminated


### PR DESCRIPTION
Post-merge review follow-up for the file-egress bridge (#1037). Two robustness fixes; **BLOCK: none** from the review — these are the items worth fixing vs. the nice-to-haves left flagged.

### 1. Host-OOM defense (don't trust an untrusted agent's `size`)
The download endpoint rejected oversize only on the agent-**reported** `size`. Agents are an untrusted trust zone — a compromised one returning `size:0, truncated:true, next_offset:advancing` could loop the host into unbounded memory. Added a **running byte counter** enforcing the 64 MB cap on bytes actually received; the upfront size check stays as a fast path.

### 2. Special-character filenames download correctly
The download (and operator-read) hop interpolated the raw path into the agent URL. A **space** ("Q3 Report.csv" — common) breaks `curl` on the sandbox backend; `?`/`#` mis-split the URL on httpx. Now `quote()` the path segment before appending the query string.

### Deliberately left as flagged nice-to-haves (not gold-plated)
- Operator-tool filename charset (`_validate_peer_artifact_name` rejects `()`,`,` — security-validator behavior change; the user download path is unaffected).
- Lost in-app error toast on a failed download (native-download tradeoff).
- Host list endpoint mapping an agent error-dict to 502 instead of 4xx (cosmetic).

### Tests
- `test_download_quotes_spaces_in_filename` — forwarded agent path is percent-quoted.
- `test_download_lying_agent_does_not_loop` — non-advancing offset terminates.
- 25 targeted tests pass; ruff clean. Host/dashboard only — no agent image rebuild needed.