### PR TITLE
fix(orchestration): stop the operator inbox back-edge event flood

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -37,6 +37,18 @@ _HANDOFF_TTL = 86_400  # 24 hours — safety net for unprocessed handoffs
 # coordination tool stays decoupled from host internals.
 _TERMINAL_STATES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
 
+# Cap on back-edge events returned by ``check_inbox``. The operator is the
+# originator of nearly every workflow, so on a busy fleet the back-edge
+# event list (7-day TTL, never pruned by the call) can grow to hundreds of
+# entries and flood the LLM context (~80k-170k tokens) on every heartbeat.
+# Actionable kinds (task_failed / task_blocked) are NEVER dropped; the cap
+# only evicts the newest-surviving informational events.
+_MAX_INBOX_EVENTS = 25
+
+# Back-edge kinds the originator must act on. Mirrors the host-side
+# ``_BACK_EDGE_WAKE_KINDS`` — these survive capping in ``check_inbox``.
+_ACTIONABLE_EVENT_KINDS: frozenset[str] = frozenset({"task_failed", "task_blocked"})
+
 
 def _failed_transition_envelope(
     *, kind: str, detail: str, exc: Exception, extras: dict | None = None,
@@ -504,11 +516,39 @@ async def check_inbox(*, mesh_client=None) -> dict:
             mesh_client.agent_id, e,
         )
 
+    # Bound the event list before returning. The operator originates almost
+    # every workflow, so without a cap this list grows to hundreds of entries
+    # (7-day TTL) and re-floods the LLM context on every heartbeat. Actionable
+    # events (task_failed / task_blocked) must NEVER be dropped; informational
+    # events (task_completed / task_cancelled) are evicted oldest-first to make
+    # room. Within the returned list, actionable events come first (newest
+    # actionable first) so the LLM sees what it must act on at the top.
+    events_total = len(events)
+
+    def _event_ts(ev: dict) -> float:
+        ts = ev.get("ts")
+        try:
+            return float(ts) if ts is not None else 0.0
+        except (TypeError, ValueError):
+            return 0.0
+
+    actionable = [e for e in events if e.get("kind") in _ACTIONABLE_EVENT_KINDS]
+    informational = [e for e in events if e.get("kind") not in _ACTIONABLE_EVENT_KINDS]
+    actionable.sort(key=_event_ts, reverse=True)
+    informational.sort(key=_event_ts, reverse=True)
+
+    # Actionable events are always retained (never dropped). Informational
+    # events fill whatever slots remain under the cap, newest first.
+    remaining = max(_MAX_INBOX_EVENTS - len(actionable), 0)
+    capped_events = actionable + informational[:remaining]
+
     return {
         "tasks": tasks,
         "count": len(tasks),
-        "events": events,
-        "event_count": len(events),
+        "events": capped_events,
+        "event_count": len(capped_events),
+        "events_total": events_total,
+        "events_truncated": events_total > len(capped_events),
     }
 
 

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -267,10 +267,19 @@ class Blackboard:
         """List all entries matching a key prefix."""
         # Escape LIKE wildcards so literal '%' and '_' in keys match exactly
         escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        # Filter out TTL-expired rows inline. The TTL GC is throttled to once
