### PR TITLE
fix(orchestration): gate blocker_note in status_changed audit event

### DIFF
--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -1291,7 +1291,16 @@ class Tasks:
                     {
                         "from": current,
                         "to": status,
-                        "blocker_note": blocker_note,
+                        # Mirror the column + bus-payload gating: only
+                        # blocked/failed carry a reason. A note on any other
+                        # transition is stale context that must not be echoed
+                        # into the audit event row (exposed via
+                        # /mesh/tasks/{id}/events).
+                        "blocker_note": (
+                            blocker_note
+                            if status in ("blocked", "failed")
+                            else None
+                        ),
                     },
                 )
                 # Chain-break detection — only on the ``done`` transition.


### PR DESCRIPTION
## What

Follow-up to #1050. `Tasks.update_status` gates `blocker_note` to `blocked`/`failed` transitions in two places — the `tasks.blocker_note` column write and the `status_changed` bus payload — but the inner SQLite **audit event row** wrote `blocker_note` unconditionally. A note passed on any other transition (e.g. a `done`/`cancelled` call that happens to carry one) was echoed into the audit log, which is exposed via `GET /mesh/tasks/{id}/events`.

This makes all three write paths agree.

## Why it's low-risk

The value is already run through `normalize_blocker_note` (redacted + collapsed) before this line, so this is a **contract-consistency** fix, not a secret-leak fix. In practice callers don't pass `blocker_note` on non-blocked/failed transitions, so the emitted value is `None` either way today — this just enforces the invariant.

## Provenance

Surfaced during the post-merge principal-engineer review of #1050 (independently flagged by Codex as the top item). The other two review findings were judged non-actionable: the `output_too_large` tool-name path is captured by `[\w.\-]+` from the controlled builtin-tool set, and the operator-403 string fallback is intentional (handles non-`HTTPStatusError` exceptions that still wrap the by-design 403).

## Test

`pytest tests/test_orchestration_endpoints.py` → 41 passed.