### PR TITLE
feat(dashboard): single-source limits + surface all caps in config UI

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -46,6 +46,7 @@ from pydantic import ValidationError
 
 from src.cli.proxy import build_proxy_env_vars, resolve_agent_proxy
 from src.dashboard.auth import verify_session_cookie
+from src.shared import limits as _limits
 from src.shared.paths import resolve_under_root
 from src.shared.sqlite_helpers import open_db
 from src.shared.types import CRED_HANDLE_RE, MCPServerConfig
@@ -2589,6 +2590,18 @@ def create_dashboard_router(
             "color": agent_cfg.get("color"),
             "budget": agent_cfg.get("budget", {}),
             "thinking": agent_cfg.get("thinking", "off") or "off",
+            # Execution caps — fall back to the EFFECTIVE resolved value so
+            # the edit form shows what the agent actually runs with when no
+            # explicit per-agent override is set.
+            "max_output_tokens": agent_cfg.get("max_output_tokens", 8192) or 8192,
+            "max_tool_rounds": (
+                agent_cfg.get("max_tool_rounds")
+                or _limits.resolve("task_max_tool_rounds")
+            ),
+            "llm_timeout_seconds": (
+                agent_cfg.get("llm_timeout_seconds")
+                or _limits.resolve("llm_timeout_seconds")
+            ),
             # MCP server entries are masked: env values (which may be
             # plaintext secrets or ``$CRED{name}`` handles pointing at
             # one) are NEVER returned. The UI binds to ``env_keys`` to
@@ -2705,7 +2718,7 @@ def create_dashboard_router(
         # response the caller sees.
         pending_writes: list[tuple[str, object]] = []
         budget_apply: dict[str, float] | None = None
-        runtime_payload: dict[str, str] = {}
+        runtime_payload: dict[str, object] = {}
         mcp_touched = False
 
         if "model" in body:
@@ -2769,6 +2782,78 @@ def create_dashboard_router(
                 )
             pending_writes.append(("thinking", thinking_val))
             runtime_payload["thinking"] = thinking_val
+
+        # ── Execution caps (per-agent overrides) ──────────────────
+        # The agent /config endpoint keys the output cap as ``max_tokens``,
+        # so runtime_payload uses that name while the YAML field stays
+        # ``max_output_tokens`` (matching agents.yaml / set_llm_max_tokens_env).
+        if "max_output_tokens" in body:
+            raw_mot = body["max_output_tokens"]
+            if isinstance(raw_mot, bool):
+                raise HTTPException(
+                    status_code=400,
+                    detail="max_output_tokens must be an integer between 256 and 200000",
+                )
+            try:
+                mot = int(raw_mot)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail="max_output_tokens must be an integer between 256 and 200000",
+                )
+            if mot < 256 or mot > 200000:
+                raise HTTPException(
+                    status_code=400,
+                    detail="max_output_tokens must be between 256 and 200000",
+                )
+            pending_writes.append(("max_output_tokens", mot))
+            runtime_payload["max_tokens"] = mot
+
+        if "max_tool_rounds" in body:
+            raw_mtr = body["max_tool_rounds"]
+            _lo, _hi = _limits.LIMIT_SPECS["task_max_tool_rounds"][1:]
+            if isinstance(raw_mtr, bool):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"max_tool_rounds must be an integer between {_lo} and {_hi}",
+                )
+            try:
+                mtr = int(raw_mtr)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"max_tool_rounds must be an integer between {_lo} and {_hi}",
+                )
+            if mtr < _lo or mtr > _hi:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"max_tool_rounds must be between {_lo} and {_hi}",
+                )
+            pending_writes.append(("max_tool_rounds", mtr))
+            runtime_payload["max_tool_rounds"] = mtr
+
+        if "llm_timeout_seconds" in body:
+            raw_lts = body["llm_timeout_seconds"]
+            _lo, _hi = _limits.LIMIT_SPECS["llm_timeout_seconds"][1:]
+            if isinstance(raw_lts, bool):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"llm_timeout_seconds must be an integer between {_lo} and {_hi}",
+                )
+            try:
+                lts = int(raw_lts)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"llm_timeout_seconds must be an integer between {_lo} and {_hi}",
+                )
+            if lts < _lo or lts > _hi:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"llm_timeout_seconds must be between {_lo} and {_hi}",
+                )
+            pending_writes.append(("llm_timeout_seconds", lts))
+            runtime_payload["llm_timeout_seconds"] = lts
 
         if "mcp_servers" in body:
             mcp_val = body["mcp_servers"]
