### PR TITLE
fix(dashboard): operator chat stuck on "starting up" — relax readiness gate

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1884,7 +1884,15 @@ function dashboard() {
     checkOperatorReady() {
       const op = this.agents.find(a => a.id === 'operator');
       const wasReady = this.operatorReady;
-      this.operatorReady = op && op.health_status === 'healthy';
+      // The operator is a fleet-global agent that the health monitor does NOT
+      // track (it's excluded from the fleet status), so /api/agents reports its
+      // health_status as the default 'unknown' — it never becomes 'healthy'.
+      // Requiring === 'healthy' left the main chat stuck on "starting up..."
+      // forever even though the operator was up and serving (the side panel,
+      // which doesn't gate, worked). Ready = present and not genuinely down;
+      // only the real not-ready states keep the "starting up" message.
+      this.operatorReady = !!op
+        && !['stopped', 'failed', 'restarting'].includes(op.health_status);
       // Fix #4 — when operator transitions unhealthy → healthy and the
       // user is still in a first-visit state, retry starting the
       // wizard. Without this, an operator that boots slowly (e.g.


### PR DESCRIPTION
## Symptom
The main operator chat page shows **"Your operator is starting up… (15–30 seconds)"** indefinitely, while the side-panel operator chat works fine.

## Root cause (verified live on a prod box)
`operatorReady` gated on `operator.health_status === 'healthy'`. But the operator is a fleet-global agent the **health monitor doesn't track** (excluded from fleet status), so `/api/agents` reports its `health_status` as the default **`'unknown'`** — never `'healthy'`. So the gate never opens. The side panel doesn't use `operatorReady`, which is why it works. Confirmed: operator container up, `/status` responsive (idle), metrics track only workers. **A restart doesn't fix it** — the operator stays `'unknown'`; the gate is the bug.

## Fix (KISS)
`operatorReady = !!op && !['stopped','failed','restarting'].includes(op.health_status)` — ready when present and not genuinely down. `'unknown'`/`'healthy'` both count as ready (matches the side panel); a real boot still shows "starting up" (operator not yet in the list).

## Deferred
Registering the operator with the health monitor so it reports real health everywhere — larger change.

Frontend-only (one method). `node --check` clean.