### PR TITLE
feat(llm): stream task/handoff execution so large generations can't time out (P3)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -41,7 +41,7 @@ _VALID_FIELDS = frozenset({
     "instructions", "soul", "model", "role", "heartbeat",
     "heartbeat_schedule",
     "interface", "thinking", "budget", "permissions",
-    "max_output_tokens",
+    "max_output_tokens", "max_tool_rounds", "llm_timeout_seconds",
 })
 
 # Per-agent output-token cap bounds. Mirrors the clamp in
@@ -164,6 +164,15 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
                     f"got {value}"
                 ),
             }
+    if field in ("max_tool_rounds", "llm_timeout_seconds"):
+        # Per-agent operational caps. Range = the clamp spec in the central
+        # limits table (single source of truth). bool rejected explicitly.
+        from src.shared import limits
+        if not isinstance(value, int) or isinstance(value, bool):
+            return {"error": f"{field} must be an integer, got {value!r}"}
+        _d, lo, hi = limits.LIMIT_SPECS[limits.AGENT_CONFIG_KEYS[field]]
+        if not (lo <= value <= hi):
+            return {"error": f"{field} must be {lo}-{hi}, got {value}"}
     return None
 
 
@@ -179,7 +188,7 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
         "Returns ``{agent_id, config: {...}}`` with these fields: "
         "model, instructions, soul, heartbeat, heartbeat_schedule, "
         "interface, role, permissions, budget, thinking, "
