### PR TITLE
fix(agent): operator context/memory hygiene — tail-keep MEMORY.md, system-prompt-aware compaction

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -28,6 +28,7 @@ logger = setup_logging("agent.context")
 _FLUSH_THRESHOLD = 0.60  # proactive fact extraction before compaction
 _COMPACT_THRESHOLD = 0.70  # summarize-and-replace conversation history
 _WARNING_THRESHOLD = 0.80  # warn agent to wrap up or save facts
+_EMERGENCY_THRESHOLD = 0.90  # hard-prune fallback when summarization can't recover
 
 _encoding_cache: dict[str, object | None] = {}
 
@@ -156,6 +157,14 @@ class ContextManager:
 
     Modes:
       safeguard (default) — auto-compact at 70%, emergency prune at 90%
+
+    Compaction decisions in :meth:`maybe_compact` are made against
+    *effective* usage — the conversation messages PLUS the system prompt's
+    token cost — because the system prompt (large and churning for the
+    operator agent) genuinely consumes the window. At >= 90% effective usage
+    the emergency path summarises and, if still over the compact threshold,
+    additionally hard-prunes. ``usage`` / ``should_compact`` remain
+    messages-only for backward compatibility with other callers.
     """
 
     def __init__(
@@ -205,6 +214,24 @@ class ContextManager:
     def should_compact(self, messages: list[dict]) -> bool:
         return self.usage(messages) >= _COMPACT_THRESHOLD
 
+    def _effective_usage(self, system_prompt: str, messages: list[dict]) -> float:
+        """Usage fraction including the system prompt's token cost.
+
+        The system prompt is not part of ``messages`` but is sent on every
+        request and consumes the context window — for the operator agent it
+        is the largest, most-churning block. Counting only ``messages`` (as
+        ``usage`` does) makes compaction underfire for exactly that agent, so
+        :meth:`maybe_compact` decides against this fraction instead.
+        """
+        system_tokens = (
+            estimate_tokens(
+                [{"role": "system", "content": system_prompt}], model=self.model
+            )
+            if system_prompt
+            else 0
+        )
+        return (self.token_count(messages) + system_tokens) / self.max_tokens
+
     async def maybe_compact(
         self, system_prompt: str, messages: list[dict],
     ) -> tuple[list[dict], bool]:
@@ -213,11 +240,16 @@ class ContextManager:
         Returns ``(messages, did_compact)`` where ``did_compact`` is True only
         when the conversation was actually summarised and replaced.
 
+        Decisions are made against *effective* usage = messages tokens +
+        system-prompt tokens / ``max_tokens`` (see :meth:`_effective_usage`),
+        so a large system prompt (operator agent) is correctly accounted for.
+
         1. If between 60-70%, proactively flush structured facts (once).
         2. If above 70%, flush to MEMORY.md, then summarize.
-        3. If above 90%, hard-prune oldest messages as emergency fallback.
+        3. If above 90% AND summarization can't pull effective usage back below
+           70%, additionally hard-prune the result as an emergency fallback.
         """