+        # per 60s and only fires on writes, so without this filter a reader can
+        # see entries that should already be gone (e.g. back-edge task events
+        # past their TTL re-flooding check_inbox). Mirrors the expiry condition
+        # in _gc_expired_unlocked; history/ entries carry no TTL so they are
+        # unaffected (the deletion-side history exclusion isn't needed here).
         rows = self.db.execute(
             "SELECT key, value, written_by, workflow_id, "
             "created_at, updated_at, ttl, version FROM entries "
-            "WHERE key LIKE ? ESCAPE '\\' ORDER BY key",
+            "WHERE key LIKE ? ESCAPE '\\' "
+            "AND NOT (ttl IS NOT NULL AND "
+            "datetime(updated_at, '+' || ttl || ' seconds') < datetime('now')) "
+            "ORDER BY key",
             (escaped + "%",),
         ).fetchall()
         return [

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5250,6 +5250,14 @@ def create_mesh_app(
         "cancelled": "task_cancelled",
     }
     _BACK_EDGE_WAKE_KINDS = frozenset({"task_failed", "task_blocked"})
+    # TTL split for back-edge events. Actionable kinds (task_failed /
+    # task_blocked) keep the 7-day window so the originator can recover even
+    # after a long gap. Informational kinds (task_completed / task_cancelled)
+    # get a much shorter window: the operator originates almost every workflow,
+    # so without this split completed-task events accumulate for a week and
+    # flood check_inbox / the operator's LLM context on every heartbeat.
+    _BACK_EDGE_TTL_ACTIONABLE = 604800  # 7 days
+    _BACK_EDGE_TTL_INFORMATIONAL = 86400  # 24 hours
     _BACK_EDGE_WAKE_WINDOW_SECONDS = 60.0
     _back_edge_wake_state: dict[str, float] = {}
 
@@ -5311,10 +5319,15 @@ def create_mesh_app(
                 for k, v in payload_extras.items():
                     if k not in payload:
                         payload[k] = v
+            back_edge_ttl = (
+                _BACK_EDGE_TTL_ACTIONABLE
+                if event_kind in _BACK_EDGE_WAKE_KINDS
+                else _BACK_EDGE_TTL_INFORMATIONAL
+            )
             try:
                 blackboard.write(
                     f"inbox/{origin_user}/task_event/{task_id}",
-                    payload, written_by="mesh", ttl=604800,  # 7 days
+                    payload, written_by="mesh", ttl=back_edge_ttl,
                 )
             except Exception as e:
                 logger.warning(

--- a/tests/test_back_edge_helper.py
+++ b/tests/test_back_edge_helper.py
@@ -278,3 +278,76 @@ class TestBackEdgeHelperEligibility:
             r.value.get("task_id") == "task_human_1" for r in rows
         )
         assert lane.calls == []
+
+
+class TestBackEdgeTTLSplit:
+    """Actionable events keep the 7-day TTL; informational events get a
+    much shorter 24h TTL so they don't pile up for a week and flood the
+    operator's check_inbox / LLM context on every heartbeat."""
+
+    def test_completed_event_gets_informational_ttl(
+        self, mesh_app_with_back_edge,
+    ):
+        app, blackboard, _lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_ttl_done", status="done")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_completed",
+            payload_extras={"summary": "ok"},
+        )
+        _settle()
+
+        entry = next(
+            r for r in blackboard.list_by_prefix("inbox/scout/task_event/")
+            if r.value.get("task_id") == "task_ttl_done"
+        )
+        assert entry.ttl == 86400  # 24 hours
+
+    def test_cancelled_event_gets_informational_ttl(
+        self, mesh_app_with_back_edge,
+    ):
+        app, blackboard, _lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_ttl_cancel", status="cancelled")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_cancelled",
+        )
+        _settle()
+
+        entry = next(
+            r for r in blackboard.list_by_prefix("inbox/scout/task_event/")
+            if r.value.get("task_id") == "task_ttl_cancel"
+        )
+        assert entry.ttl == 86400  # 24 hours
+
+    def test_failed_event_keeps_actionable_ttl(self, mesh_app_with_back_edge):
+        app, blackboard, _lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_ttl_fail", status="failed")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        entry = next(
+            r for r in blackboard.list_by_prefix("inbox/scout/task_event/")
+            if r.value.get("task_id") == "task_ttl_fail"
+        )
+        assert entry.ttl == 604800  # 7 days
+
+    def test_blocked_event_keeps_actionable_ttl(self, mesh_app_with_back_edge):
+        app, blackboard, _lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_ttl_block", status="blocked")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_blocked",
+            payload_extras={"blocker_note": "need creds"},
+        )
+        _settle()
+
+        entry = next(
+            r for r in blackboard.list_by_prefix("inbox/scout/task_event/")
+            if r.value.get("task_id") == "task_ttl_block"
+        )
+        assert entry.ttl == 604800  # 7 days

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -387,6 +387,116 @@ class TestCheckInbox:
 
         assert result["count"] == 0
         assert result["tasks"] == []
