### PR TITLE
docs(license): re-license to PolyForm Perimeter 1.0.1 under OpenLegion LLC

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,54 +1,154 @@
-# OpenLegion.ai — Contributor License Agreement (CLA)
+# OpenLegion — Contributor License Agreement (CLA)
 
-Thank you for your interest in contributing to OpenLegion.ai.
+**Version 2.0 — effective 2026**
 
-By signing this Agreement, you accept the following terms. This is a legally binding agreement.
+Thank you for your interest in contributing to OpenLegion.
+
+This Contributor License Agreement ("**Agreement**") is a legally binding
+agreement between you and **OpenLegion LLC**, a Wyoming limited liability
+company ("**OpenLegion**", "**we**", or "**us**"). It sets out the rights you
+grant us in the Contributions you submit to any project we maintain.
+
+You accept this Agreement by signing it through the CLA Assistant bot on your
+first pull request, or by otherwise indicating acceptance in writing. If you do
+not agree, do not submit a Contribution.
 
 ## 1. Definitions
 
-**"Licensor"** means Yu-wen Jeffrey Tseng.
+**"You"** (or **"Your"**) means the individual or legal entity that owns, or is
+legally entitled to grant the rights in, the Contribution and that accepts this
+Agreement. For a legal entity, "You" includes that entity and all entities that
+control, are controlled by, or are under common control with it.
 
-**"Contribution"** means any original work of authorship submitted to the OpenLegion.ai project, including code, documentation, and other materials submitted via pull request or other means.
+**"Contribution"** means any original work of authorship — including any
+modifications or additions to existing work, and any associated documentation,
+configuration, or other materials — that You intentionally submit to OpenLegion
+for inclusion in, or documentation of, any project we maintain. "Submit" means
+any form of communication sent to us or our representatives, including via
+pull request, issue, commit, or electronic, verbal, or written communication,
+but excludes communication You conspicuously mark in writing as "Not a
+Contribution."
 
-## 2. Grant of Rights
+## 2. You Retain Ownership
 
-You retain copyright to your Contribution.
+You keep all right, title, and interest in Your Contribution. This Agreement
+grants licenses; it does not transfer ownership of Your copyright.
 
-However, you hereby grant to the Licensor a perpetual, worldwide, irrevocable, royalty-free, non-exclusive license to:
+## 3. Copyright License
 
-- Use, reproduce, modify, distribute, and display the Contribution
-- Create derivative works based on the Contribution
-- Sublicense the Contribution
-- Re-license the Contribution under different license terms
-- Commercially exploit the Contribution
-- Incorporate the Contribution into proprietary or commercial products
+You grant OpenLegion and the recipients of software distributed by OpenLegion a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contribution and such derivative works.
 
-This license includes the right to assign these rights to a future corporate entity formed by the Licensor.
+This license includes the right for OpenLegion to:
 
-## 3. Patent Grant
+- license and re-license the Contribution under any license terms, including
+  the license then applied to the project, other source-available terms, open
+  source terms, and proprietary or commercial terms; and
+- incorporate the Contribution into proprietary, commercial, or hosted products
+  and services offered by OpenLegion.
 
-You hereby grant to the Licensor and to recipients of software distributed by the Licensor a perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contribution alone or by combination of your Contribution with the project to which it was submitted.
+This relicensing right is what allows OpenLegion to keep the project under a
+single, consistent license and to offer commercial and managed-hosting
+editions. The current project license is described in [LICENSE](LICENSE).
 
-## 4. Representations
+## 4. Patent License
+
+You grant OpenLegion and the recipients of software distributed by OpenLegion a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as
+stated in this Section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer Your Contribution. This license applies
+only to those patent claims licensable by You that are necessarily infringed by
+Your Contribution alone or by combination of Your Contribution with the project
+to which it was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the project to which it was submitted, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or project terminate as of the
+date such litigation is filed.
+
+## 5. Moral Rights
+
+To the fullest extent permitted by applicable law, You waive, and agree not to
+assert, any moral rights or rights of attribution or integrity You may have in
+the Contribution against OpenLegion or its licensees, transferees, or
+sublicensees. Where such rights cannot be waived, You agree not to enforce them
+in a manner that interferes with the rights granted in this Agreement.
+
+## 6. Representations
 
 You represent and warrant that:
 
