### PR TITLE
fix(agent): let operator + task agents view uploaded images/PDFs

### DIFF
--- a/src/agent/attachments.py
+++ b/src/agent/attachments.py
@@ -27,9 +27,14 @@ from src.shared.utils import setup_logging
 logger = setup_logging("agent.attachments")
 
 # Annotation pattern emitted by the dashboard when a user attaches a file.
-# Format: "📎 File attached: <name> (available at /data/uploads/<name>)"
+# Two composers emit slightly different prose for the same breadcrumb:
+#   regular agent chat: "📎 File attached: <name> (available at /data/uploads/<name>)"
+#   operator chat:      "📎 <name> (at /data/uploads/<name>)"
+# Match only the stable invariant — the "/data/uploads/<name>" path inside the
+# trailing parentheses — so enrichment is independent of the surrounding wording
+# (and survives any future composer drift). The display name is the path basename.
 _ATTACHMENT_RE = re.compile(
-    r"📎 File attached: (?P<name>[^\n(]+?) \(available at (?P<path>/data/uploads/[^\)]+)\)"
+    r"📎[^\n]*?\((?:\s*(?:available at|at)\s+)?(?P<path>/data/uploads/[^)]+?)\s*\)"
 )
 
 _IMAGE_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
@@ -129,8 +134,8 @@ def enrich_message_with_attachments(message: str) -> str | list[dict]:
         if text_before:
             blocks.append({"type": "text", "text": text_before})
 
-        name = m.group("name").strip()
-        fpath = Path(m.group("path"))
+        fpath = Path(m.group("path").strip())
+        name = fpath.name
         ext = fpath.suffix.lower()
 
         if ext in _IMAGE_EXTS:

--- a/src/agent/attachments.py
+++ b/src/agent/attachments.py
@@ -33,8 +33,11 @@ logger = setup_logging("agent.attachments")
 # Match only the stable invariant — the "/data/uploads/<name>" path inside the
 # trailing parentheses — so enrichment is independent of the surrounding wording
 # (and survives any future composer drift). The display name is the path basename.
+# The path runs up to the closing ")" that ends the breadcrumb (followed by
+# whitespace or end-of-string), so filenames that themselves contain ")" — e.g.
+# the common browser-download "report(1).png" — are captured whole.
 _ATTACHMENT_RE = re.compile(
-    r"📎[^\n]*?\((?:\s*(?:available at|at)\s+)?(?P<path>/data/uploads/[^)]+?)\s*\)"
+    r"📎[^\n]*?\((?:\s*(?:available at|at)\s+)?(?P<path>/data/uploads/.+?)\)(?=\s|$)"
 )
 
 _IMAGE_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp"})
@@ -138,7 +141,13 @@ def enrich_message_with_attachments(message: str) -> str | list[dict]:
         name = fpath.name
         ext = fpath.suffix.lower()
 
-        if ext in _IMAGE_EXTS:
+        # Defense-in-depth: the breadcrumb is user-controllable text, so a
+        # crafted "/data/uploads/../../x.png" could otherwise escape the
+        # read-only uploads mount when read below. Any traversal segment →
+        # keep the plain-text reference (the agent may still try file_tool).
+        traversal = ".." in fpath.parts
+
+        if not traversal and ext in _IMAGE_EXTS:
             block = _read_image_block(fpath)
             if block:
                 blocks.append(block)
@@ -147,7 +156,7 @@ def enrich_message_with_attachments(message: str) -> str | list[dict]:
                 # Fall back to plain-text reference
                 blocks.append({"type": "text", "text": m.group(0)})
 
-        elif ext == ".pdf":
+        elif not traversal and ext == ".pdf":
             text = _extract_pdf_text(fpath)
             if text:
                 blocks.append({"type": "text", "text": f"[Contents of {name}]\n\n{text}"})

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1546,7 +1546,11 @@ class AgentLoop:
         if assignment.context:
             parts.append(f"## Shared Context from Other Agents\n{sanitize_for_prompt(format_dict(assignment.context))}")
 
