### PR TITLE
feat(memory): add memory_think — synthesized, cited recall with gap analysis

### DIFF
--- a/src/agent/builtins/memory_tool.py
+++ b/src/agent/builtins/memory_tool.py
@@ -125,6 +125,142 @@ async def memory_search(
     return {"results": results, "count": len(results)}
 
 
+def _gather_evidence(query: str, max_facts: int, workspace_manager, memory_store, db_facts):
+    """Build a numbered evidence list from DB facts + workspace hits.
+
+    The numbers are the citation anchors the LLM cites inline as [n].
+    Each item is a dict carrying enough metadata to return as a citation.
+    """
+    evidence: list[dict] = []
+
+    if db_facts:
+        for fact in db_facts:
+            evidence.append({
+                "source": "memory_db",
+                "key": fact.key,
+                "value": fact.value,
+                "category": fact.category,
+                "confidence": fact.confidence,
+            })
+
+    if workspace_manager is not None:
+        try:
+            ws_hits = workspace_manager.search(query, max_results=max_facts)
+        except Exception as e:
+            logger.warning("Workspace search failed in memory_think: %s", e)
+            ws_hits = []
+        for hit in ws_hits:
+            evidence.append({
+                "source": "workspace",
+                "file": hit.get("file"),
+                "snippet": hit.get("snippet"),
+                "score": hit.get("score"),
+            })
+
+    return evidence
+
+
+def _render_evidence(evidence: list[dict]) -> str:
+    """Render the numbered evidence list for the LLM prompt.
+
+    Facts come from our own DB / workspace, so this is light; we still trim
+    whitespace to keep the prompt compact.
+    """
+    lines = []
+    for i, item in enumerate(evidence, start=1):
+        if item["source"] == "memory_db":
+            lines.append(f"[{i}] (memory_db) {item['key']}: {item['value']}".strip())
+        else:
+            snippet = (item.get("snippet") or "").strip()
+            lines.append(f"[{i}] (workspace:{item.get('file')}) {snippet}")
+    return "\n".join(lines)
+
+
+_THINK_SYSTEM_PROMPT = (
+    "You are synthesizing an answer strictly from a numbered list of memory "
+    "evidence. Rules: (1) Answer ONLY using the numbered evidence below — do "
+    "not invent facts. (2) Cite each claim inline with its source number, e.g. "
+    "[1] or [2][3]. (3) Be concise: under 150 words. (4) End with a final line "
+    "beginning exactly 'Unknown / not in memory:' that states what the "
+    "question asks for which the evidence does NOT cover (write 'nothing "
+    "obvious' if the evidence fully covers it)."
+)
+
+
+@tool(
+    name="memory_think",
+    description=(
+        "Synthesize an answer from your long-term memory. Unlike memory_search "
+        "(which returns raw hits), this retrieves the most relevant facts and "
+        "produces a SHORT cited answer plus an explicit note about what your "
+        "memory does NOT yet cover. Use when you want a reasoned recall rather "
+        "than a list of matches."
+    ),
+    parameters={
+        "query": {"type": "string", "description": "The question to answer from memory"},
+        "max_facts": {
+            "type": "integer",
+            "description": "Maximum facts to retrieve as evidence (default 8)",
+            "default": 8,
+        },
+    },
+)
+async def memory_think(
+    query: str, max_facts: int = 8,
+    *, workspace_manager=None, memory_store=None, mesh_client=None,
+) -> dict:
+    """Retrieve relevant memory and synthesize a cited answer with a gap note."""
+    if memory_store is None and workspace_manager is None:
+        return {"error": "No memory backends available"}
+
+    # 1. Retrieve evidence from both backends.
+    db_facts = None
+    if memory_store is not None:
+        db_facts = await _search_with_fallback(memory_store, query, max_facts)
+    evidence = _gather_evidence(query, max_facts, workspace_manager, memory_store, db_facts)
+
+    if not evidence:
+        return {"answer": "", "note": "No relevant memory found.", "evidence_count": 0}
+
+    # 2. Resolve the parent LLM via the established registry (tools are not
+    #    injected an LLM directly — same pattern as spawn_subagent).
+    from src.agent.builtins.subagent_tool import _get_parent_llm
+
+    agent_id = getattr(mesh_client, "agent_id", None)
+    llm = _get_parent_llm(agent_id) if agent_id else None
+
+    # 3. Graceful degradation: no LLM → return raw evidence without synthesis.
+    if llm is None:
+        return {
+            "answer": None,
+            "note": "Synthesis unavailable; returning raw matches.",
+            "results": evidence,
+            "evidence_count": len(evidence),
+        }
+
+    # 4. Synthesize. Any failure falls back to raw evidence — never crash.
+    rendered = _render_evidence(evidence)
+    user_msg = f"Question: {query}\n\nNumbered evidence:\n{rendered}"
+    try:
+        resp = await llm.chat(
+            system=_THINK_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_msg}],
+            max_tokens=512,
+            temperature=0.2,
+        )
+        answer = (resp.content or "").strip()
+    except Exception as e:
+        logger.warning("memory_think synthesis failed, returning raw matches: %s", e)
+        return {
+            "answer": None,
+            "note": "Synthesis unavailable; returning raw matches.",
+            "results": evidence,
+            "evidence_count": len(evidence),
+        }
+
+    return {"answer": answer, "citations": evidence, "evidence_count": len(evidence)}
+
+
 @tool(
     name="memory_save",
     description=(

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -229,7 +229,7 @@ _READ_ONLY_TOOLS = frozenset({
     "list_peer_files", "read_peer_file",
     "get_team_outputs",
     # Memory / file reads (writes go through memory_save / write_file)
-    "memory_search", "read_file",
+    "memory_search", "memory_think", "read_file",
     # Credential discovery — names only, no values
     "vault_list",
     # Self-introspection

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1758,7 +1758,7 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # Operator self-notes + workspace management. Workspace file caps
     # already enforce safety on writes; write_file is intentionally NOT
     # granted (operator orchestrates, doesn't author arbitrary files).
-    "memory_save", "memory_search",
+    "memory_save", "memory_search", "memory_think",
     "update_workspace", "read_file",
     # Internet access (gated by ``can_use_internet`` permission — the
     # agent's runtime filters these out of the effective allowlist when

--- a/src/cli/formatting.py
+++ b/src/cli/formatting.py
@@ -44,6 +44,8 @@ def _format_tool_summary(name: str, inp: dict, out: dict) -> str:
         return inp.get("key", inp.get("content", ""))[:60]
     elif name == "memory_search":
         return inp.get("query", "")
+    elif name == "memory_think":
+        return inp.get("query", "")
     else:
         text = dumps_safe(inp)
         if len(text) > 80:

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10923,6 +10923,7 @@ function dashboard() {
         file_write: 'writing a file',
         file_list: 'listing files',
         memory_search: 'checking memory',
+        memory_think: 'reasoning over memory',
         memory_save: 'saving to memory',
         hand_off: 'handing off to a teammate',
         check_inbox: 'checking the inbox',

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import shutil
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
-from src.agent.builtins.memory_tool import memory_save, memory_search
+from src.agent.builtins.memory_tool import memory_save, memory_search, memory_think
 from src.agent.workspace import WorkspaceManager
+from src.shared.types import LLMResponse, MemoryFact
 
 
 class TestMemorySearch:
@@ -73,4 +76,122 @@ class TestMemoryToolDiscovery:
         registry = ToolRegistry(tools_dir="/nonexistent/path")
         assert "memory_search" in registry.tools
         assert "memory_save" in registry.tools
+        assert "memory_think" in registry.tools
         assert "category" in registry.tools["memory_search"]["parameters"]
+
+
+def _make_facts(*pairs) -> list[MemoryFact]:
+    return [
+        MemoryFact(key=k, value=v, category="general", confidence=0.9)
+        for k, v in pairs
+    ]
+
+
+def _fake_memory_store(facts: list[MemoryFact]) -> SimpleNamespace:
+    """A memory_store stub whose search returns the given facts."""
+    store = SimpleNamespace()
+    store.search_hierarchical = AsyncMock(return_value=facts)
+    store.search = AsyncMock(return_value=facts)
+    return store
+
+
+def _fake_mesh_client(agent_id: str = "agent-think") -> SimpleNamespace:
+    return SimpleNamespace(agent_id=agent_id)
+
+
+class TestMemoryThink:
+    def setup_method(self):
+        # Isolate the parent-LLM registry per test.
+        from src.agent.builtins import subagent_tool
+
+        self._subagent_tool = subagent_tool
+        self._saved_refs = dict(subagent_tool._parent_llm_refs)
+        subagent_tool._parent_llm_refs.clear()
+
+    def teardown_method(self):
+        self._subagent_tool._parent_llm_refs.clear()
+        self._subagent_tool._parent_llm_refs.update(self._saved_refs)
+
+    @pytest.mark.asyncio
+    async def test_synthesis_path(self):
+        facts = _make_facts(
+            ("favourite colour", "blue"),
+            ("home city", "Lisbon"),
+            ("role", "ML engineer"),
+        )
+        store = _fake_memory_store(facts)
+        mesh = _fake_mesh_client("agent-think")
+
+        llm = SimpleNamespace()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(
+                content="The user likes blue [1] and lives in Lisbon [2].\n"
+                "Unknown / not in memory: their age.",
+            )
+        )
+        self._subagent_tool.register_parent_llm("agent-think", llm)
+
+        result = await memory_think(
+            "Tell me about the user", memory_store=store, mesh_client=mesh,
+        )
+
+        assert result["answer"]
+        assert "blue" in result["answer"]
+        assert result["evidence_count"] > 0
+        assert len(result["citations"]) == result["evidence_count"]
+        # Exercised the LLM exactly once with our tuned params.
+        llm.chat.assert_awaited_once()
+        kwargs = llm.chat.await_args.kwargs
+        assert kwargs["max_tokens"] == 512
+        assert kwargs["temperature"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_degraded_path_no_llm_registered(self):
+        facts = _make_facts(("favourite colour", "blue"))
+        store = _fake_memory_store(facts)
+        mesh = _fake_mesh_client("unregistered-agent")
+
+        result = await memory_think(
+            "what colour", memory_store=store, mesh_client=mesh,
+        )
+
+        assert result["answer"] is None
+        assert result["results"]
+        assert result["evidence_count"] == 1
+        assert "Synthesis unavailable" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_empty_retrieval(self):
+        store = _fake_memory_store([])
+        mesh = _fake_mesh_client("agent-think")
+
+        result = await memory_think(
+            "anything", memory_store=store, mesh_client=mesh,
+        )
+
+        assert result["evidence_count"] == 0
+        assert result["answer"] == ""
+        assert "No relevant memory" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_no_backends_returns_error(self):
+        result = await memory_think("anything")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_synthesis_failure_falls_back_to_raw(self):
+        facts = _make_facts(("favourite colour", "blue"))
+        store = _fake_memory_store(facts)
+        mesh = _fake_mesh_client("agent-think")
+
+        llm = SimpleNamespace()
+        llm.chat = AsyncMock(side_effect=RuntimeError("boom"))
+        self._subagent_tool.register_parent_llm("agent-think", llm)
+
+        result = await memory_think(
+            "what colour", memory_store=store, mesh_client=mesh,
+        )
+
+        assert result["answer"] is None
+        assert result["results"]
+        assert result["evidence_count"] == 1


### PR DESCRIPTION
## What & why
Part 3 of the memory-system batch (from the *gbrain* review). Adds a `memory_think` tool: the synthesis counterpart to `memory_search`.

- `memory_search` → raw hits.
- `memory_think` → retrieves the most relevant facts + workspace matches, then the LLM produces a **short, inline-cited answer** (`[1]`, `[2]`) **plus an explicit "Unknown / not in memory:" gap line**. Reasoned recall instead of a match list, and honest about what it doesn't know.

## Changes
- **`builtins/memory_tool.py`** — new `memory_think`. Resolves the agent's LLM via the existing parent-LLM registry (`_get_parent_llm`) — tools aren't injected an LLM directly. **Graceful degradation, never crashes the agent:** no backends → `error`; empty retrieval → `note`; no LLM registered or synthesis exception → returns the raw matches.
- Registered everywhere `memory_search` is: operator allowlist (`cli/config.py`), the read-only tool classification (`loop.py`), and the activity-label map (`cli/formatting.py`).

Independent of embeddings — works on keyword retrieval, sharper with vectors (PR #1060).

## Tests
`memory_think`: 11 passed (synthesis, no-LLM degrade, empty, no-backends, synthesis-exception fallback). Operator config/tools pinning: 130 passed. loop read-only/tool subset: 58 passed. Ruff clean.

⚠️ Do not merge yet — part of a batch reviewed together at the end.