### PR TITLE
Friendly, user-actionable task failure surfaces

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -381,7 +381,20 @@ async def hand_off(
     }
     if artifact_ref:
         result["output_key"] = artifact_ref
-    if wake_error is not None:
+    if wake_error is not None and to == "operator":
+        # By design, worker agents CANNOT synchronously wake the operator —
+        # the mesh /mesh/wake endpoint returns 403 for worker→operator and
+        # the operator discovers queued work on its heartbeat poll. The
+        # durable task row was persisted above, so a queued handoff to the
+        # operator IS the intended successful outcome. Classifying the
+        # expected 403 as ``wake_failed`` (the branch below) marked the
+        # ORIGINATING task ``failed`` and surfaced a scary, technical
+        # "403 Forbidden … host.docker.internal" note to the user. The mesh
+        # permission boundary is untouched; we only stop mislabelling the
+        # expected denial as a failure.
+        result["handed_off"] = True
+        result["queued_for_heartbeat"] = True
+    elif wake_error is not None:
         # Bug G: the durable task row sits in SQLite at status='pending'
         # for the next-heartbeat discovery path — we don't transition it
         # to failed because a transient wake error (network blip, agent
@@ -459,17 +472,20 @@ async def check_inbox(*, mesh_client=None) -> dict:
         entries = await mesh_client.list_blackboard(prefix, global_scope=True)
         for entry in entries:
             value = entry.get("value") or {}