-- The Contribution is your original work, or you have the legal right to submit it under the project's license
-- The Contribution does not knowingly infringe any third-party intellectual property rights
-- You have the authority to enter into this Agreement
+- Each Contribution is Your original creation, or You have the legal right and
+  authority to submit it under the terms of this Agreement;
+- To the best of Your knowledge, the Contribution does not infringe or
+  misappropriate any third party's intellectual property or other rights;
+- If any third party (for example, Your employer) has rights to intellectual
+  property You create, You have received permission to make the Contribution on
+  behalf of that party, or that party has waived such rights for the
+  Contribution; and
+- You have the authority to enter into this Agreement. If You are accepting on
+  behalf of a legal entity, You represent that You are authorized to bind that
+  entity.
 
-## 5. No Ownership Transfer
+Except for the warranties above, the Contribution is provided "AS IS", without
+warranties or conditions of any kind, to the extent permitted by law. You are
+not expected to provide support for Your Contribution.
 
-This Agreement does not grant you ownership of the OpenLegion.ai project, trademarks, branding, or repository. All project-level intellectual property remains with the Licensor unless explicitly assigned in writing.
+## 7. Third-Party Materials
 
-## 6. No Obligation
+If Your Contribution includes or depends on work that is not Your original
+creation, You must identify it, along with the source and any license or
+restriction (including related patents, trademarks, and license agreements) of
+which You are aware, by conspicuously marking it when You submit it. You must
+not submit third-party materials under a license incompatible with the project
+license.
 
-The Licensor is not obligated to use, merge, or distribute any Contribution.
+## 8. No Ownership of the Project
 
-## 7. Governing Law
+This Agreement does not grant You any ownership of OpenLegion, its projects,
+trademarks, branding, logos, or repositories. All such rights remain with
+OpenLegion unless expressly assigned in writing. Nothing in this Agreement
+grants You a license to use any OpenLegion trademark; see [TRADEMARK.md](TRADEMARK.md).
 
-This Agreement shall be governed by the laws of the Licensor's jurisdiction at the time of signing.
+## 9. No Obligation
 
-## 8. Acceptance
+OpenLegion is under no obligation to use, merge, distribute, or otherwise
+exploit any Contribution. You are under no obligation to provide further
+Contributions.
 
-Signing this CLA via the CLA Assistant bot constitutes your electronic signature and acceptance of this Agreement.
+## 10. Inbound = Outbound
+
+To the extent OpenLegion redistributes Your Contribution as part of a project,
+it will do so under the license then applied to that project, consistent with
+the rights granted in Section 3.
+
+## 11. Governing Law
+
+This Agreement is governed by the laws of the State of Wyoming, USA, without
+regard to its conflict-of-laws rules. The exclusive venue for any dispute
+arising out of or relating to this Agreement is the state and federal courts
+located in Wyoming, and You consent to personal jurisdiction there. The United
+Nations Convention on Contracts for the International Sale of Goods does not
+apply.
+
+## 12. Entire Agreement; Severability
+
+This Agreement is the entire agreement between You and OpenLegion regarding
+Contributions and supersedes any prior agreement on that subject. If any
+provision is held unenforceable, the remaining provisions remain in effect, and
+the unenforceable provision will be modified to the minimum extent necessary to
+make it enforceable.
+
+## 13. Acceptance
+
+Signing this CLA via the CLA Assistant bot, or otherwise indicating acceptance
+in writing, constitutes Your electronic signature and acceptance of this
+Agreement.
+
+---
+
+*Questions about this Agreement? Contact admin@openlegion.ai.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to OpenLegion.ai
+# Contributing to OpenLegion
 
 Thanks for wanting to contribute! Here's how to get started.
 
@@ -7,15 +7,27 @@ Thanks for wanting to contribute! Here's how to get started.
 1. **Fork** this repo and create a branch (`feat/`, `fix/`, etc.)
 2. Make your changes — keep them focused and well-scoped
 3. Open a pull request against `main`
