### PR TITLE
feat(limits): centralize + raise operational caps, make them adjustable

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncIterator
 
 import httpx
 
+from src.shared import limits
 from src.shared.types import APIProxyRequest, LLMResponse, ToolCallInfo
 from src.shared.utils import setup_logging
 
@@ -61,6 +62,29 @@ class LLMClient:
         # arguments". 8192 is the safe floor across common modern models
         # (gpt-4o family = 16384, Claude 3.5 Sonnet = 8192, Claude 4.x = 64K+).
         self.max_output_tokens = max_output_tokens
+        # LLM call timeout, resolved from the central limits table (env ->
+        # high default). With streaming task execution this is an *idle*
+        # (between-chunk) ceiling; on the non-streaming path it is the total
+        # response wait. The old hard-coded 120s could not accommodate the
+        # large generations the per-agent max_output_tokens permits (an 80k
+        # token output cannot complete in 120s) — that mismatch surfaced as
+        # httpx.ReadTimeout and failed the task. See src/shared/limits.py.
+        self.timeout_seconds = limits.resolve("llm_timeout_seconds")
+        # Consistency guardrail: the timeout must be able to accommodate the
+        # output the agent is permitted to generate, or large completions
+        # ReadTimeout and fail the task (the exact mismatch that bit the
+        # production fleet). Warn loudly rather than silently shipping a
+        # self-contradictory config. ~20 tok/s is a deliberately conservative
+        # floor (real throughput is several times higher).
+        _needed = self.max_output_tokens / 20
+        if self.timeout_seconds < _needed:
+            logger.warning(
+                "llm_timeout_seconds=%ds may be too low for max_output_tokens=%d "
+                "(needs ~%ds at a conservative 20 tok/s) — large generations may "
+                "ReadTimeout. Raise OPENLEGION_LLM_TIMEOUT_SECONDS or lower the "
+                "output cap.",
+                self.timeout_seconds, self.max_output_tokens, int(_needed),
+            )
         self._client: httpx.AsyncClient | None = None
         self._client_lock = asyncio.Lock()
         self._auth_token: str = os.environ.get("MESH_AUTH_TOKEN", "")
@@ -74,7 +98,7 @@ class LLMClient:
                 headers: dict[str, str] = {}
                 if self._auth_token:
                     headers["Authorization"] = f"Bearer {self._auth_token}"
-                self._client = httpx.AsyncClient(timeout=120, headers=headers)
+                self._client = httpx.AsyncClient(timeout=self.timeout_seconds, headers=headers)
             return self._client
 
     async def close(self) -> None:
@@ -169,7 +193,7 @@ class LLMClient:
         # whack-a-mole'ing message text.
         _retryable = (
             "rate limit", "ratelimit", "429", "too many requests",
-            "overloaded", "503", "empty response", "retrying may help",
+            "overloaded", "503", "529", "empty response", "retrying may help",
         )
         if any(kw in error_msg.lower() for kw in _retryable):
             raise LLMRetryableError(f"{prefix}: {error_msg}")
@@ -241,7 +265,7 @@ class LLMClient:
         params.update(kwargs)
         self._apply_thinking_params(params, model, kwargs)
 
-        request = APIProxyRequest(service="llm", action="chat", params=params, timeout=120)
+        request = APIProxyRequest(service="llm", action="chat", params=params, timeout=self.timeout_seconds)
 
         from src.shared.trace import trace_headers
 
@@ -302,7 +326,7 @@ class LLMClient:
         params.update(kwargs)
         self._apply_thinking_params(params, model, kwargs)
 
-        request = APIProxyRequest(service="llm", action="chat", params=params, timeout=120)
+        request = APIProxyRequest(service="llm", action="chat", params=params, timeout=self.timeout_seconds)
 
         from src.shared.trace import trace_headers
 
@@ -313,7 +337,7 @@ class LLMClient:
             json=request.model_dump(mode="json"),
             params={"agent_id": self.agent_id},
             headers=trace_headers(),
-            timeout=120,
+            timeout=self.timeout_seconds,
         ) as response:
             response.raise_for_status()
             async for line in response.aiter_lines():

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -20,6 +20,7 @@ import httpx
 from src.agent.attachments import enrich_message_with_attachments
 from src.agent.loop_detector import ToolLoopDetector
 from src.agent.workspace import INTROSPECT_PERM_KEYS