+        assert result["events"] == []
+        assert result["event_count"] == 0
+        assert result["events_total"] == 0
+        assert result["events_truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_check_inbox_caps_events_at_25(self):
+        """A flood of completed events is capped at _MAX_INBOX_EVENTS and the
+        truncation metadata reflects the full pre-cap count."""
+        from src.agent.builtins.coordination_tool import (
+            _MAX_INBOX_EVENTS,
+            check_inbox,
+        )
+
+        mc = _make_mesh_client(agent_id="operator")
+        # 40 completed events — more than the cap.
+        entries = [
+            {
+                "key": f"inbox/operator/task_event/task_{i:03d}",
+                "value": {
+                    "kind": "task_completed",
+                    "task_id": f"task_{i:03d}",
+                    "recipient": "worker",
+                    "title": f"task {i}",
+                    "status": "done",
+                    "ts": i,  # ascending — higher i = newer
+                    "summary": f"summary {i}",
+                },
+            }
+            for i in range(40)
+        ]
+        mc.list_blackboard.return_value = entries
+
+        result = await check_inbox(mesh_client=mc)
+
+        assert result["event_count"] == _MAX_INBOX_EVENTS
+        assert len(result["events"]) == _MAX_INBOX_EVENTS
+        assert result["events_total"] == 40
+        assert result["events_truncated"] is True
+        # Newest informational events survive (ts 39 down to 15).
+        kept_ts = {e["ts"] for e in result["events"]}
+        assert max(kept_ts) == 39
+        assert min(kept_ts) == 40 - _MAX_INBOX_EVENTS  # 15
+
+    @pytest.mark.asyncio
+    async def test_check_inbox_retains_actionable_over_completed(self):
+        """task_failed / task_blocked events are NEVER dropped even when there
+        are far more than 25 completed events; completed events evict first."""
+        from src.agent.builtins.coordination_tool import check_inbox
+
+        mc = _make_mesh_client(agent_id="operator")
+        completed = [
+            {
+                "key": f"inbox/operator/task_event/done_{i:03d}",
+                "value": {
+                    "kind": "task_completed",
+                    "task_id": f"done_{i:03d}",
+                    "recipient": "worker",
+                    "title": f"done {i}",
+                    "status": "done",
+                    "ts": 1000 + i,
+                    "summary": "ok",
+                },
+            }
+            for i in range(40)
+        ]
+        actionable = [
+            {
+                "key": "inbox/operator/task_event/fail_1",
+                "value": {
+                    "kind": "task_failed",
+                    "task_id": "fail_1",
+                    "recipient": "worker",
+                    "title": "broken pipeline",
+                    "status": "failed",
+                    "ts": 5,  # deliberately old — must still survive
+                    "error": "boom",
+                },
+            },
+            {
+                "key": "inbox/operator/task_event/block_1",
+                "value": {
+                    "kind": "task_blocked",
+                    "task_id": "block_1",
+                    "recipient": "worker",
+                    "title": "stuck",
+                    "status": "blocked",
+                    "ts": 6,
+                    "blocker_note": "need creds",
+                },
+            },
+        ]
+        mc.list_blackboard.return_value = completed + actionable
+
+        result = await check_inbox(mesh_client=mc)
+
+        kinds = [e["kind"] for e in result["events"]]
+        # Both actionable events retained despite being the oldest by ts.
+        assert "task_failed" in kinds
+        assert "task_blocked" in kinds
+        # Actionable events are ordered first (newest actionable first).
+        assert kinds[0] == "task_blocked"  # ts 6 > ts 5
+        assert kinds[1] == "task_failed"
+        task_ids = {e["task_id"] for e in result["events"]}
+        assert "fail_1" in task_ids
+        assert "block_1" in task_ids
+        # Total still reflects the full set; list is capped at 25.
+        assert result["events_total"] == 42
+        assert result["event_count"] == 25
+        assert result["events_truncated"] is True
 
 
 class TestHandOffOriginPropagation:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -48,6 +48,32 @@ def test_blackboard_list_by_prefix(blackboard):
     assert len(task_entries) == 1
 
 
+def test_blackboard_list_by_prefix_excludes_ttl_expired(blackboard):
+    """TTL-expired rows must not be returned by list_by_prefix. The TTL GC is
+    throttled (once/60s, write-triggered) so a reader could otherwise see
+    entries past their TTL — the root cause of the operator inbox flood."""
+    # A live entry (no TTL) and a live TTL entry that has NOT expired.
+    blackboard.write("inbox/op/task_event/live", {"x": 1}, written_by="a1")
+    blackboard.write(
+        "inbox/op/task_event/fresh", {"x": 2}, written_by="a1", ttl=3600
+    )
+    # An entry with a TTL whose updated_at we backdate so it is firmly expired.
+    blackboard.write(
+        "inbox/op/task_event/stale", {"x": 3}, written_by="a1", ttl=60
+    )
+    blackboard.db.execute(
+        "UPDATE entries SET updated_at = datetime('now', '-2 hours') "
+        "WHERE key = ?",
+        ("inbox/op/task_event/stale",),
+    )
+    blackboard.db.commit()
+
+    entries = blackboard.list_by_prefix("inbox/op/task_event/")
+    keys = {e.key for e in entries}
+    assert keys == {"inbox/op/task_event/live", "inbox/op/task_event/fresh"}
+    assert "inbox/op/task_event/stale" not in keys
+
+
 def test_blackboard_delete(blackboard):
     blackboard.write("context/del_me", {"x": 1}, written_by="a1")
     blackboard.delete("context/del_me", deleted_by="a1")

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -641,7 +641,9 @@ async def test_terminal_transition_writes_back_edge_for_agent_origin(tmp_path):
         assert payload["recipient"] == "beta"
         assert payload["status"] == "done"
         assert payload["summary"] == "all done"
-        assert entry.ttl == 604800
+        # task_completed is an informational back-edge kind → 24h TTL (the
+        # actionable kinds task_failed/task_blocked keep the 7-day window).
+        assert entry.ttl == 86400
     finally:
         _teardown_mesh(bb, tasks_store)
 


### PR DESCRIPTION
## Problem

The operator originates nearly every workflow, so it is the recipient of nearly every back-edge task event written to `inbox/{user}/task_event/{id}`. Those events carried a flat **7-day TTL** and `check_inbox` returned the **full, unbounded list** on every call. On a busy fleet this grew to hundreds of entries and re-flooded the operator's LLM context (~80k–170k tokens) on **every heartbeat** — crowding out real work and inflating cost.

## Fix — three coordinated changes

1. **`coordination_tool.check_inbox`** caps returned events at **25**. Actionable kinds (`task_failed` / `task_blocked`) are **never dropped** and surface first (newest-first); informational kinds (`task_completed` / `task_cancelled`) fill remaining slots, oldest-evicted. Adds `events_total` / `events_truncated` so the caller knows the list was bounded.
2. **`server.py`** splits the back-edge TTL by kind: actionable events keep the 7-day recovery window; informational events drop to **24h** so completed-task noise self-expires instead of accumulating for a week.
3. **`mesh.Blackboard.list_prefix`** filters TTL-expired rows **inline**. The TTL GC is throttled (once/60s, write-triggered), so a reader could otherwise still see events past their TTL and re-flood `check_inbox`. Mirrors the expiry condition in `_gc_expired_unlocked`; `history/` entries carry no TTL and are unaffected.

## Tests

- `tests/test_coordination.py`, `tests/test_mesh.py`, `tests/test_back_edge_helper.py` extended.
- Affected files: **161 passed**.
- Broader subset (coordination + mesh + orchestration + operator heartbeat): **370 passed**.