-        "max_output_tokens. Pass "
+        "max_output_tokens, max_tool_rounds, llm_timeout_seconds. Pass "
         "``fields=['instructions','soul']`` to scope the read to a subset."
     ),
     parameters={
@@ -684,7 +693,13 @@ async def list_available_models(
         "- max_output_tokens: integer 256-200000 — per-agent cap on output "
         "tokens per LLM call. Raise it for agents that emit large single "
         "tool calls (e.g. a translator that PUTs a whole file in one call) "
-        "and hit 'Truncated tool-call arguments'. Default 8192."
+        "and hit 'Truncated tool-call arguments'. Default 8192.\n"
+        "- max_tool_rounds: integer — per-task tool-round budget before a task "
+        "is closed as blocked (convergence cap). Raise it for agents doing "
+        "long multi-step work that legitimately needs many rounds.\n"
+        "- llm_timeout_seconds: integer — per-call LLM timeout. Raise it for "
+        "agents that produce very large outputs (paired with a high "
+        "max_output_tokens) so big generations don't time out."
     ),
     parameters={
         "agent_id": {
@@ -698,14 +713,15 @@ async def list_available_models(
                 "instructions", "soul", "model", "role", "heartbeat",
                 "heartbeat_schedule",
                 "interface", "thinking", "budget", "permissions",
-                "max_output_tokens",
+                "max_output_tokens", "max_tool_rounds", "llm_timeout_seconds",
             ],
         },
         "value": {
             "type": ["string", "object", "integer"],
             "description": (
                 "New value for the field. String/object for most fields; "
-                "integer for max_output_tokens."
+                "integer for max_output_tokens / max_tool_rounds / "
+                "llm_timeout_seconds."
             ),
         },
         "reason": {

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -415,16 +415,14 @@ class LLMClient:
                 if chunk.get("type") == "done":
                     final = chunk.get("response")
         except (LLMRetryableError, LLMAuthError, LLMConfigError):
-            raise
-        except RuntimeError:
-            # Non-retryable application errors surfaced via the SSE error frame
-            # (and budget-exceeded) arrive as plain RuntimeError. They must
-            # propagate — falling back here would swallow a real error AND fire
-            # a second, billable non-streaming generation after the stream may
-            # already have produced/billed tokens. Only genuine transport
-            # failures (httpx etc., below) fall back.
-            raise
-        except Exception as e:
+            raise  # classified errors -> _llm_call_with_retry handles backoff
+        except httpx.HTTPError as e:
+            # Only genuine transport/HTTP failures fall back to non-streaming.
+            # Everything else propagates untouched: non-retryable application
+            # errors (SSE error frames, budget) arrive as plain RuntimeError,
+            # and any unexpected error (parsing bug, etc.) must surface — not be
+            # masked by a second, billable non-streaming generation after the
+            # stream may already have produced/billed tokens.
             logger.warning(
                 "Streaming transport failed (%s); falling back to non-streaming",
                 type(e).__name__,

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -424,9 +424,17 @@ class LLMClient:
                     final = chunk.get("response")
         except (LLMRetryableError, LLMAuthError, LLMConfigError):
             raise
+        except RuntimeError:
+            # Non-retryable application errors surfaced via the SSE error frame
+            # (and budget-exceeded) arrive as plain RuntimeError. They must
+            # propagate — falling back here would swallow a real error AND fire
+            # a second, billable non-streaming generation after the stream may
+            # already have produced/billed tokens. Only genuine transport
+            # failures (httpx etc., below) fall back.
+            raise
         except Exception as e:
             logger.warning(
-                "Streaming chat failed (%s); falling back to non-streaming",
+                "Streaming transport failed (%s); falling back to non-streaming",
                 type(e).__name__,
             )
             return await self.chat(system, messages, **_passthru)

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -85,6 +85,13 @@ class LLMClient:
                 "output cap.",
                 self.timeout_seconds, self.max_output_tokens, int(_needed),
             )
+        # Stream task/handoff LLM calls (default on). Streaming turns the read
+        # timeout into a per-chunk *idle* bound instead of a total-response
+        # bound, so large generations can't ReadTimeout mid-flight. Set
+        # OPENLEGION_TASK_STREAMING=0 to force the non-streaming path.
+        self.stream_task_exec = os.environ.get(
+            "OPENLEGION_TASK_STREAMING", "1",
+        ).strip().lower() not in ("0", "false", "no", "off")
         self._client: httpx.AsyncClient | None = None
         self._client_lock = asyncio.Lock()
         self._auth_token: str = os.environ.get("MESH_AUTH_TOKEN", "")
@@ -376,6 +383,59 @@ class LLMClient:
                         model=data.get("model", ""),
                     )
                     yield {"type": "done", "response": llm_resp}
+
+    async def chat_collect(
+        self,
+        system: str,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float = 0.7,
+        **kwargs,
+    ) -> LLMResponse:
+        """Run a completion over the streaming endpoint, returning the final
+        assembled ``LLMResponse``.
+
+        Streaming makes the httpx read timeout a per-chunk (idle) bound instead
+        of a total-response bound, so a large generation the agent's
+        ``max_output_tokens`` permits can't ``ReadTimeout`` mid-flight — the
+        failure that broke task execution on the fleet. Contract-identical to
+        ``chat``: the stream's terminal ``done`` frame carries the same
+        fully-parsed ``LLMResponse`` (content, thinking, tool_calls, tokens).
+
+        Falls back to non-streaming ``chat`` when streaming is disabled, the
+        stream ends without a terminal frame, or the transport fails for a
+        non-classified reason (mirrors the documented ``chat_stream`` fallback
+        intent). Classified errors (auth / config / retryable) propagate to
+        ``_llm_call_with_retry`` so its backoff still applies.
+        """
+        _passthru = dict(
+            tools=tools, model=model, max_tokens=max_tokens,
+            temperature=temperature, **kwargs,
+        )
+        if not self.stream_task_exec:
+            return await self.chat(system, messages, **_passthru)
+        from src.shared.errors import LLMAuthError, LLMConfigError
+        final: LLMResponse | None = None
+        try:
+            async for chunk in self.chat_stream(system, messages, **_passthru):
+                if chunk.get("type") == "done":
+                    final = chunk.get("response")
+        except (LLMRetryableError, LLMAuthError, LLMConfigError):
+            raise
+        except Exception as e:
+            logger.warning(
+                "Streaming chat failed (%s); falling back to non-streaming",
+                type(e).__name__,
+            )
+            return await self.chat(system, messages, **_passthru)
+        if final is None:
+            logger.warning(
+                "Stream ended without a final frame; falling back to non-streaming",
+            )
+            return await self.chat(system, messages, **_passthru)
+        return final
 
     async def embed(self, text: str, model: str | None = None) -> list[float]:
         """Generate an embedding vector through the mesh proxy."""

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -85,13 +85,6 @@ class LLMClient:
                 "output cap.",
                 self.timeout_seconds, self.max_output_tokens, int(_needed),
             )
-        # Stream task/handoff LLM calls (default on). Streaming turns the read
-        # timeout into a per-chunk *idle* bound instead of a total-response
-        # bound, so large generations can't ReadTimeout mid-flight. Set
-        # OPENLEGION_TASK_STREAMING=0 to force the non-streaming path.
-        self.stream_task_exec = os.environ.get(
-            "OPENLEGION_TASK_STREAMING", "1",
-        ).strip().lower() not in ("0", "false", "no", "off")
         self._client: httpx.AsyncClient | None = None
         self._client_lock = asyncio.Lock()
         self._auth_token: str = os.environ.get("MESH_AUTH_TOKEN", "")
@@ -404,18 +397,17 @@ class LLMClient:
         ``chat``: the stream's terminal ``done`` frame carries the same
         fully-parsed ``LLMResponse`` (content, thinking, tool_calls, tokens).
 
-        Falls back to non-streaming ``chat`` when streaming is disabled, the
-        stream ends without a terminal frame, or the transport fails for a
-        non-classified reason (mirrors the documented ``chat_stream`` fallback
-        intent). Classified errors (auth / config / retryable) propagate to
+        Falls back to non-streaming ``chat`` only when the stream ends without
+        a terminal frame or the transport fails for a non-classified reason
+        (mirrors the documented ``chat_stream`` fallback intent) — that
+        fallback is resilience, not a toggle. Classified errors (auth / config
+        / retryable) and other RuntimeErrors propagate to
         ``_llm_call_with_retry`` so its backoff still applies.
         """
         _passthru = dict(
             tools=tools, model=model, max_tokens=max_tokens,
             temperature=temperature, **kwargs,
         )
-        if not self.stream_task_exec:
-            return await self.chat(system, messages, **_passthru)
         from src.shared.errors import LLMAuthError, LLMConfigError
         final: LLMResponse | None = None
         try:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -939,7 +939,7 @@ class AgentLoop:
 
                 available_tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 llm_response = await _llm_call_with_retry(
-                    self.llm.chat,
+                    self.llm.chat_collect,
                     system=effective_system,
                     messages=messages,
                     tools=available_tools,
@@ -2125,7 +2125,7 @@ class AgentLoop:
                     )
 
                     llm_response = await _llm_call_with_retry(
-                        self.llm.chat,
+                        self.llm.chat_collect,
                         system=system_prompt,
                         messages=messages,
                         tools=iter_tools,
@@ -3321,7 +3321,7 @@ class AgentLoop:
         """
         try:
             llm_response = await _llm_call_with_retry(
-                self.llm.chat,
+                self.llm.chat_collect,
                 system=system,
                 messages=self._chat_messages,
                 tools=None,
@@ -3456,7 +3456,7 @@ class AgentLoop:
                     self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 )
                 llm_response = await _llm_call_with_retry(
-                    self.llm.chat,
+                    self.llm.chat_collect,
                     system=_round_system,
                     messages=self._chat_messages,
                     tools=_iter_tools,
@@ -3767,7 +3767,7 @@ class AgentLoop:
             # Max tool rounds exhausted — force final text response.
             # Omit tools so the LLM cannot return more tool calls.
             llm_response = await _llm_call_with_retry(
-                self.llm.chat,
+                self.llm.chat_collect,
                 system=system,
                 messages=self._chat_messages,
                 tools=None,

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -620,6 +620,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         model = body.get("model") if "model" in body else None
         thinking = body.get("thinking") if "thinking" in body else None
         max_tokens = body.get("max_tokens") if "max_tokens" in body else None
+        max_tool_rounds = body.get("max_tool_rounds") if "max_tool_rounds" in body else None
+        llm_timeout = body.get("llm_timeout_seconds") if "llm_timeout_seconds" in body else None
         internet = body.get("internet_access_enabled") if "internet_access_enabled" in body else None
         browser = body.get("browser_access_enabled") if "browser_access_enabled" in body else None
         if "model" in body and (not isinstance(model, str) or not model):
@@ -645,6 +647,23 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             raise HTTPException(
                 400, "browser_access_enabled must be a boolean",
             )
+        # Per-agent operational caps — validated against the central limits
+        # clamp spec (single source of truth). bool rejected (int subclass).
+        from src.shared import limits as _limits
+        for _k, _val in (
+            ("max_tool_rounds", max_tool_rounds),
+            ("llm_timeout_seconds", llm_timeout),
+        ):
+            if _k in body:
+                _d, _lo, _hi = _limits.LIMIT_SPECS[_limits.AGENT_CONFIG_KEYS[_k]]
+                if (
+                    not isinstance(_val, int)
+                    or isinstance(_val, bool)
+                    or not (_lo <= _val <= _hi)
+                ):
+                    raise HTTPException(
+                        400, f"{_k} must be an integer between {_lo} and {_hi}",
+                    )
 
         updated: dict = {}
         if "model" in body:
@@ -656,6 +675,16 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if "max_tokens" in body:
             loop.llm.max_output_tokens = max_tokens
             updated["max_tokens"] = max_tokens
+        if "max_tool_rounds" in body:
+            # Honour the TASK <= CHAT invariant (mirrors AgentLoop.__init__).
+            loop.TASK_MAX_TOOL_ROUNDS = min(max_tool_rounds, loop.CHAT_MAX_TOOL_ROUNDS)
+            updated["max_tool_rounds"] = loop.TASK_MAX_TOOL_ROUNDS
+        if "llm_timeout_seconds" in body:
+            loop.llm.timeout_seconds = llm_timeout
+            # Reset the pooled httpx client so the new timeout takes effect on
+            # the next call (httpx fixes the timeout at client construction).
+            await loop.llm.close()
+            updated["llm_timeout_seconds"] = llm_timeout
         if "internet_access_enabled" in body:
             # Mesh-side push from the Operator Settings → Internet
             # access toggle. When False, hide http_request + web_search

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7053,12 +7053,13 @@ def create_mesh_app(
             # Falls back to the LLMClient default (8192) when never set, so the
             # operator sees the effective cap, not a blank.
             "max_output_tokens": raw.get("max_output_tokens", 8192) or 8192,
-            # Per-agent operational caps — fall back to the central limits
-            # default so the operator sees the effective value, not a blank.
+            # Per-agent operational caps — fall back to the EFFECTIVE value
+            # (env/global → default), so the operator sees what the agent
+            # actually runs, not just the static floor.
             "max_tool_rounds": raw.get("max_tool_rounds")
-            or _limits_mod.LIMIT_SPECS["task_max_tool_rounds"][0],
+            or _limits_mod.resolve("task_max_tool_rounds"),
             "llm_timeout_seconds": raw.get("llm_timeout_seconds")
-            or _limits_mod.LIMIT_SPECS["llm_timeout_seconds"][0],
+            or _limits_mod.resolve("llm_timeout_seconds"),
         }
 
         # Permissions live in PERMISSIONS_FILE, not agents.yaml. Load via
@@ -7766,10 +7767,11 @@ def create_mesh_app(
             if field == "max_output_tokens":
                 _missing_default: object = 8192
             elif field in ("max_tool_rounds", "llm_timeout_seconds"):
+                # Resolve the EFFECTIVE value (env/global → built-in default),
+                # not the static default, so Undo restores what the agent was
+                # actually running, not the floor.
                 from src.shared import limits as _limits
-                _missing_default = _limits.LIMIT_SPECS[
-                    _limits.AGENT_CONFIG_KEYS[field]
-                ][0]
+                _missing_default = _limits.resolve(_limits.AGENT_CONFIG_KEYS[field])
             else:
                 _missing_default = ""
             old_value = agents[agent_id].get(yaml_key, _missing_default)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7039,6 +7039,7 @@ def create_mesh_app(
             raise HTTPException(404, f"Agent '{agent_id}' not found")
         raw = agents[agent_id]
 
+        from src.shared import limits as _limits_mod
         # Translate yaml internals -> canonical edit_agent field names.
         full: dict = {
             "model": raw.get("model", ""),
@@ -7052,6 +7053,12 @@ def create_mesh_app(
             # Falls back to the LLMClient default (8192) when never set, so the
             # operator sees the effective cap, not a blank.
             "max_output_tokens": raw.get("max_output_tokens", 8192) or 8192,
+            # Per-agent operational caps — fall back to the central limits
+            # default so the operator sees the effective value, not a blank.
+            "max_tool_rounds": raw.get("max_tool_rounds")
+            or _limits_mod.LIMIT_SPECS["task_max_tool_rounds"][0],
+            "llm_timeout_seconds": raw.get("llm_timeout_seconds")
+            or _limits_mod.LIMIT_SPECS["llm_timeout_seconds"][0],
         }
 
         # Permissions live in PERMISSIONS_FILE, not agents.yaml. Load via
@@ -7408,14 +7415,17 @@ def create_mesh_app(
             "model": "model",
             "thinking": "thinking",
             "max_output_tokens": "max_tokens",
+            "max_tool_rounds": "max_tool_rounds",
+            "llm_timeout_seconds": "llm_timeout_seconds",
         }.get(field)
+        _int_push_fields = ("max_output_tokens", "max_tool_rounds", "llm_timeout_seconds")
         if (
             transport
             and agent_id in router.agent_registry
             and _config_push_key is not None
             and (
                 isinstance(new_value, str)
-                or (field == "max_output_tokens" and isinstance(new_value, int))
+                or (field in _int_push_fields and isinstance(new_value, int))
             )
         ):
             try:
@@ -7691,6 +7701,18 @@ def create_mesh_app(
                 raise HTTPException(
                     400, "max_output_tokens must be between 256 and 200000",
                 )
+        elif field in ("max_tool_rounds", "llm_timeout_seconds"):
+            # Per-agent operational caps. Re-enforce server-side; range is the
+            # central limits clamp spec (single source of truth). bool is an
+            # int subclass — reject it so True/False can't slip through as 1/0.
+            from src.shared import limits as _limits
+            if not isinstance(new_value, int) or isinstance(new_value, bool):
+                raise HTTPException(400, f"{field} must be an integer")
+            _d, _lo, _hi = _limits.LIMIT_SPECS[_limits.AGENT_CONFIG_KEYS[field]]
+            if not (_lo <= new_value <= _hi):
+                raise HTTPException(
+                    400, f"{field} must be between {_lo} and {_hi}",
+                )
         elif field == "permissions":
             # Finding H1 (May 2026 remediation): re-enforce the operator
             # permission ceiling server-side. The operator tool's
@@ -7738,7 +7760,18 @@ def create_mesh_app(
             # the hot-reload push forwards to the agent /config (the push
             # guard requires an int) so the live agent actually drops back to
             # 8192 instead of silently keeping the raised cap until restart.
-            _missing_default = 8192 if field == "max_output_tokens" else ""
+            # Default the audit "before" value to the effective limit (not "")
+            # when a field was never set, so Undo writes back a usable int that
+            # the hot-reload push will forward to the live agent.
+            if field == "max_output_tokens":
+                _missing_default: object = 8192
+            elif field in ("max_tool_rounds", "llm_timeout_seconds"):
+                from src.shared import limits as _limits
+                _missing_default = _limits.LIMIT_SPECS[
+                    _limits.AGENT_CONFIG_KEYS[field]
+                ][0]
+            else:
+                _missing_default = ""
             old_value = agents[agent_id].get(yaml_key, _missing_default)
 
         # Apply directly via the same write helper used by the confirm

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -54,7 +54,8 @@ here.
 """
 
 HARD_EDIT_FIELDS = frozenset(
-    {"model", "permissions", "budget", "thinking", "max_output_tokens"}
+    {"model", "permissions", "budget", "thinking", "max_output_tokens",
+     "max_tool_rounds", "llm_timeout_seconds"}
 )
 """Agent-config fields that earn the longer 30-min Undo window (the
 "hard" review path). Mirrors :data:`SOFT_EDIT_FIELDS` — the union is

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -32,6 +32,12 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None) -> AgentLoop:
         llm.chat = AsyncMock(return_value=LLMResponse(content="Hello!", tokens_used=50))
     llm.default_model = "test-model"
 
+    # Task/_chat_inner paths call chat_collect (streaming). Delegate to whatever
+    # llm.chat is at call time so mocks (incl. per-test reassignments) drive it.
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
+
     mesh_client = MagicMock()
     mesh_client.send_system_message = AsyncMock(return_value={})
 

--- a/tests/test_chat_collect.py
+++ b/tests/test_chat_collect.py
@@ -87,3 +87,20 @@ async def test_chat_collect_propagates_classified_errors():
     with pytest.raises(LLMRetryableError):
         await c.chat_collect("sys", [])
     c.chat.assert_not_called()  # classified errors must NOT silently fall back
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_does_not_swallow_non_transport_errors():
+    # A non-transport, non-RuntimeError exception (e.g. a parsing bug) must
+    # propagate, not be masked by a second non-streaming call (Codex finding).
+    c = _client()
+
+    async def bug(*a, **k):
+        raise KeyError("unexpected stream shape")
+        yield  # pragma: no cover
+
+    c.chat_stream = bug
+    c.chat = AsyncMock()
+    with pytest.raises(KeyError):
+        await c.chat_collect("sys", [])
+    c.chat.assert_not_called()

--- a/tests/test_chat_collect.py
+++ b/tests/test_chat_collect.py
@@ -75,19 +75,6 @@ async def test_chat_collect_falls_back_when_no_done_frame():
 
 
 @pytest.mark.asyncio
-async def test_chat_collect_flag_off_uses_non_streaming(monkeypatch):
-    monkeypatch.setenv("OPENLEGION_TASK_STREAMING", "0")
-    c = _client()
-    assert c.stream_task_exec is False
-    direct = LLMResponse(content="d", tokens_used=1)
-    c.chat = AsyncMock(return_value=direct)
-    c.chat_stream = AsyncMock()  # must NOT be used
-    out = await c.chat_collect("sys", [])
-    assert out is direct
-    c.chat_stream.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_chat_collect_propagates_classified_errors():
     c = _client()
 

--- a/tests/test_chat_collect.py
+++ b/tests/test_chat_collect.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
-from src.agent.llm import LLMClient
+from src.agent.llm import LLMClient, LLMRetryableError
 from src.shared.types import LLMResponse
 
 
@@ -32,7 +33,7 @@ async def test_chat_collect_falls_back_on_stream_transport_error():
     fallback = LLMResponse(content="fb", tokens_used=1)
 
     async def boom(*a, **k):
-        raise RuntimeError("transport down")
+        raise httpx.ConnectError("stream endpoint down")
         yield  # pragma: no cover — makes this an async generator
 
     c.chat_stream = boom
@@ -40,6 +41,23 @@ async def test_chat_collect_falls_back_on_stream_transport_error():
     out = await c.chat_collect("sys", [])
     assert out is fallback
     c.chat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_propagates_runtime_error_without_second_call():
+    # A non-retryable SSE error frame (or budget) arrives as plain RuntimeError
+    # — it must propagate, NOT trigger a second (billable) non-streaming call.
+    c = _client()
+
+    async def app_error(*a, **k):
+        raise RuntimeError("LLM stream error: invalid request")
+        yield  # pragma: no cover
+
+    c.chat_stream = app_error
+    c.chat = AsyncMock()
+    with pytest.raises(RuntimeError):
+        await c.chat_collect("sys", [])
+    c.chat.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -71,7 +89,6 @@ async def test_chat_collect_flag_off_uses_non_streaming(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_chat_collect_propagates_classified_errors():
-    from src.agent.llm import LLMRetryableError
     c = _client()
 
     async def transient(*a, **k):

--- a/tests/test_chat_collect.py
+++ b/tests/test_chat_collect.py
@@ -1,0 +1,85 @@
+"""Unit tests for LLMClient.chat_collect (streaming task execution, P3)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.agent.llm import LLMClient
+from src.shared.types import LLMResponse
+
+
+def _client() -> LLMClient:
+    return LLMClient(mesh_url="http://mesh.invalid", agent_id="a")
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_returns_done_response():
+    c = _client()
+    resp = LLMResponse(content="hi", tokens_used=5)
+
+    async def fake_stream(*a, **k):
+        yield {"type": "text_delta", "content": "h"}
+        yield {"type": "done", "response": resp}
+
+    c.chat_stream = fake_stream
+    out = await c.chat_collect("sys", [{"role": "user", "content": "x"}])
+    assert out is resp
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_falls_back_on_stream_transport_error():
+    c = _client()
+    fallback = LLMResponse(content="fb", tokens_used=1)
+
+    async def boom(*a, **k):
+        raise RuntimeError("transport down")
+        yield  # pragma: no cover — makes this an async generator
+
+    c.chat_stream = boom
+    c.chat = AsyncMock(return_value=fallback)
+    out = await c.chat_collect("sys", [])
+    assert out is fallback
+    c.chat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_falls_back_when_no_done_frame():
+    c = _client()
+    fallback = LLMResponse(content="fb", tokens_used=1)
+
+    async def only_text(*a, **k):
+        yield {"type": "text_delta", "content": "h"}
+
+    c.chat_stream = only_text
+    c.chat = AsyncMock(return_value=fallback)
+    out = await c.chat_collect("sys", [])
+    assert out is fallback
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_flag_off_uses_non_streaming(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_TASK_STREAMING", "0")
+    c = _client()
+    assert c.stream_task_exec is False
+    direct = LLMResponse(content="d", tokens_used=1)
+    c.chat = AsyncMock(return_value=direct)
+    c.chat_stream = AsyncMock()  # must NOT be used
+    out = await c.chat_collect("sys", [])
+    assert out is direct
+    c.chat_stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_collect_propagates_classified_errors():
+    from src.agent.llm import LLMRetryableError
+    c = _client()
+
+    async def transient(*a, **k):
+        raise LLMRetryableError("overloaded")
+        yield  # pragma: no cover
+
+    c.chat_stream = transient
+    c.chat = AsyncMock()
+    with pytest.raises(LLMRetryableError):
+        await c.chat_collect("sys", [])
+    c.chat.assert_not_called()  # classified errors must NOT silently fall back

--- a/tests/test_chat_workspace.py
+++ b/tests/test_chat_workspace.py
@@ -48,6 +48,10 @@ def _make_loop_with_workspace(
         llm.chat = AsyncMock(return_value=LLMResponse(content="Hello!", tokens_used=50))
     llm.default_model = "test-model"
 
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
+
     mesh_client = MagicMock()
     mesh_client.send_system_message = AsyncMock(return_value={})
 
@@ -365,6 +369,10 @@ class TestChatTranscriptIntegration:
         llm = MagicMock()
         llm.chat = AsyncMock(return_value=LLMResponse(content="Reply", tokens_used=10))
         llm.default_model = "test"
+
+        async def _chat_collect_delegate(*args, **kwargs):
+            return await llm.chat(*args, **kwargs)
+        llm.chat_collect = _chat_collect_delegate
 
         mesh = MagicMock()
         mesh.send_system_message = AsyncMock(return_value={})

--- a/tests/test_execute_task_guards.py
+++ b/tests/test_execute_task_guards.py
@@ -67,6 +67,10 @@ def _make_loop(
         ))
     llm.default_model = "test-model"
 
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
+
     mesh_client = MagicMock()
     mesh_client.is_standalone = False
     mesh_client.send_system_message = AsyncMock(return_value={})

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -68,3 +68,25 @@ def test_set_llm_limits_env_clamps():
     _default, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
     limits.set_llm_limits_env(env, {"max_tool_rounds": hi + 5000})
     assert env["OPENLEGION_TASK_MAX_TOOL_ROUNDS"] == str(hi)
+
+
+# --- edit_agent field support for the per-agent limit knobs (PR B) ---
+
+def test_new_limit_fields_are_editable():
+    from src.shared.types import HARD_EDIT_FIELDS
+    assert "max_tool_rounds" in HARD_EDIT_FIELDS
+    assert "llm_timeout_seconds" in HARD_EDIT_FIELDS
+
+
+def test_validate_edit_accepts_valid_rounds():
+    from src.agent.builtins.operator_tools import _validate_edit
+    assert _validate_edit("a", "max_tool_rounds", 250) is None
+    assert _validate_edit("a", "llm_timeout_seconds", 900) is None
+
+
+def test_validate_edit_rejects_out_of_range_and_bool():
+    from src.agent.builtins.operator_tools import _validate_edit
+    _d, _lo, hi = limits.LIMIT_SPECS["task_max_tool_rounds"]
+    assert _validate_edit("a", "max_tool_rounds", hi + 1) is not None
+    assert _validate_edit("a", "max_tool_rounds", True) is not None
+    assert _validate_edit("a", "llm_timeout_seconds", "nope") is not None

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -69,6 +69,13 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None, *, real_memory: b
         llm.chat = AsyncMock(return_value=LLMResponse(content='{"result": {"answer": "42"}}', tokens_used=100))
     llm.default_model = "test-model"
 
+    # Task/handoff paths call chat_collect (streaming). Delegate to whatever
+    # llm.chat is at call time so existing mocks (incl. per-test reassignments
+    # of loop.llm.chat) drive both the streaming and non-streaming paths.
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
+
     mesh_client = MagicMock()
     mesh_client.is_standalone = False
     mesh_client.send_system_message = AsyncMock(return_value={})

--- a/tests/test_operator_e2e.py
+++ b/tests/test_operator_e2e.py
@@ -52,6 +52,10 @@ def _make_mock_llm(responses=None):
             ),
         )
     llm.default_model = "test-model"
+
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
     return llm
 
 

--- a/tests/test_task_checkpoint.py
+++ b/tests/test_task_checkpoint.py
@@ -49,6 +49,10 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None, *, real_memory: b
         llm.chat = AsyncMock(return_value=LLMResponse(content='{"result": {"answer": "42"}}', tokens_used=100))
     llm.default_model = "test-model"
 
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
+
     mesh_client = MagicMock()
     mesh_client.is_standalone = False
     mesh_client.send_system_message = AsyncMock(return_value={})
@@ -471,6 +475,10 @@ class TestTaskCheckpointLoop:
             return_value=LLMResponse(content='{"result": {"done": true}}', tokens_used=50)
         )
         llm.default_model = "test-model"
+
+        async def _chat_collect_delegate(*args, **kwargs):
+            return await llm.chat(*args, **kwargs)
+        llm.chat_collect = _chat_collect_delegate
 
         tools = MagicMock()
         tools.get_tool_definitions = MagicMock(return_value=[])

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -106,6 +106,10 @@ def _make_loop_with_mocks():
     ))
     llm.default_model = "test-model"
 
+    async def _chat_collect_delegate(*args, **kwargs):
+        return await llm.chat(*args, **kwargs)
+    llm.chat_collect = _chat_collect_delegate
+
     mesh_client = MagicMock()
     mesh_client.agent_id = "test_agent"
     mesh_client.is_standalone = True


### PR DESCRIPTION
**Stacked on #1055 → #1054** — review/merge those first.

## What (P3 — structural fix for the ReadTimeout class)
Headless task/handoff execution used the non-streaming `chat()` path, whose httpx read timeout is a **total-response** bound. A large generation the agent's `max_output_tokens` permits can't finish within it → `ReadTimeout` → task failed (the social-strategist failure). **Streaming makes the read timeout a per-chunk *idle* bound** — as long as tokens keep arriving, the call can't time out, independent of total length.

- **llm.py** — new `chat_collect()` drains the existing `chat_stream` and returns the terminal `done` frame's fully-assembled `LLMResponse` (contract-identical to `chat`: same content/thinking/**tool_calls**/tokens). Falls back to non-streaming `chat()` when streaming is disabled, the stream ends without a `done` frame, or transport fails for a non-classified reason; classified errors (auth/config/retryable) propagate to `_llm_call_with_retry`. Gated by `OPENLEGION_TASK_STREAMING` (default on).
- **loop.py** — the 5 task / `_chat_inner` LLM calls now use `chat_collect`. The two interactive-streaming-path force-compose fallbacks deliberately stay on non-streaming `chat()`.

## Why this is safe
`chat_stream`'s `done` event already yields a full `LLMResponse` with `tool_calls` parsed by the same `_parse_tool_calls` as `chat()`, and the interactive dashboard path already relies on it. `chat_collect` reuses that exact contract, with a non-streaming fallback so a flaky/absent stream endpoint can never fail a task outright.

## Tests
`test_chat_collect.py` (done-response, both fallback paths, flag-off, classified-error propagation). `_make_loop` aliases `chat_collect`→`chat` so all existing task tests exercise both. Verified: imports OK · ruff clean · `test_chat_collect.py` 5 passed · `test_loop.py` 199 passed.

## Deploy note
Agent-side code → needs an agent image rebuild + restart to deploy.