+from src.shared import limits
 from src.shared.errors import LLMAuthError, LLMConfigError
 from src.shared.types import SILENT_REPLY_TOKEN, AgentStatus, LLMResponse, TaskAssignment, TaskResult
 from src.shared.utils import dumps_safe, format_dict, generate_id, sanitize_for_prompt, setup_logging, truncate
@@ -37,7 +38,7 @@ logger = setup_logging("agent.loop")
 
 
 # Status codes that indicate transient server-side errors worth retrying
-_RETRYABLE_STATUS_CODES = {429, 502, 503}
+_RETRYABLE_STATUS_CODES = {429, 502, 503, 504, 529}  # 529 = Anthropic overloaded
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 1  # seconds: 1, 2, 4
 _TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "300"))  # seconds — hard ceiling per tool
@@ -331,32 +332,23 @@ class AgentLoop:
         context_manager: ContextManager | None = None,
         allowed_tools: frozenset[str] | None = None,
     ):
-        # Override class defaults from env vars (set by dashboard system settings)
-        def _clamp_env(name: str, default: int, lo: int, hi: int) -> int:
-            try:
-                val = int(os.environ.get(name, str(default)))
-            except ValueError:
-                logger.warning("Invalid %s value, using default %d", name, default)
-                return default
-            clamped = max(lo, min(val, hi))
-            if clamped != val:
-                logger.info("%s=%d clamped to %d (range %d-%d)", name, val, clamped, lo, hi)
-            return clamped
-
-        self.MAX_ITERATIONS = _clamp_env("OPENLEGION_MAX_ITERATIONS", 20, 1, 100)
-        self.CHAT_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_CHAT_MAX_TOOL_ROUNDS", 30, 1, 200)
-        self.CHAT_MAX_TOTAL_ROUNDS = _clamp_env("OPENLEGION_CHAT_MAX_TOTAL_ROUNDS", 200, 1, 1000)
-        # Per-task convergence budget (RC-1). A much tighter bound on tool
-        # rounds that applies ONLY when a durable ``task_id`` is driving the
-        # chat turn (handoff / lane dispatch). It bounds the task path well
-        # below the interactive ceiling (CHAT_MAX_TOOL_ROUNDS × session
-        # auto-continues) AND below the mesh-side 900s lane wall-clock cap.
-        # This is an ADVISORY convergence/UX bound, NOT a security control:
-        # it does NOT replace or weaken any mesh-side control (per-agent
-        # daily budget preflight, lane wall-clock cap). It only ADDS a
-        # tighter soft bound below them. Interactive chat (no task_id) is
-        # completely unaffected.
-        self.TASK_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_TASK_MAX_TOOL_ROUNDS", 20, 1, 100)
+        # Round caps resolve through the central limits table (env -> default,
+        # both clamped to the spec range). Defaults are HIGH and operator-
+        # adjustable; the host injects per-agent / settings.json overrides into
+        # the container env at creation. See src/shared/limits.py.
+        self.MAX_ITERATIONS = limits.resolve("max_iterations")
+        self.CHAT_MAX_TOOL_ROUNDS = limits.resolve("chat_max_tool_rounds")
+        self.CHAT_MAX_TOTAL_ROUNDS = limits.resolve("chat_max_total_rounds")
+        # Per-task convergence budget (RC-1). A bound on tool rounds that
+        # applies ONLY when a durable ``task_id`` is driving the chat turn
+        # (handoff / lane dispatch). It bounds the task path below the
+        # interactive ceiling (CHAT_MAX_TOOL_ROUNDS × session auto-continues)
+        # AND below the mesh-side lane wall-clock cap. This is an ADVISORY
+        # convergence/UX bound, NOT a security control: it does NOT replace or
+        # weaken any mesh-side control (per-agent daily budget preflight, lane
+        # wall-clock cap). It only ADDS a soft bound below them. Interactive
+        # chat (no task_id) is completely unaffected.
+        self.TASK_MAX_TOOL_ROUNDS = limits.resolve("task_max_tool_rounds")
         # Item 3 (Codex r4): TASK_MAX and CHAT_MAX are independently
         # env-clamped, so a misconfig (TASK_MAX > CHAT_MAX) could let a task
         # exhaust the interactive CHAT_MAX_TOOL_ROUNDS bound — falling through

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -1415,6 +1415,8 @@ class REPLSession:
             restart_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
         # Per-agent output-token cap → LLM_MAX_TOKENS (survives /restart).
         set_llm_max_tokens_env(restart_env, agent_cfg)
