### PR TITLE
feat(memory): provider-agnostic, configurable-dim embeddings (safe by default)

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -48,6 +48,11 @@ def main() -> None:
 
     llm_model = os.environ.get("LLM_MODEL", "openai/gpt-4o-mini")
     embedding_model = os.environ.get("EMBEDDING_MODEL", "")
+    try:
+        embedding_dim = int(os.environ.get("EMBEDDING_DIM", "1536"))
+    except ValueError:
+        logger.warning("Invalid EMBEDDING_DIM, using default 1536")
+        embedding_dim = 1536
     thinking = os.environ.get("THINKING", "off")
     try:
         max_output_tokens = int(os.environ.get("LLM_MAX_TOKENS", "8192"))
@@ -65,7 +70,9 @@ def main() -> None:
         mesh_url=mesh_url, agent_id=agent_id, project_name=project_name or None,
     )
     embed_fn = llm.embed if embedding_model and embedding_model.lower() != "none" else None
-    memory = MemoryStore(db_path=f"/data/{agent_id}.db", embed_fn=embed_fn)
+    memory = MemoryStore(
+        db_path=f"/data/{agent_id}.db", embed_fn=embed_fn, embedding_dim=embedding_dim,
+    )
 
     # MCP server support — parse config from environment
     mcp_client = None

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -63,6 +63,7 @@ class MemoryStore:
         db_path: str,
         embed_fn: EmbedFn | None = None,
         categorize_fn: CategorizeFn | None = None,
+        embedding_dim: int = EMBEDDING_DIM,
     ):
         self._close_lock = threading.Lock()
         self.db = open_db(db_path)
@@ -73,6 +74,12 @@ class MemoryStore:
         self.embed_fn = embed_fn
         self._embed_failures = 0
         self.categorize_fn = categorize_fn
+        # Dimension the vec0 tables are bound to. Configurable so non-OpenAI
+        # embedding providers work (Voyage 1024, Gemini 768, …); a change
+        # between boots triggers a vec-table rebuild in
+        # _reconcile_embedding_dim(). Falls back to the 1536 default on a
+        # non-positive value.
+        self.embedding_dim = embedding_dim if embedding_dim and embedding_dim > 0 else EMBEDDING_DIM
         self._init_schema()
 
     def _record_embed_failure(self, error: Exception, context: str = "Embedding") -> None:
@@ -88,8 +95,86 @@ class MemoryStore:
         else:
             logger.warning("%s failed: %s", context, error)
 
