### PR TITLE
docs: align docs + README with code (accuracy audit 2026-06)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ OpenLegion was designed from day one assuming agents will be compromised.
 | **Cost controls** | None | Per-agent daily + monthly budget caps |
 | **Multi-agent routing** | LLM CEO agent | Fleet model — blackboard + pub/sub coordination |
 | **LLM providers** | Broad | 100+ via LiteLLM with health-tracked failover |
-| **Test coverage** | Minimal | 5800+ tests across 155 test files including full Docker E2E |
+| **Test coverage** | Minimal | 5800+ tests across 193 test files including full Docker E2E |
 | **Codebase size** | 430,000+ lines | ~77,000 lines in `src/` — still auditable in a day |
 
 ---
@@ -165,7 +165,7 @@ Chat with your agent fleet via **Telegram**, **Discord**, **Slack**, **WhatsApp*
 via cron schedules, webhooks, and heartbeat monitoring — without being
 prompted.
 
-**5800+ tests passing** across 155 test files.
+**5800+ tests passing** across 193 test files.
 **Fully auditable in a day.**
 No LangChain. No Redis. No Kubernetes. No CEO agent. Source-available (PolyForm Perimeter).
 
@@ -710,14 +710,14 @@ openlegion [--verbose/-v] [--quiet/-q] [--json]
 ├── status [--port PORT] [--wide/-w] [--watch N] [--json]  # Show agent status
 ├── teams [--port PORT] [--json]                           # List active teams (alias: ``projects``)
 ├── team <team_id> [--port PORT] [--json]                  # Show one team (members, blockers, task counts) (alias: ``project``)
-├── tasks [--agent X] [--team Y | --project Y] [--status S] [--port PORT] [--json]   # List durable task records
+├── tasks [--agent X] [--team Y] [--status S] [--port PORT] [--json]   # List durable task records
 ├── pending [--port PORT] [--json]                         # List pending actions awaiting confirmation
 ├── confirm <nonce> [--port PORT]                          # Confirm a pending action
 ├── cancel <nonce> [--port PORT]                           # Cancel a pending action
 ├── reset [-y]                                             # DESTRUCTIVE: stop everything and wipe config/, data/, agent_tools/* (keeps .env)
 ├── version [--verbose/-v]                                 # Show version and environment info
 └── wallet                                                 # Manage agent wallets (derives EVM + Solana from one master seed)
-    ├── init                                               # Generate the master wallet seed (shown once; HTTP 410 thereafter)
+    ├── init                                               # Generate the master wallet seed (shown once; refuses to regenerate while ``OPENLEGION_SYSTEM_WALLET_MASTER_SEED`` is set)
     └── show [agent_id]                                    # Show wallet addresses
 ```
 
@@ -988,7 +988,7 @@ pytest tests/
 
 ### Test Coverage
 
-Roughly **5800+ test cases across 155 test files** (`find tests -name '*.py' | xargs grep -c '^def test_'`). Coverage includes every module under `src/` — `tests/test_FOO.py` maps to `src/.../FOO.py` (see CLAUDE.md for the full mapping). The four `tests/test_e2e*.py` files require Docker and a real LLM key; everything else runs in CI in under a few minutes per shard.
+Roughly **5800+ test cases across 193 test files** (`find tests -name '*.py' | xargs grep -c '^def test_'`). Coverage includes every module under `src/` — `tests/test_FOO.py` maps to `src/.../FOO.py` (see CLAUDE.md for the full mapping). The four `tests/test_e2e*.py` files require Docker and a real LLM key; everything else runs in CI in under a few minutes per shard.
 
 ---
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -12,7 +12,7 @@ Agents interact with their environment through **tools** -- Python functions reg
 
 ### File Operations
 
-All file operations are scoped to `/data` inside the container. Path traversal is blocked (two-stage: reject `..` then resolve symlinks via `lstat()`). `_MAX_READ=500_000`, `_MAX_LIST_ENTRIES=500`. Direct writes to `SOUL.md` / `AGENTS.md` / `INSTRUCTIONS.md` / `HEARTBEAT.md` / `USER.md` / `MEMORY.md` / `INTERFACE.md` are blocked — use `update_workspace`.
+All file operations are scoped to `/data` inside the container. Path traversal is blocked (two-stage: reject `..` then resolve symlinks via `lstat()`). `_MAX_READ=500_000`, `_MAX_LIST_ENTRIES=500`. Direct writes to `SOUL.md` / `AGENTS.md` / `INSTRUCTIONS.md` / `HEARTBEAT.md` / `USER.md` / `MEMORY.md` are blocked — use `update_workspace`.
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
@@ -102,7 +102,7 @@ An OS-level device profile is selected by `BROWSER_DEVICE_PROFILE` (`desktop-win
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, `INTERFACE.md`, `GOALS.md`, or `GOALS.json`) to persist learnings across sessions |
+| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, or `INTERFACE.md`) to persist learnings across sessions |
 
 ### Scheduling & Automation
 
@@ -169,7 +169,7 @@ Agents can interact with EVM and Solana blockchains through the wallet signing s
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `get_system_status` | `section` (default "all"; values: `permissions` / `budget` / `fleet` / `cron` / `health` / `all`) | Query live runtime state |
+| `get_system_status` | `section` (default "all"; values: `permissions` / `budget` / `fleet` / `cron` / `health` / `llm` / `all`) | Query live runtime state |
 
 Agents receive system awareness through three layers:
 
@@ -177,7 +177,7 @@ Agents receive system awareness through three layers:
 2. **Runtime Context** — A compact block injected into the system prompt on each turn (5-minute cache). Shows live budget numbers, permission patterns, fleet roster, and cron schedule.
 3. **`get_system_status` tool** — On-demand access to fresh data when agents need exact numbers mid-conversation.
 
-The `section` parameter accepts: `permissions`, `budget`, `fleet`, `cron`, `health`, or `all` (default). Fleet data is filtered by `can_message` permissions — agents only see teammates they can interact with.
+The `section` parameter accepts: `permissions`, `budget`, `fleet`, `cron`, `health`, `llm` (LLM provider availability), or `all` (default). Fleet data is filtered by `can_message` permissions — agents only see teammates they can interact with.
 
 ### Multi-Agent Coordination
 
@@ -220,22 +220,31 @@ stale LLM prompt fails fast and retries on the canonical name.
 | Tool | Parameters | Description |
 |------|-----------|-------------|
 | `inspect_agents` | `agent_id` (default ""), `depth` (default `"summary"`; values: `summary` / `profile` / `history`), `stale_threshold_hours` (default 0, range 1–168; 0/None = skip) | Look up agents. Empty `agent_id` lists the fleet at `summary` depth; passing an `agent_id` with `profile` returns the collaboration interface, or with `history` returns recent conversation history. Pass `stale_threshold_hours=N` to annotate each roster entry with `stale_task_count` + up to 5 oldest stale task IDs. Replaces `list_agents` / `get_agent_profile` / `read_agent_history` for the operator. |
+| `read_agent_config` | `agent_id`, `fields` (optional list) | Read an agent's current config — symmetric inverse of `edit_agent`. Returns the same fields `edit_agent` can change so you can review current values before/after a tweak. |
+| `read_user_notifications` | `hours` (default 24), `limit` (default 50) | Read recent notifications agents pushed to the human user's chat via `notify_user`. Observational/diagnostic only. |
+| `list_peer_artifacts` | `agent_id` | List a teammate's artifact files (those written via `save_artifact`). Operator-only read path. |
+| `read_peer_artifact` | `agent_id`, `name` | Read a single artifact file written by a teammate. Use after `list_peer_artifacts`. |
+| `list_available_models` | `provider` (optional) | List models currently usable given the active credential setup. Call before `edit_agent` / `create_agent` to avoid OAuth-allowlist rejections. |
+| `workflow_snapshot` | `root_task_id` | Read a workflow chain snapshot for a multi-stage handoff. Pass the kickoff task_id; returns every descendant stage with status (and `blocker_note`). |
+| `await_task_event` | `task_id`, `timeout_s`, `poll_interval_s` (default 3) | Block until a task reaches a terminal status (`done` / `failed` / `blocked` / `cancelled`) or the timeout elapses. Polls the operator's back-edge inbox. |
 | `inspect_teams` | `detail` (default `"names"`; values: `names` / `status` / `full`), `team_name` (default "") | Look up teams. With no `team_name`, `names` returns name+description, `status` returns task-count rollups. Passing a `team_name` returns the full record. |
 | `manage_team` | `action` (enum: `archive` / `unarchive` / `propose_delete`), `team_name` | Lifecycle for a team. `propose_delete` requires the team to already be archived (returns a confirmation nonce). |
 | `manage_agent` | `agent_id`, `action` (enum: `archive` / `delete`) | Lifecycle for an agent. Same archive-then-delete contract as `manage_team`. Replaces `archive_agent` / `delete_agent`. |
 | `manage_task` | `task_id`, `action` (enum: `cancel` / `reroute` / `retry`), `new_assignee` (default "", required for `reroute`, optional override for `retry`), `reason` (default ""), `with_changes` (default {}, `retry` only — optional override for assignee/title/description) | Single entry point for task ops. Reroute and retry refuse if the target agent is over budget. `reason` is recorded on the audit trail. Replaces `cancel_task` / `reroute_task` / `retry_failed_task`. |
 | `edit_agent` | `agent_id`, `field` (enum: `instructions` / `soul` / `role` / `heartbeat` / `heartbeat_schedule` / `interface` / `model` / `thinking` / `budget` / `permissions`), `value`, `reason` (default `"user_asked"`; values: `user_asked` / `operator_proactive`) | Single entry point for agent config changes. ALL fields apply immediately and emit an undo receipt — soft fields (`instructions`, `soul`, `role`, `heartbeat`, `heartbeat_schedule`, `interface`) carry a 5-minute Undo window; hard fields (`model`, `thinking`, `budget`, `permissions`) carry a 30-minute Undo window. No pre-execution confirm step. `heartbeat_schedule` also retargets the live cron job in lockstep with the YAML write. |
 | `undo_change` | `undo_token` | Reverse an edit applied via `edit_agent`. Token is returned with the edit and remains valid for 5 minutes (soft fields) or 30 minutes (hard fields); 404 if expired or already undone. |