-        usage = self.usage(messages)
+        usage = self._effective_usage(system_prompt, messages)
 
         # Proactive flush at 60% — save facts before compaction discards them
         if (
@@ -234,10 +266,27 @@ class ContextManager:
             await self._proactive_flush(system_prompt, messages)
             return messages, False  # don't compact yet
 
-        if not self.should_compact(messages):
+        if usage < _COMPACT_THRESHOLD:
             return messages, False
 
         result = await self._do_compact(system_prompt, messages, label="Compaction")
+
+        # Emergency prune at 90%: if even after summarization the effective
+        # usage is still over the compact threshold, hard-prune the result so
+        # the next request doesn't blow the window. Without this the "90%
+        # emergency prune" the docstrings advertise never actually fired.
+        if (
+            usage >= _EMERGENCY_THRESHOLD
+            and self._effective_usage(system_prompt, result) >= _COMPACT_THRESHOLD
+        ):
+            logger.warning(
+                "Emergency prune: effective usage still %d%% after "
+                "summarization (>=%d%%); hard-pruning",
+                int(self._effective_usage(system_prompt, result) * 100),
+                int(_COMPACT_THRESHOLD * 100),
+            )
+            result = self._hard_prune(result)
+
         return result, True
 
     async def force_compact(

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -81,6 +81,32 @@ def _maybe_add_header(filename: str, content: str) -> str:
         return content
     return f"## {filename} — {desc}\n\n{content}"
 
+
+def _truncate_keep_tail(content: str, cap: int) -> str:
+    """Keep the LAST ``cap`` characters of ``content``, trimmed to a clean start.
+
+    Used for append-only files (MEMORY.md) where the newest, most relevant
+    facts live at the tail. After slicing the last ``cap`` chars we trim
+    *forward* to the next clean block boundary so the prompt never starts
+    mid-line: prefer the first ``"\n## "`` (markdown block header) inside the
+    kept slice, else the first ``"\n"``. A notice is prepended so the agent
+    knows older history exists and can recover it via ``memory_search``.
+    """
+    if len(content) <= cap:
+        return content
+    tail = content[-cap:]
+    marker = tail.find("\n## ")
+    if marker != -1:
+        tail = tail[marker + 1:]  # drop the leading newline, keep "## ..."
+    else:
+        nl = tail.find("\n")
+        if nl != -1:
+            tail = tail[nl + 1:]
+    return (
+        "... (older memory truncated — use memory_search for full history)\n\n"
+        + tail
+    )
+
 # Permission keys surfaced to agents in SYSTEM.md and Runtime Context.
 # Keep in sync with the introspect endpoint in src/host/server.py.
 INTROSPECT_PERM_KEYS = (
@@ -92,6 +118,10 @@ _MAX_INSTRUCTIONS = 12_000
 _MAX_SOUL = 4_000
 _MAX_USER = 4_000
 _MAX_MEMORY = 16_000
+# On-disk cap for MEMORY.md. Appends accumulate at the tail; once the file
+# exceeds this we rewrite it keeping the newest content (trimmed forward to a
+# block boundary) so it can never creep toward the 200KB read ceiling.
+_MEMORY_FILE_MAX = 32_000  # == 2 × _MAX_MEMORY
 
 # Public mapping for external consumers (tool response, dashboard).
 # Files not listed have no per-file bootstrap cap.
@@ -494,9 +524,17 @@ class WorkspaceManager:
                 continue
             content = content.strip()
             if len(content) > cap:
-                content = content[:cap] + (
-                    "\n\n... (truncated, use memory_search for full content)"
-                )
+                if filename == "MEMORY.md":
+                    # MEMORY.md grows by APPEND at the tail, so a head-slice
+                    # (content[:cap]) would freeze the oldest facts into the
+                    # prompt forever. Keep the TAIL (newest facts) instead.
+                    content = _truncate_keep_tail(content, cap)
+                else:
+                    # INSTRUCTIONS/SOUL/USER are authored top-down — the head
+                    # is the most important part, so head-slice is correct.
+                    content = content[:cap] + (
+                        "\n\n... (truncated, use memory_search for full content)"
+                    )
             parts.append(_maybe_add_header(filename, content))
 
         combined = "\n\n---\n\n".join(parts)
@@ -535,10 +573,28 @@ class WorkspaceManager:
             f.write(line)
 
     def append_memory(self, content: str) -> None:
-        """Append to MEMORY.md (used by context manager before compacting)."""
+        """Append to MEMORY.md (used by context manager before compacting).
+
+        Enforces an on-disk cap (``_MEMORY_FILE_MAX``): once the file grows
+        past the cap we rewrite it keeping the TAIL (newest entries), trimmed
+        forward to the next ``"\n## "`` block boundary so we never persist a
+        half block. Without this the append-only file creeps toward the 200KB
+        read ceiling unbounded.
+        """
         path = self.root / self.MEMORY_FILE
         with path.open("a") as f:
             f.write(f"\n{content}\n")
+
+        try:
+            current = path.read_text(errors="replace")
+            if len(current) > _MEMORY_FILE_MAX:
+                tail = current[-_MEMORY_FILE_MAX:]
+                marker = tail.find("\n## ")
+                tail = tail[marker + 1:] if marker != -1 else tail
+                path.write_text("<!-- older memory trimmed -->\n" + tail)
+        except Exception as e:
+            logger.warning(f"Failed to enforce MEMORY.md on-disk cap: {e}")
+
         self._bootstrap_cache = None  # MEMORY.md is part of bootstrap
 
     # Files agents are allowed to update themselves

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.agent.context import (
+    _COMPACT_THRESHOLD,
+    _EMERGENCY_THRESHOLD,
     ContextManager,
     estimate_tokens,
     group_messages_by_tool_call,
@@ -227,6 +229,109 @@ class TestCompaction:
             # With such a short conversation, _flush_to_memory should skip
             # (< 100 chars of conversation text), so only summarize is called
             assert llm.chat.call_count <= 2
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestSystemPromptAwareCompaction:
+    @pytest.mark.asyncio
+    async def test_large_system_prompt_triggers_compaction(self):
+        """Messages alone are under the compact threshold, but a large system
+        prompt pushes EFFECTIVE usage over it — compaction must fire."""
+        cm = ContextManager(max_tokens=1000, llm=None, workspace=None)
+        msgs = _make_messages(10, chars_each=50)  # well under threshold alone
+
+        # Sanity: messages-only usage is below the compact threshold.
+        assert cm.usage(msgs) < _COMPACT_THRESHOLD
+        # No-op compaction (no system prompt) confirms baseline.
+        result_no_sys, did_no_sys = await cm.maybe_compact("", msgs)
+        assert did_no_sys is False
+        assert result_no_sys == msgs
+
+        # A big system prompt (~3000 tokens at 4 chars/token) pushes effective
+        # usage over 70%.
+        big_system = "S" * 12_000
+        assert cm._effective_usage(big_system, msgs) >= _COMPACT_THRESHOLD
+        result, did_compact = await cm.maybe_compact(big_system, msgs)
+        assert did_compact is True
+        assert len(result) < len(msgs)
+
+    def test_effective_usage_counts_system_prompt(self):
+        cm = ContextManager(max_tokens=10_000)
+        msgs = _make_messages(2, chars_each=100)
+        bare = cm.usage(msgs)
+        with_sys = cm._effective_usage("X" * 8_000, msgs)
+        assert with_sys > bare
+
+    def test_effective_usage_empty_system_prompt_matches_usage(self):
+        cm = ContextManager(max_tokens=10_000)
+        msgs = _make_messages(3, chars_each=100)
+        assert cm._effective_usage("", msgs) == pytest.approx(cm.usage(msgs))
+
+
+class TestEmergencyPrune:
+    @pytest.mark.asyncio
+    async def test_emergency_prune_when_summary_does_not_recover(self):
+        """At >= 90% effective usage, if summarization leaves the result still
+        over the compact threshold, the result is additionally hard-pruned."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            workspace = WorkspaceManager(workspace_dir=tmpdir)
+            llm = MagicMock()
+            # Summary is HUGE so summarization alone can't pull usage down.
+            llm.chat = AsyncMock(
+                side_effect=[
+                    LLMResponse(content="[]", tokens_used=10),  # flush: no facts
+                    LLMResponse(content="S" * 8_000, tokens_used=2000),  # fat summary
+                ]
+            )
+            # max_tokens tuned so 14 messages of 200 chars sit >= 90%.
+            cm = ContextManager(max_tokens=850, llm=llm, workspace=workspace)
+            msgs = _make_messages(14, chars_each=200)
+            assert cm._effective_usage("system", msgs) >= _EMERGENCY_THRESHOLD
+
+            result, did_compact = await cm.maybe_compact("system", msgs)
+            assert did_compact is True
+            # Hard prune ran on top of summarize: result is short (first +
+            # last-4 groups) rather than the summary + recent tail.
+            assert len(result) <= 6
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_emergency_prune_via_no_llm_hard_prune(self):
+        """No-LLM path: _do_compact hard-prunes; when usage is >= 90% and the
+        prune still leaves it over the compact threshold, a second hard-prune
+        fires. Deterministic exercise of the emergency branch."""
+        cm = ContextManager(max_tokens=80, llm=None, workspace=None)
+        msgs = _make_messages(40, chars_each=200)
+        assert cm._effective_usage("system", msgs) >= _EMERGENCY_THRESHOLD
+        result, did_compact = await cm.maybe_compact("system", msgs)
+        assert did_compact is True
+        assert len(result) < len(msgs)
+
+    @pytest.mark.asyncio
+    async def test_no_emergency_prune_below_90(self):
+        """Between 70-90% the normal compact path runs without the emergency
+        hard-prune kicking in on top."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            workspace = WorkspaceManager(workspace_dir=tmpdir)
+            llm = MagicMock()
+            llm.chat = AsyncMock(
+                side_effect=[
+                    LLMResponse(content="[]", tokens_used=10),
+                    LLMResponse(content="Short summary.", tokens_used=10),
+                ]
+            )
+            cm = ContextManager(max_tokens=750, llm=llm, workspace=workspace)
+            msgs = _make_messages(10, chars_each=200)
+            eff = cm._effective_usage("system", msgs)
+            assert _COMPACT_THRESHOLD <= eff < _EMERGENCY_THRESHOLD
+            result, did_compact = await cm.maybe_compact("system", msgs)
+            assert did_compact is True
+            # Summary present (not an emergency hard-prune, which would drop it).
+            assert any("Summary" in m.get("content", "") for m in result)
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9,11 +9,14 @@ from pathlib import Path
 import pytest
 
 from src.agent.workspace import (
+    _MAX_MEMORY,
     _MAX_SYSTEM,
+    _MEMORY_FILE_MAX,
     WorkspaceManager,
     _bm25_score,
     _maybe_add_header,
     _tokenize,
+    _truncate_keep_tail,
     generate_system_md,
 )
 
@@ -293,6 +296,44 @@ class TestBootstrapContent:
         assert "truncated" in content
         assert "memory_search" in content
 
+    def test_bootstrap_keeps_tail_of_oversized_memory(self):
+        # MEMORY.md is append-only: bootstrap must keep the NEWEST (tail)
+        # blocks, not freeze the oldest head-slice into the prompt forever.
+        root = Path(self._tmpdir)
+        # Oldest block first, newest last; pad each to push over _MAX_MEMORY.
+        oldest = "## Oldest Block\n\n" + ("o" * 12_000)
+        newest = "## Newest Block\n\n" + ("n" * 12_000)
+        (root / "MEMORY.md").write_text(oldest + "\n" + newest + "\n")
+        ws = WorkspaceManager(workspace_dir=self._tmpdir)
+        content = ws.get_bootstrap_content()
+        assert "Newest Block" in content          # tail kept
+        assert "Oldest Block" not in content      # head dropped
+        assert "older memory truncated" in content
+
+    def test_bootstrap_still_head_keeps_instructions(self):
+        # INSTRUCTIONS.md is authored top-down — head-keep is still correct.
+        root = Path(self._tmpdir)
+        head = "## Top Procedures\n\n" + ("h" * 13_000)
+        tail = "## Bottom Notes\n\n" + ("t" * 5_000)
+        (root / "INSTRUCTIONS.md").write_text(head + "\n" + tail + "\n")
+        ws = WorkspaceManager(workspace_dir=self._tmpdir)
+        content = ws.get_bootstrap_content()
+        assert "Top Procedures" in content        # head kept
+        assert "Bottom Notes" not in content       # tail dropped
+
+    def test_truncate_keep_tail_prefers_block_boundary(self):
+        content = (
+            "## First\n\n" + ("a" * 100)
+            + "\n## Second\n\n" + ("b" * 100)
+            + "\n## Third\n\n" + ("c" * 100)
+        )
+        cap = 250  # forces dropping at least the first block
+        out = _truncate_keep_tail(content, cap)
+        assert out.startswith("... (older memory truncated")
+        # Starts at a clean block header, not mid-line.
+        body = out.split("\n\n", 1)[1]
+        assert body.startswith("## ")
+
     def test_bootstrap_enforces_total_cap(self):
         root = Path(self._tmpdir)
         # Fill every file close to its per-file cap to exceed total
@@ -443,6 +484,35 @@ class TestMemoryFile:
         content = ws.load_memory()
         assert "Existing fact" in content
         assert "New fact" in content
+
+    def test_append_memory_enforces_ondisk_cap(self):
+        path = Path(self._tmpdir) / "MEMORY.md"
+        # Pre-fill past the on-disk cap with old blocks.
+        old = "".join(
+            f"## Old Block {i}\n\n" + ("x" * 2_000) + "\n"
+            for i in range(30)
+        )
+        path.write_text(old)
+        ws = WorkspaceManager(workspace_dir=self._tmpdir)
+        ws.append_memory("## Newest Block\n\nfresh fact")
+
+        on_disk = path.read_text()
+        # Trimmed to within the cap (+ small margin for the marker line).
+        assert len(on_disk) <= _MEMORY_FILE_MAX + 100
+        # Newest content survives; the very oldest blocks are gone.
+        assert "fresh fact" in on_disk
+        assert "Old Block 0" not in on_disk
+        assert on_disk.startswith("<!-- older memory trimmed -->")
+        # Starts at a clean block boundary (no half block after the marker).
+        body = on_disk.split("\n", 1)[1]
+        assert body.lstrip().startswith("## ")
+
+    def test_append_memory_no_trim_under_cap(self):
+        ws = WorkspaceManager(workspace_dir=self._tmpdir)
+        ws.append_memory("small fact")
+        on_disk = (Path(self._tmpdir) / "MEMORY.md").read_text()
+        assert "older memory trimmed" not in on_disk
+        assert _MEMORY_FILE_MAX == 2 * _MAX_MEMORY
 
 
 class TestBM25Search:


### PR DESCRIPTION
## Why

The **operator** agent degrades ("loopy") over long sessions due to two context-management defects.

### Defect A — stale head-slice memory
`MEMORY.md` is injected into every prompt but was truncated with a HEAD slice (`content[:cap]`), while new facts are APPENDED to the tail. Once the file exceeds the cap, the operator is fed a frozen snapshot of the **oldest** facts forever, and the file grows **unbounded** on disk (no rotation), creeping toward the 200KB read ceiling.

### Defect B — system-prompt-blind + phantom-90% compaction
`ContextManager.maybe_compact`'s threshold decisions counted only the message list, **not** the system prompt — but the operator's system prompt is its largest, most-churning block, so compaction underfired for exactly that agent. The class / `maybe_compact` docstrings also advertised an "emergency prune at 90%" that **no code implemented**.

## Changes

**`src/agent/workspace.py`**
- New `_truncate_keep_tail(content, cap)` helper; `get_bootstrap_content` now keeps the **TAIL** (newest facts) of an over-cap `MEMORY.md`, trimmed forward to the next `"\n## "` block boundary (else first `"\n"`), with a `... (older memory truncated — use memory_search for full history)` notice. INSTRUCTIONS/SOUL/USER keep the existing **head**-slice (authored top-down).
- `append_memory` enforces a new on-disk cap `_MEMORY_FILE_MAX = 32_000` (`== 2 × _MAX_MEMORY`): once exceeded it rewrites the file keeping the tail, trimmed to a `"\n## "` block boundary, behind a `<!-- older memory trimmed -->` marker. Cache invalidation preserved.

**`src/agent/context.py`**
- New `_effective_usage(system_prompt, messages)` = `(message tokens + system-prompt tokens) / max_tokens` (guards empty/None system prompt → 0). `maybe_compact` now makes its flush / compact / emergency decisions against this effective fraction.
- `usage()` / `should_compact()` stay **messages-only** for backward compatibility (other callers/tests rely on them).
- New `_EMERGENCY_THRESHOLD = 0.90`: after the normal compact path, if effective usage ≥ 90% and post-compaction effective usage is still ≥ the compact threshold (0.70), the result is **additionally hard-pruned** (logged as a warning). Sub-90% paths behave exactly as before.
- Class + `maybe_compact` docstrings updated so the "90%" claim matches reality.

## Behavioral note
Counting the system prompt makes compaction fire **slightly earlier for all agents** — this is an intended correctness fix, since the system prompt genuinely consumes the context window.

## Tests
Added in `tests/test_workspace.py` and `tests/test_context.py`:
- `get_bootstrap_content` keeps the TAIL of an over-cap `MEMORY.md` (newest block present, oldest absent) and still head-keeps `INSTRUCTIONS.md`; `_truncate_keep_tail` starts at a block boundary.
- `append_memory` trims the on-disk file to ≤ `_MEMORY_FILE_MAX`, keeping newest content and starting at a block boundary; no trim under the cap.
- `maybe_compact` triggers compaction when a large `system_prompt` pushes effective usage over the compact threshold even though messages alone are under it; `_effective_usage` accounts for the system prompt.
- Emergency prune: at ≥ 90% effective usage with a fat summary (and via the no-LLM hard-prune path), the result is additionally hard-pruned; the 70–90% band runs the normal compact without it.

Targeted run: `tests/test_context.py` + `tests/test_workspace.py` → **190 passed**. Full suite (e2e ignored) reached 100% with **zero failures** (the trailing process-exit hang is the known pytest-sweep hang). Ruff clean.