### PR TITLE
feat(limits): make per-agent round/timeout caps editable + hot-reloadable (P2 UI)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -41,7 +41,7 @@ _VALID_FIELDS = frozenset({
     "instructions", "soul", "model", "role", "heartbeat",
     "heartbeat_schedule",
     "interface", "thinking", "budget", "permissions",
-    "max_output_tokens",
+    "max_output_tokens", "max_tool_rounds", "llm_timeout_seconds",
 })
 
 # Per-agent output-token cap bounds. Mirrors the clamp in
@@ -164,6 +164,15 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
                     f"got {value}"
                 ),
             }
+    if field in ("max_tool_rounds", "llm_timeout_seconds"):
+        # Per-agent operational caps. Range = the clamp spec in the central
+        # limits table (single source of truth). bool rejected explicitly.
+        from src.shared import limits
+        if not isinstance(value, int) or isinstance(value, bool):
+            return {"error": f"{field} must be an integer, got {value!r}"}
+        _d, lo, hi = limits.LIMIT_SPECS[limits.AGENT_CONFIG_KEYS[field]]
+        if not (lo <= value <= hi):
+            return {"error": f"{field} must be {lo}-{hi}, got {value}"}
     return None
 
 
@@ -179,7 +188,7 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
         "Returns ``{agent_id, config: {...}}`` with these fields: "
         "model, instructions, soul, heartbeat, heartbeat_schedule, "
         "interface, role, permissions, budget, thinking, "
