### PR TITLE
feat(dashboard): embedding-provider selector + semantic-memory status

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6140,11 +6140,22 @@ def create_dashboard_router(
                 (p for p, m, _d in _EMBEDDING_PROVIDER_LADDER if m == raw_embed),
                 "custom",
             )
+        # An explicit configured model bypasses the resolver's key check, so
+        # verify the provider actually has a key — otherwise the status would
+        # claim ON after the key was removed. A "custom" model outside the
+        # ladder can't be verified here, so it's trusted.
+        on = str(eff_model).lower() != "none"
+        if (
+            on and raw_embed is not None
+            and configured_provider != "custom"
+            and configured_provider not in keyed
+        ):
+            on = False
         result["embedding"] = {
             "configured": raw_embed,
             "configured_provider": configured_provider,
             "effective_model": eff_model,
-            "on": str(eff_model).lower() != "none",
+            "on": on,
             "available_providers": [
                 p for p, _m, _d in _EMBEDDING_PROVIDER_LADDER if p in keyed
             ],
@@ -6229,7 +6240,10 @@ def create_dashboard_router(
         """
         import yaml
 
-        from src.cli.runtime import _EMBEDDING_PROVIDER_LADDER
+        from src.cli.runtime import (
+            _EMBEDDING_PROVIDER_LADDER,
+            _embedding_providers_with_keys,
+        )
 
         body = await request.json()
         value = str(body.get("value", "")).strip()
@@ -6247,6 +6261,14 @@ def create_dashboard_router(
             )
             if model is None:
                 raise HTTPException(400, f"Unknown embedding provider: {value}")
+            # Reject a provider with no configured key — persisting it would
+            # mint a dead embedding model that agents restart into (the embed
+            # proxy authenticates by key only). Validate at config-write time,
+            # matching the model-allowlist convention used elsewhere.
+            if value not in _embedding_providers_with_keys():
+                raise HTTPException(
+                    400, f"No API key configured for embedding provider: {value}",
+                )
             stored = model
 
         config_path = Path("config/mesh.yaml")

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6120,6 +6120,35 @@ def create_dashboard_router(
         # Include default_model from mesh.yaml
         cfg = _load_config()
         result["default_model"] = cfg.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
+
+        # Embedding / semantic-memory selection + resolved status.
+        from src.cli.runtime import (
+            _EMBEDDING_PROVIDER_LADDER,
+            _embedding_providers_with_keys,
+            _resolve_embedding,
+        )
+
+        raw_embed = cfg.get("llm", {}).get("embedding_model")
+        keyed = _embedding_providers_with_keys()
+        eff_model, _eff_dim = _resolve_embedding(raw_embed, keyed)
+        if raw_embed is None:
+            configured_provider = "auto"
+        elif str(raw_embed).lower() == "none":
+            configured_provider = "none"
+        else:
+            configured_provider = next(
+                (p for p, m, _d in _EMBEDDING_PROVIDER_LADDER if m == raw_embed),
+                "custom",
+            )
+        result["embedding"] = {
+            "configured": raw_embed,
+            "configured_provider": configured_provider,
+            "effective_model": eff_model,
+            "on": str(eff_model).lower() != "none",
+            "available_providers": [
+                p for p, _m, _d in _EMBEDDING_PROVIDER_LADDER if p in keyed
+            ],
+        }
         return result
 
     @api_router.post("/api/system-settings")
@@ -6187,6 +6216,54 @@ def create_dashboard_router(
             yaml.dump(mesh_cfg, f, default_flow_style=False, sort_keys=False)
 
         return {"model": model}
+
+    @api_router.post("/api/embedding-model")
+    async def api_set_embedding_model(request: Request) -> dict:
+        """Update the embedding model selection in mesh.yaml.
+
+        Body: ``{"value": "<provider>|none|auto"}``.
+          - ``"auto"``  → remove ``llm.embedding_model`` so the resolver
+            auto-picks the best available embedding-capable key.
+          - ``"none"``  → store ``"none"`` (keyword-only memory).
+          - a provider in the embedding ladder → store that provider's model.
+        """
+        import yaml
+
+        from src.cli.runtime import _EMBEDDING_PROVIDER_LADDER
+
+        body = await request.json()
+        value = str(body.get("value", "")).strip()
+        if not value:
+            raise HTTPException(400, "value is required")
+
+        stored: str | None
+        if value == "auto":
+            stored = None
+        elif value.lower() == "none":
+            stored = "none"
+        else:
+            model = next(
+                (m for p, m, _d in _EMBEDDING_PROVIDER_LADDER if p == value), None
+            )
+            if model is None:
+                raise HTTPException(400, f"Unknown embedding provider: {value}")
+            stored = model
+
+        config_path = Path("config/mesh.yaml")
+        mesh_cfg: dict = {}
+        if config_path.exists():
+            with open(config_path) as f:
+                mesh_cfg = yaml.safe_load(f) or {}
+        llm_cfg = mesh_cfg.setdefault("llm", {})
+        if stored is None:
+            llm_cfg.pop("embedding_model", None)
+        else:
+            llm_cfg["embedding_model"] = stored
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(config_path, "w") as f:
+            yaml.dump(mesh_cfg, f, default_flow_style=False, sort_keys=False)
+
+        return {"value": value, "embedding_model": stored}
 
     # ── Restart agents ────────────────────────────────────────
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -7923,6 +7923,29 @@ function dashboard() {
       } catch (e) { console.warn('saveDefaultModel failed:', e); }
     },
 
+    async saveEmbeddingModel(value) {
+      if (!value) return;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/embedding-model`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value }),
+        });
+        if (resp.ok) {
+          // Refresh the resolved status (on/off + effective model) from
+          // the server, which recomputes against the available keys.
+          await this.fetchSystemSettings();
+          this.showToast(`Embedding provider set to ${value}`);
+          // EMBEDDING_MODEL is only read at agent launch, so a restart is
+          // required to apply. Auto-apply so the change isn't silently stale.
+          await this._restartAllAgentsAuto('Applying embedding setting — restarting agents…');
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          this.showToast(`Error: ${err.detail || 'Update failed'}`);
+        }
+      } catch (e) { console.warn('saveEmbeddingModel failed:', e); }
+    },
+
     // Restart the whole fleet WITHOUT a confirmation prompt. Used to
     // auto-apply dashboard changes that are only picked up at container
     // launch (execution limits, default model). The user-facing

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -7483,6 +7483,41 @@
             </div>
           </div>
 
+          <!-- ── 1c. Embedding / Semantic memory ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings || !systemSettingsLoading">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+              <h3 class="text-base font-medium text-gray-200">Semantic Memory</h3>
+              <span class="text-[11px] text-amber-500/70 ml-auto">restart required</span>
+            </div>
+            <div class="space-y-3" x-show="systemSettings">
+              <div class="text-xs text-gray-400 flex items-center gap-1.5"
+                :class="systemSettings?.embedding?.on ? 'text-green-400' : 'text-gray-400'">
+                <span class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  :class="systemSettings?.embedding?.on ? 'bg-green-400' : 'bg-gray-600'"></span>
+                <span x-text="systemSettings?.embedding?.on
+                  ? ('Semantic memory: ON — ' + systemSettings.embedding.effective_model)
+                  : 'Semantic memory: OFF (keyword-only)'"></span>
+              </div>
+              <div>
+                <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Embedding Provider
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Powers semantic (meaning-based) memory search. Requires a SYSTEM API key from an embedding-capable provider (OpenAI / Voyage / Gemini / Cohere). "Auto" picks the best available key; "None" falls back to keyword-only search. Changing this restarts all agents.</span></span>
+                </label>
+                <select class="dash-select w-full"
+                  x-effect="if (systemSettings?.embedding) $el.value = systemSettings.embedding.configured_provider"
+                  @change="saveEmbeddingModel($event.target.value)">
+                  <option value="auto">Auto (best available key)</option>
+                  <template x-for="p in (systemSettings?.embedding?.available_providers || [])" :key="p">
+                    <option :value="p" x-text="p.charAt(0).toUpperCase()+p.slice(1)"></option>
+                  </template>
+                  <option value="none">None (keyword-only)</option>
+                  <option value="custom" disabled x-show="systemSettings?.embedding?.configured_provider === 'custom'"
+                    x-text="'Custom: ' + (systemSettings?.embedding?.configured || '')"></option>
+                </select>
+              </div>
+            </div>
+          </div>
+
           <!-- ── 2. Budgets ── -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings || !systemSettingsLoading">
             <div class="flex items-center gap-2 mb-4">

--- a/tests/test_embedding_model_endpoint.py
+++ b/tests/test_embedding_model_endpoint.py
@@ -96,7 +96,8 @@ class TestEmbeddingModelEndpoint:
 
     # ── POST /api/embedding-model ───────────────────────────────────────
 
-    def test_provider_writes_model_string(self, mesh_yaml):
+    def test_provider_writes_model_string(self, mesh_yaml, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_SYSTEM_VOYAGE_API_KEY", "vk-test")
         resp = self.client.post(
             "/dashboard/api/embedding-model",
             json={"value": "voyage"},
@@ -154,6 +155,18 @@ class TestEmbeddingModelEndpoint:
         )
         assert resp.status_code == 400
 
+    def test_provider_without_key_rejected(self, mesh_yaml, monkeypatch):
+        # A provider with no configured API key is rejected — persisting it
+        # would mint a dead embedding model agents restart into.
+        monkeypatch.delenv("OPENLEGION_SYSTEM_VOYAGE_API_KEY", raising=False)
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "voyage"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 400
+        assert self._read_embedding(mesh_yaml) == "__ABSENT__"
+
     # ── GET /api/system-settings embedding block ────────────────────────
 
     def test_system_settings_embedding_block_off(self, mesh_yaml, monkeypatch):
@@ -195,6 +208,21 @@ class TestEmbeddingModelEndpoint:
         assert emb["configured_provider"] == "openai"
         assert emb["configured"] == "text-embedding-3-small"
         assert emb["on"] is True
+
+    def test_system_settings_explicit_provider_no_key_is_off(
+        self, mesh_yaml, monkeypatch,
+    ):
+        # Explicit model whose provider key was removed → honest OFF status.
+        for p in ("OPENAI", "VOYAGE", "GEMINI", "COHERE"):
+            monkeypatch.delenv(f"OPENLEGION_SYSTEM_{p}_API_KEY", raising=False)
+        mesh_yaml.write_text(
+            yaml.dump({"llm": {"embedding_model": "voyage/voyage-3.5"}})
+        )
+        resp = self.client.get("/dashboard/api/system-settings")
+        assert resp.status_code == 200, resp.text
+        emb = resp.json()["embedding"]
+        assert emb["configured_provider"] == "voyage"
+        assert emb["on"] is False  # provider has no key → not actually on
 
     def test_system_settings_embedding_custom(self, mesh_yaml, monkeypatch):
         # A model not in the ladder → "custom".

--- a/tests/test_embedding_model_endpoint.py
+++ b/tests/test_embedding_model_endpoint.py
@@ -1,0 +1,208 @@
+"""Dashboard endpoint tests for the embedding / semantic-memory selector.
+
+Covers ``POST /dashboard/api/embedding-model`` (writes ``llm.embedding_model``
+to ``config/mesh.yaml``) and the ``embedding`` block added to
+``GET /dashboard/api/system-settings``.
+
+Harness mirrors ``tests/test_dashboard_ui.py`` (``create_dashboard_router`` →
+``FastAPI`` → ``TestClient``). The router-level ``_csrf_check`` requires the
+``X-Requested-With`` header on state-changing requests, so POSTs set it
+explicitly (the browser fetch monkey-patch that auto-adds it isn't in play
+under ``TestClient``).
+
+The POST handler writes a *relative* ``config/mesh.yaml`` (cwd-anchored) while
+``GET`` reads it through ``cli.config._load_config`` → ``CONFIG_FILE`` (an
+absolute path). We point both at the same temp file by ``chdir``-ing into a
+tmp dir AND patching ``CONFIG_FILE``.
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import src.cli.config as cli_config
+
+_CSRF = {"X-Requested-With": "XMLHttpRequest"}
+
+
+class TestEmbeddingModelEndpoint:
+    def setup_method(self):
+        from unittest.mock import MagicMock
+
+        from src.dashboard.events import EventBus
+        from src.dashboard.server import create_dashboard_router
+        from src.dashboard.telemetry import DashboardTelemetry
+        from src.host.costs import CostTracker
+        from src.host.health import HealthMonitor
+        from src.host.mesh import Blackboard
+        from src.host.traces import TraceStore
+
+        self._tmpdir = tempfile.mkdtemp()
+        bb = Blackboard(db_path=os.path.join(self._tmpdir, "bb.db"))
+        cost_tracker = CostTracker(db_path=os.path.join(self._tmpdir, "costs.db"))
+        trace_store = TraceStore(db_path=os.path.join(self._tmpdir, "traces.db"))
+        runtime_mock = MagicMock()
+        runtime_mock.browser_vnc_url = None
+        runtime_mock.browser_service_url = None
+        runtime_mock.browser_auth_token = ""
+        health_monitor = HealthMonitor(
+            runtime=runtime_mock,
+            transport=MagicMock(),
+            router=MagicMock(),
+        )
+        self.components = {
+            "blackboard": bb,
+            "health_monitor": health_monitor,
+            "cost_tracker": cost_tracker,
+            "trace_store": trace_store,
+            "event_bus": EventBus(),
+            "agent_registry": {},
+        }
+        self.telemetry = DashboardTelemetry(
+            db_path=os.path.join(self._tmpdir, "telemetry.db"),
+        )
+        router = create_dashboard_router(
+            **self.components, mesh_port=8420, telemetry=self.telemetry,
+        )
+        app = FastAPI()
+        app.include_router(router)
+        self.client = TestClient(app)
+
+    def teardown_method(self):
+        self.telemetry.close()
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    @pytest.fixture
+    def mesh_yaml(self, tmp_path, monkeypatch):
+        """Anchor both the POST write and the GET read at one temp mesh.yaml."""
+        cfg_path = tmp_path / "config" / "mesh.yaml"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        monkeypatch.chdir(tmp_path)  # POST writes relative config/mesh.yaml
+        monkeypatch.setattr(cli_config, "CONFIG_FILE", cfg_path)  # GET reads it
+        return cfg_path
+
+    def _read_embedding(self, cfg_path: Path):
+        data = yaml.safe_load(cfg_path.read_text()) if cfg_path.exists() else {}
+        return (data or {}).get("llm", {}).get("embedding_model", "__ABSENT__")
+
+    # ── POST /api/embedding-model ───────────────────────────────────────
+
+    def test_provider_writes_model_string(self, mesh_yaml):
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "voyage"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body == {"value": "voyage", "embedding_model": "voyage/voyage-3.5"}
+        assert self._read_embedding(mesh_yaml) == "voyage/voyage-3.5"
+
+    def test_none_stores_none(self, mesh_yaml):
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "none"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["embedding_model"] == "none"
+        assert self._read_embedding(mesh_yaml) == "none"
+
+    def test_auto_removes_key(self, mesh_yaml):
+        # Seed an explicit value, then "auto" must remove it (and leave
+        # other llm keys intact).
+        mesh_yaml.write_text(
+            yaml.dump(
+                {"llm": {"default_model": "openai/gpt-4o-mini",
+                         "embedding_model": "voyage/voyage-3.5"}},
+            )
+        )
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "auto"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["embedding_model"] is None
+        assert self._read_embedding(mesh_yaml) == "__ABSENT__"
+        # Sibling llm key preserved.
+        data = yaml.safe_load(mesh_yaml.read_text())
+        assert data["llm"]["default_model"] == "openai/gpt-4o-mini"
+
+    def test_bogus_value_400(self, mesh_yaml):
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "bogus"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 400
+
+    def test_empty_value_400(self, mesh_yaml):
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": ""},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 400
+
+    # ── GET /api/system-settings embedding block ────────────────────────
+
+    def test_system_settings_embedding_block_off(self, mesh_yaml, monkeypatch):
+        # No embedding-capable keys → effective "none" → off.
+        for p in ("OPENAI", "VOYAGE", "GEMINI", "COHERE"):
+            monkeypatch.delenv(f"OPENLEGION_SYSTEM_{p}_API_KEY", raising=False)
+        resp = self.client.get("/dashboard/api/system-settings")
+        assert resp.status_code == 200, resp.text
+        emb = resp.json()["embedding"]
+        assert emb["configured_provider"] == "auto"  # absent key → auto
+        assert emb["on"] is False
+        assert emb["effective_model"] == "none"
+        assert emb["available_providers"] == []
+
+    def test_system_settings_embedding_block_on(self, mesh_yaml, monkeypatch):
+        # A Voyage key present, embedding_model absent → resolver auto-picks
+        # the first laddered keyed provider.
+        for p in ("OPENAI", "VOYAGE", "GEMINI", "COHERE"):
+            monkeypatch.delenv(f"OPENLEGION_SYSTEM_{p}_API_KEY", raising=False)
+        monkeypatch.setenv("OPENLEGION_SYSTEM_VOYAGE_API_KEY", "vk-test")
+        resp = self.client.get("/dashboard/api/system-settings")
+        assert resp.status_code == 200, resp.text
+        emb = resp.json()["embedding"]
+        assert emb["configured_provider"] == "auto"
+        assert emb["on"] is True
+        assert emb["effective_model"] == "voyage/voyage-3.5"
+        assert "voyage" in emb["available_providers"]
+
+    def test_system_settings_embedding_explicit_provider(
+        self, mesh_yaml, monkeypatch,
+    ):
+        monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", "sk-test")
+        mesh_yaml.write_text(
+            yaml.dump({"llm": {"embedding_model": "text-embedding-3-small"}})
+        )
+        resp = self.client.get("/dashboard/api/system-settings")
+        assert resp.status_code == 200, resp.text
+        emb = resp.json()["embedding"]
+        assert emb["configured_provider"] == "openai"
+        assert emb["configured"] == "text-embedding-3-small"
+        assert emb["on"] is True
+
+    def test_system_settings_embedding_custom(self, mesh_yaml, monkeypatch):
+        # A model not in the ladder → "custom".
+        mesh_yaml.write_text(
+            yaml.dump({"llm": {"embedding_model": "some/exotic-embed-v9"}})
+        )
+        resp = self.client.get("/dashboard/api/system-settings")
+        assert resp.status_code == 200, resp.text
+        emb = resp.json()["embedding"]
+        assert emb["configured_provider"] == "custom"
+        assert emb["configured"] == "some/exotic-embed-v9"


### PR DESCRIPTION
## What & why
Part 4 of the memory-system batch. Surfaces the provider-agnostic embedding backend (**#1060**) in the UI so users can **select their embedding provider from the keys they actually have**, make it **optional** ("None / keyword-only"), and see an honest **"Semantic memory: ON/OFF"** status — exactly what was requested.

## Changes
- **`server.py`** — `POST /api/embedding-model` writes `llm.embedding_model` to `config/mesh.yaml` (mirrors the shipped `/api/default-model`): `"auto"` removes the key so the resolver auto-picks; `"none"` disables; a provider maps to its model via PR1's `_EMBEDDING_PROVIDER_LADDER`. `GET /api/system-settings` gains an `embedding` block (`configured` / `configured_provider` / `effective_model` / `on` / `available_providers`) computed with PR1's `_resolve_embedding` + `_embedding_providers_with_keys` — **no hardcoded models**.
- **`index.html`** — a "Semantic Memory" card in Settings (after the LLM card): provider dropdown sourced from configured keys (`Auto` / each keyed provider / `None`) + a green/grey status line.
- **`app.js`** — `saveEmbeddingModel` mirrors `saveDefaultModel` (POST + `_restartAllAgentsAuto`, since `EMBEDDING_MODEL` is read at agent launch) and refreshes the resolved status.

## UX decision (as discussed)
No raw "pick an embedding model" jargon dropdown — users pick a **provider** (or Auto/None), and the status line tells them whether semantic memory is on and via which model. Onboarding-modal selector deferred (optional; **Auto** is the safe default that already does the right thing).

## Tests
9 new endpoint tests (provider→model mapping, none, auto-removes-key, bad-provider 400, system-settings `embedding` block) + existing dashboard UI suite: 188 passed, 4 skipped. Ruff clean.

## ⚠️ Stacked on #1060
Base branch is `feat/memory-activate-rag` (reuses its resolver/ladder). **Merge #1060 first**, then this retargets to `main`.

⚠️ Do not merge yet — part of a batch reviewed together at the end.