+    def _get_meta(self, key: str) -> str | None:
+        try:
+            row = self.db.execute(
+                "SELECT value FROM memory_meta WHERE key = ?", (key,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return None
+        return row[0] if row else None
+
+    def _set_meta(self, key: str, value: str) -> None:
+        self.db.execute(
+            "INSERT INTO memory_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        self.db.commit()
+
+    def _reconcile_embedding_dim(self) -> None:
+        """Rebuild the vec0 tables if the configured embedding dimension
+        changed since they were created.
+
+        vec0 virtual tables are bound to a fixed dimension at CREATE time,
+        and embedding spaces are incompatible across models anyway, so a
+        dimension change (operator switched embedding provider) makes the
+        old vectors unusable. We drop + recreate ``facts_vec`` /
+        ``categories_vec`` at the new dimension. Fact and category ROWS are
+        preserved — only their now-incompatible vectors are dropped; they
+        repopulate on the next ``store_fact``. Keyword search (FTS5) is
+        never touched, so recall keeps working throughout. Wrapped so a
+        rebuild failure degrades to keyword-only rather than crashing the
+        agent.
+        """
+        stored = self._get_meta("embedding_dim")
+        if stored is None:
+            # First boot at this schema (or a pre-existing DB created at the
+            # legacy 1536 default, which is also the default here) — record
+            # the current dimension without rebuilding.
+            self._set_meta("embedding_dim", str(self.embedding_dim))
+            return
+        try:
+            stored_dim = int(stored)
+        except (TypeError, ValueError):
+            self._set_meta("embedding_dim", str(self.embedding_dim))
+            return
+        if stored_dim == self.embedding_dim:
+            return
+        logger.warning(
+            "Embedding dimension changed %d→%d — rebuilding vector tables "
+            "(keyword search unaffected; vectors repopulate as facts are "
+            "re-saved).",
+            stored_dim, self.embedding_dim,
+        )
+        try:
+            self.db.executescript(
+                f"""
+                DROP TABLE IF EXISTS facts_vec;
+                DROP TABLE IF EXISTS categories_vec;
+                CREATE VIRTUAL TABLE facts_vec USING vec0(
+                    id TEXT PRIMARY KEY,
+                    embedding float[{self.embedding_dim}]
+                );
+                CREATE VIRTUAL TABLE categories_vec USING vec0(
+                    id INTEGER PRIMARY KEY,
+                    embedding float[{self.embedding_dim}]
+                );
+                """
+            )
+            # Stored category embeddings (BLOB) and fact→category links are
+            # now wrong-dimension; clear them so categories rebuild cleanly.
+            self.db.execute("UPDATE categories SET embedding = NULL")
+            self.db.execute("UPDATE facts SET category_id = NULL")
+            self._set_meta("embedding_dim", str(self.embedding_dim))
+            self.db.commit()
+        except Exception as e:
+            logger.warning(
+                "Vector-table rebuild failed (continuing keyword-only): %s", e,
+            )
+
     def _init_schema(self) -> None:
-        self.db.executescript("""
+        self.db.executescript(f"""
             CREATE TABLE IF NOT EXISTS facts (
                 id TEXT PRIMARY KEY,
                 key TEXT NOT NULL,
@@ -104,7 +189,7 @@ class MemoryStore:
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS facts_vec USING vec0(
                 id TEXT PRIMARY KEY,
-                embedding float[1536]
+                embedding float[{self.embedding_dim}]
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
                 fact_id,
@@ -122,7 +207,7 @@ class MemoryStore:
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS categories_vec USING vec0(
                 id INTEGER PRIMARY KEY,
-                embedding float[1536]
+                embedding float[{self.embedding_dim}]
             );
             CREATE TABLE IF NOT EXISTS logs (
                 id TEXT PRIMARY KEY,
@@ -168,6 +253,11 @@ class MemoryStore:
                 flush_triggered INTEGER NOT NULL DEFAULT 0,
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
+
+            CREATE TABLE IF NOT EXISTS memory_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
         """)
         # Lazy migration: add category_id FK to facts if not present
         try:
@@ -175,6 +265,9 @@ class MemoryStore:
         except sqlite3.OperationalError:
             pass  # Column already exists
         self.db.commit()
+        # Reconcile the dimension the vec0 tables were built at against the
+        # configured dimension (rebuilds on an embedding-provider switch).
+        self._reconcile_embedding_dim()
 
     async def _run_db(self, fn: Callable[..., _T], *args: Any) -> _T:
         """Run a blocking DB function in the default thread pool."""
@@ -246,6 +339,17 @@ class MemoryStore:
             except Exception as e:
                 self._record_embed_failure(e, "Embedding")
 
+        # Guard against a wrong-dimension vector reaching ANY vec0 table
+        # (facts_vec via _store_fact_sync, or categories_vec via
+        # _auto_categorize) — that would raise inside sqlite-vec. Drop to
+        # keyword-only for this fact instead; never crash the caller.
+        if embedding is not None and len(embedding) != self.embedding_dim:
+            logger.warning(
+                "Embedding length %d != configured dim %d; storing fact %r "
+                "keyword-only.", len(embedding), self.embedding_dim, key,
+            )
+            embedding = None
+
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
             self._store_fact_sync, key, value, category, source, confidence, embedding,
@@ -265,6 +369,16 @@ class MemoryStore:
         self.db.commit()
 
     def _store_embedding(self, fact_id: str, embedding: list[float]) -> None:
+        # Defensive: a mismatched embedding length would raise inside
+        # sqlite-vec and count toward the 3-strike disable. Skip the vector
+        # write instead — the fact stays keyword-searchable.
+        if len(embedding) != self.embedding_dim:
+            logger.warning(
+                "Embedding length %d != configured dim %d; skipping vector "
+                "store for %s (keyword search unaffected).",
+                len(embedding), self.embedding_dim, fact_id,
+            )
+            return
         blob = serialize_float32(embedding)
         self.db.execute("DELETE FROM facts_vec WHERE id = ?", (fact_id,))
         self.db.execute("INSERT INTO facts_vec (id, embedding) VALUES (?, ?)", (fact_id, blob))
@@ -310,6 +424,11 @@ class MemoryStore:
                 query_embedding = await self.embed_fn(query)
             except Exception as e:
                 self._record_embed_failure(e, "Vector search")
+
+        # A wrong-dimension query vector would raise inside sqlite-vec — skip
+        # the vector tier and use keyword search only for this query.
+        if query_embedding is not None and len(query_embedding) != self.embedding_dim:
+            query_embedding = None
 
         return await self._run_db(self._search_sync, query, query_embedding, top_k)
 
@@ -677,7 +796,7 @@ class MemoryStore:
         if not rows:
             return
 
-        dim = EMBEDDING_DIM
+        dim = self.embedding_dim
         avg = [0.0] * dim
         for (blob,) in rows:
             values = struct.unpack(f"{dim}f", blob)

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -95,57 +95,45 @@ class MemoryStore:
         else:
             logger.warning("%s failed: %s", context, error)
 
-    def _get_meta(self, key: str) -> str | None:
-        try:
-            row = self.db.execute(
-                "SELECT value FROM memory_meta WHERE key = ?", (key,),
-            ).fetchone()
-        except sqlite3.OperationalError:
-            return None
-        return row[0] if row else None
+    def _facts_vec_dim(self) -> int | None:
+        """Dimension ``facts_vec`` was actually created at, parsed from its
+        stored CREATE statement. ``None`` if the table doesn't exist.
 
-    def _set_meta(self, key: str, value: str) -> None:
-        self.db.execute(
-            "INSERT INTO memory_meta (key, value) VALUES (?, ?) "
-            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            (key, value),
-        )
-        self.db.commit()
+        Reading the real schema (rather than a side-table of our own) means
+        a DB created by ANY prior version — including before this code added
+        dimension tracking — is reconciled correctly.
+        """
+        row = self.db.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='facts_vec'",
+        ).fetchone()
+        if not row or not row[0]:
+            return None
+        m = re.search(r"float\s*\[\s*(\d+)\s*\]", row[0])
+        return int(m.group(1)) if m else None
 
     def _reconcile_embedding_dim(self) -> None:
-        """Rebuild the vec0 tables if the configured embedding dimension
-        changed since they were created.
+        """Rebuild the vec0 tables if their actual dimension differs from the
+        configured one.
 
         vec0 virtual tables are bound to a fixed dimension at CREATE time,
         and embedding spaces are incompatible across models anyway, so a
-        dimension change (operator switched embedding provider) makes the
-        old vectors unusable. We drop + recreate ``facts_vec`` /
-        ``categories_vec`` at the new dimension. Fact and category ROWS are
-        preserved — only their now-incompatible vectors are dropped; they
-        repopulate on the next ``store_fact``. Keyword search (FTS5) is
-        never touched, so recall keeps working throughout. Wrapped so a
-        rebuild failure degrades to keyword-only rather than crashing the
-        agent.
+        dimension change (operator switched embedding provider) makes the old
+        vectors unusable. We compare the ACTUAL ``facts_vec`` dimension
+        against the configured one and, on a mismatch, drop + recreate
+        ``facts_vec`` / ``categories_vec`` at the new dimension. Fact and
+        category ROWS are preserved — only their now-incompatible vectors are
+        dropped; they repopulate on the next ``store_fact``. Keyword search
+        (FTS5) is never touched. Wrapped so a rebuild failure degrades to
+        keyword-only rather than crashing the agent.
         """
-        stored = self._get_meta("embedding_dim")
-        if stored is None:
-            # First boot at this schema (or a pre-existing DB created at the
-            # legacy 1536 default, which is also the default here) — record
-            # the current dimension without rebuilding.
-            self._set_meta("embedding_dim", str(self.embedding_dim))
-            return
-        try:
-            stored_dim = int(stored)
-        except (TypeError, ValueError):
-            self._set_meta("embedding_dim", str(self.embedding_dim))
-            return
-        if stored_dim == self.embedding_dim:
+        actual = self._facts_vec_dim()
+        if actual is None or actual == self.embedding_dim:
             return
         logger.warning(
             "Embedding dimension changed %d→%d — rebuilding vector tables "
             "(keyword search unaffected; vectors repopulate as facts are "
             "re-saved).",
-            stored_dim, self.embedding_dim,
+            actual, self.embedding_dim,
         )
         try:
             self.db.executescript(
@@ -166,7 +154,6 @@ class MemoryStore:
             # now wrong-dimension; clear them so categories rebuild cleanly.
             self.db.execute("UPDATE categories SET embedding = NULL")
             self.db.execute("UPDATE facts SET category_id = NULL")
-            self._set_meta("embedding_dim", str(self.embedding_dim))
             self.db.commit()
         except Exception as e:
             logger.warning(
@@ -252,11 +239,6 @@ class MemoryStore:
                 budget_estimated_cost REAL NOT NULL DEFAULT 0.0,
                 flush_triggered INTEGER NOT NULL DEFAULT 0,
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-            );
-
-            CREATE TABLE IF NOT EXISTS memory_meta (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
             );
         """)
         # Lazy migration: add category_id FK to facts if not present
@@ -369,16 +351,6 @@ class MemoryStore:
         self.db.commit()
 
     def _store_embedding(self, fact_id: str, embedding: list[float]) -> None:
-        # Defensive: a mismatched embedding length would raise inside
-        # sqlite-vec and count toward the 3-strike disable. Skip the vector
-        # write instead — the fact stays keyword-searchable.
-        if len(embedding) != self.embedding_dim:
-            logger.warning(
-                "Embedding length %d != configured dim %d; skipping vector "
-                "store for %s (keyword search unaffected).",
-                len(embedding), self.embedding_dim, fact_id,
-            )
-            return
         blob = serialize_float32(embedding)
         self.db.execute("DELETE FROM facts_vec WHERE id = ?", (fact_id,))
         self.db.execute("INSERT INTO facts_vec (id, embedding) VALUES (?, ?)", (fact_id, blob))
@@ -849,18 +821,22 @@ class MemoryStore:
             try:
                 query_embedding = await self.embed_fn(query)
 
-                # Tier 1+2: Category search + scoped search (sync → executor)
-                scoped = await self._run_db(
-                    self._hierarchical_tier12_sync, query, query_embedding, top_k,
-                )
-                for fact in scoped:
-                    if fact.id not in seen_ids:
-                        results.append(fact)
-                        seen_ids.add(fact.id)
+                # A wrong-dimension query vector would raise inside sqlite-vec.
+                # Skip the category tier (NOT an embedding failure) and let the
+                # guarded flat fallback below handle recall — mirrors search().
+                if len(query_embedding) == self.embedding_dim:
+                    # Tier 1+2: Category search + scoped search (sync → executor)
+                    scoped = await self._run_db(
+                        self._hierarchical_tier12_sync, query, query_embedding, top_k,
+                    )
+                    for fact in scoped:
+                        if fact.id not in seen_ids:
+                            results.append(fact)
+                            seen_ids.add(fact.id)
 
-                # Sufficiency check
-                if len(results) >= top_k:
-                    return results[:top_k]
+                    # Sufficiency check
+                    if len(results) >= top_k:
+                        return results[:top_k]
             except Exception as e:
                 self._record_embed_failure(e, "Hierarchical search tier 1/2")
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -101,7 +101,7 @@ def _resolve_embedding(
     at runtime without data loss.
     """
     if cfg_embedding_model:
-        model = cfg_embedding_model.strip()
+        model = str(cfg_embedding_model).strip()
         return model, _EMBEDDING_MODEL_DIMS.get(model, _DEFAULT_EMBEDDING_DIM)
     for provider, model, dim in _EMBEDDING_PROVIDER_LADDER:
         if provider in keyed_providers:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -33,26 +33,80 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("cli")
 
-# Provider prefix → default embedding model.  Providers without embedding
-# APIs (Anthropic, xAI, Groq, …) map to "none" which disables vector search.
-# Only map providers whose embedding models output 1536-dim vectors,
-# matching EMBEDDING_DIM in memory.py.  Other providers default to "none".
-_PROVIDER_EMBEDDING_DEFAULTS: list[tuple[str, str]] = [
-    ("openai/",  "text-embedding-3-small"),
-    ("gpt-",     "text-embedding-3-small"),
-    ("o1",       "text-embedding-3-small"),
-    ("o3",       "text-embedding-3-small"),
-    ("o4",       "text-embedding-3-small"),
+# Embedding-provider ladder for auto-selecting a default embedding model
+# when the operator hasn't set one. Each entry: (provider, litellm model,
+# output dim), ordered by preference. Only providers that actually offer an
+# embeddings API appear — Anthropic/xAI/Groq have none, so an Anthropic-only
+# deployment correctly falls through to keyword-only memory. Non-OpenAI
+# models are fully qualified (``voyage/…``) so the mesh provider resolver
+# maps them to the right SYSTEM API key with no extra config.
+_EMBEDDING_PROVIDER_LADDER: list[tuple[str, str, int]] = [
+    ("openai", "text-embedding-3-small", 1536),
+    ("voyage", "voyage/voyage-3.5", 1024),        # Anthropic's recommended embedder
+    ("gemini", "gemini/text-embedding-004", 768),
+    ("cohere", "cohere/embed-english-v3.0", 1024),
 ]
 
+# Known embedding model → output dimension. Sets EMBEDDING_DIM for an
+# explicit operator override. Unknown models fall back to the 1536 default;
+# the agent self-heals a wrong dim at runtime (memory.py
+# _reconcile_embedding_dim + the _store_embedding length guard), so this map
+# is an optimization, not a correctness dependency.
+_EMBEDDING_MODEL_DIMS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+    "voyage/voyage-3.5": 1024,
+    "voyage/voyage-3": 1024,
+    "gemini/text-embedding-004": 768,
+    "cohere/embed-english-v3.0": 1024,
+    "cohere/embed-multilingual-v3.0": 1024,
+}
+_DEFAULT_EMBEDDING_DIM = 1536
 
-def _default_embedding_model(llm_model: str) -> str:
-    """Pick a sensible embedding model default based on the LLM provider."""
-    lower = llm_model.lower()
-    for prefix, embed_model in _PROVIDER_EMBEDDING_DEFAULTS:
-        if lower.startswith(prefix):
-            return embed_model
-    return "none"
+
+def _embedding_providers_with_keys() -> set[str]:
+    """Embedding-capable providers (from the ladder) that have a SYSTEM API
+    key configured in the environment.
+
+    Deliberately checks the API key directly rather than reusing
+    ``get_available_providers()``: the mesh embed proxy authenticates with
+    an API key only (no OAuth path), so an OAuth-only provider must NOT be
+    treated as embedding-capable — it would select embeddings that then fail.
+    """
+    return {
+        provider
+        for provider, _model, _dim in _EMBEDDING_PROVIDER_LADDER
+        if os.environ.get(f"OPENLEGION_SYSTEM_{provider.upper()}_API_KEY")
+    }
+
+
+def _resolve_embedding(
+    cfg_embedding_model: str | None,
+    keyed_providers: set[str],
+) -> tuple[str, int]:
+    """Resolve ``(embedding_model, output_dim)`` to run with.
+
+    Priority:
+      1. Explicit operator choice (``llm.embedding_model`` in config),
+         including the literal ``"none"`` to force keyword-only memory.
+      2. First embedding-capable provider with a configured API key, walked
+         in ``_EMBEDDING_PROVIDER_LADDER`` order — this is what lets an
+         Anthropic-chat deployment light up semantic memory via a Voyage or
+         OpenAI key.
+      3. ``"none"`` — no embedding-capable key; memory runs on BM25/FTS5
+         keyword search only (fully supported, never an error).
+
+    The returned ``dim`` is advisory; the agent corrects a wrong dimension
+    at runtime without data loss.
+    """
+    if cfg_embedding_model:
+        model = cfg_embedding_model.strip()
+        return model, _EMBEDDING_MODEL_DIMS.get(model, _DEFAULT_EMBEDDING_DIM)
+    for provider, model, dim in _EMBEDDING_PROVIDER_LADDER:
+        if provider in keyed_providers:
+            return model, dim
+    return "none", _DEFAULT_EMBEDDING_DIM
 
 
 # Cap on the operator-visible ``blocker_note`` written when a mesh→agent
@@ -403,8 +457,14 @@ class RuntimeContext:
             ordered.update({k: v for k, v in agents_cfg.items() if k != _OPERATOR_AGENT_ID})
             agents_cfg = ordered
 
-        embedding_model = self.cfg.get("llm", {}).get(
-            "embedding_model", _default_embedding_model(default_model),
+        # Resolve embedding model + dimension. Auto-selects from configured
+        # provider keys when the operator hasn't set one (an Anthropic-chat
+        # deployment lights up semantic memory via a Voyage/OpenAI key);
+        # falls back to keyword-only memory when no embedding-capable key
+        # exists — never an error.
+        embedding_model, embedding_dim = _resolve_embedding(
+            self.cfg.get("llm", {}).get("embedding_model"),
+            _embedding_providers_with_keys(),
         )
         mesh_port = self.cfg["mesh"]["port"]
         agent_projects = self.cfg.get("_agent_projects", {})
@@ -425,6 +485,17 @@ class RuntimeContext:
             agents_cfg = trimmed
 
         self.runtime.extra_env["EMBEDDING_MODEL"] = embedding_model
+        self.runtime.extra_env["EMBEDDING_DIM"] = str(embedding_dim)
+        if embedding_model and embedding_model.lower() != "none":
+            logger.info(
+                "Semantic memory: ON — embedding model %s (dim %d)",
+                embedding_model, embedding_dim,
+            )
+        else:
+            logger.info(
+                "Semantic memory: OFF (keyword-only) — no embedding-capable "
+                "provider key configured",
+            )
 
         # Inject dashboard system settings as env vars for agent containers
         settings_path = Path("config/settings.json")

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -214,14 +214,14 @@ class TestConfigurableEmbeddingDim:
         # Create at 1536 and store a fact (with a 1536 vector).
         store = MemoryStore(tmp_db, embed_fn=_fixed_embed(1536), embedding_dim=1536)
         await store.store_fact("switch_key", "value before provider switch")
-        assert store._get_meta("embedding_dim") == "1536"
+        assert store._facts_vec_dim() == 1536
         store.close()
 
         # Reopen at 1024 (operator switched embedding provider). Must NOT
         # crash; the fact ROW survives and stays keyword-searchable, and the
         # recorded dim is updated.
         store2 = MemoryStore(tmp_db, embed_fn=_fixed_embed(1024), embedding_dim=1024)
-        assert store2._get_meta("embedding_dim") == "1024"
+        assert store2._facts_vec_dim() == 1024   # vec tables rebuilt to the new dim
         results = await store2.search("value before provider switch")
         assert any("value before provider switch" in r.value for r in results)
         # New facts embed cleanly at the new dimension (no dim error).

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -164,3 +164,79 @@ class TestEmbeddingGracefulFallback:
         # 4th save should NOT call the embed function
         await store.store_fact("key4", "val4")
         assert tracker.call_count == 3  # still 3, not 4
+
+
+def _fixed_embed(dim: int):
+    """Return an async embed_fn that always yields a ``dim``-length vector."""
+    async def _embed(text: str):
+        return [0.1] * dim
+    return _embed
+
+
+class TestConfigurableEmbeddingDim:
+    """Configurable embedding dimension + safe provider-switch handling.
+
+    Backs the product guarantee that 'no embedding model' and 'switched
+    embedding provider' are safe, non-breaking states for every agent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_keyword_only_store_and_recall(self, tmp_db):
+        # The 'no embedding model' (EMBEDDING_MODEL=none → embed_fn=None)
+        # contract: an agent must still store and recall facts via keyword.
+        store = MemoryStore(tmp_db, embed_fn=None)
+        await store.store_fact("deploy_target", "production cluster eu-west")
+        results = await store.search("production cluster")
+        assert any("production cluster" in r.value for r in results)
+        store.close()
+
+    def test_embedding_dim_defaults_to_1536(self, tmp_db):
+        store = MemoryStore(tmp_db)
+        assert store.embedding_dim == 1536
+        store.close()
+
+    def test_non_positive_dim_falls_back_to_default(self, tmp_db):
+        store = MemoryStore(tmp_db, embedding_dim=0)
+        assert store.embedding_dim == 1536
+        store.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_dim_stores_and_searches(self, tmp_db):
+        # A non-1536 provider (e.g. Voyage 1024) works end to end.
+        store = MemoryStore(tmp_db, embed_fn=_fixed_embed(1024), embedding_dim=1024)
+        await store.store_fact("k", "voyage embedded value")
+        results = await store.search("voyage embedded value")
+        assert any("voyage embedded value" in r.value for r in results)
+        store.close()
+
+    @pytest.mark.asyncio
+    async def test_dim_change_rebuilds_and_preserves_rows(self, tmp_db):
+        # Create at 1536 and store a fact (with a 1536 vector).
+        store = MemoryStore(tmp_db, embed_fn=_fixed_embed(1536), embedding_dim=1536)
+        await store.store_fact("switch_key", "value before provider switch")
+        assert store._get_meta("embedding_dim") == "1536"
+        store.close()
+
+        # Reopen at 1024 (operator switched embedding provider). Must NOT
+        # crash; the fact ROW survives and stays keyword-searchable, and the
+        # recorded dim is updated.
+        store2 = MemoryStore(tmp_db, embed_fn=_fixed_embed(1024), embedding_dim=1024)
+        assert store2._get_meta("embedding_dim") == "1024"
+        results = await store2.search("value before provider switch")
+        assert any("value before provider switch" in r.value for r in results)
+        # New facts embed cleanly at the new dimension (no dim error).
+        await store2.store_fact("new_key", "value after switch")
+        store2.close()
+
+    @pytest.mark.asyncio
+    async def test_wrong_length_embedding_skips_vector_no_crash(self, tmp_db):
+        # embed_fn SUCCEEDS but returns a vector whose length disagrees with
+        # the configured dim (misconfiguration). store_fact + search must
+        # NOT raise, the embed call is not counted as a failure, and the
+        # fact stays keyword-searchable.
+        store = MemoryStore(tmp_db, embed_fn=_fixed_embed(999), embedding_dim=1536)
+        await store.store_fact("mismatch", "kept despite bad embedding")
+        assert store._embed_failures == 0  # the embed CALL itself succeeded
+        results = await store.search("kept despite bad embedding")
+        assert any("kept despite bad embedding" in r.value for r in results)
+        store.close()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.cli.runtime import _default_embedding_model
+from src.cli.runtime import _embedding_providers_with_keys, _resolve_embedding
 from src.host.runtime import (
     DockerBackend,
     RuntimeBackend,
@@ -463,24 +463,57 @@ class TestShouldUseHostNetwork:
             assert _should_use_host_network() is False
 
 
-# ── _default_embedding_model ─────────────────────────────────
+# ── _resolve_embedding / _embedding_providers_with_keys ──────
 
-class TestDefaultEmbeddingModel:
-    def test_openai_provider(self):
-        assert _default_embedding_model("openai/gpt-4o-mini") == "text-embedding-3-small"
+class TestResolveEmbedding:
+    def test_explicit_override_wins(self):
+        # An explicit operator choice is honored even with other keys present.
+        assert _resolve_embedding("voyage/voyage-3.5", {"openai"}) == ("voyage/voyage-3.5", 1024)
 
-    def test_gpt_prefix(self):
-        assert _default_embedding_model("gpt-4o") == "text-embedding-3-small"
+    def test_explicit_none_disables(self):
+        assert _resolve_embedding("none", {"openai"}) == ("none", 1536)
 
-    def test_gemini_no_compatible_embeddings(self):
-        """Gemini embedding models are 768-dim, incompatible with EMBEDDING_DIM=1536."""
-        assert _default_embedding_model("gemini/gemini-2.0-flash") == "none"
+    def test_openai_key_selected(self):
+        assert _resolve_embedding(None, {"openai"}) == ("text-embedding-3-small", 1536)
 
-    def test_anthropic_no_embeddings(self):
-        assert _default_embedding_model("anthropic/claude-haiku-4-5-20251001") == "none"
+    def test_voyage_for_anthropic_chat_deployment(self):
+        # No OpenAI key, but a Voyage key — Anthropic-chat users still get
+        # semantic memory (Voyage is Anthropic's recommended embedder).
+        assert _resolve_embedding(None, {"voyage"}) == ("voyage/voyage-3.5", 1024)
 
-    def test_unknown_provider_no_embeddings(self):
-        assert _default_embedding_model("deepseek/deepseek-chat") == "none"
+    def test_ladder_prefers_openai(self):
+        assert _resolve_embedding(
+            None, {"openai", "voyage", "cohere"},
+        ) == ("text-embedding-3-small", 1536)
+
+    def test_no_keys_keyword_only(self):
+        assert _resolve_embedding(None, set()) == ("none", 1536)
+
+    def test_unknown_override_uses_default_dim(self):
+        assert _resolve_embedding("some/custom-embed", set()) == ("some/custom-embed", 1536)
+
+
+class TestEmbeddingProvidersWithKeys:
+    def test_detects_configured_key(self):
+        with patch.dict(
+            "os.environ", {"OPENLEGION_SYSTEM_VOYAGE_API_KEY": "vk-test"}, clear=False,
+        ):
+            assert "voyage" in _embedding_providers_with_keys()
+
+    def test_ignores_non_ladder_or_unkeyed(self):
+        # A provider with no key must not appear. Clear the four ladder keys,
+        # set only cohere, and assert the others are absent.
+        env = {
+            "OPENLEGION_SYSTEM_OPENAI_API_KEY": "",
+            "OPENLEGION_SYSTEM_VOYAGE_API_KEY": "",
+            "OPENLEGION_SYSTEM_GEMINI_API_KEY": "",
+            "OPENLEGION_SYSTEM_COHERE_API_KEY": "ck-test",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            keyed = _embedding_providers_with_keys()
+            assert "cohere" in keyed
+            assert "voyage" not in keyed
+            assert "gemini" not in keyed
 
 
 # ── _docker_safe_name ────────────────────────────────────────


### PR DESCRIPTION
## What & why
Part 1 of the memory-system improvement batch (informed by a review of Garry Tan's *gbrain*). This activates the **existing but dormant** sqlite-vec RAG engine for far more deployments and makes embeddings **provider-agnostic** instead of hardcoded to OpenAI/1536.

Two root causes:
1. The embedding default was keyed off the **chat** model's provider — so an **Anthropic-chat** deployment stayed on keyword-only memory even with an embedding-capable key (OpenAI/Voyage/…) configured.
2. The `facts_vec` / `categories_vec` tables were hardcoded to **1536 dims** — only OpenAI's small model fits, so **Voyage** (Anthropic's recommended embedder, 1024-dim) could never work.

## Changes
- **`cli/runtime.py`** — key-based provider ladder `openai → voyage → gemini → cohere → none`, resolving `(model, dim)` from the SYSTEM API keys actually present. Honors an explicit `llm.embedding_model` override (incl. `"none"`). Gates on **API key, not OAuth** (the embed proxy authenticates by key only). Logs `Semantic memory: ON/OFF` at startup.
- **`memory.py`** — `MemoryStore(embedding_dim=…)`; vec tables built at that dim; a `memory_meta` row records it and a **provider switch (dim change) rebuilds** the vec tables, preserving fact/category rows (keyword/FTS5 untouched). **Length guards** in `store_fact` + `search` drop a wrong-dimension vector to keyword-only rather than raising.
- **`__main__.py`** — read `EMBEDDING_DIM`, pass to `MemoryStore`.

No `credentials.py` change needed — `voyage/`, `gemini/`, `cohere/` model strings route to the right key via the existing provider resolver + litellm.

## Safety guarantee (explicitly tested)
**No / misconfigured embedding never breaks an agent.** Keyword-only (BM25 + FTS5) is a first-class mode; a missing key, a provider switch, or a wrong-length vector all degrade gracefully. New tests cover keyword-only store/recall, custom-dim, dim-switch rebuild, and wrong-length-vector skip.

## Tests
213 passed (test_runtime, test_embedding_fallback, test_memory, test_memory_integration, test_memory_tools, + memory-related test_builtins). Ruff clean.

## Follow-ups in this batch
- PR2: compiled-head MEMORY.md + consolidation
- PR3: `memory_think` synthesis tool
- PR4: Settings/onboarding embedding-provider selector (depends on this PR)

⚠️ Do not merge yet — part of a batch reviewed together at the end.