### PR TITLE
feat(dashboard): team hub Goal header + Context→Brief rename

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5010,7 +5010,6 @@ def create_dashboard_router(
                 # Team goal (set via the operator's set_team_goal tool). Surfaced
                 # so the team hub can show it; null until set.
                 "north_star": pdata.get("north_star"),
-                "success_criteria": pdata.get("success_criteria"),
             })
         return {"teams": result}
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5007,6 +5007,10 @@ def create_dashboard_router(
                 "members": pdata.get("members", []),
                 "created_at": pdata.get("created_at", ""),
                 "over_limit": is_over,
+                # Team goal (set via the operator's set_team_goal tool). Surfaced
+                # so the team hub can show it; null until set.
+                "north_star": pdata.get("north_star"),
+                "success_criteria": pdata.get("success_criteria"),
             })
         return {"teams": result}
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1686,6 +1686,10 @@
                 x-text="(activeTeamData?.members || []).length + ' member' + ((activeTeamData?.members || []).length !== 1 ? 's' : '')"></span>
               <span x-show="activeTeamData?.description" class="text-[11px] text-gray-500 truncate hidden sm:block"
                 :title="activeTeamData?.description" x-text="activeTeamData?.description"></span>
+              <!-- Team goal (north_star) — display-only; set via the operator's set_team_goal -->
+              <span x-show="activeTeamData?.north_star" class="text-[11px] text-indigo-300/80 truncate hidden md:block max-w-[14rem] flex-shrink"
+                :title="'Goal: ' + (activeTeamData?.north_star || '') + (activeTeamData?.success_criteria ? ' — Success: ' + activeTeamData.success_criteria : '')"
+                x-text="'🎯 ' + (activeTeamData?.north_star || '')"></span>
               <!-- Tab pills — desktop only, click stops propagation to header toggle -->
               <div class="project-hub-desktop-tabs seg-group hidden md:flex ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">
                 <button @click="teamHubExpanded = true; teamHubTab = 'work'; _ensureWorkplaceTasks()"
@@ -1704,7 +1708,7 @@
                   class="seg-tab seg-tab-sm"
                   :class="teamHubExpanded && teamHubTab === 'docs' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'docs'">
-                  <span>Context</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared TEAM.md file visible to all agents. Use it for team-wide instructions, goals, and context.</span></span>
+                  <span>Brief</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared TEAM.md brief visible to all agents. Use it for team-wide instructions, goals, and context.</span></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'members'"
                   class="seg-tab seg-tab-sm"
@@ -1765,7 +1769,7 @@
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
                   :class="teamHubTab === 'docs' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"
                   role="tab" :aria-selected="teamHubTab === 'docs'">
-                  Context
+                  Brief
                 </button>
                 <button @click="teamHubTab = 'members'"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1688,7 +1688,7 @@
                 :title="activeTeamData?.description" x-text="activeTeamData?.description"></span>
               <!-- Team goal (north_star) — display-only; set via the operator's set_team_goal -->
               <span x-show="activeTeamData?.north_star" class="text-[11px] text-indigo-300/80 truncate hidden md:block max-w-[14rem] flex-shrink"
-                :title="'Goal: ' + (activeTeamData?.north_star || '') + (activeTeamData?.success_criteria ? ' — Success: ' + activeTeamData.success_criteria : '')"
+                :title="'Goal: ' + (activeTeamData?.north_star || '')"
                 x-text="'🎯 ' + (activeTeamData?.north_star || '')"></span>
               <!-- Tab pills — desktop only, click stops propagation to header toggle -->
               <div class="project-hub-desktop-tabs seg-group hidden md:flex ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1668,7 +1668,7 @@
             </span>
           </template>
         </div>
-        <!-- ═══ PROJECT HUB (unified: Context · Activity · State · Files · Broadcast) ═══ -->
+        <!-- ═══ TEAM HUB (Work · Files · Brief · Members · Broadcast · Advanced) ═══ -->
         <div x-show="activeTeam && agents.length > 0" x-cloak class="mb-4">
           <div class="bg-gray-900 border border-gray-800 rounded-xl">
             <!-- Hub header — always visible -->
@@ -1859,7 +1859,7 @@
                 </template>
               </div>
 
-              <!-- ── CONTEXT (TEAM.md) ── -->
+              <!-- ── BRIEF (TEAM.md) ── -->
               <div x-show="teamHubTab === 'docs'" class="px-4 py-3">
                 <p class="text-xs text-gray-500 mb-3"
                   x-text="'Shared context pushed to all ' + activeTeam + ' members automatically.'"></p>


### PR DESCRIPTION
Two low-risk polish items from the team-hub redesign follow-ups.

### Changes
- **Goal header** — surfaces the team `north_star` (set via the operator's `set_team_goal`) in the hub header, display-only, shown only when set. Added `north_star`/`success_criteria` to `/api/teams` so `activeTeamData` carries them.
- **Context → Brief** — clearer label for the shared TEAM.md charter. Tab id stays `docs` so URLs, persisted state, and the command palette stay valid.

### Deliberately deferred (flagged, not bundled)
- **Modal hoist** (in-place task drill-in) — a ~265-line relocation of a *working* modal out of the workplace tab block; real regression risk with no DOM-level test coverage. Best as an isolated, hand-verified change. Current tab-hop works.
- **Multi-hop chains** — one-hop already solves it; full tree viz is gold-plating.
- No goal **write** UI (north_star is operator-set; a form needs a new endpoint — separate feature).

### Tests
`test_dashboard.py` + `test_dashboard_ui.py`: **551 passed, 4 skipped**. server.py ruff clean. The `/api/teams` field add is additive (no assertion broke).