### PR TITLE
Settings: accessibility + correctness fixes (review follow-up)

### DIFF
--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -6825,7 +6825,7 @@
               <template x-for="entry in auditLog" :key="entry.id">
                 <div x-data="{ expanded: false }" class="rounded-lg border"
                   :class="entry.archived ? 'bg-gray-800/10 border-gray-800/30 opacity-70' : 'bg-gray-800/30 border-gray-800/50'">
-                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" tabindex="0" role="button" @click="expanded = !expanded" @keydown.enter.prevent.self="expanded = !expanded" @keydown.space.prevent.self="expanded = !expanded">
+                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" @click="expanded = !expanded">
                     <div class="text-[11px] text-gray-400 w-14 shrink-0" x-text="entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : ''"></div>
                     <div class="flex-1 min-w-0 flex items-center gap-1.5">
                       <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 font-medium" x-text="entry.action"></span>
@@ -6849,7 +6849,9 @@
                       <span x-show="!auditReverting[entry.id]">Revert</span>
                       <span x-show="auditReverting[entry.id]" x-cloak>...</span>
                     </button>
-                    <svg class="w-3 h-3 text-gray-500 transition-transform shrink-0" :class="expanded && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                    <button type="button" @click.stop="expanded = !expanded" :aria-expanded="expanded" aria-label="Toggle change details" class="shrink-0 text-gray-500 hover:text-gray-300 transition-colors">
+                      <svg class="w-3 h-3 transition-transform" :class="expanded && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                    </button>
                   </div>
                   <template x-if="expanded">
                     <div class="px-3 pb-2.5 border-t border-gray-800/40 space-y-2 pt-2">
@@ -6918,7 +6920,7 @@
                         browserMetricsStale(m.receivedAt) ? 'opacity-60' : '',
                         m.click_success_rate_100 != null ? 'cursor-pointer' : ''
                       ]"
-                      :tabindex="m.click_success_rate_100 != null ? 0 : -1" :role="m.click_success_rate_100 != null ? 'button' : null"
+                      :tabindex="m.click_success_rate_100 != null ? 0 : -1" :role="m.click_success_rate_100 != null ? 'button' : null" :aria-expanded="m.click_success_rate_100 != null ? expanded : null"
                       @click="if (m.click_success_rate_100 != null) expanded = !expanded"
                       @keydown.enter.prevent.self="if (m.click_success_rate_100 != null) expanded = !expanded"
                       @keydown.space.prevent.self="if (m.click_success_rate_100 != null) expanded = !expanded">
@@ -7311,7 +7313,7 @@
           </div>
 
           <!-- ── 1b. Image Generation ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings || !systemSettingsLoading">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Image Generation</h3>
@@ -7332,7 +7334,7 @@
           </div>
 
           <!-- ── 2. Budgets ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings || !systemSettingsLoading">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Budgets</h3>
@@ -7360,7 +7362,7 @@
           </div>
 
           <!-- ── 3. Agents ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings || !systemSettingsLoading">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Agent Execution</h3>
@@ -7407,7 +7409,7 @@
           </div>
 
           <!-- ── 4. Health & Recovery ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings || !systemSettingsLoading">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Health &amp; Recovery</h3>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4634,11 +4634,12 @@
         <!-- Period Selector + Charts -->
         <div class="mb-5">
           <div class="flex items-center justify-between mb-4">
-            <div class="seg-group flex">
+            <div class="seg-group flex" role="tablist" aria-label="Cost period">
               <template x-for="p in ['today', 'week', 'month']" :key="p">
                 <button
                   @click="costPeriod = p; fetchCosts()"
                   class="seg-tab"
+                  role="tab" :aria-selected="costPeriod === p"
                   :class="costPeriod === p ? 'seg-tab-active' : ''"
                   x-text="p.charAt(0).toUpperCase() + p.slice(1)"
                 ></button>
@@ -4650,7 +4651,7 @@
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
               <div class="text-[11px] text-gray-400 uppercase tracking-wider mb-3">Cost by Agent</div>
               <div class="h-64" x-show="costData.agents && costData.agents.length > 0">
-                <canvas id="costChart"></canvas>
+                <canvas id="costChart" role="img" aria-label="Cost by agent over time"></canvas>
               </div>
               <div x-show="!costData.agents || costData.agents.length === 0" class="empty-state h-64">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