-        return [{"role": "user", "content": "\n\n".join(parts)}]
+        # Enrich any 📎 /data/uploads/ references in the task so a worker handed
+        # an image/PDF can actually see it (mirrors the chat path). Returns a
+        # plain string unchanged when there is nothing to enrich.
+        content = enrich_message_with_attachments("\n\n".join(parts))
+        return [{"role": "user", "content": content}]
 
     def _trim_context(self, messages: list[dict], max_tokens: int = 100_000) -> list[dict]:
         """Trim old tool exchanges to manage context window.

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1600,9 +1600,17 @@ class AgentLoop:
         # same-role messages, which violates the LLM role-alternation invariant.
         if not first_group:
             result = [{"role": "user", "content": summary_text.strip()}]
-        elif first_group[0].get("role") == "user" and isinstance(first_group[0].get("content"), str):
-            first_msg = {**first_group[0], "content": first_group[0]["content"] + summary_text}
-            result = [first_msg] + first_group[1:]
+        elif first_group[0].get("role") == "user":
+            first_msg = first_group[0]
+            content0 = first_msg.get("content")
+            if isinstance(content0, list):
+                # Multimodal first message (e.g. an uploaded image): append the
+                # summary as a trailing text block so the turn stays a single
+                # user message and the LLM role-alternation invariant holds.
+                merged = content0 + [{"type": "text", "text": summary_text}]
+            else:
+                merged = (content0 or "") + summary_text
+            result = [{**first_msg, "content": merged}] + first_group[1:]
         else:
             result = first_group + [{"role": "user", "content": summary_text.strip()}]
         for group in recent_groups:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -279,6 +279,34 @@ def test_enrich_bare_path_no_preposition(tmp_path: Path, monkeypatch: pytest.Mon
     assert any(b["type"] == "image_url" for b in result)
 
 
+def test_enrich_filename_with_parens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Filenames that contain ")" — e.g. the common browser-download
+    "report(1).png" — must be captured whole, not truncated at the first ")"."""
+    img_path = tmp_path / "report(1).png"
+    img_path.write_bytes(_make_tiny_png())
+
+    monkeypatch.setattr(
+        "src.agent.attachments.Path",
+        lambda p: tmp_path / Path(p).name if "/data/uploads/" in p else Path(p),
+    )
+
+    msg = "📎 report(1).png (at /data/uploads/report(1).png)"
+    result = enrich_message_with_attachments(msg)
+    assert isinstance(result, list)
+    assert any(b["type"] == "image_url" for b in result)
+
+
+def test_enrich_rejects_path_traversal() -> None:
+    """A crafted "/data/uploads/../../x.png" breadcrumb must NOT be read — the
+    traversal guard keeps the plain-text reference instead of escaping the
+    read-only uploads mount. Uses the real Path (no monkeypatch) so the ".."
+    segments survive to reach the guard."""
+    msg = "📎 (at /data/uploads/../../secret.png)"
+    result = enrich_message_with_attachments(msg)
+    # Guard fires → no enrichment → returned unchanged as a plain string.
+    assert result == msg
+
+
 # ---------------------------------------------------------------------------
 # convert_openai_image_blocks
 # ---------------------------------------------------------------------------

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -242,6 +242,43 @@ def test_enrich_multiple_attachments(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert len(image_blocks) == 2
 
 
+def test_enrich_operator_breadcrumb_format(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator composer emits "📎 <name> (at /data/uploads/<name>)" — the shorter
+    form that previously did NOT match the regex, leaving the operator unable to
+    view uploaded images. Regression guard for that mismatch."""
+    img_path = tmp_path / "photo.jpg"
+    img_path.write_bytes(_make_tiny_png())
+
+    monkeypatch.setattr(
+        "src.agent.attachments.Path",
+        lambda p: tmp_path / Path(p).name if "/data/uploads/" in p else Path(p),
+    )
+
+    msg = "What is this? 📎 photo.jpg (at /data/uploads/photo.jpg)"
+    result = enrich_message_with_attachments(msg)
+    assert isinstance(result, list)
+    assert any(b["type"] == "image_url" for b in result)
+    text_blocks = [b for b in result if b["type"] == "text"]
+    assert any("What is this?" in b["text"] for b in text_blocks)
+
+
+def test_enrich_bare_path_no_preposition(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A breadcrumb with no "at"/"available at" prose still enriches — only the
+    /data/uploads/ path is the contract."""
+    img_path = tmp_path / "chart.png"
+    img_path.write_bytes(_make_tiny_png())
+
+    monkeypatch.setattr(
+        "src.agent.attachments.Path",
+        lambda p: tmp_path / Path(p).name if "/data/uploads/" in p else Path(p),
+    )
+
+    msg = "📎 (/data/uploads/chart.png)"
+    result = enrich_message_with_attachments(msg)
+    assert isinstance(result, list)
+    assert any(b["type"] == "image_url" for b in result)
+
+
 # ---------------------------------------------------------------------------
 # convert_openai_image_blocks
 # ---------------------------------------------------------------------------

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4885,3 +4885,45 @@ async def test_interactive_chat_no_task_id_completely_unaffected():
         c for c in loop._auto_close_task.await_args_list
         if len(c.args) >= 2 and c.args[1] == "blocked"
     ]
+
+
+def test_trim_context_preserves_multimodal_first_message() -> None:
+    """Regression: when the initial user message is multimodal (list content,
+    e.g. an uploaded image enriched by _build_initial_context), trimming must
+    fold the summary into that message as a trailing text block — not append a
+    second consecutive user message, which would violate the LLM
+    role-alternation invariant (Constraint #7)."""
+    loop = _make_loop()
+    img_block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+    messages: list[dict] = [
+        {"role": "user", "content": [{"type": "text", "text": "Review this"}, img_block]},
+    ]
+    # >3 tool-call groups so trimming engages and the middle groups summarize.
+    for i in range(4):
+        messages.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": f"c{i}", "type": "function",
+                "function": {"name": "noop", "arguments": "{}"},
+            }],
+        })
+        messages.append({"role": "tool", "tool_call_id": f"c{i}", "content": f"result {i}"})
+
+    trimmed = loop._trim_context(messages, max_tokens=5)
+
+    # No two consecutive user-role messages anywhere in the result.
+    roles = [m["role"] for m in trimmed]
+    assert not any(
+        roles[i] == "user" and roles[i + 1] == "user" for i in range(len(roles) - 1)
+    ), f"consecutive user messages: {roles}"
+    # First message stays the multimodal user turn with the image intact.
+    assert trimmed[0]["role"] == "user"
+    assert isinstance(trimmed[0]["content"], list)
+    assert img_block in trimmed[0]["content"]
+    # The summary was folded in as a trailing text block.
+    assert any(
+        isinstance(b, dict) and b.get("type") == "text"
+        and "Previous Actions" in b.get("text", "")
+        for b in trimmed[0]["content"]
+    )


