### PR TITLE
docs(license): add COMMERCIAL.md commercial/hosting license guide

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,57 @@
+# Commercial & Managed-Hosting Licensing
+
+OpenLegion is source-available under the **PolyForm Perimeter License 1.0.1**
+(see [LICENSE](LICENSE)), published by **OpenLegion LLC**. Self-hosting is free
+for almost everything — including running OpenLegion inside your own
+organization for commercial, internal operations.
+
+This page is **not** a license. It explains when you need terms beyond the
+LICENSE, and how to get them. The [LICENSE](LICENSE) always controls.
+
+## You do NOT need a commercial license to
+
+- Self-host OpenLegion for your own use — including for-profit, internal
+  business operations.
+- Modify the source and run your modified version internally.
+- Distribute your modified version, as long as you keep the required notices
+  and don't use it to compete with OpenLegion.
+- Build on top of OpenLegion, integrate it, and operate it on your own
+  infrastructure.
+
+## You DO need a commercial license to
+
+- Offer OpenLegion to others as a **hosted, managed, or Software-as-a-Service
+  (SaaS)** product.
+- Provide any product or service that **competes with OpenLegion** — i.e. that
+  serves as a substitute for the functionality or value of the software —
+  through any interface (service, library, or plug-in), on any platform, in any
+  language, even free of charge.
+- Embed or redistribute OpenLegion inside a commercial product where the
+  license's noncompete terms would otherwise apply.
+- Obtain terms the LICENSE does not grant (e.g. a warranty, indemnity, support
+  commitment, or removal of the noncompete restriction).
+
+If you're unsure whether your use case is permitted, ask us — we're happy to
+clarify in writing.
+
+## What's available
+
+- **Commercial license** — written terms from OpenLegion LLC for uses the
+  PolyForm Perimeter License does not permit (including hosting/SaaS resale and
+  OEM/embedding).
+- **Managed hosting** — OpenLegion LLC operates OpenLegion for you, so you don't
+  have to run your own infrastructure.
+
+## How to get one
+
+Email **admin@openlegion.ai**. To help us respond quickly, please include:
+
+- Your company and a brief description of the intended use.
+- Whether you need a commercial license, managed hosting, or both.
+- Expected scale (e.g. number of agents, teams, end users, or deployments).
+- Any specific terms you require (support, SLA, indemnity, etc.).
+
+## Trademarks
+
+A commercial license to the code does not grant rights to the "OpenLegion" name
+or logo. See [TRADEMARK.md](TRADEMARK.md).

--- a/README.md
+++ b/README.md
@@ -1194,7 +1194,8 @@ commercial, internal use.
 You may NOT provide it to others as a product or service that competes with
 OpenLegion (for example, offering it as a hosted, managed, or SaaS product).
 
-Need a commercial or hosting license? Contact admin@openlegion.ai.
+Need a commercial or hosting license? See [COMMERCIAL.md](COMMERCIAL.md) or
+contact admin@openlegion.ai.
 
 "OpenLegion" and the OpenLegion logo are trademarks of OpenLegion LLC; see
 [TRADEMARK.md](TRADEMARK.md). See [LICENSE](LICENSE) for the full terms and


### PR DESCRIPTION
Companion to the PolyForm Perimeter relicense (#1046).

Adds **COMMERCIAL.md** — a plain-language guide explaining:
- What you can do for free under the source-available LICENSE (incl. internal commercial self-hosting)
- When you need terms beyond it (offering OpenLegion as a hosted/managed/SaaS product, or otherwise competing)
- What OpenLegion LLC offers (commercial license + managed hosting)
- How to inquire (admin@openlegion.ai)

It is **not** a license — `LICENSE` controls. Linked from the README License section for discoverability.