@@ -4662,7 +4663,7 @@
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
               <div class="text-[11px] text-gray-400 uppercase tracking-wider mb-3">Cost by Model</div>
               <div class="h-64" x-show="costData.by_model && costData.by_model.length > 0">
-                <canvas id="modelChart"></canvas>
+                <canvas id="modelChart" role="img" aria-label="Cost by model"></canvas>
               </div>
               <div x-show="!costData.by_model || costData.by_model.length === 0" class="empty-state h-64">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"/><path d="M13.5 3.5a7.5 7.5 0 0 1 7 7h-7v-7Z"/></svg>
@@ -4866,7 +4867,8 @@
                       <td class="py-3 px-4 text-gray-500 text-xs font-mono" x-text="job.last_run || 'never'"></td>
                       <td class="py-3 px-4 font-mono text-gray-300" x-text="job.run_count"></td>
                       <td class="py-3 px-4 font-mono" :class="job.error_count > 0 ? 'text-red-400' : 'text-gray-500'" x-text="job.error_count"></td>
-                      <td class="py-3 px-4 flex gap-1">
+                      <td class="py-3 px-4">
+                        <div class="flex gap-1">
                         <button @click="runCronJob(job.id)" :disabled="cronRunLoading[job.id] === true" class="text-[11px] px-1.5 py-0.5 rounded bg-indigo-900/30 hover:bg-indigo-800/40 text-indigo-300 hover:text-indigo-200 transition-colors disabled:opacity-50" x-text="cronRunLoading[job.id] === true ? '...' : 'Run'"></button>
                         <button x-show="job.enabled" @click="pauseCronJob(job.id)" :disabled="cronPauseLoading[job.id] === true"
                           class="text-[11px] px-1.5 py-0.5 rounded bg-gray-700 hover:bg-yellow-900/30 text-gray-300 hover:text-yellow-400 transition-colors disabled:opacity-50" x-text="cronPauseLoading[job.id] === true ? '...' : 'Pause'"></button>
@@ -4874,6 +4876,7 @@
                           class="text-[11px] px-1.5 py-0.5 rounded bg-gray-700 hover:bg-green-900/30 text-gray-300 hover:text-green-400 transition-colors disabled:opacity-50" x-text="cronPauseLoading[job.id] === true ? '...' : 'Resume'"></button>
                         <button x-show="!job.heartbeat" @click="deleteCronJob(job.id)"
                           class="text-[11px] px-1.5 py-0.5 rounded bg-gray-700 hover:bg-red-900/30 text-gray-300 hover:text-red-400 transition-colors">Delete</button>
+                        </div>
                       </td>
                     </tr>
                   </template>
@@ -6200,17 +6203,20 @@
         <!-- ═══ ACTIVITY SUB-TAB ═══ -->
         <div x-show="systemTab === 'activity'">
         <div class="flex items-center justify-between mb-3">
-          <div class="seg-group flex">
+          <div class="seg-group flex" role="tablist" aria-label="Activity view">
             <button @click="setActivityView('traces')"
               class="seg-tab"
+              role="tab" :aria-selected="activityView === 'traces'"
               :class="activityView === 'traces' ? 'seg-tab-active' : ''"
             >Traces</button>
             <button @click="setActivityView('events')"
               class="seg-tab"
+              role="tab" :aria-selected="activityView === 'events'"
               :class="activityView === 'events' ? 'seg-tab-active' : ''"
             >Live Feed</button>
             <button @click="setActivityView('logs')"
               class="seg-tab"
+              role="tab" :aria-selected="activityView === 'logs'"
               :class="activityView === 'logs' ? 'seg-tab-active' : ''"
             >Logs</button>
           </div>
@@ -6222,11 +6228,11 @@
         <div x-show="activityView === 'traces'">
           <div class="flex items-center gap-3 mb-3">
             <div class="flex-1 relative">
-              <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-              <input type="text" x-model="activitySearch" placeholder="Search traces..."
+              <svg aria-hidden="true" class="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+              <input type="text" x-model="activitySearch" placeholder="Search traces..." aria-label="Search traces"
                 class="w-full bg-gray-800/50 border border-gray-700/50 rounded-lg pl-9 pr-3 py-1.5 text-xs text-gray-300 placeholder-gray-600 outline-none focus:border-indigo-500/50">
             </div>
