### PR TITLE
feat(dashboard): lead the team hub with a live Work view; demote raw State/Activity to Advanced

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -507,9 +507,13 @@ function dashboard() {
     auditArchiveDays: 30,
     auditArchiving: false,
 
-    // Unified Team Hub (replaces separate TEAM.md + Comms + Broadcast panels)
-    teamHubExpanded: false,
-    teamHubTab: 'docs',  // 'docs' | 'activity' | 'state' | 'artifacts' | 'broadcast' | 'members'
+    // Unified Team Hub (replaces separate TEAM.md + Comms + Broadcast panels).
+    // Leads with the live Work view; raw State + Activity are demoted under
+    // the Advanced sub-tab (teamHubAdvTab).
+    teamHubExpanded: true,
+    teamHubTab: 'work',  // 'work' | 'artifacts' | 'docs' | 'members' | 'broadcast' | 'advanced'
+    teamHubAdvTab: 'state',  // within Advanced: 'state' | 'activity'
+    _teamWorkLoaded: false,  // load the workplace ledger once, then WS keeps it live
 
     // TEAM.md banner on Agents tab (kept for backward compat, not used by template)
     teamBannerExpanded: false,
@@ -5618,8 +5622,8 @@ function dashboard() {
       this.teamEditing = false;
       this.teamEditBuffer = '';
       this.teamBannerExpanded = false;
-      this.teamHubExpanded = false;
-      this.teamHubTab = 'docs';
+      this.teamHubExpanded = true;
+      this.teamHubTab = 'work';
       this.showTeamForm = false;
       this.commsView = 'activity';
       this.commsExpanded = false;
@@ -5633,10 +5637,49 @@ function dashboard() {
       this.artifactsList = [];
       this.fetchTeamContent();
       if (name) {
-        this.fetchCommsActivity();
-        this.fetchBlackboard();
-        this.fetchArtifacts();
+        // Work leads — ensure the task ledger is loaded (WS keeps it live).
+        // State/Activity (Advanced) and Files lazy-load on their own tabs, so
+        // switching teams no longer eagerly fans out blackboard + artifact reads.
+        this._ensureWorkplaceTasks();
       }
+    },
+
+    // Load the workplace task ledger once per session; the WS reducer
+    // (handleWorkplaceEvent) + the debounced reload keep it current after that,
+    // so the team-hub Work view derives from already-live shared state rather
+    // than its own fetch loop.
+    _ensureWorkplaceTasks() {
+      if (this.workplaceEnabled === false || this._teamWorkLoaded) return;
+      if (typeof this.loadWorkplaceTasks !== 'function') return;
+      this._teamWorkLoaded = true;
+      this.loadWorkplaceTasks();
+    },
+
+    // Buckets the live ledger for the active team into the hub Work view.
+    // Derives from workplaceTasks (shared with the Work tab) — no extra fetch.
+    get teamWork() {
+      const team = this.activeTeam;
+      const active = { pending: 1, accepted: 1, working: 1 };
+      const midnight = new Date(); midnight.setHours(0, 0, 0, 0);
+      const todayMs = midnight.getTime();
+      const blocked = [], inflight = [], doneToday = [];
+      for (const t of (this.workplaceTasks || [])) {
+        if (t.project_id !== team) continue;
+        if (t.status === 'blocked') blocked.push(t);
+        else if (active[t.status]) inflight.push(t);
+        else if (t.status === 'done' && ((t.completed_at || 0) * 1000) >= todayMs) doneToday.push(t);
+      }
+      return { blocked, inflight, doneToday, total: blocked.length + inflight.length + doneToday.length };
+    },
+
+    // One-hop handoff label for a task row: "creator → assignee" (or just the
+    // assignee when it wasn't handed off). Plain text — bind with x-text.
+    teamHandoffLabel(t) {
+      const who = this.agentDisplayName(t.assignee);
+      if (t && t.creator && t.creator !== t.assignee) {
+        return `${this.agentDisplayName(t.creator)} → ${who}`;
+      }
+      return who;
     },
 
     openTeamModal() {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -3815,6 +3815,14 @@ function dashboard() {
           t.status = data.new_status;
           if (data.assignee) t.assignee = data.assignee;
           if (data.blocker_note !== undefined) t.blocker_note = data.blocker_note;
+          // The status-change payload omits completed_at, but the team-hub
+          // Work view buckets "Delivered today" by it — without this a task
+          // that completes while the hub is open drops out of every bucket
+          // until a full reload. Prefer a server value if one is ever added;
+          // otherwise approximate with the client clock (corrected on reload).
+          if (data.new_status === 'done' && !t.completed_at) {
+            t.completed_at = (data.completed_at != null) ? data.completed_at : (Date.now() / 1000);
+          }
         }
         // Pinned blockers list lives on a separate endpoint; refresh it
         // whenever a task transitions in to or out of ``blocked``.
@@ -5653,7 +5661,12 @@ function dashboard() {
     // so the team-hub Work view derives from already-live shared state rather
     // than its own fetch loop.
     _ensureWorkplaceTasks() {
-      if (this.workplaceEnabled === false || this._teamWorkLoaded) return;
+      if (this.workplaceEnabled === false) return;
+      if (this.workplaceSectionLoading && this.workplaceSectionLoading.tasks) return;  // already in flight
+      // Skip only if we loaded successfully once. If the last load errored,
+      // workplaceErrors.tasks is set — retry on the next entry rather than
+      // wedging the Work view empty with no recovery path.
+      if (this._teamWorkLoaded && !(this.workplaceErrors && this.workplaceErrors.tasks)) return;
       if (typeof this.loadWorkplaceTasks !== 'function') return;
       this._teamWorkLoaded = true;
       this.loadWorkplaceTasks();

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -2401,6 +2401,10 @@ function dashboard() {
         this.fetchSettings();
         this.fetchTeamContent();
         this.fetchTeams();
+        // Lead-with-Work: ensure the task ledger is loaded when entering the
+        // Teams tab with a team active (init restores activeTeam directly, not
+        // via switchTeam, so the Work view would otherwise render empty).
+        if (this.activeTeam) this._ensureWorkplaceTasks();
       }
       if (tab === 'system') {
         this.fetchSettings();

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1688,23 +1688,11 @@
                 :title="activeTeamData?.description" x-text="activeTeamData?.description"></span>
               <!-- Tab pills — desktop only, click stops propagation to header toggle -->
               <div class="project-hub-desktop-tabs seg-group hidden md:flex ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">
-                <button @click="teamHubExpanded = true; teamHubTab = 'docs'"
+                <button @click="teamHubExpanded = true; teamHubTab = 'work'; _ensureWorkplaceTasks()"
                   class="seg-tab seg-tab-sm"
-                  :class="teamHubExpanded && teamHubTab === 'docs' ? 'seg-tab-active' : ''"
-                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'docs'">
-                  <span>Context</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared TEAM.md file visible to all agents. Use it for team-wide instructions, goals, and context.</span></span>
-                </button>
-                <button @click="teamHubExpanded = true; teamHubTab = 'activity'; if (commsActivity.length === 0 && !commsActivityLoading) fetchCommsActivity()"
-                  class="seg-tab seg-tab-sm"
-                  :class="teamHubExpanded && teamHubTab === 'activity' ? 'seg-tab-active' : ''"
-                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'activity'">
-                  <span>Activity</span><span x-show="commsActivity.length > 0" class="ml-1 opacity-50 font-mono text-[11px]" x-text="'(' + commsActivity.length + ')'"></span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">Real-time feed of blackboard writes and pub/sub events between agents. Shows how agents are coordinating.</span></span>
-                </button>
-                <button @click="teamHubExpanded = true; teamHubTab = 'state'; fetchBlackboard(); if (Object.keys(commsSubs).length === 0) fetchCommsActivity()"
-                  class="seg-tab seg-tab-sm"
-                  :class="teamHubExpanded && teamHubTab === 'state' ? 'seg-tab-active' : ''"
-                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'state'">
-                  <span>State</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared blackboard — a key-value store where agents read and write data to coordinate. Browse, edit, or delete entries.</span></span>
+                  :class="teamHubExpanded && teamHubTab === 'work' ? 'seg-tab-active' : ''"
+                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'work'">
+                  <span>Work</span><span x-show="teamWork.blocked.length > 0" class="ml-1 w-1.5 h-1.5 rounded-full bg-amber-400 inline-block" :title="teamWork.blocked.length + ' blocked'"></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'artifacts'; fetchArtifacts()"
                   class="seg-tab seg-tab-sm"
@@ -1712,17 +1700,29 @@
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'artifacts'">
                   Files
                 </button>
-                <button @click="teamHubExpanded = true; teamHubTab = 'broadcast'"
+                <button @click="teamHubExpanded = true; teamHubTab = 'docs'"
                   class="seg-tab seg-tab-sm"
-                  :class="teamHubExpanded && teamHubTab === 'broadcast' ? 'seg-tab-active' : ''"
-                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'broadcast'">
-                  <span>Broadcast</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">Send a message to all agents at once. Useful for fleet-wide instructions or status requests.</span></span>
+                  :class="teamHubExpanded && teamHubTab === 'docs' ? 'seg-tab-active' : ''"
+                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'docs'">
+                  <span>Context</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared TEAM.md file visible to all agents. Use it for team-wide instructions, goals, and context.</span></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'members'"
                   class="seg-tab seg-tab-sm"
                   :class="teamHubExpanded && teamHubTab === 'members' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'members'">
                   Members<span class="ml-1 opacity-50 font-mono text-[11px]" x-text="'(' + (activeTeamData?.members || []).length + ')'"></span>
+                </button>
+                <button @click="teamHubExpanded = true; teamHubTab = 'broadcast'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'broadcast' ? 'seg-tab-active' : ''"
+                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'broadcast'">
+                  <span>Broadcast</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">Send a message to all agents at once. Useful for fleet-wide instructions or status requests.</span></span>
+                </button>
+                <button @click="teamHubExpanded = true; teamHubTab = 'advanced'; if (teamHubAdvTab === 'state') { fetchBlackboard(); if (Object.keys(commsSubs).length === 0) fetchCommsActivity(); } else if (commsActivity.length === 0 && !commsActivityLoading) { fetchCommsActivity(); }"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'advanced' ? 'seg-tab-active' : ''"
+                  role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'advanced'">
+                  <span>Advanced</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">Power-user: the raw shared blackboard (State) and the agent coordination event log (Activity). For debugging how agents coordinate.</span></span>
                 </button>
               </div>
               <!-- Team options kebab menu -->
@@ -1749,23 +1749,11 @@
             <div x-show="teamHubExpanded" x-transition class="border-t border-gray-800/60">
               <!-- Mobile tab strip (sm:hidden) -->
               <div class="project-hub-tabs project-hub-mobile-tabs md:hidden" role="tablist" aria-label="Team sections">
-                <button @click="teamHubTab = 'docs'"
+                <button @click="teamHubTab = 'work'; _ensureWorkplaceTasks()"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
-                  :class="teamHubTab === 'docs' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
-                  role="tab" :aria-selected="teamHubTab === 'docs'">
-                  Context
-                </button>
-                <button @click="teamHubTab = 'activity'; if (commsActivity.length === 0 && !commsActivityLoading) fetchCommsActivity()"
-                  class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
-                  :class="teamHubTab === 'activity' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
-                  role="tab" :aria-selected="teamHubTab === 'activity'">
-                  Activity
-                </button>
-                <button @click="teamHubTab = 'state'; fetchBlackboard(); if (Object.keys(commsSubs).length === 0) fetchCommsActivity()"
-                  class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
-                  :class="teamHubTab === 'state' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
-                  role="tab" :aria-selected="teamHubTab === 'state'">
-                  State
+                  :class="teamHubTab === 'work' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
+                  role="tab" :aria-selected="teamHubTab === 'work'">
+                  Work
                 </button>
                 <button @click="teamHubTab = 'artifacts'; fetchArtifacts()"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
@@ -1773,11 +1761,11 @@
                   role="tab" :aria-selected="teamHubTab === 'artifacts'">
                   Files
                 </button>
-                <button @click="teamHubTab = 'broadcast'"
+                <button @click="teamHubTab = 'docs'"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
-                  :class="teamHubTab === 'broadcast' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
-                  role="tab" :aria-selected="teamHubTab === 'broadcast'">
-                  Broadcast
+                  :class="teamHubTab === 'docs' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
+                  role="tab" :aria-selected="teamHubTab === 'docs'">
+                  Context
                 </button>
                 <button @click="teamHubTab = 'members'"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
@@ -1785,6 +1773,86 @@
                   role="tab" :aria-selected="teamHubTab === 'members'">
                   Members
                 </button>
+                <button @click="teamHubTab = 'broadcast'"
+                  class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
+                  :class="teamHubTab === 'broadcast' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
+                  role="tab" :aria-selected="teamHubTab === 'broadcast'">
+                  Broadcast
+                </button>
+                <button @click="teamHubTab = 'advanced'; if (teamHubAdvTab === 'state') { fetchBlackboard(); if (Object.keys(commsSubs).length === 0) fetchCommsActivity(); } else if (commsActivity.length === 0 && !commsActivityLoading) { fetchCommsActivity(); }"
+                  class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
+                  :class="teamHubTab === 'advanced' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
+                  role="tab" :aria-selected="teamHubTab === 'advanced'">
+                  Advanced
+                </button>
+              </div>
+
+              <!-- ── WORK (live task flow — derived from the shared workplace ledger) ── -->
+              <div x-show="teamHubTab === 'work'" x-cloak class="px-4 py-3">
+                <div x-show="workplaceEnabled === false" class="text-gray-500 text-sm py-6 text-center">
+                  Task tracking isn't enabled for this instance.
+                </div>
+                <template x-if="workplaceEnabled !== false">
+                  <div>
+                    <!-- first-load spinner -->
+                    <div x-show="workplaceSectionLoading.tasks && teamWork.total === 0" class="flex items-center gap-2 text-gray-500 py-6 justify-center">
+                      <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                      <span class="text-xs">Loading work…</span>
+                    </div>
+                    <!-- empty -->
+                    <div x-show="!workplaceSectionLoading.tasks && teamWork.total === 0" class="text-gray-500 text-sm py-6 text-center">
+                      No active work for <span class="text-gray-400" x-text="activeTeam"></span> yet.<br>
+                      <span class="text-xs text-gray-600">Tasks appear here as agents pick them up and hand off to each other.</span>
+                    </div>
+                    <div x-show="teamWork.total > 0" class="space-y-4">
+                      <!-- Blocked -->
+                      <div x-show="teamWork.blocked.length > 0">
+                        <h4 class="text-[11px] font-semibold uppercase tracking-wide text-amber-400/90 mb-1.5">&#9888; Blocked &middot; <span x-text="teamWork.blocked.length"></span></h4>
+                        <div class="space-y-1">
+                          <template x-for="t in teamWork.blocked" :key="t.id">
+                            <button @click="switchTab('workplace'); openTaskDrillIn(t.id)" class="w-full text-left bg-amber-500/5 hover:bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 transition-colors">
+                              <div class="flex items-center justify-between gap-2">
+                                <span class="text-sm text-gray-200 truncate" x-text="t.title"></span>
+                                <span class="text-[11px] text-gray-500 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
+                              </div>
+                              <div x-show="t.blocker_note" class="text-[11px] text-red-400 mt-0.5 truncate" x-text="'⛔ ' + (t.blocker_note || '')"></div>
+                            </button>
+                          </template>
+                        </div>
+                      </div>
+                      <!-- In flight -->
+                      <div x-show="teamWork.inflight.length > 0">
+                        <h4 class="text-[11px] font-semibold uppercase tracking-wide text-blue-400/90 mb-1.5">&#9679; In flight &middot; <span x-text="teamWork.inflight.length"></span></h4>
+                        <div class="space-y-1">
+                          <template x-for="t in teamWork.inflight" :key="t.id">
+                            <button @click="switchTab('workplace'); openTaskDrillIn(t.id)" class="w-full text-left bg-gray-800/40 hover:bg-gray-800/70 border border-gray-700/50 rounded-lg px-3 py-2 transition-colors">
+                              <div class="flex items-center justify-between gap-2">
+                                <span class="text-sm text-gray-200 truncate" x-text="t.title"></span>
+                                <span class="text-[11px] text-gray-500 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
+                              </div>
+                              <div class="text-[11px] text-gray-600 mt-0.5" x-text="t.status"></div>
+                            </button>
+                          </template>
+                        </div>
+                      </div>
+                      <!-- Delivered today -->
+                      <div x-show="teamWork.doneToday.length > 0">
+                        <h4 class="text-[11px] font-semibold uppercase tracking-wide text-emerald-400/90 mb-1.5">&#10003; Delivered today &middot; <span x-text="teamWork.doneToday.length"></span></h4>
+                        <div class="space-y-1">
+                          <template x-for="t in teamWork.doneToday" :key="t.id">
+                            <button @click="switchTab('workplace'); openTaskDrillIn(t.id)" class="w-full text-left bg-gray-800/30 hover:bg-gray-800/60 border border-gray-800 rounded-lg px-3 py-2 transition-colors">
+                              <div class="flex items-center justify-between gap-2">
+                                <span class="text-sm text-gray-300 truncate" x-text="t.title"></span>
+                                <span class="text-[11px] text-gray-600 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
+                              </div>
+                              <div x-show="t.outcome" class="text-[11px] text-emerald-400/80 mt-0.5" x-text="'✓ ' + (t.outcome || '')"></div>
+                            </button>
+                          </template>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </template>
               </div>
 
               <!-- ── CONTEXT (TEAM.md) ── -->
@@ -1842,8 +1910,21 @@
                 </div>
               </div>
 
-              <!-- ── ACTIVITY ── -->
-              <div x-show="teamHubTab === 'activity'" x-cloak>
+              <!-- ── ADVANCED (power-user: raw State + Activity, demoted from the primary tabs) ── -->
+              <div x-show="teamHubTab === 'advanced'" x-cloak class="px-4 pt-3">
+                <p class="text-[11px] text-gray-500 mb-2">Power-user view — the raw shared blackboard and the agent coordination event log, for debugging how agents coordinate.</p>
+                <div class="seg-group inline-flex" role="tablist" aria-label="Advanced sections">
+                  <button @click="teamHubAdvTab = 'state'; fetchBlackboard(); if (Object.keys(commsSubs).length === 0) fetchCommsActivity()"
+                    class="seg-tab seg-tab-sm" :class="teamHubAdvTab === 'state' ? 'seg-tab-active' : ''"
+                    role="tab" :aria-selected="teamHubAdvTab === 'state'">State</button>
+                  <button @click="teamHubAdvTab = 'activity'; if (commsActivity.length === 0 && !commsActivityLoading) fetchCommsActivity()"
+                    class="seg-tab seg-tab-sm" :class="teamHubAdvTab === 'activity' ? 'seg-tab-active' : ''"
+                    role="tab" :aria-selected="teamHubAdvTab === 'activity'">Activity</button>
+                </div>
+              </div>
+
+              <!-- ── ACTIVITY (under Advanced) ── -->
+              <div x-show="teamHubTab === 'advanced' && teamHubAdvTab === 'activity'" x-cloak>
                 <!-- Activity header row: subs + refresh -->
                 <div class="flex items-center gap-2 px-4 pt-3 pb-2">
                   <div x-show="Object.keys(commsSubs).length > 0" class="flex items-center gap-1.5 flex-wrap flex-1 min-w-0" x-cloak>
@@ -1902,7 +1983,7 @@
               </div>
 
               <!-- ── SHARED STATE (Blackboard) ── -->
-              <div x-show="teamHubTab === 'state'" x-cloak class="p-4">
+              <div x-show="teamHubTab === 'advanced' && teamHubAdvTab === 'state'" x-cloak class="p-4">
                 <div class="mb-3 flex gap-2">
                   <input type="text" x-model="bbPrefix" @keyup.enter="fetchBlackboard()"
                     placeholder="Filter by prefix…"


### PR DESCRIPTION
Redesigns the per-team hub (the panel with `Context · Activity · State · Files · Broadcast · Members`) from a config/plumbing console into a **work view** — the reviewed must-build core from the design + Codex pass.

### What changed
- **New `Work` tab (default)** — the team's live task flow in three buckets: **⚠ Blocked** (with the `blocker_note`), **● In flight**, **✓ Delivered today** — each row showing a one-hop `creator → assignee` handoff label. Click a row → hops to the Work tab and opens the existing task drill-in.
- **`State` + `Activity` → a single `Advanced` tab** (power-user/debug), lazy-loaded. The blackboard **write/delete is preserved** — only relocated.
- **Tab order leads with value:** Work · Files · Context · Members · Broadcast · Advanced.
- `switchTeam` no longer eagerly fans out blackboard + comms + artifact reads — those lazy-load on their own tabs (a perf win).

### How it satisfies the review must-fixes
- **No new fetch/unbounded query:** the Work view derives from the shared `workplaceTasks` ledger the global Work tab already loads + keeps live via the WS reducer; loaded once per session.
- **task_created lacks `parent_task_id`:** the existing 250 ms debounced reload replaces the stub, so handoff labels resolve within 250 ms.
- **Command-palette coupling:** `docs`/`broadcast`/`members` tabs are kept, so palette refs stay valid.
- **State write/delete:** preserved verbatim under Advanced.

### Live/retrospective split
Team-hub Work = **live/operational** (in-flight, blocked, delivered-today). Global Work tab stays **retrospective** (summary cards, ratings). No competing screens.

### Deferred (flagged, not in this PR)
Goal header (`north_star` + CTA), Context→Brief rename, multi-hop chains, and **hoisting the task drill-in modal to top-level** so the hub can open it in place (today it's scoped inside the workplace tab block).

### Tests
Front-end only. `test_dashboard.py` + `test_dashboard_ui.py`: **551 passed, 4 skipped**. `node --check` clean.