+            # Free-text fields here re-enter THIS agent's LLM context, so
+            # sanitize them at the input boundary (a failed peer's note can
+            # echo arbitrary/injected content). Enum/id fields are safe.
             events.append({
                 "key": entry.get("key", ""),
                 "kind": value.get("kind", ""),
                 "task_id": value.get("task_id", ""),
                 "recipient": value.get("recipient", ""),
-                "title": value.get("title", ""),
+                "title": sanitize_for_prompt(value.get("title", "")),
                 "status": value.get("status", ""),
                 "ts": value.get("ts"),
-                "summary": value.get("summary", ""),
-                "error": value.get("error", ""),
-                "blocker_note": value.get("blocker_note", ""),
+                "summary": sanitize_for_prompt(value.get("summary", "")),
+                "error": sanitize_for_prompt(value.get("error", "")),
+                "blocker_note": sanitize_for_prompt(value.get("blocker_note", "")),
             })
     except Exception as e:
         logger.warning(

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -360,6 +360,7 @@ async def hand_off(
     # next cron. Forward task_id so the recipient's lane → /chat → loop
     # chain auto-closes the task on completion (Constraint #16).
     wake_error: str | None = None
+    wake_status: int | None = None
     try:
         await mesh_client.wake_agent(
             to, f"New task from {mesh_client.agent_id}: {summary[:200]}",
@@ -370,6 +371,10 @@ async def hand_off(
         # Redact BEFORE truncation — HTTP-level exceptions can quote
         # the failing URL with an API key in the query string.
         wake_error = redact_text_with_urls(str(e))[:200]
+        # Capture the HTTP status (httpx.HTTPStatusError carries .response)
+        # so we can distinguish the BY-DESIGN worker→operator 403 from a
+        # genuine infra failure (500 / network) below.
+        wake_status = getattr(getattr(e, "response", None), "status_code", None)
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
@@ -381,7 +386,11 @@ async def hand_off(
     }
     if artifact_ref:
         result["output_key"] = artifact_ref
-    if wake_error is not None and to == "operator":
+    _operator_by_design_403 = (
+        to == "operator"
+        and (wake_status == 403 or "403 forbidden" in (wake_error or "").lower())
+    )
+    if wake_error is not None and _operator_by_design_403:
         # By design, worker agents CANNOT synchronously wake the operator —
         # the mesh /mesh/wake endpoint returns 403 for worker→operator and
         # the operator discovers queued work on its heartbeat poll. The
@@ -391,7 +400,9 @@ async def hand_off(
         # ORIGINATING task ``failed`` and surfaced a scary, technical
         # "403 Forbidden … host.docker.internal" note to the user. The mesh
         # permission boundary is untouched; we only stop mislabelling the
-        # expected denial as a failure.
+        # expected denial as a failure. A NON-403 operator wake error (500,
+        # network) is a genuine infra failure and still flows to the
+        # ``wake_failed`` envelope below so it stays visible.
         result["handed_off"] = True
         result["queued_for_heartbeat"] = True
     elif wake_error is not None:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3863,7 +3863,10 @@ class AgentLoop:
         except Exception as e:
             self.state = "idle"
             logger.error(f"Chat failed: {e}", exc_info=True)
-            msg = f"Error: {e}"
+            # Some exceptions stringify to empty, which produced the useless
+            # "exception: Error:" blocker notes seen in production. Fall back
+            # to the exception class name so the reason is always meaningful.
+            msg = f"Error: {e}" if str(e).strip() else f"Error: {type(e).__name__}"
             self._finalize_chat_turn(
                 turn_id=turn_id,
                 accumulated_content="\n".join(turn_content_parts),

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -3180,6 +3180,10 @@ function dashboard() {
         // does the same for the browser-login flow; everything else
         // falls back to the legacy "Drill in" task drawer.
         const classification = this._humanizeBlocker(b.blocker_note || '');
+        // Show only blockers the user can act on. Engine-internal / transient
+        // ones are noise here — they live in the team's Technical activity
+        // group, not the "Needs you" panel.
+        if (classification.audience !== 'user') continue;
         const primary = (classification.kind === 'credential' || classification.kind === 'browser_login')
           ? {
               label: 'Fix',
@@ -3251,21 +3255,27 @@ function dashboard() {
     // ``cred:<name>`` shorthand or the trailing word of a sentence;
     // callers should treat empty as "unknown".
     _humanizeBlocker(rawNote) {
+      // Decode a machine blocker_note into plain English + an AUDIENCE.
+      //   audience 'user'     → the person can act on it; shown in the
+      //                          primary Work view with a clear next step.
+      //   audience 'internal' → engine plumbing the user can't act on
+      //                          (transient / automatic); hidden into the
+      //                          collapsible "Technical activity" group.
+      // Returns { kind, label, service, audience }.
       const note = String(rawNote || '').trim();
-      if (!note) return { kind: 'unknown', label: '', service: '' };
+      if (!note) return { kind: 'unknown', label: '', service: '', audience: 'internal' };
       const lower = note.toLowerCase();
-      // Credential-style: ``no_credentials``, ``missing_credentials``,
-      // or ``cred:<name>`` shorthand. Best-effort service extraction
-      // from the colon-prefixed form.
+
+      // ── User-actionable ──────────────────────────────────────────
       if (lower === 'no_credentials' || lower === 'missing_credentials') {
-        return { kind: 'credential', label: 'Needs a credential', service: '' };
+        return { kind: 'credential', label: 'Needs a credential', service: '', audience: 'user' };
       }
       if (lower.startsWith('cred:')) {
         const service = note.slice(5).trim();
         return {
           kind: 'credential',
           label: service ? `Needs a credential: ${service}` : 'Needs a credential',
-          service,
+          service, audience: 'user',
         };
       }
       // Browser-login codes. URL/service hint may follow with a colon
@@ -3277,17 +3287,52 @@ function dashboard() {
         return {
           kind: 'browser_login',
           label: hint ? `Needs a browser login: ${hint}` : 'Needs a browser login',
-          service: hint,
+          service: hint, audience: 'user',
         };
       }
       if (lower === 'awaiting_feedback' || lower === 'awaiting_user') {
-        return { kind: 'feedback', label: 'Waiting for your feedback', service: '' };
+        return { kind: 'feedback', label: 'Waiting for your feedback', service: '', audience: 'user' };
       }
       if (lower === 'quota_exceeded' || lower === 'budget_exceeded') {
-        return { kind: 'budget', label: 'Hit cost limit', service: '' };
+        return { kind: 'budget', label: 'Hit cost limit', service: '', audience: 'user' };
       }
-      // Already a sentence — render verbatim.
-      return { kind: 'other', label: note, service: '' };
+      // Task too large to finish in one run — the user can split / retry it.
+      if (lower.startsWith('lane_timeout')) {
+        return {
+          kind: 'too_big',
+          label: 'This task was too large to finish in one run — try breaking it into smaller pieces.',
+          service: '', audience: 'user',
+        };
+      }
+
+      // ── Engine-internal / transient (hidden from the primary view) ──
+      if (lower.startsWith('output_too_large')) {
+        return { kind: 'internal', label: 'The agent tried to save more than fits in one step.', service: '', audience: 'internal' };
+      }
+      if (lower.startsWith('convergence_cap') || lower.startsWith('max_iterations')) {
+        return { kind: 'internal', label: 'The task ran out of steps before finishing.', service: '', audience: 'internal' };
+      }
+      if (lower.startsWith('no_outbound_effects')) {
+        return { kind: 'internal', label: 'The agent finished without producing any output.', service: '', audience: 'internal' };
+      }
+      if (lower.startsWith('agent_quarantined')) {
+        return { kind: 'internal', label: 'The agent was paused after repeated errors.', service: '', audience: 'internal' };
+      }
+      // Transient AI-provider hiccups.
+      if (lower.includes('llm call failed') || lower.includes('returned empty response')
+          || lower.includes('oauth') || lower.includes('rate limit') || lower.includes(' 429')
+          || lower.includes('connection to the ai provider')) {
+        return { kind: 'provider', label: 'The AI provider was briefly unavailable.', service: '', audience: 'internal' };
+      }
+      if (lower === 'internal_error' || lower.startsWith('exception')
+          || lower.startsWith('dispatch_error') || lower.startsWith('auth_failure')
+          || lower.startsWith('config_error')) {
+        return { kind: 'internal', label: 'Something went wrong inside the system.', service: '', audience: 'internal' };
+      }
+
+      // A free-form note an agent wrote deliberately — a real, user-directed
+      // message. Render verbatim and treat as user-actionable.
+      return { kind: 'other', label: note, service: '', audience: 'user' };
     },
 
     // Per-card preview disclosure state for the Needs-you panel.
@@ -5860,14 +5905,22 @@ function dashboard() {
       const active = { pending: 1, accepted: 1, working: 1 };
       const midnight = new Date(); midnight.setHours(0, 0, 0, 0);
       const todayMs = midnight.getTime();
-      const blocked = [], inflight = [], doneToday = [];
+      const blocked = [], inflight = [], doneToday = [], technical = [];
       for (const t of (this.workplaceTasks || [])) {
         if (t.project_id !== team) continue;
-        if (t.status === 'blocked') blocked.push(t);
+        if (t.status === 'blocked') {
+          // Surface only user-actionable blockers in the primary view;
+          // engine-internal ones go to the Technical activity group.
+          if (this._humanizeBlocker(t.blocker_note || '').audience === 'user') blocked.push(t);
+          else technical.push(t);
+        }
         else if (active[t.status]) inflight.push(t);
         else if (t.status === 'done' && ((t.completed_at || 0) * 1000) >= todayMs) doneToday.push(t);
+        else if (t.status === 'failed') technical.push(t);  // failures are engine-internal by default
       }
-      return { blocked, inflight, doneToday, total: blocked.length + inflight.length + doneToday.length };
+      // ``total`` counts only the user-facing buckets so the badge reflects
+      // work that's relevant to the person, not internal noise.
+      return { blocked, inflight, doneToday, technical, total: blocked.length + inflight.length + doneToday.length };
     },
 
     // One-hop handoff label for a task row: "creator → assignee" (or just the

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -3249,11 +3249,12 @@ function dashboard() {
     },
 
     // Plain-English mapping for blocker_note codes. Returns
-    // ``{ kind, label, service }`` so callers can both render the
-    // sentence and pick a CTA (credential vs. browser-login vs.
-    // drill-in). ``service`` is best-effort — extracted from a
-    // ``cred:<name>`` shorthand or the trailing word of a sentence;
-    // callers should treat empty as "unknown".
+    // ``{ kind, label, service, audience }`` so callers can render the
+    // sentence, pick a CTA (credential vs. browser-login vs. drill-in),
+    // and route by ``audience`` ('user' shows in the primary view;
+    // 'internal' is hidden into the Technical activity group). ``service``
+    // is best-effort — extracted from a ``cred:<name>`` shorthand or the
+    // trailing word of a sentence; callers should treat empty as "unknown".
     _humanizeBlocker(rawNote) {
       // Decode a machine blocker_note into plain English + an AUDIENCE.
       //   audience 'user'     → the person can act on it; shown in the
@@ -3318,9 +3319,11 @@ function dashboard() {
       if (lower.startsWith('agent_quarantined')) {
         return { kind: 'internal', label: 'The agent was paused after repeated errors.', service: '', audience: 'internal' };
       }
-      // Transient AI-provider hiccups.
+      // Transient AI-provider hiccups. Match only unambiguous error phrases —
+      // bare tokens like "oauth"/"rate limit" could appear in a real user note
+      // ("please complete OAuth login") and must not be hidden. Anything that
+      // slips past here still lands in the generic 'exception' branch below.
       if (lower.includes('llm call failed') || lower.includes('returned empty response')
-          || lower.includes('oauth') || lower.includes('rate limit') || lower.includes(' 429')
           || lower.includes('connection to the ai provider')) {
         return { kind: 'provider', label: 'The AI provider was briefly unavailable.', service: '', audience: 'internal' };
       }
@@ -5908,15 +5911,16 @@ function dashboard() {
       const blocked = [], inflight = [], doneToday = [], technical = [];
       for (const t of (this.workplaceTasks || [])) {
         if (t.project_id !== team) continue;
-        if (t.status === 'blocked') {
-          // Surface only user-actionable blockers in the primary view;
-          // engine-internal ones go to the Technical activity group.
+        // Blocked AND failed both carry a blocker_note. Surface the ones the
+        // user can act on (e.g. a too-large task they can split) in the
+        // primary view; route engine-internal / transient ones (the bulk of
+        // failures) to the collapsed Technical activity group.
+        if (t.status === 'blocked' || t.status === 'failed') {
           if (this._humanizeBlocker(t.blocker_note || '').audience === 'user') blocked.push(t);
           else technical.push(t);
         }
         else if (active[t.status]) inflight.push(t);
         else if (t.status === 'done' && ((t.completed_at || 0) * 1000) >= todayMs) doneToday.push(t);
-        else if (t.status === 'failed') technical.push(t);  // failures are engine-internal by default
       }
       // ``total`` counts only the user-facing buckets so the badge reflects
       // work that's relevant to the person, not internal noise.

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1803,8 +1803,8 @@
                       <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
                       <span class="text-xs">Loading work…</span>
                     </div>
-                    <!-- empty -->
-                    <div x-show="!workplaceSectionLoading.tasks && teamWork.total === 0" class="text-gray-500 text-sm py-6 text-center">
+                    <!-- empty (only when there's genuinely nothing — internal-only activity still shows the Technical group below) -->
+                    <div x-show="!workplaceSectionLoading.tasks && teamWork.total === 0 && teamWork.technical.length === 0" class="text-gray-500 text-sm py-6 text-center">
                       No active work for <span class="text-gray-400" x-text="activeTeam"></span> yet.<br>
                       <span class="text-xs text-gray-600">Tasks appear here as agents pick them up and hand off to each other.</span>
                     </div>
@@ -1819,7 +1819,7 @@
                                 <span class="text-sm text-gray-200 truncate" x-text="t.title"></span>
                                 <span class="text-[11px] text-gray-500 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
                               </div>
-                              <div x-show="t.blocker_note" class="text-[11px] text-red-400 mt-0.5 truncate" x-text="'⛔ ' + (t.blocker_note || '')"></div>
+                              <div x-show="t.blocker_note" class="text-[11px] text-amber-300/90 mt-0.5 truncate" x-text="_humanizeBlocker(t.blocker_note).label"></div>
                             </button>
                           </template>
                         </div>
@@ -1853,6 +1853,24 @@
                             </button>
                           </template>
                         </div>
+                      </div>
+                    </div>
+                    <!-- Technical activity — engine-internal failures the user can't act on. Collapsed by default; shown even when there's no user-facing work so it's always reachable. -->
+                    <div x-show="teamWork.technical.length > 0" x-data="{ open: false }" :class="teamWork.total > 0 ? 'mt-4' : ''">
+                      <button @click="open = !open" class="w-full flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-gray-500 hover:text-gray-400 mb-1.5">
+                        <span x-text="open ? '▾' : '▸'"></span>
+                        <span>Technical activity &middot; <span x-text="teamWork.technical.length"></span></span>
+                      </button>
+                      <div x-show="open" class="space-y-1">
+                        <template x-for="t in teamWork.technical" :key="t.id">
+                          <button @click="switchTab('workplace'); openTaskDrillIn(t.id)" class="w-full text-left bg-gray-800/20 hover:bg-gray-800/50 border border-gray-800 rounded-lg px-3 py-2 transition-colors">
+                            <div class="flex items-center justify-between gap-2">
+                              <span class="text-sm text-gray-400 truncate" x-text="t.title"></span>
+                              <span class="text-[11px] text-gray-600 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
+                            </div>
+                            <div x-show="t.blocker_note" class="text-[11px] text-gray-500 mt-0.5 truncate" x-text="_humanizeBlocker(t.blocker_note).label"></div>
+                          </button>
+                        </template>
                       </div>
                     </div>
                   </div>
@@ -4537,9 +4555,14 @@
                        Colour: amber for blocked, red for failed. -->
                   <template x-if="!drillInLoading && drillInData?.task && drillInData.task.blocker_note && ['blocked','failed'].includes(drillInData.task.status)">
                     <div class="mt-2 text-xs">
-                      <span x-show="drillInData.task.status === 'blocked'" class="text-amber-400 font-medium">Blocked:</span>
-                      <span x-show="drillInData.task.status === 'failed'" class="text-red-400 font-medium">Failed:</span>
-                      <span class="text-gray-200 whitespace-pre-wrap" x-text="drillInData.task.blocker_note"></span>
+                      <span x-show="drillInData.task.status === 'blocked'" class="text-amber-400 font-medium">Needs you:</span>
+                      <span x-show="drillInData.task.status === 'failed'" class="text-red-400 font-medium">Didn't finish:</span>
+                      <span class="text-gray-200 whitespace-pre-wrap" x-text="_humanizeBlocker(drillInData.task.blocker_note).label"></span>
+                      <!-- Raw (already redacted server-side) note for when you want the detail. -->
+                      <details class="mt-1" x-show="_humanizeBlocker(drillInData.task.blocker_note).label !== drillInData.task.blocker_note">
+                        <summary class="text-gray-500 hover:text-gray-400 cursor-pointer select-none">Technical details</summary>
+                        <span class="text-gray-500 whitespace-pre-wrap font-mono break-words" x-text="drillInData.task.blocker_note"></span>
+                      </details>
                     </div>
                   </template>
                 </div>

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from src.shared.redaction import normalize_blocker_note
 from src.shared.task_titles import normalize_title_and_description
 from src.shared.utils import dumps_safe, setup_logging
 
@@ -1213,6 +1214,12 @@ class Tasks:
         """
         if status not in VALID_STATUSES:
             raise ValueError(f"unknown status: {status!r}")
+        # Single choke point for the failure-reason column: redact secrets,
+        # collapse noisy raw dumps (truncated tool-call payloads, empty
+        # exceptions) to stable codes, and bound length — BEFORE the value
+        # is persisted at the UPDATE below or echoed into the
+        # ``status_changed`` event payload. Every write path funnels here.
+        blocker_note = normalize_blocker_note(blocker_note)
         now = time.time()
         # Captured outside the txn so the event-emit (which goes through
         # the bus / asyncio loop) doesn't run while we hold BEGIN IMMEDIATE.

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -1345,6 +1345,13 @@ class Tasks:
                 # the bell for already-rated (e.g. auto-graded) work.
                 "title": task_title,
                 "outcome": task_outcome,
+                # Carry the (already-normalized) failure reason so the SPA can
+                # live-patch it and bucket by audience without a full reload.
+                # Mirror the persistence rule: only blocked/failed keep a note;
+                # other transitions explicitly send null so a stale note clears.
+                "blocker_note": (
+                    blocker_note if new_status in ("blocked", "failed") else None
+                ),
             }
             # Merge caller-supplied context (e.g. cancel ``reason``) so
             # the dashboard activity feed can render rich status_changed

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5756,13 +5756,14 @@ def create_mesh_app(
         # with no ``blocker_note`` but carries an ``error`` string (the
         # canonical shape ``mesh_client.set_task_status`` sends for
         # auto-close paths), promote ``error`` to ``blocker_note`` so the
-        # store persists the reason. Truncate to 500 chars to match the
-        # column's expected size and avoid runaway bloat from huge LLM
-        # tracebacks. Existing explicit ``blocker_note`` callers win.
+        # store persists the reason. Existing explicit ``blocker_note``
+        # callers win. Redaction + length-bounding is owned centrally by
+        # ``normalize_blocker_note`` inside ``store.update_status`` (it
+        # redacts BEFORE truncating, so a secret can't be cut mid-token).
         if status == "failed" and not blocker_note:
             _err = body.get("error")
             if isinstance(_err, str) and _err.strip():
-                blocker_note = _err.strip()[:500]
+                blocker_note = _err.strip()
         if status not in VALID_STATUSES:
             raise HTTPException(
                 400,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5800,11 +5800,13 @@ def create_mesh_app(
             result_dict = raw_result if isinstance(raw_result, dict) else {}
             payload_extras: dict = {}
             if status == "blocked":
-                payload_extras["blocker_note"] = blocker_note or ""
+                # Use the stored value — update_status ran it through
+                # normalize_blocker_note (redacted + collapsed), so this
+                # back-edge (read by other agents via check_inbox) can't
+                # leak a secret from the raw request body.
+                payload_extras["blocker_note"] = (fresh.get("blocker_note") or "")
             elif status == "failed":
-                payload_extras["error"] = (
-                    body.get("error") or result_dict.get("error", "") or ""
-                )
+                payload_extras["error"] = (fresh.get("blocker_note") or "")
             elif status == "done":
                 payload_extras["summary"] = result_dict.get("summary", "")
             _write_task_event_back_edge(

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -395,6 +395,63 @@ def redact_text_with_urls(text: str) -> str:
     return redact_string(text)
 
 
+# ── Blocker-note normalization (the failure-reason column) ──────────────────
+
+# Max length of the persisted ``tasks.blocker_note``. Matches the legacy
+# truncation the mesh status endpoint applied ad-hoc; centralized here so
+# every write path is bounded identically.
+BLOCKER_NOTE_MAX_CHARS = 500
+
+# A truncated tool-call argument dump is multi-KB of broken JSON (the model
+# blew past its output-token cap mid tool-call). Capture the tool name so we
+# can collapse the whole payload to a short, stable reason code.
+_TRUNCATED_ARGS_RE = re.compile(
+    r"Truncated tool-call arguments for ['\"]?(?P<tool>[\w.\-]+)",
+    re.IGNORECASE,
+)
+# A contentless exception note — ``exception:``, ``exception: Error:``,
+# ``Error:`` — carries no signal. Collapse to a stable code so the UI never
+# shows a blank "failed" reason.
+_EMPTY_EXCEPTION_RE = re.compile(
+    r"^(exception:)?\s*(error:?)?\s*$", re.IGNORECASE,
+)
+
+
+def normalize_blocker_note(note: str | None) -> str | None:
+    """Sanitize a task ``blocker_note`` before it is persisted or surfaced.
+
+    The single choke point for the failure-reason column. Three jobs:
+
+    1. **Collapse noisy raw payloads to stable codes.** A truncated tool-call
+       dump becomes ``output_too_large: <tool>`` (the multi-KB broken-JSON
+       payload is dropped); a contentless ``exception:`` note becomes
+       ``internal_error``. Callers that already pass clean prefixed codes
+       (``lane_timeout:``, ``convergence_cap:``, ``no_outbound_effects:`` …)
+       fall through untouched.
+    2. **Redact secrets.** The text is UNTRUSTED — exception / HTTP error
+       strings can quote credential-bearing URLs or token-shaped values, so
+       it runs through :func:`redact_text_with_urls`.
+    3. **Bound length** to :data:`BLOCKER_NOTE_MAX_CHARS`.
+
+    Returns ``None`` for empty / whitespace-only input so the column stores
+    NULL rather than a meaningless blank. Pure and idempotent.
+    """
+    if note is None:
+        return None
+    text = str(note).strip()
+    if not text:
+        return None
+    # 1a. Truncated tool-call dump → clean code (the payload is discarded).
+    m = _TRUNCATED_ARGS_RE.search(text)
+    if m:
+        return f"output_too_large: {m.group('tool')}"
+    # 1b. Contentless exception note → stable internal_error code.
+    if _EMPTY_EXCEPTION_RE.match(text):
+        return "internal_error"
+    # 2 + 3. Redact secrets, then bound length.
+    return redact_text_with_urls(text)[:BLOCKER_NOTE_MAX_CHARS]
+
+
 # ── Deep recursion over JSON-shaped structures ──────────────────────────────
 
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -164,6 +164,29 @@ class TestHandOff:
         assert "error" not in result
 
     @pytest.mark.asyncio
+    async def test_hand_off_to_operator_non_403_wake_error_still_fails(self):
+        """The operator carve-out is narrowed to the BY-DESIGN 403. A genuine
+        infra failure (500 / network) on an operator wake must NOT be masked
+        as success — it stays visible via the ``wake_failed`` envelope.
+        """
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="dev-publisher")
+        mc.list_agents.return_value = {"operator": {"project": "ops"}}
+        mc.wake_agent.side_effect = Exception(
+            "Server error '500 Internal Server Error' for url "
+            "'http://host.docker.internal:8420/mesh/wake'"
+        )
+
+        result = await hand_off(
+            to="operator", summary="pipeline stalled", mesh_client=mc,
+        )
+
+        assert result["handed_off"] is False
+        assert result.get("wake_failed") is True
+        assert "queued_for_heartbeat" not in result
+
+    @pytest.mark.asyncio
     async def test_hand_off_to_worker_wake_failure_still_fails(self):
         """A wake failure to a NON-operator peer is a genuine problem and
         must keep the existing ``wake_failed`` envelope — the operator carve

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -137,6 +137,54 @@ class TestHandOff:
         )
 
     @pytest.mark.asyncio
+    async def test_hand_off_to_operator_wake_403_is_queued_success(self):
+        """A worker→operator wake is denied 403 BY DESIGN (the operator
+        polls on heartbeat). The task row is persisted, so a queued operator
+        handoff is the intended SUCCESS — it must not be classified as
+        ``wake_failed`` (which marked the originating task ``failed`` and
+        surfaced a scary "403 Forbidden … host.docker.internal" note).
+        """
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="dev-publisher")
+        mc.list_agents.return_value = {"operator": {"project": "ops"}}
+        mc.wake_agent.side_effect = Exception(
+            "Client error '403 Forbidden' for url "
+            "'http://host.docker.internal:8420/mesh/wake?target=operator'"
+        )
+
+        result = await hand_off(
+            to="operator", summary="pipeline stalled", mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result.get("queued_for_heartbeat") is True
+        # The expected denial must NOT leak as a failure envelope.
+        assert "wake_failed" not in result
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_hand_off_to_worker_wake_failure_still_fails(self):
+        """A wake failure to a NON-operator peer is a genuine problem and
+        must keep the existing ``wake_failed`` envelope — the operator carve
+        out must not swallow real handoff failures between workers.
+        """
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"writer": {"project": "scout"}}
+        mc.wake_agent.side_effect = Exception("connection refused")
+
+        result = await hand_off(
+            to="writer", summary="here you go", mesh_client=mc,
+        )
+
+        assert result["handed_off"] is False
+        assert result.get("wake_failed") is True
+        assert result.get("task_queued") is True
+        assert "error" in result
+
+    @pytest.mark.asyncio
     async def test_hand_off_to_global_scope_agent_writes_with_global_scope(self):
         """Forward-compat: any agent with ``scope: "global"`` on the
         registry (not just the literal name "operator") routes with

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -565,10 +565,13 @@ async def test_failed_status_explicit_blocker_note_wins_over_error(v2_app):
 
 @pytest.mark.asyncio
 async def test_failed_status_error_truncated_to_500_chars(v2_app):
-    """Huge ``error`` strings (e.g. LLM tracebacks) are truncated to 500
-    chars in the promoted ``blocker_note`` to avoid runaway bloat."""
+    """Huge ``error`` strings (e.g. LLM tracebacks) are bounded to 500 chars
+    in the promoted ``blocker_note`` (now via the central
+    ``normalize_blocker_note`` choke point) to avoid runaway bloat."""
     app, _, _ = v2_app
-    huge = "x" * 5000
+    # A long, non-secret-shaped message so the assertion targets the length
+    # bound, not the redactor (which would shrink a token-shaped run).
+    huge = "verbose traceback line. " * 300
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.post(
             "/mesh/tasks",
@@ -589,7 +592,8 @@ async def test_failed_status_error_truncated_to_500_chars(v2_app):
         assert r.status_code == 200
         note = r.json()["blocker_note"]
         assert note is not None
-        assert len(note) == 500
+        assert len(note) <= 500
+        assert note.startswith("verbose traceback line.")
 
 
 @pytest.mark.asyncio

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -497,3 +497,65 @@ class TestRedactTextWithUrls:
         # ``filter`` is not in SENSITIVE_QUERY_PARAMS — value survives.
         assert "filter=red" in out
         assert "failed" in out
+
+
+class TestNormalizeBlockerNote:
+    """``normalize_blocker_note`` — the single failure-reason choke point.
+
+    Three jobs: collapse noisy raw payloads to stable codes, redact secrets,
+    bound length. Returns None for contentless input.
+    """
+
+    def test_none_and_empty_return_none(self):
+        from src.shared.redaction import normalize_blocker_note
+        assert normalize_blocker_note(None) is None
+        assert normalize_blocker_note("") is None
+        assert normalize_blocker_note("   ") is None
+
+    def test_contentless_exception_collapses_to_internal_error(self):
+        from src.shared.redaction import normalize_blocker_note
+        # The exact useless notes seen in production.
+        assert normalize_blocker_note("exception: Error:") == "internal_error"
+        assert normalize_blocker_note("exception:") == "internal_error"
+        assert normalize_blocker_note("Error:") == "internal_error"
+
+    def test_truncated_tool_args_collapses_and_drops_payload(self):
+        from src.shared.redaction import normalize_blocker_note
+        raw = (
+            "exception: Error: Truncated tool-call arguments for 'write_file': "
+            '{"path": "x.md", "content": "---\\ntitle: huge blob ...'
+        )
+        out = normalize_blocker_note(raw)
+        assert out == "output_too_large: write_file"
+        # The multi-KB payload must NOT survive.
+        assert "content" not in out and "{" not in out
+
+    def test_clean_codes_pass_through(self):
+        from src.shared.redaction import normalize_blocker_note
+        for code in (
+            "lane_timeout: task exceeded 900s wall-clock cap",
+            "convergence_cap: task hit its per-task round budget",
+            "no_outbound_effects: the recipient completed the turn",
+        ):
+            assert normalize_blocker_note(code) == code
+
+    def test_redacts_secrets_in_free_form_note(self):
+        from src.shared.redaction import normalize_blocker_note
+        raw = "wake_failed: GET https://api.example.com/x?api_key=SUPERSECRETVALUE failed"
+        out = normalize_blocker_note(raw)
+        assert "SUPERSECRETVALUE" not in out
+        assert "[REDACTED]" in out
+
+    def test_bounds_length(self):
+        from src.shared.redaction import (
+            normalize_blocker_note, BLOCKER_NOTE_MAX_CHARS,
+        )
+        out = normalize_blocker_note("blocked: " + ("x" * 2000))
+        assert len(out) <= BLOCKER_NOTE_MAX_CHARS
+
+    def test_idempotent(self):
+        from src.shared.redaction import normalize_blocker_note
+        once = normalize_blocker_note(
+            "exception: Error: Truncated tool-call arguments for 'save_artifact': {...}"
+        )
+        assert normalize_blocker_note(once) == once

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -548,7 +548,8 @@ class TestNormalizeBlockerNote:
 
     def test_bounds_length(self):
         from src.shared.redaction import (
-            normalize_blocker_note, BLOCKER_NOTE_MAX_CHARS,
+            BLOCKER_NOTE_MAX_CHARS,
+            normalize_blocker_note,
         )
         out = normalize_blocker_note("blocked: " + ("x" * 2000))
         assert len(out) <= BLOCKER_NOTE_MAX_CHARS


### PR DESCRIPTION
## Why

Diagnosed live on a customer instance (`cake`): ~20% of tasks were terminating as `failed`/`blocked`, and every failure card showed **raw engine internals** to a non-technical user — Python exceptions, HTTP 403s, internal Docker URLs (`host.docker.internal:8420`), model IDs, and multi-KB truncated tool-call JSON blobs. Worse, most of those were engine plumbing the user can't act on, presented as a wall of red. Representative notes seen: `exception: Error:` (blank), `no_outbound_effects: …`, `convergence_cap: …`, `Truncated tool-call arguments for 'write_file': {…}`.

## What

Two layers, split along the security boundary (**redact at write, humanize + hide at read**):

**Server — security:**
- `normalize_blocker_note()` (`shared/redaction.py`): collapses noisy payloads to stable codes (`output_too_large: <tool>`, `internal_error`), redacts secrets via the existing `redact_text_with_urls`, bounds to 500 chars.
- Wired at the **single write funnel** `Tasks.update_status`, covering every producer (mesh endpoint, lane watchdog, agent loop, dispatch error). Drops the redundant `[:500]` in the mesh status endpoint — `normalize` redacts *before* truncating, so a secret can't be cut mid-token.

**Client — presentation:**
- `_humanizeBlocker()` now returns an `audience` (`user` | `internal`). User-actionable blockers (credential / browser-login / feedback / budget / task-too-big) render in the primary Work view in plain English; engine-internal/transient ones move into a collapsed **"Technical activity"** group and are dropped from the **"Needs you"** panel.
- Drill-in banner shows the humanized line; raw (redacted) note sits behind a **"Technical details"** disclosure.

**Behavior fix:** `hand_off` to `operator` no longer reports failure on the **by-design** 403 (workers can't synchronously wake the operator) — the task row is queued for heartbeat, which is the intended success. **The mesh permission boundary is unchanged**; only the misclassification is fixed.

**Hardening:** `check_inbox` sanitizes free-text event fields before they re-enter an agent's LLM context; chat-failure capture falls back to the exception class name (no more blank `exception: Error:`).

## Security

Net-positive: adds redaction to two previously-raw write paths and sanitization to one agent-read path. No boundary relaxed. Humanizer copy is static (no raw-tail interpolation into user-facing text); dashboard Jinja autoescape still handles XSS.

## Tests

`normalize_blocker_note` unit coverage (collapse / redact / bound / idempotent / None), wake-403 queued-success + non-operator-still-fails, and the endpoint truncation test updated for redact-then-bound semantics. Ran `test_shared_redaction`, `test_coordination`, `test_orchestration*`, `test_handoff_integration`, `test_loop`, `test_lanes` — all green locally; `node --check` + `ruff` clean.

## Deliberately out of scope (follow-up epics)

Root-cause reductions that make failures *not happen*: chunked/streamed large writes (the `output_too_large` source), task-level retry of transient provider errors, and bulk-task decomposition for `lane_timeout`. These improve operator-quality / cost; with this PR the user-facing experience is already clean.