-            <select x-model="activityAgentFilter"
+            <select x-model="activityAgentFilter" aria-label="Filter traces by agent"
               class="text-xs bg-gray-800/50 border border-gray-700/50 rounded-lg px-2 py-1.5 text-gray-300 outline-none">
               <option value="">All agents</option>
               <template x-for="a in activityAgents" :key="a">
@@ -6439,7 +6445,7 @@
         <!-- Runtime Logs view -->
         <div x-show="activityView === 'logs'">
           <div class="flex items-center gap-3 mb-3">
-            <select x-model="systemLogsLevel" @change="fetchSystemLogs()"
+            <select x-model="systemLogsLevel" @change="fetchSystemLogs()" aria-label="Filter logs by level"
               class="text-xs bg-gray-800/50 border border-gray-700/50 rounded-lg px-2 py-1.5 text-gray-300 outline-none">
               <option value="">All levels</option>
               <option value="debug">Debug</option>
@@ -6819,7 +6825,7 @@
               <template x-for="entry in auditLog" :key="entry.id">
                 <div x-data="{ expanded: false }" class="rounded-lg border"
                   :class="entry.archived ? 'bg-gray-800/10 border-gray-800/30 opacity-70' : 'bg-gray-800/30 border-gray-800/50'">
-                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" @click="expanded = !expanded">
+                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" tabindex="0" role="button" @click="expanded = !expanded" @keydown.enter.prevent="expanded = !expanded" @keydown.space.prevent="expanded = !expanded">
                     <div class="text-[11px] text-gray-400 w-14 shrink-0" x-text="entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : ''"></div>
                     <div class="flex-1 min-w-0 flex items-center gap-1.5">
                       <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 font-medium" x-text="entry.action"></span>
@@ -6895,6 +6901,7 @@
               </div>
             </template>
             <template x-if="browserMetricsList().length > 0">
+              <div class="overflow-x-auto">
               <table class="w-full text-xs">
                 <thead>
                   <tr class="text-[11px] uppercase tracking-wide text-gray-400 border-b border-gray-800">
@@ -6911,7 +6918,10 @@
                         browserMetricsStale(m.receivedAt) ? 'opacity-60' : '',
                         m.click_success_rate_100 != null ? 'cursor-pointer' : ''
                       ]"
-                      @click="if (m.click_success_rate_100 != null) expanded = !expanded">
+                      :tabindex="m.click_success_rate_100 != null ? 0 : -1" :role="m.click_success_rate_100 != null ? 'button' : null"
+                      @click="if (m.click_success_rate_100 != null) expanded = !expanded"
+                      @keydown.enter.prevent="if (m.click_success_rate_100 != null) expanded = !expanded"
+                      @keydown.space.prevent="if (m.click_success_rate_100 != null) expanded = !expanded">
                       <td class="py-3 pr-3 text-gray-200 font-mono truncate max-w-[14rem]" x-text="m.agent"></td>
                       <td class="py-3 pr-3">
                         <template x-if="m.click_success_rate_100 != null">
@@ -6969,6 +6979,7 @@
                   </tbody>
                 </template>
               </table>
+              </div>
             </template>
           </div>
 
@@ -7073,7 +7084,7 @@
               </div>
               <div class="flex items-center gap-2 mb-2">
                 <span class="text-[11px] text-gray-500 w-8 shrink-0">0.25×</span>
-                <input type="range" min="0.25" max="4.0" step="0.05"
+                <input type="range" min="0.25" max="4.0" step="0.05" aria-label="Browser action speed multiplier"
                   :value="browserSpeed"
                   @input="saveBrowserSpeed($event.target.value)"
                   class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
@@ -7110,7 +7121,7 @@
               </div>
               <div class="flex items-center gap-2 mb-2">
                 <span class="text-[11px] text-gray-500 w-8 shrink-0">0s</span>
-                <input type="range" min="0" max="10" step="0.5"
+                <input type="range" min="0" max="10" step="0.5" aria-label="Browser think time between actions in seconds"
                   :value="browserDelay"
                   @input="saveBrowserDelay($event.target.value)"
                   class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
@@ -7300,7 +7311,7 @@
           </div>
 
           <!-- ── 1b. Image Generation ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Image Generation</h3>
@@ -7321,7 +7332,7 @@
           </div>
 
           <!-- ── 2. Budgets ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Budgets</h3>
