### PR TITLE
fix(agent): stop tool loader from importing entire .venv / repo tree

### DIFF
--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import inspect
+import os
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -19,6 +20,18 @@ if TYPE_CHECKING:
     from src.agent.mcp_client import MCPClient
 
 logger = setup_logging("agent.tools")
+
+# Directories that never contain agent tools. The loader walks tools_dir
+# recursively, so without this guard a stray virtualenv, VCS checkout, or
+# vendored dependency tree (e.g. an agent running `pip install` in its tools
+# dir, or tools_dir accidentally resolving to a repo root) would make it try
+# to import thousands of library .py files as tools — flooding logs and
+# stalling startup. Pruning whole subtrees keeps discovery fast and robust.
+_NON_TOOL_DIRS = frozenset({
+    ".git", ".venv", "venv", "env", "__pycache__", "node_modules",
+    "site-packages", ".tox", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    ".idea", ".vscode", "dist", "build", ".egg-info",
+})
 
 # Global registry populated by the @tool decorator.
 # Protected by _tool_staging_lock during reload to prevent
@@ -151,17 +164,31 @@ class ToolRegistry:
         self._load_modules_from(tools_path, label="tool")
 
     def _load_modules_from(self, directory: Path, label: str) -> None:
-        """Load all .py modules from a directory, registering decorated tools."""
-        for py_file in directory.glob("**/*.py"):
-            if py_file.name.startswith("_"):
-                continue
-            try:
-                spec = importlib.util.spec_from_file_location(py_file.stem, str(py_file))
-                if spec and spec.loader:
-                    module = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(module)
-            except Exception as e:
-                logger.warning(f"Failed to load {label} {py_file}: {e}")
+        """Load all .py modules from a directory, registering decorated tools.
+
+        Recurses into subdirectories but prunes dependency/VCS/cache trees
+        (see ``_NON_TOOL_DIRS``) and any hidden dir so a stray ``.venv`` or
+        vendored package tree can never be mistaken for a pile of tools.
+        """
+        for root, dirs, files in os.walk(directory):
+            # Prune in place so os.walk never descends into these subtrees.
+            dirs[:] = [
+                d for d in dirs
+                if d not in _NON_TOOL_DIRS and not d.startswith(".")
+            ]
+            for fname in files:
+                if not fname.endswith(".py") or fname.startswith("_"):
+                    continue
+                py_file = Path(root) / fname
+                try:
+                    spec = importlib.util.spec_from_file_location(
+                        py_file.stem, str(py_file)
+                    )
+                    if spec and spec.loader:
+                        module = importlib.util.module_from_spec(spec)
+                        spec.loader.exec_module(module)
+                except Exception as e:
+                    logger.warning(f"Failed to load {label} {py_file}: {e}")
 
     def _register_mcp_tools(self) -> None:
         """Register tools from connected MCP servers."""

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -456,7 +456,8 @@ class REPLSession:
         # Reload permissions so the mesh grants the new agent API access
         self.ctx.permissions.reload()
         agent_cfg_data = _load_config().get("agents", {}).get(new_name, {})
-        tools_dir = os.path.abspath(agent_cfg_data.get("tools_dir", ""))
+        _td = agent_cfg_data.get("tools_dir", "")
+        tools_dir = os.path.abspath(_td) if _td else ""
         add_mcp_servers = agent_cfg_data.get("mcp_servers") or None
         add_thinking = agent_cfg_data.get("thinking", "")
         # Build per-agent env overrides (no shared extra_env mutation)
@@ -1403,7 +1404,8 @@ class REPLSession:
         fresh_cfg = _load_config()
         agent_cfg = fresh_cfg.get("agents", {}).get(name, {})
         default_model = fresh_cfg.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
-        tools_dir = os.path.abspath(agent_cfg.get("tools_dir", ""))
+        _td = agent_cfg.get("tools_dir", "")
+        tools_dir = os.path.abspath(_td) if _td else ""
         agent_model = agent_cfg.get("model", default_model)
         agent_mcp_servers = agent_cfg.get("mcp_servers") or None
         agent_thinking = agent_cfg.get("thinking", "")

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -455,7 +455,11 @@ class RuntimeContext:
                     daily_usd=budget.get("daily_usd", 10.0),
                     monthly_usd=budget.get("monthly_usd", 200.0),
                 )
