### PR TITLE
feat(defaults): raise default caps for a smoother out-of-box experience

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -50,10 +50,10 @@ def main() -> None:
     embedding_model = os.environ.get("EMBEDDING_MODEL", "")
     thinking = os.environ.get("THINKING", "off")
     try:
-        max_output_tokens = int(os.environ.get("LLM_MAX_TOKENS", "8192"))
+        max_output_tokens = int(os.environ.get("LLM_MAX_TOKENS", "16384"))
     except ValueError:
-        logger.warning("Invalid LLM_MAX_TOKENS, using default 8192")
-        max_output_tokens = 8192
+        logger.warning("Invalid LLM_MAX_TOKENS, using default 16384")
+        max_output_tokens = 16384
     max_output_tokens = max(256, min(max_output_tokens, 200_000))
     llm = LLMClient(
         mesh_url=mesh_url, agent_id=agent_id,

--- a/src/agent/builtins/http_tool.py
+++ b/src/agent/builtins/http_tool.py
@@ -21,7 +21,7 @@ import httpx
 from src.agent.builtins import CRED_HANDLE_RE
 from src.agent.tools import tool
 
-_MAX_BODY = 50_000
+_MAX_BODY = 1_000_000
 _MAX_REDIRECTS = 5
 # Hard ceiling on bytes pulled off the wire. We decode bytes→text *after*
 # bounding, so worst-case multibyte expansion can't exceed this; we read a

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -693,7 +693,7 @@ async def list_available_models(
         "- max_output_tokens: integer 256-200000 — per-agent cap on output "
         "tokens per LLM call. Raise it for agents that emit large single "
         "tool calls (e.g. a translator that PUTs a whole file in one call) "
-        "and hit 'Truncated tool-call arguments'. Default 8192.\n"
+        "and hit 'Truncated tool-call arguments'. Default 16384.\n"
         "- max_tool_rounds: integer — per-task tool-round budget before a task "
         "is closed as blocked (convergence cap). Raise it for agents doing "
         "long multi-step work that legitimately needs many rounds.\n"

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -39,7 +39,7 @@ class LLMClient:
         default_model: str = "openai/gpt-4o-mini",
         embedding_model: str = "",
         thinking: str = "off",
-        max_output_tokens: int = 8192,
+        max_output_tokens: int = 16384,
     ):
         if thinking and thinking not in self.VALID_THINKING_LEVELS:
             logger.warning(
@@ -59,8 +59,9 @@ class LLMClient:
         # tool calls with large argument payloads (e.g. write_file of a
         # 15-20KB file): the model hit the cap mid-tool-call, the JSON never
         # closed, and the call failed permanently with "Truncated tool-call
-        # arguments". 8192 is the safe floor across common modern models
-        # (gpt-4o family = 16384, Claude 3.5 Sonnet = 8192, Claude 4.x = 64K+).
+        # arguments". 16384 is a generous default that suits gpt-4o (16384)
+        # and Claude 4.x (64K+); models that cap lower (e.g. Claude 3.5 Sonnet
+        # at 8192) need a per-agent override down.
         self.max_output_tokens = max_output_tokens
         # LLM call timeout, resolved from the central limits table (env ->
         # high default). With streaming task execution this is an *idle*

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -41,7 +41,7 @@ logger = setup_logging("agent.loop")
 _RETRYABLE_STATUS_CODES = {429, 502, 503, 504, 529}  # 529 = Anthropic overloaded
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 1  # seconds: 1, 2, 4
-_TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "300"))  # seconds — hard ceiling per tool
+_TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "900"))  # seconds — hard ceiling per tool
 _FLEET_ROSTER_TTL = 600  # seconds — cache TTL for fleet roster
 _GOALS_TTL = 300  # seconds — cache TTL for goals fetch
 _FALLBACK_MAX_TOKENS = 100_000  # context trim fallback when no context manager

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2593,7 +2593,7 @@ def create_dashboard_router(
             # Execution caps — fall back to the EFFECTIVE resolved value so
             # the edit form shows what the agent actually runs with when no
             # explicit per-agent override is set.
-            "max_output_tokens": agent_cfg.get("max_output_tokens", 8192) or 8192,
+            "max_output_tokens": agent_cfg.get("max_output_tokens", 16384) or 16384,
             "max_tool_rounds": (
                 agent_cfg.get("max_tool_rounds")
                 or _limits.resolve("task_max_tool_rounds")
@@ -3121,7 +3121,7 @@ def create_dashboard_router(
             restart_env.update(_proxy_env)
             # Per-agent output-token cap → LLM_MAX_TOKENS so an edit_agent
             # change survives a single-agent dashboard restart (not just the
-            # live hot-reload). Absent = LLMClient default 8192.
+            # live hot-reload). Absent = LLMClient default 16384.
             set_llm_max_tokens_env(restart_env, agent_cfg)
             from src.shared.limits import set_llm_limits_env
             set_llm_limits_env(restart_env, agent_cfg)
@@ -6193,9 +6193,9 @@ def create_dashboard_router(
     })
 
     _SYSTEM_SETTINGS_DEFAULTS: dict[str, float | int] = {
-        "default_daily_budget": 10.0,
+        "default_daily_budget": 50.0,
         "default_monthly_budget": 200.0,
-        "tool_timeout": 300,
+        "tool_timeout": 900,
         "browser_idle_timeout": 30,
         "health_poll_interval": 30,
         "health_max_failures": 3,

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3340,7 +3340,7 @@
                           <!-- ── Execution caps (per-agent overrides) ── -->
                           <div>
                             <label class="text-xs text-gray-400 mb-1 block">Max output tokens</label>
-                            <input type="number" step="1" min="256" max="200000" x-model.number="editForm.max_output_tokens" class="dash-input w-full" placeholder="8192">
+                            <input type="number" step="1" min="256" max="200000" x-model.number="editForm.max_output_tokens" class="dash-input w-full" placeholder="16384">
                           </div>
                           <div>
                             <label class="text-xs text-gray-400 mb-1 block">Max tool rounds (per task)</label>
@@ -7561,7 +7561,7 @@
               </div>
               <div>
                 <label class="text-xs text-gray-400 mb-1 flex items-center gap-1.5">Tool Timeout (seconds)
-                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Hard ceiling for any single tool execution (shell command, browser action, HTTP request). If a tool exceeds this, it's killed and the agent gets an error result. Default: 300s (5 min).</span></span>
+                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Hard ceiling for any single tool execution (shell command, browser action, HTTP request). If a tool exceeds this, it's killed and the agent gets an error result. Default: 900s (15 min).</span></span>
                 </label>
                 <input type="number" step="1" min="10" max="3600"
                   class="dash-input w-full"

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -28,7 +28,7 @@ def _default_budget() -> dict:
         if p.exists():
             data = json.loads(p.read_text())
             return {
-                "daily_usd": data.get("default_daily_budget", 10.0),
+                "daily_usd": data.get("default_daily_budget", 50.0),
                 "monthly_usd": data.get("default_monthly_budget", 200.0),
             }
     except (json.JSONDecodeError, OSError):

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -2121,7 +2121,7 @@ class CredentialVault:
         body: dict = {
             "model": model,
             "messages": converted,
-            "max_tokens": params.get("max_tokens", 8192),
+            "max_tokens": params.get("max_tokens", 16384),
         }
         if system_parts:
             body["system"] = "\n\n".join(system_parts)
@@ -2356,7 +2356,7 @@ class CredentialVault:
         sdk_kwargs: dict = {
             "model": body["model"],
             "messages": body["messages"],
-            "max_tokens": body.get("max_tokens", 8192),
+            "max_tokens": body.get("max_tokens", 16384),
             "stream": True,
         }
         if "system" in body:

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -584,7 +584,7 @@ class HealthMonitor:
             # Per-agent output-token cap → LLM_MAX_TOKENS so an operator's
             # max_output_tokens edit survives an automatic crash-recovery
             # restart. Read from fresh YAML (the registry ``info`` dict
-            # doesn't carry it); no-op when unset → LLMClient default 8192.
+            # doesn't carry it); no-op when unset → LLMClient default 16384.
             _hcfg = _agents_cfg.get(agent_id, {})
             set_llm_max_tokens_env(restart_env, _hcfg)
             from src.shared.limits import set_llm_limits_env

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7050,9 +7050,9 @@ def create_mesh_app(
             "soul": raw.get("initial_soul", ""),
             "heartbeat": raw.get("initial_heartbeat", ""),
             "interface": raw.get("initial_interface", ""),
-            # Falls back to the LLMClient default (8192) when never set, so the
+            # Falls back to the LLMClient default (16384) when never set, so the
             # operator sees the effective cap, not a blank.
-            "max_output_tokens": raw.get("max_output_tokens", 8192) or 8192,
+            "max_output_tokens": raw.get("max_output_tokens", 16384) or 16384,
             # Per-agent operational caps — fall back to the EFFECTIVE value
             # (env/global → default), so the operator sees what the agent
             # actually runs, not just the static floor.
@@ -7755,17 +7755,17 @@ def create_mesh_app(
         else:
             yaml_key = _CONFIG_FIELD_MAP.get(field, field)
             # For max_output_tokens, default the "before" value to the
-            # effective cap (LLMClient default 8192) rather than "" when it
+            # effective cap (LLMClient default 16384) rather than "" when it
             # was never set. This keeps the audit before-value sensible AND
             # makes Undo work end-to-end: the undo writes back an int, which
             # the hot-reload push forwards to the agent /config (the push
             # guard requires an int) so the live agent actually drops back to
-            # 8192 instead of silently keeping the raised cap until restart.
+            # 16384 instead of silently keeping the raised cap until restart.
             # Default the audit "before" value to the effective limit (not "")
             # when a field was never set, so Undo writes back a usable int that
             # the hot-reload push will forward to the live agent.
             if field == "max_output_tokens":
-                _missing_default: object = 8192
+                _missing_default: object = 16384
             elif field in ("max_tool_rounds", "llm_timeout_seconds"):
                 # Resolve the EFFECTIVE value (env/global → built-in default),
                 # not the static default, so Undo restores what the agent was

--- a/src/shared/limits.py
+++ b/src/shared/limits.py
@@ -50,7 +50,7 @@ LIMIT_SPECS: dict[str, tuple[int, int, int]] = {
     # Interactive cross-turn total round ceiling for one session.
     "chat_max_total_rounds": (1000, 1, 5000),
     # Legacy execute_task bounded-loop ceiling.
-    "max_iterations": (60, 1, 500),
+    "max_iterations": (300, 1, 500),
     # Host-side lane wall-clock watchdog (hung-stream / stuck-tool backstop).
     "lane_timeout_seconds": (14400, 30, 86400),
     # Host-side per-agent followup queue depth cap (0 disables).

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -25,7 +25,7 @@ def set_llm_max_tokens_env(env: dict[str, str], agent_cfg: dict) -> None:
     the already-running container.
 
     No-op when the cap is unset or not a plain int, so the LLMClient default
-    (8192) then applies. ``bool`` is rejected explicitly (it is an ``int``
+    (16384) then applies. ``bool`` is rejected explicitly (it is an ``int``
     subclass) so a stray ``True``/``False`` can't become ``1``/``0``. Also a
     no-op for a missing/malformed agent config (a null agents.yaml entry yields
     ``None``) rather than raising AttributeError on the restart path.

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1137,13 +1137,14 @@ def test_thinking_params_anthropic():
 
 
 def test_thinking_params_anthropic_max_tokens_covers_budget():
-    """max_tokens is auto-set to budget + 4096 for Anthropic thinking."""
+    """max_tokens is max(output cap, budget + 4096) for Anthropic thinking —
+    the budget+4096 floor wins only when it exceeds the output cap."""
     from src.agent.llm import LLMClient
 
     for level, expected_budget in [("low", 5_000), ("medium", 10_000), ("high", 25_000)]:
         client = LLMClient(mesh_url="http://test", thinking=level)
         params = client._get_thinking_params("anthropic/claude-sonnet-4-5-20250929")
-        assert params["max_tokens"] == expected_budget + 4096
+        assert params["max_tokens"] == max(client.max_output_tokens, expected_budget + 4096)
 
 
 def test_thinking_params_openai_o_series():

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -169,13 +169,13 @@ async def test_edit_soft_accepts_max_output_tokens_and_writes_yaml(mesh_app):
     assert cfg["agents"]["writer"]["max_output_tokens"] == 32000
 
     # When the cap was never set before, the recorded "before" value is the
-    # effective default (8192), not "". This makes the audit sensible and —
+    # effective default (16384), not "". This makes the audit sensible and —
     # critically — makes Undo restore an int that the hot-reload push can
     # forward to the live agent (the push guard requires an int), instead of
     # silently leaving the running container on the raised cap.
     change = app.change_history.peek(body["undo_token"])
     assert change is not None
-    assert change["old_value"] == 8192
+    assert change["old_value"] == 16384
     assert change["new_value"] == 32000
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -328,10 +328,11 @@ async def test_chat_stream_auth_failure_still_raises_auth_error():
             pass
 
 
-def test_default_max_output_tokens_is_8192():
-    """The hardcoded 4096 cap was too small for large tool-call payloads."""
+def test_default_max_output_tokens_is_16384():
+    """Default raised to 16384 for a smoother out-of-box experience with
+    larger outputs (models that cap lower take a per-agent override down)."""
     llm = LLMClient(mesh_url="http://mesh:8420", agent_id="a1")
-    assert llm.max_output_tokens == 8192
+    assert llm.max_output_tokens == 16384
 
 
 def test_max_output_tokens_override():
@@ -370,18 +371,18 @@ async def test_chat_uses_instance_max_tokens_default():
     assert captured["max_tokens"] == 16384
 
 
-def test_thinking_max_tokens_preserves_default_floor():
-    """With the default 8192 cap, an Anthropic thinking call keeps the
-    historical ``budget + 4096`` ceiling — taking the max introduces no
-    regression because 8192 <= budget + 4096 at every thinking level."""
+def test_thinking_max_tokens_preserves_budget_floor():
+    """When the thinking ``budget + 4096`` floor exceeds the default output
+    cap, ``max()`` keeps the floor so thinking always has room. With the
+    raised 16384 default this still bites at ``high`` (25_000 + 4096)."""
     llm = LLMClient(
         mesh_url="http://mesh:8420", agent_id="a1",
-        default_model="anthropic/claude-sonnet-4-6", thinking="medium",
+        default_model="anthropic/claude-sonnet-4-6", thinking="high",
     )
     params = llm._get_thinking_params()
-    # medium budget = 10_000 → 10_000 + 4096
-    assert params["max_tokens"] == 14096
-    assert params["thinking"]["budget_tokens"] == 10_000
+    # high budget = 25_000 → 25_000 + 4096 = 29_096 > default 16384
+    assert params["max_tokens"] == 29096
+    assert params["thinking"]["budget_tokens"] == 25_000
 
 
 def test_thinking_max_tokens_honours_raised_cap():


### PR DESCRIPTION
Stacked on #1064 (top of the limits stack). Raises user-facing defaults so the out-of-box experience is smooth; everything stays operator-adjustable (tune down if needed).

| Cap | Before | After |
|---|---|---|
| max_iterations | 60 | 300 |
| tool_timeout | 300s | 900s |
| max_output_tokens (default) | 8192 | 16384 |
| http_request read cap | 50KB | 1MB |
| default_daily_budget | $10/day | $50/day |

Single-sourced where applicable (max_iterations via LIMIT_SPECS; dashboard defaults; UI hints/placeholders; costs/credentials fallbacks aligned). max_output_tokens stays per-agent overridable (models that cap lower, e.g. Claude 3.5, tune down). Updated 4 tests that pinned old defaults. Full suite green.