-        "max_output_tokens. Pass "
+        "max_output_tokens, max_tool_rounds, llm_timeout_seconds. Pass "
         "``fields=['instructions','soul']`` to scope the read to a subset."
     ),
     parameters={
@@ -684,7 +693,13 @@ async def list_available_models(
         "- max_output_tokens: integer 256-200000 — per-agent cap on output "
         "tokens per LLM call. Raise it for agents that emit large single "
         "tool calls (e.g. a translator that PUTs a whole file in one call) "
-        "and hit 'Truncated tool-call arguments'. Default 8192."
+        "and hit 'Truncated tool-call arguments'. Default 8192.\n"
+        "- max_tool_rounds: integer — per-task tool-round budget before a task "
+        "is closed as blocked (convergence cap). Raise it for agents doing "
+        "long multi-step work that legitimately needs many rounds.\n"
+        "- llm_timeout_seconds: integer — per-call LLM timeout. Raise it for "
+        "agents that produce very large outputs (paired with a high "
+        "max_output_tokens) so big generations don't time out."
     ),
     parameters={
         "agent_id": {
@@ -698,14 +713,15 @@ async def list_available_models(
                 "instructions", "soul", "model", "role", "heartbeat",
                 "heartbeat_schedule",
                 "interface", "thinking", "budget", "permissions",
-                "max_output_tokens",
+                "max_output_tokens", "max_tool_rounds", "llm_timeout_seconds",
             ],
         },
         "value": {
             "type": ["string", "object", "integer"],
             "description": (
                 "New value for the field. String/object for most fields; "
-                "integer for max_output_tokens."
+                "integer for max_output_tokens / max_tool_rounds / "
+                "llm_timeout_seconds."
             ),
         },
         "reason": {

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -620,6 +620,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         model = body.get("model") if "model" in body else None
         thinking = body.get("thinking") if "thinking" in body else None
         max_tokens = body.get("max_tokens") if "max_tokens" in body else None
+        max_tool_rounds = body.get("max_tool_rounds") if "max_tool_rounds" in body else None
+        llm_timeout = body.get("llm_timeout_seconds") if "llm_timeout_seconds" in body else None
         internet = body.get("internet_access_enabled") if "internet_access_enabled" in body else None
         browser = body.get("browser_access_enabled") if "browser_access_enabled" in body else None
         if "model" in body and (not isinstance(model, str) or not model):
@@ -645,6 +647,23 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             raise HTTPException(
                 400, "browser_access_enabled must be a boolean",
             )
+        # Per-agent operational caps — validated against the central limits
+        # clamp spec (single source of truth). bool rejected (int subclass).
+        from src.shared import limits as _limits
+        for _k, _val in (
+            ("max_tool_rounds", max_tool_rounds),
+            ("llm_timeout_seconds", llm_timeout),
+        ):
+            if _k in body:
+                _d, _lo, _hi = _limits.LIMIT_SPECS[_limits.AGENT_CONFIG_KEYS[_k]]
+                if (
+                    not isinstance(_val, int)
+                    or isinstance(_val, bool)
+                    or not (_lo <= _val <= _hi)
+                ):
+                    raise HTTPException(
+                        400, f"{_k} must be an integer between {_lo} and {_hi}",
+                    )
 
         updated: dict = {}
         if "model" in body:
@@ -656,6 +675,16 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if "max_tokens" in body:
             loop.llm.max_output_tokens = max_tokens
             updated["max_tokens"] = max_tokens
+        if "max_tool_rounds" in body:
+            # Honour the TASK <= CHAT invariant (mirrors AgentLoop.__init__).
+            loop.TASK_MAX_TOOL_ROUNDS = min(max_tool_rounds, loop.CHAT_MAX_TOOL_ROUNDS)
+            updated["max_tool_rounds"] = loop.TASK_MAX_TOOL_ROUNDS
+        if "llm_timeout_seconds" in body:
+            loop.llm.timeout_seconds = llm_timeout
+            # Reset the pooled httpx client so the new timeout takes effect on
+            # the next call (httpx fixes the timeout at client construction).
+            await loop.llm.close()
+            updated["llm_timeout_seconds"] = llm_timeout
         if "internet_access_enabled" in body:
             # Mesh-side push from the Operator Settings → Internet
             # access toggle. When False, hide http_request + web_search

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7053,12 +7053,13 @@ def create_mesh_app(
             # Falls back to the LLMClient default (8192) when never set, so the
             # operator sees the effective cap, not a blank.
             "max_output_tokens": raw.get("max_output_tokens", 8192) or 8192,
-            # Per-agent operational caps — fall back to the central limits
-            # default so the operator sees the effective value, not a blank.
+            # Per-agent operational caps — fall back to the EFFECTIVE value
+            # (env/global → default), so the operator sees what the agent
+            # actually runs, not just the static floor.
             "max_tool_rounds": raw.get("max_tool_rounds")
-            or _limits_mod.LIMIT_SPECS["task_max_tool_rounds"][0],
+            or _limits_mod.resolve("task_max_tool_rounds"),
             "llm_timeout_seconds": raw.get("llm_timeout_seconds")
-            or _limits_mod.LIMIT_SPECS["llm_timeout_seconds"][0],
+            or _limits_mod.resolve("llm_timeout_seconds"),
         }
 
         # Permissions live in PERMISSIONS_FILE, not agents.yaml. Load via
@@ -7766,10 +7767,11 @@ def create_mesh_app(
             if field == "max_output_tokens":
                 _missing_default: object = 8192
             elif field in ("max_tool_rounds", "llm_timeout_seconds"):
+                # Resolve the EFFECTIVE value (env/global → built-in default),
+                # not the static default, so Undo restores what the agent was
+                # actually running, not the floor.
                 from src.shared import limits as _limits
-                _missing_default = _limits.LIMIT_SPECS[
-                    _limits.AGENT_CONFIG_KEYS[field]
-                ][0]
+                _missing_default = _limits.resolve(_limits.AGENT_CONFIG_KEYS[field])
             else:
                 _missing_default = ""
             old_value = agents[agent_id].get(yaml_key, _missing_default)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7039,6 +7039,7 @@ def create_mesh_app(
             raise HTTPException(404, f"Agent '{agent_id}' not found")
         raw = agents[agent_id]
 
+        from src.shared import limits as _limits_mod
         # Translate yaml internals -> canonical edit_agent field names.
         full: dict = {
             "model": raw.get("model", ""),
@@ -7052,6 +7053,12 @@ def create_mesh_app(
             # Falls back to the LLMClient default (8192) when never set, so the
             # operator sees the effective cap, not a blank.
             "max_output_tokens": raw.get("max_output_tokens", 8192) or 8192,
+            # Per-agent operational caps — fall back to the central limits
+            # default so the operator sees the effective value, not a blank.
+            "max_tool_rounds": raw.get("max_tool_rounds")
+            or _limits_mod.LIMIT_SPECS["task_max_tool_rounds"][0],
+            "llm_timeout_seconds": raw.get("llm_timeout_seconds")
+            or _limits_mod.LIMIT_SPECS["llm_timeout_seconds"][0],
         }
 
         # Permissions live in PERMISSIONS_FILE, not agents.yaml. Load via
@@ -7408,14 +7415,17 @@ def create_mesh_app(
             "model": "model",
             "thinking": "thinking",
             "max_output_tokens": "max_tokens",
+            "max_tool_rounds": "max_tool_rounds",
+            "llm_timeout_seconds": "llm_timeout_seconds",
         }.get(field)
+        _int_push_fields = ("max_output_tokens", "max_tool_rounds", "llm_timeout_seconds")
         if (
             transport
             and agent_id in router.agent_registry
             and _config_push_key is not None
             and (
                 isinstance(new_value, str)
-                or (field == "max_output_tokens" and isinstance(new_value, int))
+                or (field in _int_push_fields and isinstance(new_value, int))
             )
         ):
             try:
@@ -7691,6 +7701,18 @@ def create_mesh_app(
                 raise HTTPException(
                     400, "max_output_tokens must be between 256 and 200000",
                 )
+        elif field in ("max_tool_rounds", "llm_timeout_seconds"):
+            # Per-agent operational caps. Re-enforce server-side; range is the
+            # central limits clamp spec (single source of truth). bool is an
+            # int subclass — reject it so True/False can't slip through as 1/0.
+            from src.shared import limits as _limits
+            if not isinstance(new_value, int) or isinstance(new_value, bool):
+                raise HTTPException(400, f"{field} must be an integer")
+            _d, _lo, _hi = _limits.LIMIT_SPECS[_limits.AGENT_CONFIG_KEYS[field]]
+            if not (_lo <= new_value <= _hi):
+                raise HTTPException(
+                    400, f"{field} must be between {_lo} and {_hi}",
+                )
         elif field == "permissions":
             # Finding H1 (May 2026 remediation): re-enforce the operator
             # permission ceiling server-side. The operator tool's
@@ -7738,7 +7760,18 @@ def create_mesh_app(
             # the hot-reload push forwards to the agent /config (the push
             # guard requires an int) so the live agent actually drops back to
             # 8192 instead of silently keeping the raised cap until restart.
-            _missing_default = 8192 if field == "max_output_tokens" else ""
+            # Default the audit "before" value to the effective limit (not "")
+            # when a field was never set, so Undo writes back a usable int that
+            # the hot-reload push will forward to the live agent.
+            if field == "max_output_tokens":
+                _missing_default: object = 8192
+            elif field in ("max_tool_rounds", "llm_timeout_seconds"):
+                from src.shared import limits as _limits
+                _missing_default = _limits.LIMIT_SPECS[
+                    _limits.AGENT_CONFIG_KEYS[field]
+                ][0]
+            else:
+                _missing_default = ""
             old_value = agents[agent_id].get(yaml_key, _missing_default)
 
         # Apply directly via the same write helper used by the confirm

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -54,7 +54,8 @@ here.
 """
 
 HARD_EDIT_FIELDS = frozenset(
-    {"model", "permissions", "budget", "thinking", "max_output_tokens"}
+    {"model", "permissions", "budget", "thinking", "max_output_tokens",
+     "max_tool_rounds", "llm_timeout_seconds"}
 )
 """Agent-config fields that earn the longer 30-min Undo window (the
 "hard" review path). Mirrors :data:`SOFT_EDIT_FIELDS` — the union is

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -68,3 +68,25 @@ def test_set_llm_limits_env_clamps():
     _default, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
     limits.set_llm_limits_env(env, {"max_tool_rounds": hi + 5000})
     assert env["OPENLEGION_TASK_MAX_TOOL_ROUNDS"] == str(hi)
+
+
+# --- edit_agent field support for the per-agent limit knobs (PR B) ---
+
+def test_new_limit_fields_are_editable():
+    from src.shared.types import HARD_EDIT_FIELDS
+    assert "max_tool_rounds" in HARD_EDIT_FIELDS
+    assert "llm_timeout_seconds" in HARD_EDIT_FIELDS
+
+
+def test_validate_edit_accepts_valid_rounds():
+    from src.agent.builtins.operator_tools import _validate_edit
+    assert _validate_edit("a", "max_tool_rounds", 250) is None
+    assert _validate_edit("a", "llm_timeout_seconds", 900) is None
+
+
+def test_validate_edit_rejects_out_of_range_and_bool():
+    from src.agent.builtins.operator_tools import _validate_edit
+    _d, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
+    assert _validate_edit("a", "max_tool_rounds", hi + 1) is not None
+    assert _validate_edit("a", "max_tool_rounds", True) is not None
+    assert _validate_edit("a", "llm_timeout_seconds", "nope") is not None


### PR DESCRIPTION
**Stacked on #1054** (base branch `feat/adjustable-limits`) — review/merge #1054 first.

## What
Completes **P2** of the limits workstream: makes `max_tool_rounds` and `llm_timeout_seconds` first-class **editable + hot-reloadable** per-agent fields, mirroring the `max_output_tokens` path end to end. An operator can now raise one agent's convergence budget or LLM timeout from the dashboard / operator tool — applied live, persisted to YAML, surviving restart (via the injection in #1054).

- **types.py** — both added to `HARD_EDIT_FIELDS` (30-min Undo).
- **operator_tools.py** — `_VALID_FIELDS`, `_validate_edit` (range = central limits clamp spec), and `edit_agent` / `read_agent_config` descriptions + enum.
- **host/server.py** — edit-soft validation; hot-reload push map + int-push guard extended; audit "before" defaults to the limits default so Undo round-trips a usable int; read endpoint returns both.
- **agent/server.py `/config`** — live-apply: `max_tool_rounds` honours the TASK≤CHAT invariant; `llm_timeout_seconds` resets the pooled httpx client so the new timeout applies next call.

## Tests
New edit-field tests in `test_limits.py`. Verified: imports OK · ruff clean · 325 targeted tests (limits/operator_tools/operator_config/loop) passing.

## Follow-up
Dashboard SPA form inputs for the two knobs (editable via operator tool + API already).