-            tools_dir = os.path.abspath(agent_cfg.get("tools_dir", ""))
+            # Guard the empty case: os.path.abspath("") resolves to the CWD
+            # (the repo root), which would bind-mount the whole tree — .venv,
+            # .git, src — into the agent. Empty stays empty (no tools mount).
+            _td = agent_cfg.get("tools_dir", "")
+            tools_dir = os.path.abspath(_td) if _td else ""
             agent_model = agent_cfg.get("model", default_model)
             agent_mcp_servers = agent_cfg.get("mcp_servers") or None
             agent_thinking = agent_cfg.get("thinking", "")

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2359,7 +2359,8 @@ def create_dashboard_router(
             acfg = cfg.get("agents", {}).get(name, {})
             if template:
                 role = acfg.get("role", role)
-            tools_dir = os.path.abspath(acfg.get("tools_dir", ""))
+            _td = acfg.get("tools_dir", "")
+            tools_dir = os.path.abspath(_td) if _td else ""
             # Build per-agent env overrides (no shared extra_env mutation)
             agent_env: dict[str, str] = {}
             for env_key, cfg_key in (

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -474,9 +474,12 @@ class HealthMonitor:
         default_model = fresh_cfg.get("llm", {}).get(
             "default_model", "openai/gpt-4o-mini",
         )
+        # Empty stays empty: os.path.abspath("") resolves to the CWD (repo
+        # root), which would bind-mount the whole tree into the rebuilt agent.
+        _td = agent_cfg.get("tools_dir", "")
         return {
             "role": agent_cfg.get("role", ""),
-            "tools_dir": os.path.abspath(agent_cfg.get("tools_dir", "")),
+            "tools_dir": os.path.abspath(_td) if _td else "",
             "model": agent_cfg.get("model", default_model),
             "mcp_servers": agent_cfg.get("mcp_servers") or None,
             "thinking": agent_cfg.get("thinking", ""),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -64,6 +64,42 @@ async def test_unknown_tool_raises():
         await registry.execute("nonexistent", {})
 
 
+def _write_tool_file(path: Path, tool_name: str) -> None:
+    """Write a minimal @tool module that registers ``tool_name`` on import."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "from src.agent.tools import tool\n"
+        f"@tool(name='{tool_name}', description='d', parameters={{}})\n"
+        f"def {tool_name}():\n"
+        "    return 1\n"
+    )
+
+
+def test_loader_prunes_dependency_and_vcs_trees(tmp_path):
+    """The loader must recurse normal subdirs but never descend into a
+    .venv / site-packages / __pycache__ / .git tree — otherwise a stray
+    virtualenv (or tools_dir resolving to a repo root) makes it try to
+    import thousands of library .py files as tools."""
+    # Legit tools: one top-level, one in an ordinary nested package.
+    _write_tool_file(tmp_path / "good_tool.py", "good_one")
+    _write_tool_file(tmp_path / "pkg" / "nested_tool.py", "nested_one")
+    # Poison trees the loader must skip entirely.
+    _write_tool_file(
+        tmp_path / ".venv" / "lib" / "site-packages" / "venv_tool.py", "venv_one"
+    )
+    _write_tool_file(tmp_path / "__pycache__" / "cache_tool.py", "cache_one")
+    _write_tool_file(tmp_path / ".git" / "hooks" / "git_tool.py", "git_one")
+
+    registry = ToolRegistry.__new__(ToolRegistry)
+    registry._load_modules_from(tmp_path, label="tool")
+
+    assert "good_one" in _tool_staging
+    assert "nested_one" in _tool_staging  # ordinary recursion still works
+    assert "venv_one" not in _tool_staging
+    assert "cache_one" not in _tool_staging
+    assert "git_one" not in _tool_staging
+
+
 def test_get_tool_definitions():
     @tool(
         name="tool_test",


### PR DESCRIPTION
## Diagnosis (live, production fleet)

The client's recurring "engine keeps breaking" turned out to be a **fleet-wide agent startup failure**, confirmed on a production instance (running latest `main`, fully deployed):

- Every agent container bind-mounts **`/opt/openlegion/repo` → `/app/tools`** — the entire repo root, including the 93 MB host `.venv`, `.git`, and `src`.
- The tool loader recursively imports every `.py` it finds under `/app/tools`: **7722 files, 7402 of them library internals** (`anthropic`, `starlette`, …).
- Logs show hundreds of `Failed to load tool .../site-packages/anthropic/...: attempted relative import` per startup, immediately followed by `Agent 'operator' did not respond within 60s` and `✗ operator failed to start`. The operator is the user's entire interface → reads as "the engine is broken."

### Two compounding root causes

1. **`os.path.abspath("")` footgun.** Agent configs carry no `tools_dir` key (`config/agents.yaml` has zero). `os.path.abspath(cfg.get("tools_dir", ""))` → `os.path.abspath("")` → **CWD = repo root**, defeating the runtime's `if tools_dir:` mount guard.
2. **Unbounded loader glob.** `_load_modules_from` did `directory.glob("**/*.py")` with no exclusions — so it tried to `exec_module()` the entire mounted tree on every startup *and* every `reload()` (i.e. after every self-authored tool).

## Fix (KISS, defense in depth)

- **Keystone — loader:** `_load_modules_from` now walks with `os.walk` and prunes dependency/VCS/cache subtrees (`_NON_TOOL_DIRS`) plus any hidden dir. A stray `.venv`, a vendored package tree, or `tools_dir` resolving to a repo root can no longer poison discovery. Ordinary nested tool packages still load. This single chokepoint makes discovery robust regardless of what `tools_dir` points at.
- **Callers:** an empty `tools_dir` now stays `""` (→ no mount) instead of silently becoming the CWD (`cli/runtime.py`, `cli/repl.py` ×2, `dashboard/server.py`). Also stops mounting `src`/`.git` into untrusted agent containers.

## Tests

- New `test_loader_prunes_dependency_and_vcs_trees`: asserts the loader skips `.venv/site-packages`, `__pycache__`, and `.git` while still recursing ordinary subdirs.
- `test_tools.py` 58 passed · `test_runtime.py`+`test_builtins.py` 359 passed · ruff clean.

## Deploy note

Fleet-wide issue — affects all instances and every new user. After merge, deploy needs an **agent image rebuild** (loader is agent-side code, baked into `openlegion-agent:latest`), then `systemctl restart openlegion`.