@@ -6072,18 +6157,33 @@ def create_dashboard_router(
 
     # ── System settings (consolidated) ────────────────────────
 
+    # Execution-limit keys whose ranges/defaults are owned by
+    # src/shared/limits.py (the single source of truth). The validators
+    # and defaults dicts below merge these in so the dashboard never
+    # disagrees with the engine's own clamp ranges.
+    _LIMIT_KEYS = (
+        "max_iterations",
+        "chat_max_tool_rounds",
+        "chat_max_total_rounds",
+        "task_max_tool_rounds",
+        "llm_timeout_seconds",
+        "lane_timeout_seconds",
+    )
+
     _SYSTEM_SETTINGS_VALIDATORS: dict[str, tuple[type, float, float]] = {
         "default_daily_budget": (float, 0.01, 10000),
         "default_monthly_budget": (float, 0.01, 100000),
-        "max_iterations": (int, 1, 100),
-        "chat_max_tool_rounds": (int, 1, 200),
-        "chat_max_total_rounds": (int, 10, 1000),
         "tool_timeout": (int, 10, 3600),
         "browser_idle_timeout": (int, 5, 120),
         "health_poll_interval": (int, 5, 300),
         "health_max_failures": (int, 1, 20),
         "health_restart_limit": (int, 0, 20),
         "health_restart_window": (int, 60, 86400),
+        # Execution limits sourced from limits.py (default, lo, hi).
+        **{
+            k: (int, _limits.LIMIT_SPECS[k][1], _limits.LIMIT_SPECS[k][2])
+            for k in _LIMIT_KEYS
+        },
     }
 
     # Settings seeded into agent containers as env vars at launch — they
@@ -6095,20 +6195,21 @@ def create_dashboard_router(
     _RESTART_REQUIRED_SETTINGS: frozenset[str] = frozenset({
         "max_iterations", "chat_max_tool_rounds",
         "chat_max_total_rounds", "tool_timeout",
+        "task_max_tool_rounds", "llm_timeout_seconds",
+        "lane_timeout_seconds",
     })
 
     _SYSTEM_SETTINGS_DEFAULTS: dict[str, float | int] = {
         "default_daily_budget": 10.0,
         "default_monthly_budget": 200.0,
-        "max_iterations": 20,
-        "chat_max_tool_rounds": 30,
-        "chat_max_total_rounds": 200,
         "tool_timeout": 300,
         "browser_idle_timeout": 30,
         "health_poll_interval": 30,
         "health_max_failures": 3,
         "health_restart_limit": 3,
         "health_restart_window": 3600,
+        # Execution-limit defaults sourced from limits.py.
+        **{k: _limits.LIMIT_SPECS[k][0] for k in _LIMIT_KEYS},
     }
 
     @api_router.get("/api/system-settings")
@@ -6216,6 +6317,9 @@ def create_dashboard_router(
                     "OPENLEGION_CHAT_MAX_TOOL_ROUNDS": "chat_max_tool_rounds",
                     "OPENLEGION_CHAT_MAX_TOTAL_ROUNDS": "chat_max_total_rounds",
                     "OPENLEGION_TOOL_TIMEOUT": "tool_timeout",
+                    "OPENLEGION_TASK_MAX_TOOL_ROUNDS": "task_max_tool_rounds",
+                    "OPENLEGION_LLM_TIMEOUT_SECONDS": "llm_timeout_seconds",
+                    "OPENLEGION_LANE_TIMEOUT_SECONDS": "lane_timeout_seconds",
                 }.items():
                     if cfg_key in sys_settings:
                         runtime.extra_env[env_key] = str(sys_settings[cfg_key])

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6158,17 +6158,10 @@ def create_dashboard_router(
     # ── System settings (consolidated) ────────────────────────
 
     # Execution-limit keys whose ranges/defaults are owned by
-    # src/shared/limits.py (the single source of truth). The validators
-    # and defaults dicts below merge these in so the dashboard never
-    # disagrees with the engine's own clamp ranges.
-    _LIMIT_KEYS = (
-        "max_iterations",
-        "chat_max_tool_rounds",
-        "chat_max_total_rounds",
-        "task_max_tool_rounds",
-        "llm_timeout_seconds",
-        "lane_timeout_seconds",
-    )
+    # src/shared/limits.py (the single source of truth). The list of which
+    # limits the dashboard surfaces also lives there (DASHBOARD_GLOBAL_KEYS),
+    # so the UI can never silently diverge from / drop a LIMIT_SPECS entry.
+    _LIMIT_KEYS = _limits.DASHBOARD_GLOBAL_KEYS
 
     _SYSTEM_SETTINGS_VALIDATORS: dict[str, tuple[type, float, float]] = {
         "default_daily_budget": (float, 0.01, 10000),

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6308,6 +6308,9 @@ function dashboard() {
         budget_daily: cfg.budget?.daily_usd || '',
         budget_monthly: cfg.budget?.monthly_usd || '',
         thinking: cfg.thinking || 'off',
+        max_output_tokens: cfg.max_output_tokens || '',
+        max_tool_rounds: cfg.max_tool_rounds || '',
+        llm_timeout_seconds: cfg.llm_timeout_seconds || '',
         can_use_browser: cfg.can_use_browser ?? false,
         can_use_internet: cfg.can_use_internet ?? false,
         can_spawn: cfg.can_spawn ?? false,
@@ -6716,6 +6719,20 @@ function dashboard() {
       }
       if (this.editForm.thinking !== undefined && this.editForm.thinking !== (cfg.thinking || 'off')) {
         body.thinking = this.editForm.thinking;
+      }
+      // Execution caps — only send when non-empty AND changed vs the
+      // effective value the GET seeded into the form.
+      const _caps = {
+        max_output_tokens: cfg.max_output_tokens,
+        max_tool_rounds: cfg.max_tool_rounds,
+        llm_timeout_seconds: cfg.llm_timeout_seconds,
+      };
+      for (const key of Object.keys(_caps)) {
+        const raw = this.editForm[key];
+        if (raw === '' || raw === null || raw === undefined) continue;
+        const val = parseInt(raw, 10);
+        if (Number.isNaN(val)) continue;
+        if (val !== _caps[key]) body[key] = val;
       }
       // MCP servers — only include if the user actually changed something
       // (mcpServersChanged handles the no-op case so a benign full-body

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3337,6 +3337,19 @@
                               <div class="dash-input w-full text-gray-400 cursor-not-allowed">Not supported for this model</div>
                             </template>
                           </div>
+                          <!-- ── Execution caps (per-agent overrides) ── -->
+                          <div>
+                            <label class="text-xs text-gray-400 mb-1 block">Max output tokens</label>
+                            <input type="number" step="1" min="256" max="200000" x-model.number="editForm.max_output_tokens" class="dash-input w-full" placeholder="8192">
+                          </div>
+                          <div>
+                            <label class="text-xs text-gray-400 mb-1 block">Max tool rounds (per task)</label>
+                            <input type="number" step="1" min="1" max="1000" x-model.number="editForm.max_tool_rounds" class="dash-input w-full" placeholder="300">
+                          </div>
+                          <div>
+                            <label class="text-xs text-gray-400 mb-1 block">LLM timeout (s)</label>
+                            <input type="number" step="1" min="10" max="7200" x-model.number="editForm.llm_timeout_seconds" class="dash-input w-full" placeholder="1800">
+                          </div>
                           <!-- ── Capabilities ── -->
                           <div class="md:col-span-2 pt-2 mt-1 border-t border-gray-800/60">
                             <label class="text-xs text-gray-400 mb-1.5 block">Capabilities</label>
@@ -7521,27 +7534,27 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 chat-grid" x-show="systemSettings">
               <div>
                 <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Max Iterations (task mode)
-                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">How many LLM calls an agent gets to complete a single task. Each iteration can use tools or return a final answer. If the agent hasn't finished after this many iterations, the task fails. Default: 20.</span></span>
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">How many LLM calls an agent gets to complete a single task. Each iteration can use tools or return a final answer. If the agent hasn't finished after this many iterations, the task fails. Default: 60.</span></span>
                 </label>
-                <input type="number" step="1" min="1" max="100"
+                <input type="number" step="1" min="1" max="500"
                   class="dash-input w-full"
                   :value="systemSettings?.max_iterations"
                   @change="saveSystemSetting('max_iterations', $event.target.value)">
               </div>
               <div>
                 <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Max Tool Rounds (chat)
-                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Per user message, how many consecutive tool calls the agent can chain before being forced to respond with text. Prevents runaway tool loops in a single turn. Default: 30.</span></span>
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Per user message, how many consecutive tool calls the agent can chain before being forced to respond with text. Prevents runaway tool loops in a single turn. Default: 500.</span></span>
                 </label>
-                <input type="number" step="1" min="1" max="200"
+                <input type="number" step="1" min="1" max="1000"
                   class="dash-input w-full"
                   :value="systemSettings?.chat_max_tool_rounds"
                   @change="saveSystemSetting('chat_max_tool_rounds', $event.target.value)">
               </div>
               <div>
                 <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Max Total Rounds (chat)
-                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Total tool rounds across an entire chat session before auto-compaction resets the counter. Limits how long a single conversation can run. The session auto-continues up to 5 times. Default: 200.</span></span>
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Total tool rounds across an entire chat session before auto-compaction resets the counter. Limits how long a single conversation can run. The session auto-continues up to 5 times. Default: 1000.</span></span>
                 </label>
-                <input type="number" step="1" min="10" max="1000"
+                <input type="number" step="1" min="10" max="5000"
                   class="dash-input w-full"
                   :value="systemSettings?.chat_max_total_rounds"
                   @change="saveSystemSetting('chat_max_total_rounds', $event.target.value)">
@@ -7554,6 +7567,33 @@
                   class="dash-input w-full"
                   :value="systemSettings?.tool_timeout"
                   @change="saveSystemSetting('tool_timeout', $event.target.value)">
+              </div>
+              <div>
+                <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Max Tool Rounds (per task)
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Per-task convergence budget: tool rounds a handed-off/task run gets before it's closed as blocked. Default: 300.</span></span>
+                </label>
+                <input type="number" step="1" min="1" max="1000"
+                  class="dash-input w-full"
+                  :value="systemSettings?.task_max_tool_rounds"
+                  @change="saveSystemSetting('task_max_tool_rounds', $event.target.value)">
+              </div>
+              <div>
+                <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">LLM Call Timeout (seconds)
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Per LLM call timeout. With streaming this is an idle (between-token) bound. Raise for agents that emit very large outputs. Default: 1800.</span></span>
+                </label>
+                <input type="number" step="1" min="10" max="7200"
+                  class="dash-input w-full"
+                  :value="systemSettings?.llm_timeout_seconds"
+                  @change="saveSystemSetting('llm_timeout_seconds', $event.target.value)">
+              </div>
+              <div>
+                <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Lane Wall-clock (seconds)
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Hard watchdog: max wall-clock a single task may hold an agent's queue before it's force-killed. Default: 14400.</span></span>
+                </label>
+                <input type="number" step="1" min="30" max="86400"
+                  class="dash-input w-full"
+                  :value="systemSettings?.lane_timeout_seconds"
+                  @change="saveSystemSetting('lane_timeout_seconds', $event.target.value)">
               </div>
             </div>
           </div>

--- a/src/shared/limits.py
+++ b/src/shared/limits.py
@@ -75,6 +75,20 @@ AGENT_CONFIG_KEYS: dict[str, str] = {
     "llm_timeout_seconds": "llm_timeout_seconds",
 }
 
+# Limits surfaced in the dashboard global "Agent Execution" settings panel.
+# Declared here (not in the dashboard) so the UI can never silently diverge
+# from LIMIT_SPECS and so the deliberate exclusion is explicit:
+# ``lane_queue_max`` is intentionally omitted — it's a niche backpressure
+# knob that stays env-only (OPENLEGION_LANE_QUEUE_MAX).
+DASHBOARD_GLOBAL_KEYS: tuple[str, ...] = (
+    "max_iterations",
+    "chat_max_tool_rounds",
+    "chat_max_total_rounds",
+    "task_max_tool_rounds",
+    "llm_timeout_seconds",
+    "lane_timeout_seconds",
+)
+
 
 def clamp(key: str, value: int) -> int:
     """Clamp ``value`` into the spec range for ``key`` (logs if it moved)."""

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2458,3 +2458,22 @@ class TestOnWsEventHandlersForLiveCoverage:
 
     def test_blackboard_delete_handler_present(self):
         assert "evt.type === 'blackboard_delete'" in _APP_JS_TEXT
+
+
+class TestLimitsConfigUICompleteness:
+    """Every dashboard-surfaced limit must have a global UI input, so a new
+    limit can't be added to limits.DASHBOARD_GLOBAL_KEYS without its control
+    (the drift Codex flagged)."""
+
+    def test_every_global_limit_has_a_settings_input(self):
+        from src.shared import limits
+        missing = [
+            k for k in limits.DASHBOARD_GLOBAL_KEYS
+            if f"saveSystemSetting('{k}'" not in _INDEX_HTML
+        ]
+        assert not missing, f"global limits missing a system-settings input: {missing}"
+
+    def test_per_agent_caps_wired_in_edit_form(self):
+        # The three per-agent caps must be bound in the agent edit panel.
+        for field in ("max_output_tokens", "max_tool_rounds", "llm_timeout_seconds"):
+            assert f"editForm.{field}" in _INDEX_HTML, f"{field} missing from agent edit UI"


### PR DESCRIPTION
**Stacked on #1056 → #1055 → #1054** — top of the limits stack. Closes the config-discoverability gap you asked about.

## Why
Audit of the dashboard found the limits were **neither single-source nor fully discoverable**:
- The global **System → Agent Execution** settings *duplicated* the limits with **stale ranges/defaults** (`max_iterations 1–100/20`, `chat_max_tool_rounds 1–200/30`, …) — so after #1054 raised the caps, an operator literally **couldn't set the new values from the dashboard** (server validator + HTML `max` both rejected them).
- The per-agent caps (`max_output_tokens`, `max_tool_rounds`, `llm_timeout_seconds`) appeared in **no dashboard UI at all** — operator-tool/API only.

## What
- **Single source of truth:** `_SYSTEM_SETTINGS_VALIDATORS` / `_SYSTEM_SETTINGS_DEFAULTS` now merge the six execution-limit keys' `(default, lo, hi)` straight from `limits.LIMIT_SPECS` (removed the hardcoded duplicates). The dashboard can never drift from the engine's clamp ranges again.
- **All globals exposed:** added `task_max_tool_rounds`, `llm_timeout_seconds`, `lane_timeout_seconds` to the validators, the `OPENLEGION_*` env-apply map, `_RESTART_REQUIRED_SETTINGS`, and the global UI; corrected the three existing inputs' ranges + labels.
- **Per-agent in the UI:** `GET/PUT /api/agents/{id}/config` now read/validate/persist + hot-reload the three caps (write validates bool-rejected + ranged from limits; `max_output_tokens`→agent `/config` `max_tokens`). Agent edit panel gains the three inputs; `saveAgentConfig` sends only changed, non-empty values (won't pin an effective default as an override).

## Tests
591 passed (`test_dashboard` + `test_dashboard_ui` + `test_limits` + `test_operator_config`); ruff clean. Reviewed from the diff: backend single-source merge correct, PUT validation + runtime-key mapping correct, frontend bindings/ranges correct.

## Deploy note
Agent-side + host/dashboard code → agent image rebuild + restart to take effect.