-| `confirm_edit` | `change_id` | Deprecated no-op stub. The `/edit-soft` immediate-apply refactor retired the propose-then-confirm flow; `confirm_edit` returns a friendly hint and is retained only so in-flight LLM conversations that still emit it don't error. New conversations should call `edit_agent` directly. |
 | `create_agent` | `name` (lowercase, alphanumeric + hyphens, 1–32 chars), `role`, `model` (default ""), `instructions`, `soul` (default "") | Create a new custom agent. Requires user confirmation. |
 | `create_team` | `name`, `description`, `agent_ids` (default []) | Create a new team and optionally assign agents. Requires user confirmation. |
 | `add_agents_to_team` | `team_name`, `agent_ids` | Add one or more agents to a team. Requires user confirmation. |
 | `remove_agents_from_team` | `team_name`, `agent_ids` | Remove one or more agents from a team. Requires user confirmation. |
 | `update_team_context` | `team_name`, `context` | Update the shared `TEAM.md` context for a team. |
 | `set_team_goal` | `team_name`, `north_star`, `success_criteria` (default []) | Save the team's vision (≤2000 chars) and up to 10 success criteria (each ≤200 chars). Rendered prominently on every team card in the Board tab. Pass empty values to clear. No confirmation required — call proactively whenever the user describes a team goal. |
-| `list_agent_queue` | `agent_id`, `limit` (default 10, max 100) | Read an agent's task queue: current and recent tasks grouped by status (`active` / `blocked` / `done` / `failed` / `cancelled`), up to `limit` rows per bucket. Requires `OPENLEGION_ORCHESTRATION_TASKS_V2=1`. |
+| `list_agent_queue` | `agent_id`, `limit` (default 10, max 100) | Read an agent's task queue: current and recent tasks grouped by status (`active` / `blocked` / `done` / `failed` / `cancelled`), up to `limit` rows per bucket. |
 | `get_team_outputs` | `team_id` (alias `project_id` accepted), `since` (default ""; ISO timestamp or duration like `"24h"`/`"7d"`) | Completed task artifacts for a team in a time window. Default window is the last 7 days. |