+        from src.shared.limits import set_llm_limits_env
+        set_llm_limits_env(restart_env, agent_cfg)
 
         # Start new container
         url = self.ctx.runtime.start_agent(

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -485,6 +485,8 @@ class RuntimeContext:
                 agent_env["OPENLEGION_MAX_ITERATIONS"] = str(agent_max_iters)
             # Per-agent output-token cap → LLM_MAX_TOKENS (survives restart).
             set_llm_max_tokens_env(agent_env, agent_cfg)
+            from src.shared.limits import set_llm_limits_env
+            set_llm_limits_env(agent_env, agent_cfg)
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
                 # NOTE: the operator no longer seeds a boot greeting into

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3038,6 +3038,8 @@ def create_dashboard_router(
             # change survives a single-agent dashboard restart (not just the
             # live hot-reload). Absent = LLMClient default 8192.
             set_llm_max_tokens_env(restart_env, agent_cfg)
+            from src.shared.limits import set_llm_limits_env
+            set_llm_limits_env(restart_env, agent_cfg)
             url = await asyncio.wait_for(
                 asyncio.to_thread(
                     runtime.start_agent,
@@ -6291,6 +6293,8 @@ def create_dashboard_router(
                 # Per-agent output-token cap → LLM_MAX_TOKENS (survives the
                 # dashboard "restart all agents" flow, not just hot-reload).
                 set_llm_max_tokens_env(_restart_env, agent_cfg)
+                from src.shared.limits import set_llm_limits_env
+                set_llm_limits_env(_restart_env, agent_cfg)
                 url = await loop.run_in_executor(
                     None,
                     lambda aid=agent_id, acfg=agent_cfg, sd=tools_dir, re=_restart_env: runtime.start_agent(

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -2313,7 +2313,14 @@ class CredentialVault:
             # ``error_type="transient"`` and the agent's classifier routes
             # via ``LLMRetryableError`` instead of failing the task.
             le_lower = last_error.lower()
-            if "retrying may help" in le_lower or "empty response" in le_lower:
+            # "Overloaded" / overloaded_error / 529 is Anthropic's transient
+            # capacity signal — over OAuth it can surface as an HTTP-200 body
+            # ("Anthropic API error (HTTP 200): Overloaded") rather than a 529
+            # status, so it must be matched by substring here or it falls
+            # through to a non-retryable RuntimeError and needlessly fails the
+            # task instead of backing off.
+            _transient = ("retrying may help", "empty response", "overloaded", "529")
+            if any(sig in le_lower for sig in _transient):
                 raise LLMTransientError(
                     f"Anthropic OAuth error: {last_error}",
                     provider="anthropic",

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -585,7 +585,10 @@ class HealthMonitor:
             # max_output_tokens edit survives an automatic crash-recovery
             # restart. Read from fresh YAML (the registry ``info`` dict
             # doesn't carry it); no-op when unset → LLMClient default 8192.
-            set_llm_max_tokens_env(restart_env, _agents_cfg.get(agent_id, {}))
+            _hcfg = _agents_cfg.get(agent_id, {})
+            set_llm_max_tokens_env(restart_env, _hcfg)
+            from src.shared.limits import set_llm_limits_env
+            set_llm_limits_env(restart_env, _hcfg)
             try:
                 url = await loop.run_in_executor(
                     None,

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -13,13 +13,13 @@ Two queue modes control how incoming messages interact with busy agents:
 from __future__ import annotations
 
 import asyncio
-import os
 import time
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
 from src.host.orchestration import InvalidStatusTransition
+from src.shared import limits
 from src.shared.types import SILENT_REPLY_TOKEN, MessageOrigin
 from src.shared.utils import generate_id, setup_logging
 
@@ -30,11 +30,11 @@ _STEER_WAKEUP_WINDOW = 3600  # 1 hour window
 _NOTIFY_FORWARD_TIMEOUT = 30  # seconds — cap on auto-notify send
 # Per-task lane watchdog (Bug 4): a hung LLM stream or stuck tool call
 # previously blocked the lane indefinitely — every subsequent task for that
-# agent would queue forever. The default is generous (15 min) because some
-# deep-research workloads legitimately take that long; tune via env var.
-_DEFAULT_LANE_TIMEOUT_SECONDS = int(
-    os.getenv("OPENLEGION_LANE_TIMEOUT_SECONDS", "900"),
-)
+# agent would queue forever. The default is generous because some
+# deep-research / large-document workloads legitimately run long; this is the
+# hung-task backstop, so it must sit ABOVE the per-task tool-round budget ×
+# the LLM call timeout. Resolved + clamped via the central limits table.
+_DEFAULT_LANE_TIMEOUT_SECONDS = limits.resolve("lane_timeout_seconds")
 # H7 — per-agent lane queue depth cap. Bounds the un-drained followup
 # backlog so a flood of wakes/handoffs can't grow a single agent's queue
 # without limit (memory + a guarantee that backpressure surfaces as a
@@ -42,9 +42,7 @@ _DEFAULT_LANE_TIMEOUT_SECONDS = int(
 # drains serially, so a healthy agent rarely carries more than a handful
 # queued, and 100 deep is already a strong signal something is looping.
 # ``<= 0`` disables the bound (unbounded queue, pre-H7 behaviour).
-_DEFAULT_LANE_QUEUE_MAX = int(
-    os.getenv("OPENLEGION_LANE_QUEUE_MAX", "100"),
-)
+_DEFAULT_LANE_QUEUE_MAX = limits.resolve("lane_queue_max")
 
 
 class LaneQueueFull(Exception):

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3678,6 +3678,9 @@ def create_mesh_app(
                     env_overrides[env_key] = val
             # Per-agent output-token cap → LLM_MAX_TOKENS (survives restart).
             set_llm_max_tokens_env(env_overrides, acfg)
+            # Per-agent round/timeout caps → OPENLEGION_* (survives restart).
+            from src.shared.limits import set_llm_limits_env
+            set_llm_limits_env(env_overrides, acfg)
 
             try:
                 # Start container with per-agent env_overrides (not shared extra_env)

--- a/src/shared/limits.py
+++ b/src/shared/limits.py
@@ -131,8 +131,12 @@ def set_llm_limits_env(env: dict[str, str], agent_cfg: dict) -> None:
     Mirrors ``set_llm_max_tokens_env``: called by every restart-from-config
     path so an operator's ``edit_agent`` change to ``max_tool_rounds`` /
     ``llm_timeout_seconds`` survives a container restart. No-op for unset /
-    non-int values (the env/settings/default chain then applies).
+    non-int values (the env/settings/default chain then applies), and a no-op
+    for a missing/malformed agent config (a null agents.yaml entry yields
+    ``None``) rather than raising.
     """
+    if not isinstance(agent_cfg, dict):
+        return
     for cfg_key, limit_key in AGENT_CONFIG_KEYS.items():
         v = _coerce_int(agent_cfg.get(cfg_key), limit_key)
         if v is not None:

--- a/src/shared/limits.py
+++ b/src/shared/limits.py
@@ -1,0 +1,139 @@
+"""Single source of truth for the engine's operational limits.
+
+Historically these limits (LLM call timeout, per-task tool-round budget,
+interactive round ceilings, lane wall-clock) were scattered hard-coded magic
+numbers — set low, mutually inconsistent, and not operator-adjustable. A
+client whose agent was configured for an 80k-token output but given only a
+120s LLM timeout could never converge: the engine permitted work its own
+limits couldn't accommodate.
+
+This module centralizes every operational limit with a HIGH default and a
+clamp range, resolved in priority order:
+
+    per-agent override (agents.yaml / edit_agent)
+        -> OPENLEGION_* env var (incl. dashboard system-settings)
+            -> built-in default
+
+IMPORTANT: these are convergence / UX / robustness bounds, NOT cost controls.
+The per-agent daily **budget** (cost vault preflight) remains the hard spend
+backstop, and the lane wall-clock remains the hung-task backstop. Raising
+these limits widens how much *legitimate* work can complete before a soft
+bound trips; it does not remove the cost/liveness guarantees.
+
+Agent-side limits (round caps, LLM timeout) are read inside the agent
+container from env; the host injects the resolved values into each container's
+env at creation (see ``set_llm_limits_env``) so a settings.json / per-agent
+change survives a restart, mirroring the proven ``LLM_MAX_TOKENS`` path.
+Host-side limits (lane timeout/queue) are read directly in the host process.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("shared.limits")
+
+# key -> (default, lo, hi). ``hi`` is the adjustability ceiling: an operator
+# may tune anywhere in [lo, hi]; values outside are clamped (never rejected).
+LIMIT_SPECS: dict[str, tuple[int, int, int]] = {
+    # LLM call timeout. With streaming task execution this is an *idle*
+    # (between-chunk) ceiling, so it can be generous without risking a hang.
+    "llm_timeout_seconds": (1800, 10, 7200),
+    # Per-task convergence budget — tool rounds while a durable task_id drives
+    # the turn. Must stay <= chat_max_tool_rounds (loop.py enforces it).
+    "task_max_tool_rounds": (300, 1, 1000),
+    # Interactive (no task_id) per-turn round ceiling.
+    "chat_max_tool_rounds": (500, 1, 1000),
+    # Interactive cross-turn total round ceiling for one session.
+    "chat_max_total_rounds": (1000, 1, 5000),
+    # Legacy execute_task bounded-loop ceiling.
+    "max_iterations": (60, 1, 500),
+    # Host-side lane wall-clock watchdog (hung-stream / stuck-tool backstop).
+    "lane_timeout_seconds": (14400, 30, 86400),
+    # Host-side per-agent followup queue depth cap (0 disables).
+    "lane_queue_max": (100, 0, 10000),
+}
+
+# key -> OPENLEGION_* env var name (the second-lowest precedence source).
+ENV_NAMES: dict[str, str] = {
+    "llm_timeout_seconds": "OPENLEGION_LLM_TIMEOUT_SECONDS",
+    "task_max_tool_rounds": "OPENLEGION_TASK_MAX_TOOL_ROUNDS",
+    "chat_max_tool_rounds": "OPENLEGION_CHAT_MAX_TOOL_ROUNDS",
+    "chat_max_total_rounds": "OPENLEGION_CHAT_MAX_TOTAL_ROUNDS",
+    "max_iterations": "OPENLEGION_MAX_ITERATIONS",
+    "lane_timeout_seconds": "OPENLEGION_LANE_TIMEOUT_SECONDS",
+    "lane_queue_max": "OPENLEGION_LANE_QUEUE_MAX",
+}
+
+# Per-agent config keys (agents.yaml / edit_agent) -> limits key. Only the
+# limits worth tuning per-agent are exposed; the rest stay global.
+AGENT_CONFIG_KEYS: dict[str, str] = {
+    "max_tool_rounds": "task_max_tool_rounds",
+    "llm_timeout_seconds": "llm_timeout_seconds",
+}
+
+
+def clamp(key: str, value: int) -> int:
+    """Clamp ``value`` into the spec range for ``key`` (logs if it moved)."""
+    _default, lo, hi = LIMIT_SPECS[key]
+    clamped = max(lo, min(value, hi))
+    if clamped != value:
+        logger.info("limit %s=%d clamped to %d (range %d-%d)", key, value, clamped, lo, hi)
+    return clamped
+
+
+def _coerce_int(raw: Any, key: str) -> int | None:
+    """Parse ``raw`` to a clamped int, or None if absent/invalid.
+
+    ``bool`` is rejected explicitly (it is an ``int`` subclass) so a stray
+    ``True``/``False`` can't silently become ``1``/``0``.
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return clamp(key, int(raw))
+    except (TypeError, ValueError):
+        logger.warning("Invalid value %r for limit %s — ignoring", raw, key)
+        return None
+
+
+def resolve(key: str, *, agent_cfg: dict | None = None) -> int:
+    """Resolve a limit through the precedence chain to a clamped int.
+
+    per-agent override -> env var -> built-in default. The first source that
+    yields a usable value wins; everything is clamped to the spec range.
+    """
+    default, _lo, _hi = LIMIT_SPECS[key]
+
+    # 1. per-agent override (highest precedence)
+    if agent_cfg:
+        for cfg_key, limit_key in AGENT_CONFIG_KEYS.items():
+            if limit_key == key:
+                v = _coerce_int(agent_cfg.get(cfg_key), key)
+                if v is not None:
+                    return v
+
+    # 2. env var (set directly, or by the dashboard system-settings surface)
+    v = _coerce_int(os.environ.get(ENV_NAMES[key]), key)
+    if v is not None:
+        return v
+
+    # 3. built-in default
+    return default
+
+
+def set_llm_limits_env(env: dict[str, str], agent_cfg: dict) -> None:
+    """Inject per-agent limit overrides into a container env dict from config.
+
+    Mirrors ``set_llm_max_tokens_env``: called by every restart-from-config
+    path so an operator's ``edit_agent`` change to ``max_tool_rounds`` /
+    ``llm_timeout_seconds`` survives a container restart. No-op for unset /
+    non-int values (the env/settings/default chain then applies).
+    """
+    for cfg_key, limit_key in AGENT_CONFIG_KEYS.items():
+        v = _coerce_int(agent_cfg.get(cfg_key), limit_key)
+        if v is not None:
+            env[ENV_NAMES[limit_key]] = str(v)

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -26,8 +26,12 @@ def set_llm_max_tokens_env(env: dict[str, str], agent_cfg: dict) -> None:
 
     No-op when the cap is unset or not a plain int, so the LLMClient default
     (8192) then applies. ``bool`` is rejected explicitly (it is an ``int``
-    subclass) so a stray ``True``/``False`` can't become ``1``/``0``.
+    subclass) so a stray ``True``/``False`` can't become ``1``/``0``. Also a
+    no-op for a missing/malformed agent config (a null agents.yaml entry yields
+    ``None``) rather than raising AttributeError on the restart path.
     """
+    if not isinstance(agent_cfg, dict):
+        return
     value = agent_cfg.get("max_output_tokens")
     if isinstance(value, int) and not isinstance(value, bool):
         env["LLM_MAX_TOKENS"] = str(value)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -463,16 +463,20 @@ class TestToolLimitReached:
     async def test_tool_limit_sets_flag_in_response(self):
         """When CHAT_MAX_TOOL_ROUNDS is exhausted, response has tool_limit_reached=True."""
         # Each call uses a unique arg so the loop detector doesn't fire first.
+        # Pin the per-turn cap low so it trips within the supplied mock list
+        # (the default is now high — sourced from the central limits table).
+        _rounds = 5
         responses = [
             LLMResponse(
                 content="",
                 tool_calls=[ToolCallInfo(name="exec", arguments={"command": f"step_{i}"})],
                 tokens_used=10,
             )
-            for i in range(AgentLoop.CHAT_MAX_TOOL_ROUNDS)
+            for i in range(_rounds)
         ] + [LLMResponse(content="I've done what I can.", tokens_used=10)]
 
         loop = _make_loop(responses)
+        loop.CHAT_MAX_TOOL_ROUNDS = _rounds
         loop.tools.execute = AsyncMock(return_value={"result": "ok"})
         loop.tools.get_tool_definitions = MagicMock(
             return_value=[{"type": "function", "function": {"name": "exec"}}]
@@ -492,16 +496,18 @@ class TestToolLimitReached:
     @pytest.mark.asyncio
     async def test_tool_limit_streaming_sets_flag(self):
         """Streaming path also emits tool_limit_reached=True on the done event."""
+        _rounds = 5
         responses = [
             LLMResponse(
                 content="",
                 tool_calls=[ToolCallInfo(name="exec", arguments={"command": f"step_{i}"})],
                 tokens_used=10,
             )
-            for i in range(AgentLoop.CHAT_MAX_TOOL_ROUNDS)
+            for i in range(_rounds)
         ] + [LLMResponse(content="Done.", tokens_used=10)]
 
         loop = _make_loop(responses)
+        loop.CHAT_MAX_TOOL_ROUNDS = _rounds
 
         async def _no_stream(**kwargs):
             raise RuntimeError("no streaming")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -68,3 +68,12 @@ def test_set_llm_limits_env_clamps():
     _default, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
     limits.set_llm_limits_env(env, {"max_tool_rounds": hi + 5000})
     assert env["OPENLEGION_TASK_MAX_TOOL_ROUNDS"] == str(hi)
+
+
+def test_set_llm_limits_env_no_ops_on_non_dict_config():
+    # A null/malformed agents.yaml entry yields None on the restart path —
+    # must no-op, not raise AttributeError (Codex pre-merge finding).
+    env: dict[str, str] = {}
+    limits.set_llm_limits_env(env, None)
+    limits.set_llm_limits_env(env, "not-a-dict")
+    assert env == {}

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,70 @@
+"""Unit tests for the central operational-limits resolver."""
+
+from src.shared import limits
+
+
+def test_resolve_default_when_unset(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_TASK_MAX_TOOL_ROUNDS", raising=False)
+    assert limits.resolve("task_max_tool_rounds") == limits.LIMIT_SPECS["task_max_tool_rounds"][0]
+
+
+def test_resolve_env_override(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_TASK_MAX_TOOL_ROUNDS", "123")
+    assert limits.resolve("task_max_tool_rounds") == 123
+
+
+def test_resolve_env_clamped_to_ceiling(monkeypatch):
+    _default, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
+    monkeypatch.setenv("OPENLEGION_TASK_MAX_TOOL_ROUNDS", str(hi + 9999))
+    assert limits.resolve("task_max_tool_rounds") == hi
+
+
+def test_resolve_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_TASK_MAX_TOOL_ROUNDS", "not-a-number")
+    assert limits.resolve("task_max_tool_rounds") == limits.LIMIT_SPECS["task_max_tool_rounds"][0]
+
+
+def test_agent_override_beats_env(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_TASK_MAX_TOOL_ROUNDS", "50")
+    # agents.yaml key is ``max_tool_rounds`` -> limits key ``task_max_tool_rounds``
+    assert limits.resolve("task_max_tool_rounds", agent_cfg={"max_tool_rounds": 200}) == 200
+
+
+def test_agent_override_clamped(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_TASK_MAX_TOOL_ROUNDS", raising=False)
+    _default, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
+    assert limits.resolve("task_max_tool_rounds", agent_cfg={"max_tool_rounds": hi + 1}) == hi
+
+
+def test_defaults_are_high():
+    # Regression guard: the production incident was caused by low caps. Pin the
+    # new floors so a future edit can't silently shrink them back.
+    assert limits.LIMIT_SPECS["task_max_tool_rounds"][0] >= 100
+    assert limits.LIMIT_SPECS["chat_max_tool_rounds"][0] >= 100
+    assert limits.LIMIT_SPECS["llm_timeout_seconds"][0] >= 600
+    assert limits.LIMIT_SPECS["lane_timeout_seconds"][0] >= 3600
+    # The task budget must stay <= the interactive ceiling (loop.py invariant).
+    assert limits.LIMIT_SPECS["task_max_tool_rounds"][0] <= limits.LIMIT_SPECS["chat_max_tool_rounds"][0]
+
+
+def test_set_llm_limits_env_injects_per_agent():
+    env: dict[str, str] = {}
+    limits.set_llm_limits_env(env, {"max_tool_rounds": 250, "llm_timeout_seconds": 900})
+    assert env["OPENLEGION_TASK_MAX_TOOL_ROUNDS"] == "250"
+    assert env["OPENLEGION_LLM_TIMEOUT_SECONDS"] == "900"
+
+
+def test_set_llm_limits_env_skips_absent_and_bool():
+    env: dict[str, str] = {}
+    limits.set_llm_limits_env(env, {})
+    assert env == {}
+    # bool is an int subclass — must be rejected, not coerced to 1/0.
+    limits.set_llm_limits_env(env, {"max_tool_rounds": True})
+    assert env == {}
+
+
+def test_set_llm_limits_env_clamps():
+    env: dict[str, str] = {}
+    _default, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
+    limits.set_llm_limits_env(env, {"max_tool_rounds": hi + 5000})
+    assert env["OPENLEGION_TASK_MAX_TOOL_ROUNDS"] == str(hi)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -597,6 +597,9 @@ async def test_max_iterations_reached():
     ]
 
     loop = _make_loop(responses)
+    # Pin the cap below the supplied response count so the loop hits the
+    # iteration ceiling (not the mock running dry). The default is now high.
+    loop.MAX_ITERATIONS = 20
     loop.tools.get_tool_definitions = MagicMock(return_value=[{"type": "function", "function": {"name": "search"}}])
     loop.tools.execute = AsyncMock(return_value={"result": "ok"})
 
@@ -1694,6 +1697,9 @@ class TestTaskCompletionLogging:
             for i in range(25)
         ]
         loop = factory(responses)
+        # Pin the cap below the supplied response count so the loop hits the
+        # iteration ceiling (not the mock running dry). The default is now high.
+        loop.MAX_ITERATIONS = 20
         loop.tools.get_tool_definitions = MagicMock(
             return_value=[{"type": "function", "function": {"name": "search"}}]
         )
@@ -4245,10 +4251,12 @@ def _always_tool_calling_loop(*, task_max=4, tool_name="web_search"):
     return loop
 
 
-def test_task_max_tool_rounds_default_is_20():
-    """(#5) The per-task budget default is 20 (raised from 12)."""
+def test_task_max_tool_rounds_default_matches_limits_table():
+    """The per-task budget default is sourced from the central limits table
+    (raised to a high default; tune via env / per-agent config)."""
+    from src.shared import limits
     loop = _make_loop()
-    assert loop.TASK_MAX_TOOL_ROUNDS == 20
+    assert loop.TASK_MAX_TOOL_ROUNDS == limits.LIMIT_SPECS["task_max_tool_rounds"][0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Production diagnosis traced the "agents keep failing / can't finish" reports to **one design flaw**: the engine's operational limits were scattered hard-coded magic numbers — set low, mutually inconsistent, and not adjustable.

- social-strategist's strategy tasks **failed with `httpx.ReadTimeout`**: the agent was configured for **81,920** output tokens but the LLM client timeout was hard-coded to **120 s** — a large generation physically cannot complete in time. Compounded by Anthropic OAuth returning `HTTP 200: Overloaded` that evening, which wasn't classified as retryable.
- teardown tasks **blocked on `convergence_cap`**: the per-task budget was **20** tool-rounds — too low for multi-section work.

The fix isn't just bigger numbers — it's **one source of truth, high defaults, adjustability, and consistency**.

## What

New `src/shared/limits.py` — every limit has a HIGH default + clamp range, resolved:
`per-agent override (agents.yaml) → OPENLEGION_* env (incl. dashboard system-settings) → built-in default`.

| Limit | Old | New default | Ceiling |
|---|---|---|---|
| `llm_timeout_seconds` | 120 | **1800** | 7200 |
| `task_max_tool_rounds` | 20 | **300** | 1000 |
| `chat_max_tool_rounds` | 30 | **500** | 1000 |
| `chat_max_total_rounds` | 200 | **1000** | 5000 |
| `max_iterations` | 20 | **60** | 500 |
| `lane_timeout_seconds` | 900 | **14400** | 86400 |

These are **convergence/UX/robustness bounds, not cost controls** — the per-agent daily **budget** stays the hard spend backstop and the lane wall-clock the hung-task backstop.

### Changes
- **limits.py**: `LIMIT_SPECS`, `resolve()`, `clamp()`, `set_llm_limits_env()` (per-agent env injection, mirrors the proven `set_llm_max_tokens_env`).
- **agent/loop.py**: round caps via `limits.resolve()` (removes the local `_clamp_env`); `_RETRYABLE_STATUS_CODES += {504, 529}`.
- **agent/llm.py**: httpx timeout via `limits.resolve()` on both the non-stream POST and stream paths; **P5 guardrail** logs a warning when the timeout can't plausibly emit `max_output_tokens`.
- **host/lanes.py**: lane timeout/queue via `limits.resolve()`.
- **host/credentials.py** (**P4**): classify `Overloaded`/`529` (Anthropic's HTTP-200 capacity signal over OAuth) as transient → retried with backoff instead of failing the task.
- **Per-agent overrides** (`max_tool_rounds`, `llm_timeout_seconds` in `agents.yaml`) injected at all 6 restart-from-config paths.

### Tests
- New `tests/test_limits.py` (resolve precedence, clamping, per-agent override, regression-pinned high floors, env injection).
- Updated 3 `test_loop.py` tests that pinned the old low caps.
- **Verified:** imports OK · ruff clean · 370 targeted tests (limits/loop/runtime/health) + 372 dashboard tests passed.

## Maps to the plan
Covers **P1** (raise+unify), **P2** (per-agent via agents.yaml + injection), **P4** (overload resilience), **P5** (consistency guardrail).

### Follow-ups (separate PRs, same workstream)
- `edit_agent` live-edit fields + `/config` hot-reload for the new per-agent keys (P2 UI half).
- Streaming task execution (**P3**) — structurally removes the timeout class.
- The `commit_file` / file-egress fix (6th workstream).

## Deploy note
Agent-side code (loop/llm) is baked into `openlegion-agent:latest` → deploy needs an agent image rebuild + `systemctl restart openlegion`, fleet-wide.