-4. Our CLA bot will ask you to sign the [Contributor License Agreement](CLA.md) on your first PR (one-time, takes 30 seconds)
+4. On your first PR, our CLA bot will ask you to sign the
+   [Contributor License Agreement](CLA.md) (one-time, takes 30 seconds)
 5. CI runs, we review, and merge
+
+## Licensing of Contributions
+
+OpenLegion is source-available under the **PolyForm Perimeter License 1.0.1**
+(see [LICENSE](LICENSE)), maintained by **OpenLegion LLC**. By contributing, you
+agree to the [CLA](CLA.md): you keep ownership of your work and grant OpenLegion
+LLC the rights it needs to maintain the project under a single license and to
+offer commercial and managed-hosting editions.
 
 ## Code Standards
 
 - Follow existing architecture patterns
 - Include tests where appropriate
-- Do not introduce third-party code with incompatible licenses
+- Do not introduce third-party code with incompatible licenses. If a
+  contribution includes third-party material, identify its source and license in
+  the PR (see CLA §7).
 
 ## Security Issues
 
-Please report security issues privately to admin@openlegion.ai
+Please report security issues privately to admin@openlegion.ai. Do not open a
+public issue for security vulnerabilities.

--- a/LICENSE
+++ b/LICENSE
@@ -1,64 +1,110 @@
-# Business Source License 1.1
+# License
 
-Licensor: Yu-wen Jeffrey Tseng  
-Licensed Work: OpenLegion.ai (including this repository and all source code herein)  
-Change Date: January 1, 2030  
-Change License: Apache License 2.0  
+OpenLegion is source-available software, free to self-host, licensed by
+OpenLegion LLC under the **PolyForm Perimeter License 1.0.1**.
 
----
+Copyright © 2026 OpenLegion LLC. All rights reserved.
 