@@ -7349,7 +7360,7 @@
           </div>
 
           <!-- ── 3. Agents ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Agent Execution</h3>
@@ -7396,7 +7407,7 @@
           </div>
 
           <!-- ── 4. Health & Recovery ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>
               <h3 class="text-base font-medium text-gray-200">Health &amp; Recovery</h3>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -6825,7 +6825,7 @@
               <template x-for="entry in auditLog" :key="entry.id">
                 <div x-data="{ expanded: false }" class="rounded-lg border"
                   :class="entry.archived ? 'bg-gray-800/10 border-gray-800/30 opacity-70' : 'bg-gray-800/30 border-gray-800/50'">
-                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" tabindex="0" role="button" @click="expanded = !expanded" @keydown.enter.prevent="expanded = !expanded" @keydown.space.prevent="expanded = !expanded">
+                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" tabindex="0" role="button" @click="expanded = !expanded" @keydown.enter.prevent.self="expanded = !expanded" @keydown.space.prevent.self="expanded = !expanded">
                     <div class="text-[11px] text-gray-400 w-14 shrink-0" x-text="entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : ''"></div>
                     <div class="flex-1 min-w-0 flex items-center gap-1.5">
                       <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 font-medium" x-text="entry.action"></span>
@@ -6920,8 +6920,8 @@
                       ]"
                       :tabindex="m.click_success_rate_100 != null ? 0 : -1" :role="m.click_success_rate_100 != null ? 'button' : null"
                       @click="if (m.click_success_rate_100 != null) expanded = !expanded"
-                      @keydown.enter.prevent="if (m.click_success_rate_100 != null) expanded = !expanded"
-                      @keydown.space.prevent="if (m.click_success_rate_100 != null) expanded = !expanded">
+                      @keydown.enter.prevent.self="if (m.click_success_rate_100 != null) expanded = !expanded"
+                      @keydown.space.prevent.self="if (m.click_success_rate_100 != null) expanded = !expanded">
                       <td class="py-3 pr-3 text-gray-200 font-mono truncate max-w-[14rem]" x-text="m.agent"></td>
                       <td class="py-3 pr-3">
                         <template x-if="m.click_success_rate_100 != null">


### PR DESCRIPTION
Final follow-up from the Settings design review. **Rescoped:** the planned "consistency pass" (padding/header normalization) was dropped after inspecting the actual code — the padding (config tabs uniformly `p-5`, list tabs uniformly `p-4`) and the two header idioms (`h3` titled-panel vs `text-xs` section-label) are deliberate, internally-consistent choices, not bugs. Normalizing them would be ~38 edits of churn with regression risk and no real benefit. This PR does the higher-value subset instead.

### Correctness / HTML
- **Automation:** the cron actions cell was `<td class="… flex …">` — flex on a `<td>` is invalid; wrapped the buttons in an inner flex `<div>`.
- **Browser Health table:** added an `overflow-x-auto` wrapper so it scrolls instead of overflowing on narrow screens (matches the Per-Platform Success table).
- **General:** the Image/Budgets/Agent/Health cards rendered an empty bordered frame during load (body gated on `systemSettings`); guarded those four cards' outer div so they appear only once loaded. (LLM card skipped — it degrades gracefully via optional chaining; Restart card skipped — pure action.)

### Accessibility
- Segmented controls (Costs period, Activity view) → `role=tablist`/`tab` + `aria-selected`, mirroring the Team-hub tabs.
- Cost charts → `role="img"` + `aria-label`.
- Unlabeled inputs → `aria-label` (trace search + agent filter, log-level select, browser speed/think-time sliders); decorative search icon `aria-hidden`.
- Clickable expand rows (Operator audit, Browser Health) → keyboard-operable (`tabindex` + `role=button` + enter/space mirroring the click). Browser Health rows bind `tabindex`/`role` **conditionally** so non-expandable rows aren't announced as dead buttons.

### Deferred / flagged (not in this PR)
- Dead Operator "Approvals" pointer card (removal = behavior change — wants your call).
- Network System-Proxy form duplicated across 4 branches with a drifted missing "Saved" confirmation (a dedicated dedup PR).

Implemented via a worktree subagent against an exact checklist, then reviewed hunk-by-hunk. `<div>` balance identical to `main` (−2).