### PR DESCRIPTION
## Problem

Users can upload files, but the **operator** — the primary chat surface — couldn't actually *view* uploaded images/PDFs. It only ever saw a path string.

Vision enrichment already exists end-to-end (`attachments.py` converts uploads → `image_url` / PDF-text blocks; the LLM proxy forwards them; models are vision-capable). But it only fired for one composer. Two gaps:

1. **Format mismatch (the bug).** The regular agent composer emits `📎 File attached: <name> (available at /data/uploads/<name>)`; the **operator** composer emits the shorter `📎 <name> (at /data/uploads/<name>)`. `_ATTACHMENT_RE` hard-coded the longer prose, so the operator's breadcrumb never matched → no enrichment → operator can't see the file.
2. **Task path never enriched.** `_build_initial_context` returned plain string content, so a worker agent handed a file via a task assignment also couldn't view it.

## Fix (surgical, no new data model)

- **Generalize `_ATTACHMENT_RE`** to match the stable invariant — the `/data/uploads/<name>` path inside the trailing parens — independent of composer wording (and resilient to future drift). Display name derived from the path basename.
- **Enrich the task path**: run the assembled task context through `enrich_message_with_attachments`, mirroring chat. No-op when there's nothing to enrich.
- **Regression tests** pinning the operator breadcrumb format and a bare-path form.

## Out of scope (deliberately)

- Native PDF `document` blocks (visual/scanned PDFs) — text extraction already covers normal PDFs; native blocks add a new block type + provider conditionals. Follow-up.
- Telegram/Discord/Slack/WhatsApp inbound media — those channels drop media at the edge and have no shared `/data/uploads` volume; needs a typed attachments field. Separate track.

## Tests

- `tests/test_attachments.py`: 23 passed (incl. 2 new regression tests)
- `tests/test_loop.py`: 198 passed
- `ruff check`: clean