-| `summarize_team_progress` (alias `summarize_project_progress`) | `team_id` (alias `project_id` accepted) | Synthesized status summary for a team: structured counts + narrative `status_text` + top blockers + recent completions + `ask_for_user` list. |
+| `summarize_team_progress` | `team_id` (alias `project_id` accepted) | Synthesized status summary for a team: structured counts + narrative `status_text` + top blockers + recent completions + `ask_for_user` list. |
+| `compose_work_summary` | `scope_kind` (default `"team"`; `team` / `solo`), `scope_id` (default ""), `period_hours` (default 24) | Compose and persist a work summary (the Work tab's default landing surface) from recent task activity: narrative + metrics + highlights. |
+| `manage_goals` | `action` (e.g. `set` / `add` / `update` / `remove`), `goals`, `goal`, `name`, `team_names` | Manage tracked business goals shown on the user's Work tab. Source of truth is `GOALS.json` (rendered to `GOALS.md` for humans). |
+| `rate_delivery` | `task_id`, `outcome`, `feedback` (default "") | Record an outcome rating on a completed task. Operator's per-task judgment — drives the agent-feedback loop (memory writes + auto-rework spawn). |
 | `list_pending` | -- | List every non-expired pending action awaiting user confirmation. Returns nonce, action_kind, target_kind, target_id, expires_at, actor and summary per row. Use to find the nonce for `cancel_pending_action` or to surface waiting items to the user. |
 | `cancel_pending_action` | `nonce` | Cancel a pending action by nonce so it can no longer be confirmed. Use to clean up stale or incorrect proposals. Pair with `list_pending` to find the nonce. |
 | `archive_audit_before` | `before_date` (ISO 8601 date or timestamp) | Archive operator audit entries older than the given date. Rows are removed from the active audit-log view but preserved in the archived store (recoverable via `include_archived=true`). Returns the count of rows archived. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,11 +46,11 @@ OpenLegion uses a **fleet model, not hierarchy**. There is no CEO agent that rou
 
 - **Blackboard** — shared SQLite-backed key-value state (WAL, CAS via `write_if_version`, audit-log with undo/archive). Lives in `src/host/mesh.py`.
 - **PubSub** — event-driven notifications between agents (`src/host/mesh.py:PubSub`).
-- **Coordination protocol** — `hand_off`, `check_inbox`, `update_status`, `complete_task` in `src/agent/builtins/coordination_tool.py`. Behind the `OPENLEGION_ORCHESTRATION_TASKS_V2` flag, hand-offs become durable task records routed via `LaneManager`; the legacy v1 path uses blackboard `tasks/{agent}/{handoff_id}` keys.
+- **Coordination protocol** — `hand_off`, `check_inbox`, `update_status`, `complete_task` in `src/agent/builtins/coordination_tool.py`. Hand-offs are always durable SQLite task records routed via `LaneManager`; the legacy blackboard `tasks/{agent}/{handoff_id}` path was removed in PR #835.
 
 ### Operator agent
 
-A reserved agent named `operator` is auto-created at startup (`_ensure_operator_agent` in `src/cli/runtime.py`). It runs at lower resource caps (128MB RAM, 0.05 CPU) and carries fleet-management tools (`fleet_tool.py`, `operator_tools.py`). The operator is the only agent that can apply fleet templates, archive teams, or confirm hard config edits.
+A reserved agent named `operator` is auto-created at startup (`_ensure_operator_agent` is defined in `src/cli/config.py` and called from `src/cli/runtime.py`). It runs at lower resource caps (128MB RAM, 0.05 CPU) and carries fleet-management tools (`fleet_tool.py`, `operator_tools.py`). The operator is the only agent that can apply fleet templates, archive teams, or confirm hard config edits.
 
 ### Reserved agent IDs
 
@@ -69,7 +69,7 @@ The mesh host runs on the user's machine as a single FastAPI process. It is the 
 | Module | Responsibility |
 |--------|---------------|
 | `mesh.py` | Blackboard (SQLite WAL, atomic CAS, audit log with undo/archive), PubSub, MessageRouter (with cross-team block + capability-based addressing) |
-| `server.py` | FastAPI app factory — 109 `@app.*` endpoints, all permission-checked. Three auth tiers (any-auth / operator-or-internal / loopback). |
+| `server.py` | FastAPI app factory — 117 `@app.*` endpoints, all permission-checked. Three auth tiers (any-auth / operator-or-internal / loopback). |
 | `runtime.py` | `RuntimeBackend` ABC → `DockerBackend` / `SandboxBackend`; the browser-service container lives here too. SandboxBackend falls back to DockerBackend on init failure. |
 | `transport.py` | `Transport` ABC → `HttpTransport` / `SandboxTransport` |
 | `credentials.py` | Two-tier credential vault (`OPENLEGION_SYSTEM_*` / `OPENLEGION_CRED_*`) + LLM API proxy. OpenAI / Anthropic OAuth support. |
@@ -89,7 +89,7 @@ The mesh host runs on the user's machine as a single FastAPI process. It is the 
 
 ### Agent (`src/agent/`)
 
-Each agent runs in an isolated Docker container with its own FastAPI server (28 endpoints).
+Each agent runs in an isolated Docker container with its own FastAPI server (29 endpoints).
 
 | Module | Responsibility |
 |--------|---------------|
@@ -98,7 +98,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server (28 
 | `tools.py` | Tool discovery and registry; `@tool` decorator system. |
 | `mcp_client.py` | MCP server lifecycle management and tool routing. |
 | `memory.py` | SQLite + sqlite-vec + FTS5 hierarchical memory (`EMBEDDING_DIM=1536`, weighted 0.7 vector / 0.3 keyword with salience decay). |
-| `workspace.py` | Persistent markdown workspace. Scaffold files (`_SCAFFOLD_FILES`): `INSTRUCTIONS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, `HEARTBEAT.md`, `INTERFACE.md`. `TEAM.md` / `SYSTEM.md` are read-only bootstrap inclusions, not writable scaffolds. (Pre-rename `PROJECT.md` files are migrated to `TEAM.md` once at startup by `team_migration.py`; the bootstrap loader itself reads only `TEAM.md`/`team.md`.) |
+| `workspace.py` | Persistent markdown workspace. Scaffold files (`_SCAFFOLD_FILES`): `INSTRUCTIONS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, `INTERFACE.md`. `HEARTBEAT.md` is intentionally NOT bootstrapped — it is created lazily on first write. `TEAM.md` / `SYSTEM.md` are read-only bootstrap inclusions, not writable scaffolds. (Pre-rename `PROJECT.md` files are migrated to `TEAM.md` once at startup by `team_migration.py`; the bootstrap loader itself reads only `TEAM.md`/`team.md`.) |
 | `context.py` | Context window management. Flush facts at 60%, summarize-and-replace at 70%, warn at 80%. Empty summary falls back to hard prune. Write-then-compact flushes facts to `MEMORY.md` before discarding context. |
 | `llm.py` | LLM client (`chat_stream()` and `chat()`) — routes through mesh proxy, never holds keys. |
 | `mesh_client.py` | HTTP client for agent-to-mesh communication; merges `origin_header()` into `wake_agent` / `create_task`. |
@@ -113,10 +113,10 @@ Each agent runs in an isolated Docker container with its own FastAPI server (28 
 | `exec_tool.py` | Shell execution scoped to `/data` (`_MAX_TIMEOUT=300`). |
 | `file_tool.py` | File I/O with two-stage path traversal protection (`..` rejected lexically, then walked with `is_symlink` checks). |
 | `http_tool.py` | HTTP requests with `$CRED{}` handle substitution and SSRF protection (DNS pinning, IP blocking incl. CGNAT/6to4/Teredo). |
-| `browser_tool.py` | Browser automation via per-agent Camoufox (24 `@tool` tools — navigation, interaction, inspection, file transfer, CAPTCHA + handoff). |
+| `browser_tool.py` | Browser automation via per-agent Camoufox (25 `@tool` tools — navigation, interaction, inspection, file transfer, CAPTCHA + handoff). |
 | `mesh_tool.py` | Blackboard (with `sanitize_for_prompt()`), PubSub, `notify_user`, `list_agents`, artifacts, cron, spawn. |
 | `memory_tool.py` | Memory search with hierarchical fallback, memory save. |
-| `coordination_tool.py` | `hand_off`, `check_inbox`, `update_status`, `complete_task`. Origin-propagating; legacy v1 path uses blackboard, V2 path uses durable task records. |
+| `coordination_tool.py` | `hand_off`, `check_inbox`, `update_status`, `complete_task`. Origin-propagating; always writes durable SQLite task records (the legacy blackboard path was removed in PR #835). |
 | `vault_tool.py` | Credential generation without returning actual values. |
 | `web_search_tool.py` | DuckDuckGo search (no API key needed). |
 | `image_gen_tool.py` | Image generation via Gemini or OpenAI DALL-E 3 (routed through the mesh proxy with fixed-price cost tracking). |
@@ -124,7 +124,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server (28 
 | `introspect_tool.py` | Runtime state query — permissions, budget, fleet, cron, health. |
 | `tool_authoring.py` | Self-authoring with AST validation. Forbidden imports/calls/attrs prevent `eval`, `exec`, `open`, `__subclasses__`, etc. |
 | `fleet_tool.py` | Operator-only fleet management — `list_templates`, `apply_template` (per-slot creation, not atomic across slots). |
-| `operator_tools.py` | Operator-only orchestration — `edit_agent` (single tool; all fields apply immediately and emit an undo receipt: 5-min for soft fields, 30-min for hard fields), `undo_change`, deprecated `confirm_edit` no-op stub (kept for in-flight LLM conversations), `inspect_agents`, `inspect_teams` (alias `inspect_projects`), team/agent CRUD via `create_team` / `add_agents_to_team` / … (legacy `*_project` names still callable). |
+| `operator_tools.py` | Operator-only orchestration — `edit_agent` (single tool; all fields apply immediately and emit an undo receipt: 5-min for soft fields, 30-min for hard fields), `undo_change`, `inspect_agents`, `inspect_teams`, team/agent CRUD via `create_team` / `add_agents_to_team` / … (legacy `*_project` names still callable). |
 | `wallet_tool.py` | Wallet operations — get address, get balance, read contract, transfer, execute (Ethereum + Solana). |
 
 ### Browser Service (`src/browser/`)
@@ -151,7 +151,7 @@ The browser service runs in a separate container with `cap_drop=ALL` plus `cap_a
 
 ### Browser Container Resources
 
-Resources scale with the `OPENLEGION_MAX_AGENTS` environment variable (`src/host/runtime.py:386-392`). **The number of concurrent browser sessions is gated separately by `OPENLEGION_BROWSER_MAX_CONCURRENT` (legacy alias `MAX_BROWSERS`) resolved in `src/browser/__main__.py` — default 5, clamped to `[1, 64]`, startup-only.**
+Resources scale with the `OPENLEGION_MAX_AGENTS` environment variable (`src/host/runtime.py:578-599`). **The number of concurrent browser sessions is gated separately by `OPENLEGION_BROWSER_MAX_CONCURRENT` (legacy alias `MAX_BROWSERS`) resolved in `src/browser/__main__.py` — default = memory-derived autodetect (`_autodetect_default_max_browsers` / `_max_from_memory`), clamped to `[1, 64]`, startup-only.**
 
 | Tier | `OPENLEGION_MAX_AGENTS` | RAM | SHM | CPU | Max Browsers |
 |------|------------------------|-----|-----|-----|-------------|
@@ -178,7 +178,7 @@ Alpine.js SPA + Tailwind via CDN (no build step) with Jinja `autoescape=True` an
 
 | Module | Purpose |
 |--------|---------|
-| `server.py` | Dashboard FastAPI router with 143 API endpoints + VNC URL injection. Top-nav tabs: Chat / Team / Board / Settings (internal IDs `chat` / `fleet` / `workplace` / `system` — frozen for URL stability). |
+| `server.py` | Dashboard FastAPI router with 160 API endpoints + VNC URL injection. Top-nav tabs: Chat / Teams / Work / Settings (internal IDs `chat` / `fleet` / `workplace` / `system` — frozen for URL stability). |
 | `events.py` | `EventBus` for real-time WebSocket streaming on `/ws/events` (mounted on the mesh app, not the dashboard router). |
 | `auth.py` | Session cookie verification — HMAC-SHA256 over `{expiry}.{signature}`, 24h max lifetime, 5-min skew tolerance. |
 | `notifications.py` | Persistent notifications store (SQLite WAL) — backs the top-nav bell. |
@@ -206,7 +206,7 @@ The SSO callback (`/__auth/callback`) is **not implemented in this repo** — it
 
 | Module | Purpose |
 |--------|---------|
-| `types.py` | **THE contract** — all Pydantic models shared between host and agents (369 lines, 24 models). Holds `RESERVED_AGENT_IDS`, `HARD_EDIT_FIELDS` / `SOFT_EDIT_FIELDS`, and the `DashboardEvent.type` Literal enumerating 50 WebSocket event names. |
+| `types.py` | **THE contract** — all Pydantic models shared between host and agents (853 lines, 27 models). Holds `RESERVED_AGENT_IDS`, `HARD_EDIT_FIELDS` / `SOFT_EDIT_FIELDS`, and the `DashboardEvent.type` Literal enumerating 53 WebSocket event names. |
 | `utils.py` | ID generation, structured logging, prompt injection sanitization (`sanitize_for_prompt()`). |
 | `trace.py` | Distributed trace context propagation, `origin_header()` helper. |
 | `models.py` | Model cost and context window registry (backed by LiteLLM). |
@@ -247,7 +247,7 @@ through PR 2 of the project→team rename.)
 - **Blackboard scoping**: The `MeshClient` auto-prefixes all blackboard keys with `projects/{name}/`. An agent writing to `tasks/research_01` on the "sales" team actually writes to `projects/sales/tasks/research_01`. Agents see natural keys — the prefix is stripped on read. This is enforced at both the client (auto-namespacing) and server (permission matrix) layers.
 - **Agent visibility**: `list_agents` returns only team peers for team agents, or only the agent itself for solo agents.
 - **TEAM.md**: Only team members receive a `TEAM.md` mounted read-only into their container at `/app/TEAM.md`. Solo agents get none. (Pre-rename `PROJECT.md` files are migrated to `TEAM.md` once at startup by `team_migration.py`; the bootstrap loader reads only `TEAM.md`/`team.md`.)
-- **Permission management on agent create**: `POST /mesh/agents/create` writes defaults of `blackboard_read=["*"]`, `blackboard_write=["tasks/*","context/*","status/*","output/*","artifacts/*"]`, `can_publish=["*"]`, `can_subscribe=["*"]` (`src/host/server.py:2958-2965`). The effective per-team scope comes from the MeshClient's auto-prefix at runtime, not from the on-disk permission file.
+- **Permission management on agent create**: `POST /mesh/agents/create` writes defaults of `blackboard_read=["*"]`, `blackboard_write=["tasks/*","context/*","status/*","output/*","artifacts/*"]`, `can_publish=["*"]`, `can_subscribe=["*"]` (`src/host/server.py:4020-4021`). The effective per-team scope comes from the MeshClient's auto-prefix at runtime, not from the on-disk permission file.
 - **Remove from team**: When an agent is removed from a team, `blackboard_read` and `blackboard_write` are cleared to `[]`.
 - **Solo agents**: Agents not assigned to any team have no scoped blackboard prefix, see only themselves in `list_agents`, and receive no `TEAM.md`.
 - **Cross-team blackboard counter**: `_blackboard_xproject_count` is a process-lifetime observability counter (no enforcement) surfaced on `/mesh/system/metrics` as `blackboard_cross_project_total`.
@@ -284,7 +284,7 @@ The CLI REPL and dashboard chat both call agent endpoints directly. The mesh rou
 
 ### WebSocket events
 
-The dashboard receives real-time state via `/ws/events` (mounted on the mesh app at `src/host/server.py:6996`). `DashboardEvent.type` is a `Literal` of 50 event names in `src/shared/types.py` — the regex-sweep guard `test_every_emit_string_in_src_matches_a_dashboard_event_literal` prevents silent drops.
+The dashboard receives real-time state via `/ws/events` (mounted on the mesh app at `src/host/server.py:9571`). `DashboardEvent.type` is a `Literal` of 53 event names in `src/shared/types.py` — the regex-sweep guard `test_every_emit_string_in_src_matches_a_dashboard_event_literal` prevents silent drops.
 
 ## Runtime Backends
 
@@ -293,7 +293,7 @@ The dashboard receives real-time state via `/ws/events` (mounted on the mesh app
 | `DockerBackend` | Container (shared kernel) | Any Docker install |
 | `SandboxBackend` | MicroVM (own kernel) | Docker Desktop 4.58+ |
 
-Both implement `RuntimeBackend` ABC so the rest of the system is isolation-agnostic. The backend is selected at startup via `--sandbox`; if `SandboxBackend` init raises `subprocess.TimeoutExpired` or `RuntimeError`, `RuntimeContext.start()` falls back to `DockerBackend` (`src/cli/runtime.py:433-461`).
+Both implement `RuntimeBackend` ABC so the rest of the system is isolation-agnostic. The backend is selected at startup via `--sandbox`; if `SandboxBackend` init raises `subprocess.TimeoutExpired` or `RuntimeError`, `RuntimeContext.start()` falls back to `DockerBackend` (`src/cli/runtime.py:544-560`).
 
 Dockerfiles live at the repo root: `Dockerfile.agent` (python:3.12-slim, non-root UID 1000, `ENTRYPOINT ["tini","--"]`) and `Dockerfile.browser` (Firefox + Camoufox + Xvnc + Openbox + unclutter stack; root entrypoint that installs iptables then drops to UID 1000 via gosu).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,16 +251,21 @@ OPENLEGION_CRED_SLACK_BOT_TOKEN=xoxb-...
 OPENLEGION_CRED_SLACK_APP_TOKEN=xapp-...
 OPENLEGION_CRED_WHATSAPP_ACCESS_TOKEN=EAAx...
 OPENLEGION_CRED_WHATSAPP_PHONE_NUMBER_ID=1234...
-# Required for WhatsApp inbound webhook signature verification (X-Hub-Signature-256).
-# Without it, signature verification is skipped with a WARNING.
+# WhatsApp webhook-subscription handshake token (hub.verify_token). Echoed back
+# during the GET webhook verification handshake; NOT used for message signing.
 OPENLEGION_CRED_WHATSAPP_VERIFY_TOKEN=...
+# Meta app secret — env-only (read directly from the process environment, no
+# SYSTEM/CRED tiering). Gates inbound webhook X-Hub-Signature-256 verification.
+# Production-required: when MESH_AUTH_TOKEN is set but this is unset the WhatsApp
+# channel logs a hard production warning.
+WHATSAPP_APP_SECRET=...
 ```
 
 All credentials in the `OPENLEGION_SYSTEM_*` and `OPENLEGION_CRED_*` tiers are loaded by the credential vault (`src/host/credentials.py`). Agents never see values directly -- they make API calls through the mesh proxy, which injects credentials server-side.
 
 **CAPTCHA solver credentials bypass the vault.** The four secrets used by the browser CAPTCHA pipeline — `CAPTCHA_SOLVER_KEY`, `CAPTCHA_SOLVER_KEY_SECONDARY`, `CAPTCHA_SOLVER_PROXY_LOGIN`, `CAPTCHA_SOLVER_PROXY_PASSWORD` — are listed in `flags._ENV_ONLY_FLAGS` and read directly from the process environment by the browser service. They are NOT routed through the agent-tier `OPENLEGION_CRED_*` vault, do NOT appear in the credentials UI, and are explicitly stripped from `config/settings.json:browser_flags` at load with a one-time warning (settings.json is plaintext on disk). The dashboard's `POST /api/captcha-solver` endpoint writes them via `os.environ[…]` directly. Provide them as plain environment variables (e.g. via `.env`).
 
-**Channel credential fallback:** Channel bot tokens (Telegram, Discord, Slack, WhatsApp) are resolved with a four-tier fallback chain: `mesh.yaml` channel config field (e.g. `channels.telegram.bot_token`) → `OPENLEGION_SYSTEM_<NAME>` → `OPENLEGION_CRED_<NAME>` → legacy unprefixed `<NAME>` (e.g., `TELEGRAM_BOT_TOKEN`). The `OPENLEGION_CRED_` prefix is recommended for channel tokens.
+**Channel credential fallback:** Channel bot tokens (Telegram, Discord, Slack, WhatsApp) are resolved with a four-tier fallback chain: `mesh.yaml` channel config field (Telegram and Discord use `token`, Slack uses `bot_token`/`app_token`, WhatsApp uses `access_token` — e.g. `channels.telegram.token`) → `OPENLEGION_SYSTEM_<NAME>` → `OPENLEGION_CRED_<NAME>` → legacy unprefixed `<NAME>` (e.g., `TELEGRAM_BOT_TOKEN`). The `OPENLEGION_CRED_` prefix is recommended for channel tokens.
 
 **Important:** LLM provider keys **must** use the `OPENLEGION_SYSTEM_` prefix. The mesh proxy only looks for provider keys in the system tier. A provider key stored with `OPENLEGION_CRED_` will be treated as an agent-tier credential and will not be used for LLM calls.
 
@@ -301,17 +306,16 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `OPENLEGION_LOG_FORMAT` | `json` | Log output format: `json` (structured) or `text` (human-readable) |
 | `MCP_SERVERS` | -- | JSON string of MCP server configs (set automatically in containers) |
 | `MESH_AUTH_TOKEN` | -- | Agent auth token (set automatically in containers) |
-| `MESH_HOST` | -- | Mesh host URL (set automatically in containers) |
+| `MESH_URL` | -- | Mesh host URL the agent container calls back to (set automatically in containers; the agent exits if it is missing) |
 | `AGENT_ID` | -- | Agent identifier (set automatically in containers) |
 | `THINKING` | `off` | Extended thinking/reasoning mode (set automatically from `thinking` in agents.yaml) |
 | `PROJECT_NAME` | -- | Team this agent belongs to (set automatically for team members). Env-var name is retained through PR 2 of the project→team rename. |
-| `EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model for memory vector search (set automatically from `llm.embedding_model` in mesh.yaml). Set to `"none"` to disable vector search |
+| `EMBEDDING_MODEL` | *provider-conditional* | Embedding model for memory vector search (set automatically from `llm.embedding_model` in mesh.yaml). The default is derived from the default LLM provider (`src/cli/runtime.py`): openai-family models (`openai/`, `gpt-`, `o1`, `o3`, `o4`) resolve to `text-embedding-3-small`; all other providers resolve to `none`. The raw agent-container default is empty, where `""` / `"none"` disables embeddings. Set to `"none"` to disable vector search |
 | `OPENLEGION_MAX_AGENTS` | `0` | Plan limit: maximum agents to start. `0` means unlimited. If set to N > 0, only the first N agents are started. **Also drives plan-aware browser-service sizing** (`src/host/runtime.py:506-526`) — the browser container's memory, SHM, CPU quota, and `max_browsers` cap are selected across four `max_agents` tiers (see **Browser-Service Sizing Tiers** below). Note: `OPENLEGION_MAX_AGENTS=0` (the default, meaning "unlimited agents") falls into the `≤1` branch and selects the **Basic** browser-service tier — counterintuitive but intentional for self-host installs that haven't declared a plan. |
 | `OPENLEGION_MAX_TEAMS` | -- | Plan limit. Three-state semantics: **unset** (env var absent) → teams are unlimited; **set to `0`** → teams are disabled entirely, `POST /mesh/teams` returns HTTP 403; **set to N > 0** → only N teams are allowed. The pre-rename `OPENLEGION_MAX_PROJECTS` name is no longer read — use `OPENLEGION_MAX_TEAMS`. |
 | `OPENLEGION_TEAM_SCOPE_MODE` | `enforce` | Team-scope rollout kill switch. Accepts `"warn"` or `"enforce"` (case-insensitive via `.lower()`). Invalid values default to `"enforce"` with a WARNING. **Read once at module import — restart the mesh to change.** The pre-rename `OPENLEGION_PROJECT_SCOPE_MODE` name is no longer read. |
 | `OPENLEGION_SKIP_TRUST_TIER_BOOT_GATE` | -- | Bypass the fail-closed startup gate that refuses to boot when `OPENLEGION_TEAM_SCOPE_MODE=enforce` and `auth_tokens` is empty (an unverifiable `X-Agent-ID` header would otherwise make the operator trust tier forgeable). Set to `"1"` to skip the gate. Used by `tests/conftest.py` for in-process test sessions; not for production deploys (`src/host/server.py`). |
 | `OPENLEGION_TEAM_MIGRATION_RENAME_DB` | `1` | DB column rename `tasks.project_id` → `tasks.team_id` on startup. Default-on as of PR 3 of the project→team rename; set to `0` to opt out for emergency rollback. The orchestration layer introspects the live column at init via PRAGMA so either schema shape works without source changes. |
-| `OPENLEGION_ORCHESTRATION_TASKS_V2` | `1` | Toggle the durable orchestration v2 tasks store. `"1"` enables; `"0"` falls back to the legacy blackboard task path. **Read once at module import — restart the mesh to flip.** |
 | `OPENLEGION_ORCHESTRATION_TASKS_DB` | `data/tasks.db` | Override the SQLite path for the orchestration v2 tasks store. |
 | `OPENLEGION_API_KEY` | -- | Legacy single API key for back-compat with the named-key system (`config/api_keys.json`). Compared with `hmac.compare_digest`. Prefer creating named keys via `POST /api/api-keys`. |
 | `OPENLEGION_APP_URL` | -- | App URL used by the dashboard's external SSO link (read by `src/dashboard/server.py`). |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -430,7 +430,7 @@ The dashboard connects to the mesh via WebSocket at `/ws/events`. Events are str
 
 ### Event Types
 
-`DashboardEvent.type` is a `Literal[…]` of **53 values** (`src/shared/types.py:729-838`). They group into nine families:
+`DashboardEvent.type` is a `Literal[…]` of **53 values** (`src/shared/types.py:741-850`). They group into nine families:
 
 | Family | Events |
 |--------|--------|
@@ -548,7 +548,7 @@ curl -X GET "http://localhost:8420/dashboard/api/billing/captcha-rollup?tenant=a
 
 ## API Endpoints
 
-All dashboard API endpoints are prefixed with `/dashboard/api/`. The SPA root is served at `GET /dashboard/` (HTML, not an API endpoint). The dashboard router exposes **143 endpoints** registered via `@api_router.*` in `src/dashboard/server.py`. State-changing endpoints (POST/PUT/DELETE/PATCH) require the `X-Requested-With` header; see [Authentication](#authentication).
+All dashboard API endpoints are prefixed with `/dashboard/api/`. The SPA root is served at `GET /dashboard/` (HTML, not an API endpoint). The dashboard router exposes **160 endpoints** registered via `@api_router.*` in `src/dashboard/server.py`. State-changing endpoints (POST/PUT/DELETE/PATCH) require the `X-Requested-With` header; see [Authentication](#authentication).
 
 A handful of endpoints have **no UI surface** and are reachable by curl only. They are flagged inline as `(operator-curl only — no UI)`.
 
@@ -585,7 +585,7 @@ The tables below are not exhaustive — they cover the user-facing surface area 
 | `GET` | `/dashboard/api/conversations` | List active conversations (open chat panels) |
 | `POST` | `/dashboard/api/conversations/{agent_id}/open` | Mark a conversation open |
 | `POST` | `/dashboard/api/conversations/{agent_id}/close` | Mark a conversation closed |
-| `POST` | `/dashboard/api/broadcast` | Send message to all agents (request body filters by `project` name — alias `team` accepted — or `standalone: true`; operator excluded) |
+| `POST` | `/dashboard/api/broadcast` | Send message to all agents (request body filters by `project` name or `standalone: true`; operator excluded) |
 | `POST` | `/dashboard/api/broadcast/stream` | SSE streaming broadcast (same filters as above) |
 
 **Workspace**
@@ -849,7 +849,7 @@ The dashboard includes several accessibility features:
 
 | File | Role |
 |------|------|
-| `src/dashboard/server.py` | FastAPI router with all 143 API endpoints, CSP + CSRF wiring, VNC URL injection |
+| `src/dashboard/server.py` | FastAPI router with all 160 API endpoints, CSP + CSRF wiring, VNC URL injection |
 | `src/dashboard/templates/index.html` | Dashboard HTML (Alpine.js SPA template + Tailwind via CDN). Renders with `autoescape=True` |
 | `src/dashboard/static/js/app.js` | Dashboard application logic — top-nav tabs, Work surface, wizard / tutorial state, identity tabs |
 | `src/dashboard/static/js/websocket.js` | WebSocket client with exponential-backoff reconnect (`reconnectIn` countdown) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,7 +91,7 @@ Playwright is intentionally **not** in the `[dev]` extra (browser binaries ballo
 
 ### CI Matrix
 
-`.github/workflows/test.yml` runs three jobs on every PR + push:
+`.github/workflows/test.yml` runs on push to `main` and pull requests targeting `main`. `lint` and `test` run on both triggers; `coverage` is push-only:
 
 | Job | Trigger | Setup | Command |
 |-----|---------|-------|---------|
@@ -441,7 +441,7 @@ openlegion/
 │   ├── mesh.yaml
 │   ├── permissions.json
 │   └── cron.json
-├── tests/                       # Test suite (~155 test files)
+├── tests/                       # Test suite (~193 test files)
 │   └── fixtures/                # Test fixtures (echo MCP server, etc.)
 ├── tools/                       # Standalone dev tools
 │   ├── behavior_analyze.py      # Browser/captcha behavior analysis
@@ -472,6 +472,7 @@ openlegion/
 | `pypdf` | PDF text extraction for attachments |
 | `anthropic` | Anthropic SDK (used by litellm) |
 | `python-multipart` | Multipart form data parsing |
+| `Pillow` | Image processing for browser screenshots |
 
 ### Agent-Side (installed in container via Dockerfile)
 
@@ -482,6 +483,7 @@ openlegion/
 | `pydantic` | Type validation |
 | `sqlite-vec` | Vector search for memory |
 | `mcp` | Model Context Protocol client |
+| `pypdf` | PDF text extraction for attachments |
 | `camoufox` | Stealth browser automation (in browser service container) |
 
 ### Optional

--- a/docs/doc-audit-2026-06-06.md
+++ b/docs/doc-audit-2026-06-06.md
@@ -1,0 +1,120 @@
+# Documentation Accuracy Audit — 2026-06-06
+
+Principal-engineer audit of `docs/` + root `README.md` against the actual codebase.
+Method: 5 parallel code-truth extractors → merged Code Truth Document → 8 parallel doc auditors,
+each cross-referencing assigned docs against code with direct source verification.
+
+**Verdict: docs are in unusually good shape.** No dangerous false security claims. The defects are
+a handful of genuine lies (features/flags/aliases that don't exist), a cluster of stale numeric
+counts and line-number citations that drifted with the code, and a few omissions/vague spots.
+
+Legend: 🔴 Lie (code does not do this) · 🟡 Stale (was true, code changed) · 🟢 Missing (code does it, docs don't) · 🔵 Vague (misleading/incomplete)
+
+> **Status (applied in this PR):** all 🔴 Lies, 🟡 Stale, and 🟢 Missing findings below were fixed.
+> 🔵 Vague items were intentionally deferred. Numbers/line-refs in the "code truth" column are the
+> audit-run snapshot; during the fix phase every value was **re-verified against `main`** and the
+> committed docs use those verified numbers (which differ slightly where `main` had moved on —
+> e.g. test files 193 not 180, dashboard endpoints 160, DashboardEvent literal 53).
+
+---
+
+## SCOREBOARD
+
+| File | 🔴 | 🟡 | 🟢 | 🔵 | Notes |
+|---|---|---|---|---|---|
+| README.md (root) | 2 | 1 | 0 | 2 | Front door — strong overall |
+| docs/README.md | 0 | 0 | 0 | 0 | Clean index |
+| docs/architecture.md | 3 | ~11 | 0 | 2 | Most drift concentrated here |
+| docs/configuration.md | 3 | 1 | 1 | 1 | |
+| docs/agent-tools.md | 2 | 2 | 2 | 1 | |
+| docs/channels.md | 0 | 0 | 0 | 1 | Essentially clean (line drift only) |
+| docs/triggering.md | 1 | 4 | 0 | 1 | `collect` lane mode is fictional |
+| docs/security.md | 0 | ~7 | 0 | 1 | No dangerous claims; 2 stale limits, rest line refs |
+| docs/dashboard.md | 1 | 2 | 0 | 1 | |
+| docs/development.md | 0 | 2 | 2 | 1 | |
+| docs/mcp.md | 0 | 0 | 0 | 0 | Fully accurate |
+| docs/memory.md | 1 | 2 | 0 | 1 | SYSTEM.md claims stale |
+
+---
+
+## 🔴 LIES (highest priority — actively mislead)
+
+| # | File:Line | What docs say | Code truth | Fix |
+|---|---|---|---|---|
+| L1 | README.md:713 | `tasks [--agent X] [--team Y \| --project Y]` — `--project` flag on `tasks` | `tasks_cmd` (cli/main.py:745-753) has only `--agent/--team/--status/--port/--json`. `--project` errors. | Drop `\| --project Y`. (`--team` is correct.) |
+| L2 | README.md:720 | `wallet init` "shown once; **HTTP 410 thereafter**" | Local CLI command; prints "already configured" and returns. No `410` anywhere in code. | Replace with "refuses to regenerate while `OPENLEGION_SYSTEM_WALLET_MASTER_SEED` is set." |
+| L3 | architecture.md:49,119 | Coordination behind `OPENLEGION_ORCHESTRATION_TASKS_V2` flag; legacy v1 blackboard `tasks/{agent}/{handoff_id}` path | Flag does not exist. v1 path removed in PR #835 (coordination_tool.py:9, orchestration.py:7). Hand-offs always durable SQLite tasks. | Remove flag + v1/v2 fork; state hand-offs are always durable task records. |
+| L4 | architecture.md:101 | `_SCAFFOLD_FILES` includes `HEARTBEAT.md` | workspace.py:40-46 = {INSTRUCTIONS,SOUL,USER,MEMORY,INTERFACE}; comment: "HEARTBEAT.md intentionally NOT bootstrapped." | Drop HEARTBEAT.md; note it's created lazily on first write. |
+| L5 | architecture.md:154 | Browser concurrency "default 5, clamped [1,64]" | Default is memory-derived autodetect (`_autodetect_default_max_browsers`, browser/__main__.py:133-198); comment "Replaces the previous hardcoded 5 floor." Clamp [1,64] correct. | "default = memory-derived autodetect, clamped to [1,64]". |
+| L6 | configuration.md:304 | `MESH_HOST` "set automatically in containers" | No `MESH_HOST` var. Agent reads `MESH_URL`, exits if missing (agent/__main__.py:39,46). | Rename row → `MESH_URL`. |
+| L7 | configuration.md:314 | `OPENLEGION_ORCHESTRATION_TASKS_V2` default `1`, toggles v2 store | Not read anywhere. Store wired unconditionally via `OPENLEGION_ORCHESTRATION_TASKS_DB`. | Remove the row. |
+| L8 | configuration.md:254-256 | `OPENLEGION_CRED_WHATSAPP_VERIFY_TOKEN` does X-Hub-Signature-256 verification ("skipped with WARNING" without it) | VERIFY_TOKEN is only the GET handshake token (whatsapp.py:204-208). Signature verification uses `WHATSAPP_APP_SECRET` (whatsapp.py:103-105,218-229). | Move signature note to `WHATSAPP_APP_SECRET`; describe VERIFY_TOKEN as the webhook-subscription handshake. |
+| L9 | agent-tools.md:105 | `update_workspace` writable files include `GOALS.md`, `GOALS.json` | workspace.py:545 `AGENT_WRITABLE` = {HEARTBEAT,USER,SOUL,INSTRUCTIONS,INTERFACE}.md; mesh_tool.py:712 enum = those 5. GOALS.* rejected. | Remove GOALS.md/GOALS.json. |
+| L10 | agent-tools.md:229 | `confirm_edit` documented as an operator agent tool | No `@skill` named confirm_edit exists. | Remove the row. |
+| L11 | triggering.md:341 | Lanes have a third mode `collect` (batch + combine messages) | lanes.py implements only `followup` + `steer`; no `collect` branch (falls through to followup). | Remove the `collect` row. |
+| L12 | dashboard.md:588 | `/api/broadcast` "filters by `project` — alias `team` accepted" | api_broadcast (server.py:3357) reads only `body.get("project")`; no `team` fallback. | Remove "alias `team` accepted". |
+| L13 | memory.md:91 | SYSTEM.md "refreshed every 5 minutes" | Written once at startup (agent/__main__.py:182-194); no refresh loop. | Remove "refreshed every 5 minutes". |
+
+## 🟡 STALE
+
+### Counts (numeric drift)
+| File:Line | Says | Actual |
+|---|---|---|
+| README.md:11,153,168,991 | "155 test files" | 180 |
+| architecture.md:116 | browser tools 24 | 25 |
+| architecture.md:209,287 | DashboardEvent literal 50 names | 55 |
+| architecture.md:209 | types.py 369 lines / 24 models | 842 lines / 27 models |
+| architecture.md:72 | server.py 109 endpoints | 107 |
+| architecture.md:181 | dashboard 143 endpoints | ~149 |
+| architecture.md:92 | agent server 28 endpoints | 29 |
+| dashboard.md:551,852 | dashboard 143 endpoints | 148 |
+| development.md:444 | ~155 test files | ~180 |
+| security.md:275 | CAPTCHA per-agent rate limit default 20/hr | 5000/hr (service.py:352,414) |
+| security.md:418 | cookie import limit 10/hour | 60/hour (dashboard/server.py:1366) |
+| memory.md:45 | context auto-detect "12 models supported" | litellm registry + 16-entry `_FALLBACK_CONTEXT` table (models.py:332-354) |
+
+### Renamed / removed things still documented
+| File:Line | Issue |
+|---|---|
+| architecture.md:127 | `confirm_edit` no-op stub — removed (grep empty) |
+| architecture.md:127 | `inspect_projects` alias — doesn't exist (only `inspect_teams`) |
+| agent-tools.md:15 | `INTERFACE.md` listed as write-protected; it is agent-writable (file_tool.py:19-21 `_PROTECTED_WORKSPACE_FILES` excludes it) |
+| agent-tools.md:238 | `summarize_project_progress` framed as tool alias; only `summarize_team_progress` registered (project_id is a param) |
+| configuration.md:263 | mesh.yaml example `channels.telegram.bot_token` → key is `token` (channels.py:51) |
+| memory.md:16,83,94 | SYSTEM.md "Runtime snapshot of permissions/fleet" — generate_system_md returns static preamble only; runtime data comes live via Runtime Context block |
+| development.md:94 | CI "every PR + push" → triggers are push-to-`main` + PRs-targeting-`main`; coverage job is push-only |
+
+### Stale line-number citations (values/names still correct, only `:line` drifted)
+- architecture.md: ws/events :6996→:8540; sandbox fallback cli/runtime.py:433-461→~501-515; browser sizing runtime.py:386-392 (that range is the volumes dict); default-perms server.py:2958-2965→3329+; `_ensure_operator_agent` is in cli/config.py:1864 (called from runtime.py), not defined in runtime.py
+- triggering.md: skip-LLM `cron.py:394`→497-508; `_HANDOFF_TTL` :36→:33; MessageRouter :738→:737; webhook create :5706→:6135; subscribe_event :284→:285
+- security.md: `_extract_verified_agent_id` :830-862→:926-966; `_is_internal_caller` :314-337→:257-280; `_RATE_LIMITS` :788-815→:802-829; `_csrf_check` :716-726→:778-788; `_FILE_CAPS` :332-340→:383-395; PUT gate :397-402→:453-458
+- dashboard.md:433 DashboardEvent literal block 729-838→730-839 (count 53 correct)
+
+## 🟢 MISSING
+
+| File | Missing item |
+|---|---|
+| configuration.md | `WHATSAPP_APP_SECRET` — production-required (gates X-Hub-Signature-256), env-only, entirely undocumented |
+| agent-tools.md:172,180 | `get_system_status` `section="llm"` enum value (introspect_tool.py:29) |
+| agent-tools.md:201-241 | ~10 operator tools omitted: read_agent_config, read_user_notifications, list_peer_artifacts, read_peer_artifact, list_available_models, workflow_snapshot, await_task_event, compose_work_summary, manage_goals, rate_delivery |
+| development.md:458 | `Pillow>=10.0` host-side core dep (pyproject.toml) — also installed explicitly in CI |
+| development.md:476 | `pypdf` agent-side container dep (Dockerfile.agent:21) |
+
+## 🔵 VAGUE
+
+| File:Line | Issue | Suggested sharpening |
+|---|---|---|
+| README.md:627-629 | webhook *management* endpoint shown as `/api/webhooks` (trigger URL `/webhook/hook/{id}` is correct) | prefix `/dashboard/api/webhooks` or note it's a dashboard-router path |
+| README.md:818-820 | mesh.yaml `embedding_model` example reads like a working default | note it's opt-in; search disabled unless set |
+| architecture.md:3 | SandboxBackend "used opportunistically" | it's opt-in via `--sandbox`; falls back to Docker if init fails; Docker is default because sandbox isn't attempted unless requested |
+| architecture.md:173 | WhatsApp "warns once and disables verification otherwise" | in production (MESH_AUTH_TOKEN set) missing secret is a hard error; warn-and-disable only in non-prod |
+| configuration.md:308 | `EMBEDDING_MODEL` default `text-embedding-3-small` | provider-conditional: openai-family→that model, others→`none`; raw container default empty |
+| agent-tools.md:235 | `set_team_goal` "rendered on every team card in the **Board tab**" | no "Board tab"; tab IDs are chat/fleet/workplace/system (label Teams) |
+| triggering.md:296 | minor off-by-one line ref | — |
+| security.md:250 | Path-traversal "Stage 2 uses `lstat()`" | code uses `is_symlink()`+`.resolve()` per component (functionally equivalent; CLAUDE.md uses same shorthand) — optional |
+| channels.md:21 | `base.py:246-254` MessageOrigin range slightly off (constructor at 253-257) | cosmetic |
+
+---
+
+## Things verified CORRECT (high-attention, no change needed)
+Ports 8420/8400/8500; dashboard = router mounted on mesh at `/dashboard` (not a separate process); three trust zones + operator-or-internal tier; container hardening (mem 128m/384m, cpu 0.05/0.15, cap_drop ALL, no-new-privileges, read_only, tmpfs, pids_limit 256); per-agent bearer tokens + hmac.compare_digest + fail-closed boot gate; x-mesh-internal = header AND loopback; CSRF X-Requested-With; all 17 rate-limit buckets; SSRF blocklist; browser egress iptables fail-closed; AST forbidden lists (23 imports / 16 calls / 11 attrs); credential two-tier (agents never hold keys); 9 redaction patterns; 13 fleet templates; 4 frozen tab IDs (chat/fleet/workplace/system) + labels; KNOWN_BROWSER_ACTIONS=26; 25 browser tools; web_search=DuckDuckGo scrape; image_gen gemini+openai; subagent MAX_CONCURRENT=3/MAX_DEPTH=2; OAuth allowlists + model names; flags precedence; wallet limits/RPC defaults; plan-limit semantics; cron syntax + 3 heartbeat probes; webhook 1MB/3000-char + HMAC; all four Channel subclasses + token resolution (SYSTEM→CRED→bare); WhatsApp HMAC; full mcp.md (stdio transport, MCP_SERVERS JSON, graceful degradation, conflict prefixing, $CRED{} resolution).

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -13,7 +13,7 @@ Layer 4: Context Manager          <- Manages the LLM's context window
   |
 Layer 3: Workspace Files          <- Durable, human-readable storage
   |  INSTRUCTIONS.md, SOUL.md, USER.md  (loaded into system prompt)
-  |  SYSTEM.md                    (auto-generated architecture guide + runtime snapshot)
+  |  SYSTEM.md                    (auto-generated architecture guide, static preamble)
   |  MEMORY.md                    (curated long-term facts)
   |  HEARTBEAT.md                 (autonomous monitoring rules)
   |  memory/YYYY-MM-DD.md         (daily session logs)
@@ -40,7 +40,7 @@ Manages the LLM's context window to prevent overflow while preserving important 
 ### Token Tracking
 
 - **Model-aware token estimation**: tiktoken for OpenAI models (accurate), 3.5 chars/token for Anthropic, 4 chars/token fallback for unknown providers
-- **Model-aware context windows**: auto-detects max context from model name (12 models supported), with explicit `max_tokens` override
+- **Model-aware context windows**: uses litellm's `max_input_tokens` with a hardcoded fallback table (16 entries), with explicit `max_tokens` override
 - Four compaction thresholds:
   - **60%** -- proactive flush (extract facts to MEMORY.md)
   - **70%** -- auto-compact (summarize + trim, preserving tool-call group boundaries). If the LLM is unavailable or summarization returns an empty summary (`context.py:452-453`), this path falls back to hard prune.
@@ -80,7 +80,7 @@ Persistent markdown files stored on the agent's `/data/workspace` volume.
 | `USER.md` | User preferences and working style | 4K chars | System prompt |
 | `MEMORY.md` | Curated long-term facts | 16K chars | System prompt |
 | `TEAM.md` | Team-wide context (optional, per-team, mounted from host, **read-only** when present). Pre-rename `PROJECT.md` files are migrated to `TEAM.md` once at startup; the bootstrap loader reads only `TEAM.md`/`team.md`. | -- | When present in the team config |
-| `SYSTEM.md` | System architecture guide + runtime snapshot (auto-generated, read-only) | capped at 6K chars | System prompt |
+| `SYSTEM.md` | System architecture guide (auto-generated, static preamble, read-only) | capped at 6K chars | System prompt |
 | `HEARTBEAT.md` | Autonomous monitoring rules | -- | Heartbeat dispatch (auto-loaded) |
 | `INTERFACE.md` | Public collaboration contract (inputs, outputs, subscriptions) | 4K chars | Not auto-loaded into system prompt — read by other agents via `get_agent_profile` |
 
@@ -88,10 +88,9 @@ Total bootstrap injection into the system prompt is capped at 48K characters acr
 
 ### System File (`SYSTEM.md`)
 
-Auto-generated at startup and refreshed every 5 minutes. Contains two parts:
+Generated once at agent startup. Contains a static preamble only:
 
-1. **Static preamble** — Explains how the mesh, credential vault, blackboard, pub/sub, context window, and tool costs work. Includes a "common errors and what they mean" section (403, 429, budget exceeded, tool loop detected). This teaches agents *how the system works* so they can self-diagnose issues.
-2. **Runtime snapshot** — Compact permissions and fleet roster from the `/mesh/introspect` endpoint. Gives agents initial awareness of their capabilities before the live Runtime Context block kicks in.
+- **Static preamble** — Explains how the mesh, credential vault, blackboard, pub/sub, context window, and tool costs work. Includes a "common errors and what they mean" section (403, 429, budget exceeded, tool loop detected). This teaches agents *how the system works* so they can self-diagnose issues. Permissions and fleet roster are **not** in SYSTEM.md — they come live via the **Runtime Context** block injected on each turn.
 
 SYSTEM.md is capped at 6,000 characters to limit system prompt bloat. It is read-only — agents cannot modify it via `update_workspace`. The authoritative live data comes from the **Runtime Context** block injected into the system prompt on each turn (see [Agent Tools — System Introspection](agent-tools.md#system-introspection)).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -260,8 +260,8 @@ All file operations are scoped to the container's `/data` volume.
 Workspace files (the agent's own `SOUL.md` / `INSTRUCTIONS.md` / `MEMORY.md` / etc.) are managed through a dedicated `/workspace/{filename}` endpoint on the **agent's own** FastAPI server, not via the general `/data` file tools. Three protections:
 
 - **`_WORKSPACE_ALLOWLIST` frozenset** (`src/agent/server.py`) — 9 entries: `SOUL.md`, `HEARTBEAT.md`, `USER.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `MEMORY.md`, `INTERFACE.md`, `GOALS.md`, `GOALS.json`. Reads / writes to anything outside this list return HTTP 400.
-- **`_FILE_CAPS`** (`src/agent/server.py:332-340`) — char-count caps per file, enforced on `PUT` with HTTP 413 on overflow: `SOUL.md=4000`, `INSTRUCTIONS.md=12000`, `AGENTS.md=12000`, `USER.md=4000`, `MEMORY.md=16000`, `INTERFACE.md=4000`, `HEARTBEAT.md=None` (uncapped).
-- **`x-mesh-internal` gate on `PUT /workspace/{filename}`** (`src/agent/server.py:397-402`) — the agent cannot call its own workspace endpoint via `http_tool` or `exec+curl`. Writes must originate from the mesh on loopback with the internal header set. Reads from the agent's own loop are allowed without the gate.
+- **`_FILE_CAPS`** (`src/agent/server.py:480-492`) — char-count caps per file, enforced on `PUT` with HTTP 413 on overflow: `SOUL.md=4000`, `INSTRUCTIONS.md=12000`, `AGENTS.md=12000`, `USER.md=4000`, `MEMORY.md=16000`, `INTERFACE.md=4000`, `HEARTBEAT.md=None` (uncapped).
+- **`x-mesh-internal` gate on `PUT /workspace/{filename}`** (`src/agent/server.py:550-555`) — the agent cannot call its own workspace endpoint via `http_tool` or `exec+curl`. Writes must originate from the mesh on loopback with the internal header set. Reads from the agent's own loop are allowed without the gate.
 
 ### Tool Self-Authoring
 
@@ -283,7 +283,7 @@ See `docs/security-remediation-review-2026-05-29.md` (M1, H15) for the full find
 - Task mode: 20 iterations maximum (`AgentLoop.MAX_ITERATIONS`)
 - Chat mode: 30 tool rounds maximum per turn (`CHAT_MAX_TOOL_ROUNDS`), auto-compaction every 200 rounds (`CHAT_MAX_TOTAL_ROUNDS`) with session continuation (up to 5 auto-continues)
 - Per-agent token budgets enforced at the vault layer
-- CAPTCHA solver activity is bounded by a per-agent rate limit (default 20/hr), per-agent and per-tenant monthly cost caps, and pacing jitter (3000–12000 ms between solves) — see CAPTCHA Solver Controls below
+- CAPTCHA solver activity is bounded by a per-agent rate limit (default 5000/hr), per-agent and per-tenant monthly cost caps, and pacing jitter (3000–12000 ms between solves) — see CAPTCHA Solver Controls below
 - Prevents runaway loops and unbounded spend
 
 ### Rate Limiting
@@ -310,7 +310,7 @@ Per-agent rate limits on mesh endpoints prevent abuse and resource exhaustion:
 | `upload_apply` | 3000 requests | 60 seconds |
 | `auth_failure` | 60 requests | 60 seconds |
 
-`_RATE_LIMITS` declares 17 entries statically in `src/host/server.py:788-815`; `ext_credentials` and `ext_status` are registered dynamically when external-API support initializes. All other endpoints fall through to the default `(10000, 60)` — i.e. 10000 requests per 60 seconds. These ceilings exist to catch a genuinely runaway loop in a single-tenant deployment; cost budgets (`costs.py`) and per-tx wallet caps are the real spend guardrails.
+`_RATE_LIMITS` declares 17 entries statically in `src/host/server.py:1033-1072`; `ext_credentials` and `ext_status` are registered dynamically when external-API support initializes. All other endpoints fall through to the default `(10000, 60)` — i.e. 10000 requests per 60 seconds. These ceilings exist to catch a genuinely runaway loop in a single-tenant deployment; cost budgets (`costs.py`) and per-tx wallet caps are the real spend guardrails.
 
 Exceeding a rate limit returns HTTP 429. Rate-limit buckets are automatically cleaned up when agents are deregistered.
 
@@ -387,9 +387,9 @@ The mesh distinguishes three caller tiers, but only **two** identification mecha
 
 | Tier | How identified | Used by |
 |------|----------------|---------|
-| **Agent** | `Authorization: Bearer <token>` matched via `hmac.compare_digest` against the per-agent token issued at startup (`_extract_verified_agent_id`, `src/host/server.py:830-862`). | Normal `/mesh/*` calls from agent containers |
+| **Agent** | `Authorization: Bearer <token>` matched via `hmac.compare_digest` against the per-agent token issued at startup (`_extract_verified_agent_id`, `src/host/server.py:1180-1220`). | Normal `/mesh/*` calls from agent containers |
 | **Operator** | Same Bearer mechanism as Agent, but the token matches `_auth_tokens["operator"]` (`server.py:864-873`). There is no separate operator-session header on the mesh; the dashboard's `ol_session` cookie is a distinct surface that protects the dashboard UI itself (and the VNC proxy), not `/mesh/*` calls. | Dashboard-originated mutations, fleet-management routes, operator-as-agent calls |
-| **Internal** | `x-mesh-internal: 1` header **AND** loopback `request.client.host` (`_is_internal_caller`, `server.py:314-337`). Either alone is insufficient. | Same-host startup glue, browser-service ↔ mesh polling |
+| **Internal** | `x-mesh-internal: 1` header **AND** loopback `request.client.host` (`_is_internal_caller`, `server.py:432-455`). Either alone is insufficient. | Same-host startup glue, browser-service ↔ mesh polling |
 
 When `_auth_tokens` is empty (dev/unconfigured), `_extract_verified_agent_id` returns `"unknown"` and authentication is effectively off — operators running in that mode should know auth is fully disabled.
 
@@ -423,7 +423,7 @@ In other words: any guarantee about token replay / single-use lives outside engi
 ### Dashboard XSS / CSRF Posture
 
 - **Primary XSS defense is Jinja `autoescape=True`** on dashboard templates. CSP is set on the dashboard index (`script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; …`) but the `'unsafe-inline'` + `'unsafe-eval'` allowances are required for Alpine.js's `Function()` constructor and the Tailwind CDN. Be honest: those allowances materially weaken CSP's XSS-mitigation value — treat CSP here as defense-in-depth around the source-origin guarantees (`default-src 'self'`, `object-src 'none'`), not as XSS protection in its own right.
-- **CSRF**: state-changing dashboard endpoints require the `X-Requested-With` header (`_csrf_check`, `src/dashboard/server.py:716-726`), wired as a global router dependency on `/dashboard/*`. Relies on browsers' CORS preflight blocking custom headers from cross-origin scripts.
+- **CSRF**: state-changing dashboard endpoints require the `X-Requested-With` header (`_csrf_check`, `src/dashboard/server.py:784-794`), wired as a global router dependency on `/dashboard/*`. Relies on browsers' CORS preflight blocking custom headers from cross-origin scripts.
 
 ### VNC Reverse Proxy
 
@@ -438,7 +438,7 @@ The proxy then attaches a service-tier Bearer for the upstream browser-service c
 
 Several browser-related dashboard endpoints are operator-only because they let a human inject state into agent sessions:
 
-- `POST /api/agents/{agent_id}/browser/import_cookies` — operator imports cookie / session data into the named agent's browser. 256 KB body cap, 10 imports / hour rate limit, audit-logged. Agent-tier callers cannot use this — only operator session.
+- `POST /api/agents/{agent_id}/browser/import_cookies` — operator imports cookie / session data into the named agent's browser. 256 KB body cap, 60 imports / hour rate limit, audit-logged. Agent-tier callers cannot use this — only operator session.
 - `POST /api/agents/{agent_id}/fingerprint-health/reset` — clears the rolling rejection window after the operator rotates the agent's stealth profile (see Fingerprint Burn Detection below). CSRF-guarded by router.
 - `POST /api/browser-captcha-help/complete` and `/cancel` — operator-side resolution of an agent's CAPTCHA help request.
 

--- a/docs/triggering.md
+++ b/docs/triggering.md
@@ -205,7 +205,7 @@ Heartbeats skip the LLM dispatch entirely (zero cost) when all four conditions a
 3. **No recent activity** — daily logs are empty
 4. **No probes triggered** — disk usage normal, no pending signals or tasks
 
-This makes always-on heartbeats economically viable even at high frequencies. See `src/host/cron.py:394`.
+This makes always-on heartbeats economically viable even at high frequencies. See `src/host/cron.py:543`.
 
 #### Forcing the LLM to run every tick
 
@@ -259,7 +259,7 @@ The webhook payload is included in the message dispatched to the configured agen
 
 ### Creating Webhooks
 
-Webhook creation is a **dashboard-only** flow. The endpoint is `POST /api/webhooks` on the dashboard router (`src/dashboard/server.py:5706`); it uses dashboard SSO cookie auth (`ol_session`), not `MESH_AUTH_TOKEN`. There is no `/mesh/webhooks` endpoint.
+Webhook creation is a **dashboard-only** flow. The endpoint is `POST /api/webhooks` on the dashboard router (`src/dashboard/server.py:6659`); it uses dashboard SSO cookie auth (`ol_session`), not `MESH_AUTH_TOKEN`. There is no `/mesh/webhooks` endpoint.
 
 In practice you create webhooks from the dashboard System → Integrations tab. The request body is `{"name": "<label>", "agent": "<agent_id>", "instructions"?: "<extra>", "secret"?: "<existing-secret>"}`; the server stores `require_signature = bool(body.get("secret"))` and assigns a random 32-byte hex secret (`secrets.token_hex(32)`) if none was supplied. The created hook's secret is returned **once** in the response — store it immediately.
 
@@ -319,11 +319,11 @@ Pub/sub is a fan-out signal — for **direct** agent-to-agent work handoffs use 
 | `update_status(state, task_id?)` | Report progress on an active task. With 2+ active tasks and no `task_id`, returns an `ambiguous_task` payload so the LLM can pick a `task_id` without a follow-up `check_inbox` call. |
 | `complete_task(task_key)` | Mark a task complete; releases the auto-notify back to the originator. |
 
-Unprocessed handoffs expire after `_HANDOFF_TTL = 86_400` seconds (24h) as a safety net (`coordination_tool.py:36`).
+Unprocessed handoffs expire after `_HANDOFF_TTL = 86_400` seconds (24h) as a safety net (`coordination_tool.py:33`).
 
 ### MessageRouter
 
-Cross-agent calls go through `MessageRouter` (`src/host/mesh.py:738`), which resolves the target string to a container URL:
+Cross-agent calls go through `MessageRouter` (`src/host/mesh.py:737`), which resolves the target string to a container URL:
 
 - **Agent ID** — exact match against the agent registry
 - **`capability:<name>`** — first agent whose declared capabilities include `<name>`
@@ -332,13 +332,12 @@ Permissions are enforced on every routed call; unknown targets return `{"error":
 
 ### Lanes
 
-Each agent has a FIFO task lane (`src/host/lanes.py`) with three dispatch modes:
+Each agent has a FIFO task lane (`src/host/lanes.py`) with two dispatch modes:
 
 | Mode | Behavior |
 |------|----------|
 | `followup` (default) | Queue the message; process after the current task finishes. |
 | `steer` | Inject the message into the agent's active conversation between tool rounds. Rate-limited to `_STEER_WAKEUP_MAX = 10` injections per `_STEER_WAKEUP_WINDOW = 3600` seconds (per-agent). |
-| `collect` | Batch queued messages while the agent is busy, then dispatch them as a single combined message once the agent becomes free. |
 
 When a lane completes a task that originated from a channel handoff (`auto_notify=True`), the result is forwarded back to the originating channel/user with a `[agent_name]` prefix. The send is capped at `_NOTIFY_FORWARD_TIMEOUT = 30` seconds (`lanes.py:30`).
 


### PR DESCRIPTION
## What

A principal-engineer **documentation accuracy audit** of `docs/` and the root `README.md`. Method: extracted a code-truth inventory from `src/` (5 parallel extractors over commands, config, lifecycle, security, tools), then cross-checked every claim in the docs against it (8 parallel auditors), verifying against source. **The code is the single source of truth — docs were fixed to match it.**

Full discrepancy report (methodology + every finding with file:line): `docs/doc-audit-2026-06-06.md`.

## Scope

Fixes applied: 🔴 **Lies** (claims the code doesn't back), 🟡 **Stale** (drifted counts/line-refs, removed aliases), 🟢 **Missing** (real things the docs omitted). 🔵 **Vague** items were deferred. All numeric counts and line-number citations were re-verified against current `main` before writing.

**Verdict:** docs were in unusually good shape — no dangerous false security claims, and `docs/mcp.md` + `docs/README.md` needed no changes.

## Notable fixes

- **Fictional `OPENLEGION_ORCHESTRATION_TASKS_V2` flag** + the v1/v2 hand-off fork — removed from `architecture.md` and `configuration.md`. The legacy blackboard path was removed in PR #835; hand-offs are always durable SQLite task records.
- **README**: removed the non-existent `tasks --project` flag and the invented "HTTP 410" behavior on `wallet init`; corrected the test-file count.
- **configuration.md**: `MESH_HOST` → `MESH_URL`; documented `WHATSAPP_APP_SECRET` and fixed the WhatsApp signature-verification attribution; provider-conditional `EMBEDDING_MODEL` default; correct Telegram channel key.
- **agent-tools.md**: dropped `GOALS.*` from the `update_workspace` writable set; removed the non-existent `confirm_edit` tool and `summarize_project_progress` alias; added the `llm` introspect section and ~10 omitted operator tools.
- **architecture.md**: `HEARTBEAT.md` is not bootstrapped; browser concurrency is memory-autodetected (not "default 5"); corrected top-nav labels (Teams/Work) and drifted counts/line refs.
- **memory.md**: `SYSTEM.md` is generated once at startup (no 5-min refresh) and is static-preamble-only; context windows use litellm + a fallback table.
- **triggering.md**: removed the non-existent `collect` lane mode.
- **dashboard.md**: `/api/broadcast` has no `team` alias; refreshed endpoint count.
- **security.md**: corrected CAPTCHA + cookie-import rate-limit values and drifted line-number citations (no false security claims were found).
- **development.md**: accurate CI triggers; added `Pillow` + `pypdf` to the dependency tables.

## Follow-ups (deferred 🔵 vague items)
A handful of "Board" labels still live in **code** tool-description strings (e.g. `set_team_goal`); the docs faithfully mirror the code there, so fixing those means a code change, not a docs change. See the audit report's 🔵 section.