-## 1. Grant of Rights
+Required Notice: Copyright © 2026 OpenLegion LLC (https://openlegion.ai)
 
-Subject to the terms below, Licensor grants you a non-exclusive, worldwide, royalty-free license to:
+--------------------------------------------------------------------------------
+PLAIN-LANGUAGE SUMMARY — NON-BINDING
 
-- Use the Licensed Work
-- Copy the Licensed Work
-- Modify the Licensed Work
-- Create derivative works
-- Self-host and run the Licensed Work for internal, personal, or non-commercial purposes
+This summary is provided for convenience only. It is **not** part of the
+license and has **no legal effect**. If anything here conflicts with the
+license text below, the license text controls.
 
----
+  • You MAY: use, copy, modify, and self-host OpenLegion for any purpose —
+    including running it within your own organization for commercial,
+    internal operations — and distribute your modified versions, so long as
+    you keep the notices below.
 
-## 2. Commercial Restrictions
+  • You MAY NOT: provide OpenLegion to others as a product or service that
+    competes with OpenLegion — that is, anything that serves as a substitute
+    for the functionality or value of the software. This includes offering it
+    — modified or not — as a hosted, managed, or Software-as-a-Service (SaaS)
+    product, through any interface (service, library, or plug-in), on any
+    platform, in any programming language, and even free of charge.
 
-You may NOT, without explicit written permission from the Licensor:
+Need to offer OpenLegion as a hosted/managed service, or otherwise need
+rights beyond this license? A commercial license is available — contact
+admin@openlegion.ai.
 
-- Offer the Licensed Work as a hosted, managed, or Software-as-a-Service (SaaS) offering to third parties.
-- Provide a commercial product or service that competes with the Licensor’s commercial offerings using the Licensed Work.
-- Commercially sublicense, sell, rent, lease, or redistribute the Licensed Work.
-- Use the Licensed Work to provide paid AI infrastructure or platform services to third parties.
+"OpenLegion" and the OpenLegion logo are trademarks of OpenLegion LLC. This
+license grants no trademark rights. See TRADEMARK.md.
+--------------------------------------------------------------------------------
 
-Any use in violation of the above requires a separate commercial agreement with the Licensor.
+The full, controlling license text follows.
 
----
 
-## 3. Commercial Licensing
+# PolyForm Perimeter License 1.0.1
 
-To obtain a commercial license, contact:
+<https://polyformproject.org/licenses/perimeter/1.0.1>
 
-Yu-wen Jeffrey Tseng  
-admin@openlegion.ai
+## Acceptance
 
----
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
 
-## 4. Change Date
+## Copyright License
 
-On the Change Date specified above, this Licensed Work will automatically convert to the Change License (Apache License 2.0).
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
 
----
+## Distribution License
 
-## 5. Trademarks
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
 
-This License does not grant any rights to use the name “OpenLegion.ai”, associated logos, branding, or trademarks. All such rights are reserved by the Licensor.
+## Notices
 
----
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
 
-## 6. Disclaimer of Warranty
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
 
-THE LICENSED WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+## Changes and New Works License
 
----
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
 
-## 7. Limitation of Liability
+## Patent License
 
-IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM USE OF THE LICENSED WORK.
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing to others any product that competes with the software.
+
+## Competition
+
+If you use this software to market a product as a substitute for the functionality or value of the software, it competes with the software. A product may compete regardless how it is designed or deployed. For example, a product may compete even if it provides its functionality via any kind of interface (including services, libraries or plug-ins), even if it is ported to a different platform or programming language, and even if it is provided free of charge.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+A **product** can be a good or service, or a combination of them.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+OpenLegion
+Copyright © 2026 OpenLegion LLC. All rights reserved.
+
+Required Notice: Copyright © 2026 OpenLegion LLC (https://openlegion.ai)
+
+This software is licensed under the PolyForm Perimeter License 1.0.1.
+See the LICENSE file for the full terms.
+
+"OpenLegion" and the OpenLegion logo are trademarks of OpenLegion LLC.
+See TRADEMARK.md. The license does not grant any trademark rights.
+
+If you redistribute this software or any part of it, you must pass along a
+copy of the LICENSE (or its URL) and every line above that begins with
+"Required Notice:", as required by the license.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </h3>
 <div align="center">
    
-[![License: BSL 1.1](https://img.shields.io/badge/license-BSL%201.1-orange.svg)](LICENSE)
+[![License: PolyForm Perimeter 1.0.1](https://img.shields.io/badge/license-PolyForm%20Perimeter%201.0.1-orange.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
 [![Tests: 5800+](https://img.shields.io/badge/tests-5800%2B%20passing-brightgreen)](https://github.com/openlegion-ai/openlegion/actions/workflows/test.yml)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/mXNkjpDvvr)
@@ -61,7 +61,7 @@ https://github.com/user-attachments/assets/8bd3fe95-5734-474d-92f0-40616daf91ad
 
 OpenLegion is a **secure, self-hosted AI agent runtime** for running fleets of autonomous AI agents in production. Each agent runs in its own hardened Docker container (or microVM), with its own memory, tools, schedule, and budget. Agents never hold API keys - every LLM and API call routes through a central credential vault that also enforces per-agent spend limits. A trusted mesh host coordinates the fleet through shared state and pub/sub events, with permission ACLs checked on every cross-agent action.
 
-It is **source-available** under the Business Source License 1.1 (BSL): you can self-host it for free, read the entire ~77,000-line codebase, and audit it in a day. Managed hosting is available for teams that prefer not to run their own infrastructure. OpenLegion is built as a production- and team-focused **OpenClaw alternative** - it keeps the autonomy of single-user assistant frameworks and adds container isolation, credential vaulting, per-agent budgets, and auditable workflows.
+It is **source-available** under the PolyForm Perimeter License 1.0.1: you can self-host it for free — including for your own commercial, internal operations — read the entire ~77,000-line codebase, and audit it in a day. The one thing you can't do is offer it to others as a product or service that competes with OpenLegion (e.g. reselling it as your own hosted/managed service). Managed hosting is available from OpenLegion LLC for teams that prefer not to run their own infrastructure. OpenLegion is built as a production- and team-focused **OpenClaw alternative** - it keeps the autonomy of single-user assistant frameworks and adds container isolation, credential vaulting, per-agent budgets, and auditable workflows.
 
 In one line: **a multi-agent framework where security, isolation, and cost control are part of the architecture, not an afterthought.**
 
@@ -167,7 +167,7 @@ prompted.
 
 **5800+ tests passing** across 155 test files.
 **Fully auditable in a day.**
-No LangChain. No Redis. No Kubernetes. No CEO agent. BSL License.
+No LangChain. No Redis. No Kubernetes. No CEO agent. Source-available (PolyForm Perimeter).
 
 1. **Security by architecture** — every agent runs in an isolated Docker container
    (microVM when available). API keys live in the credential vault — agents call
@@ -1158,10 +1158,10 @@ config/
 OpenLegion is a secure, self-hosted AI agent runtime for running fleets of autonomous AI agents in isolated Docker containers. A central mesh host holds all credentials, enforces per-agent budgets and permission ACLs, and coordinates agents through shared state and pub/sub - so agents stay isolated, auditable, and cost-bounded.
 
 **Is OpenLegion open source?**
-OpenLegion is **source-available**, not open source. It is licensed under the Business Source License 1.1 (BSL): you can view, modify, and self-host the full codebase for free, but you cannot offer it as a competing hosted or SaaS product. The entire ~77,000-line `src/` tree is readable and auditable.
+OpenLegion is **source-available**, not open source. It is licensed by OpenLegion LLC under the PolyForm Perimeter License 1.0.1: you can view, modify, and self-host the full codebase for free — including for commercial, internal use — but you cannot provide it to others as a product or service that competes with OpenLegion (for example, reselling it as a hosted or SaaS product). The entire ~77,000-line `src/` tree is readable and auditable.
 
 **Can I self-host OpenLegion?**
-Yes. Self-hosting is the default and is free under the BSL. You need Python 3.10+, Docker, and at least one LLM provider key. See the [Quick Start](#quick-start) and the [full setup guide](QUICKSTART.md).
+Yes. Self-hosting is the default and is free under the license, including for your own commercial, internal use. You need Python 3.10+, Docker, and at least one LLM provider key. See the [Quick Start](#quick-start) and the [full setup guide](QUICKSTART.md).
 
 **Is OpenLegion a good OpenClaw alternative?**
 For production and team use, yes - it adds container/microVM isolation, a credential vault so agents never hold API keys, per-agent budget caps, and permission ACLs on top of autonomous agents. For a single-user assistant on one machine, OpenClaw or a lighter tool may be simpler. See [OpenLegion vs OpenClaw](#openlegion-vs-openclaw).
@@ -1179,19 +1179,26 @@ Defense-in-depth: per-agent Docker containers (or Docker Sandbox microVMs), a cr
 100+ providers via [LiteLLM](https://litellm.ai) (Anthropic, OpenAI, Gemini, Moonshot, DeepSeek, xAI, Groq, Minimax, Zai, Ollama, and more), with health-tracked failover across providers.
 
 **Does OpenLegion offer managed hosting?**
-Yes. Managed hosting is available for teams that prefer not to run their own infrastructure, while self-hosting stays free under the BSL.
+Yes. Managed hosting is available from OpenLegion LLC for teams that prefer not to run their own infrastructure, while self-hosting stays free under the license.
 
 ---
 
 ## License
 
-OpenLegion.ai is source-available under the Business Source License 1.1 (BSL).
+OpenLegion is source-available software, copyright © 2026 OpenLegion LLC,
+licensed under the **PolyForm Perimeter License 1.0.1**.
 
-You may view, modify, and self-host the software.
+You may view, modify, and self-host the software — including for your own
+commercial, internal use.
 
-You may NOT offer it as a competing hosted or SaaS product.
+You may NOT provide it to others as a product or service that competes with
+OpenLegion (for example, offering it as a hosted, managed, or SaaS product).
 
-See [LICENSE](LICENSE) for details.
+Need a commercial or hosting license? Contact admin@openlegion.ai.
+
+"OpenLegion" and the OpenLegion logo are trademarks of OpenLegion LLC; see
+[TRADEMARK.md](TRADEMARK.md). See [LICENSE](LICENSE) for the full terms and
+[CONTRIBUTING.md](CONTRIBUTING.md) / [CLA.md](CLA.md) to contribute.
 
 ---
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,43 @@
+# OpenLegion Trademark Policy
+
+"OpenLegion", the OpenLegion logo, and related names and marks (the "**Marks**")
+are trademarks of **OpenLegion LLC**. This policy explains how you may — and may
+not — use them.
+
+The source code is licensed under the PolyForm Perimeter License 1.0.1 (see
+[LICENSE](LICENSE)). **A copyright license to the code is not a license to the
+Marks.** Trademark rights are separate, and this policy governs them.
+
+## What you may do (no permission needed)
+
+- Use the Marks in plain text to refer truthfully to OpenLegion — for example,
+  "compatible with OpenLegion", "built on OpenLegion", or "runs OpenLegion."
+- State accurately that your self-hosted deployment runs OpenLegion.
+- Use the Marks in news, commentary, comparison, and other nominative or fair
+  use permitted by law.
+
+## What you need our written permission for
+
+- Using the Marks (or any confusingly similar name or logo) as, or as part of,
+  the name of your own product, service, company, domain, or app.
+- Using the Marks in a way that suggests OpenLegion LLC sponsors, endorses, or
+  is affiliated with your offering when it does not.
+- Using the Marks in connection with a hosted, managed, or other product or
+  service that competes with OpenLegion (which the license does not permit in any
+  event — see [LICENSE](LICENSE)).
+- Using the logo in a modified form, or in a way that implies an official
+  distribution.
+
+## Modified versions
+
+If you distribute a modified version of OpenLegion, you must not represent it as
+the official OpenLegion software, and you must not use the Marks in a way likely
+to cause confusion about its source. You must keep the copyright and
+"Required Notice:" lines required by the LICENSE.
+
+## Questions and permission requests
+
+For trademark permission or questions, contact admin@openlegion.ai.
+
+OpenLegion LLC reserves all rights in the Marks not expressly granted here, and
+may update this policy at any time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ name = "openlegion"
 version = "0.1.0"
 description = "A lean, container-isolated, memory-aware multi-agent runtime"
 requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "OpenLegion LLC", email = "admin@openlegion.ai" }]
 
 dependencies = [
     "fastapi>=0.115.0",


### PR DESCRIPTION
## What & why

Now that **OpenLegion LLC** is incorporated, this updates the entire licensing surface to (a) name the company as licensor/copyright holder and (b) adopt a license that fits our business model: **free self-hosting (including internal commercial use), but no competing/resale** — so managed hosting stays our revenue. Posture matches CockroachDB CSL / n8n (perpetual, no open-source conversion).

## Changes

- **LICENSE** — The old file was labeled "Business Source License 1.1" but was a *hand-written paraphrase*, not the real MariaDB BSL text (legally shaky + misleading badge). Replaced with the **verbatim PolyForm Perimeter License 1.0.1** (lawyer-drafted), preceded by a clearly-marked **non-binding** plain-language summary and the required copyright notice. Licensor → OpenLegion LLC.
- **CLA.md** — Re-pointed grant from the individual founder → **OpenLegion LLC**; dropped obsolete "future corporate entity" language; added entity/corporate-contributor handling, defensive patent termination, moral-rights waiver, third-party-material disclosure, inbound=outbound, and **Wyoming** governing law/venue. Kept the broad relicensing grant (needed to sell commercial/hosting editions).
- **NOTICE** (new) — carries the PolyForm `Required Notice:` line redistributors must preserve.
- **TRADEMARK.md** (new) — brand-protection policy; a code license is not a trademark license.
- **CONTRIBUTING.md / README.md / pyproject.toml** — aligned license name, entity, badge, and contact; clarified internal commercial self-hosting is allowed, only competing/resale is not.

## Follow-ups (not code — flagged for the team)

- [ ] **Founder → OpenLegion LLC IP assignment** (separate signed doc; a repo file can't transfer pre-incorporation copyright). Most important gap.
- [ ] Point the **CLA Assistant bot** at the new `CLA.md`.
- [ ] Final review by counsel before relying on these.

> Not legal advice; drafted as standards-based documents (PolyForm Perimeter is reproduced verbatim from the canonical source).