### PR TITLE
fix(dashboard): mobile scroll smoothness on Chrome

### DIFF
--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -634,23 +634,38 @@
   scrollbar-color: rgba(55, 55, 75, 0.6) transparent;
 }
 
-/* ── Scroll containment ──────────────────────────────
-   The body is a non-scrolling shell (`h-[100dvh] overflow-hidden`) and ALL
-   real scrolling happens in inner containers. Without containment, when an
-   inner scroller hits its top/bottom edge the overscroll *chains* outward to
-   that locked body — on iOS this produces a dead rubber-band that reads as a
-   frozen page (the same symptom class as the keyboard-scroll bug). Stop the
-   chain at each primary scroller, and kill any document-level bounce outright.
-   Additive + gracefully ignored on browsers without `overscroll-behavior`. */
+/* ── Scroll containment + momentum ───────────────────
+   The body is a non-scrolling shell (fixed-height, `overflow-hidden`) and ALL
+   real scrolling happens in inner containers. `overscroll-behavior: none` on
+   the document kills any page-level rubber-band outright.
+
+   We contain overscroll ONLY on the large primary scrollers (main + the chat
+   logs) so a fling that bottoms out there doesn't chain to the locked body.
+   We deliberately do NOT contain the dozens of small `.custom-scrollbar` cards
+   (trace lists, code blocks, pending queues, pickers): on touch a drag usually
+   lands on one of them, and containing it would swallow the remaining gesture
+   instead of letting it chain to `main` — i.e. the page would feel "stuck".
+   Letting these chain restores natural page scrolling on mobile; the document
+   is already locked + `overscroll-behavior: none`, so nothing bounces.
+
+   Momentum (`-webkit-overflow-scrolling: touch`) is applied to every real
+   scroller so inner scrolling has inertia on WebKit / Chrome-on-iOS.
+   Additive + gracefully ignored on browsers without these properties. */
 html, body {
   overscroll-behavior: none;
 }
 
 main,
 [id^="chat-messages-"],
+[id^="side-chat-messages-"] {
+  overscroll-behavior: contain;
+}
+
+main,
+[id^="chat-messages-"],
 [id^="side-chat-messages-"],
 .custom-scrollbar {
-  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* ── Scrollbar-hidden utility for tab strips ───────── */

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1573,7 +1573,17 @@ function dashboard() {
       // The keyboard close often only settles on the visualViewport resize that
       // follows it; catch that too (guarded by the activeElement check above so
       // it no-ops mid-typing while the keyboard is animating in).
-      if (window.visualViewport) {
+      //
+      // iOS-only: this whole recovery exists for the iOS Safari/WebKit
+      // caret-reveal-scrolls-the-document bug. On Chrome for Android the
+      // document is never scrolled (body is `overflow-hidden`), so the reset
+      // is a no-op there — but `visualViewport.resize` ALSO fires on Android's
+      // URL-bar show/hide during ordinary scrolling, so attaching it there is
+      // pure churn on the scroll path. Scope the listener to iOS to keep it.
+      // (iPadOS 13+ reports as MacIntel, hence the touch-points fallback.)
+      const isIOS = /iP(hone|ad|od)/.test(navigator.userAgent) ||
+        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+      if (isIOS && window.visualViewport) {
         this._vvResetHandler = () => this._resetDocScroll();
         window.visualViewport.addEventListener('resize', this._vvResetHandler);
       }

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -57,7 +57,7 @@
   <!-- Custom CSS -->
   <link rel="stylesheet" href="/dashboard/static/css/dashboard.css?v={{ v }}">
 </head>
-<body class="bg-gray-950 text-gray-100 h-[100dvh] overflow-hidden">
+<body class="bg-gray-950 text-gray-100 h-[100svh] overflow-hidden">
   <script>
     window.__config = {
       wsUrl: (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + "{{ ws_path }}",
@@ -67,7 +67,7 @@
     };
   </script>
 
-  <div x-data="dashboard()" x-init="init()" class="flex flex-col md:flex-row h-[100dvh]">
+  <div x-data="dashboard()" x-init="init()" class="flex flex-col md:flex-row h-[100svh]">
 
     <!-- Toast notifications -->
     <div class="fixed top-16 left-1/2 -translate-x-1/2 z-[100] flex flex-col gap-2 items-center pointer-events-none max-w-sm w-full" role="status" aria-live="polite">
@@ -500,7 +500,7 @@
       </div>
 
       <!-- Operator Chat Tab -->
-      <div x-show="activeTab === 'chat'" x-cloak class="h-full flex flex-col" style="min-height: calc(100dvh - 8rem);">
+      <div x-show="activeTab === 'chat'" x-cloak class="h-full flex flex-col" style="min-height: calc(100svh - 8rem);">
           <!-- Page header — full-width contextual top nav for the chat tab.
                Avatar alt is empty (decorative): the name sits right beside
                it, and an empty alt avoids a doubled "Operator" if the image
@@ -4132,7 +4132,7 @@
                keeps the default render to 5 rows so the panel stays small
                in the common case; once expanded it stays expanded for the
                session (no re-collapse behavior). -->
-          <div class="space-y-2 max-h-[40vh] overflow-y-auto custom-scrollbar pr-0.5">
+          <div class="space-y-2 max-h-[40dvh] overflow-y-auto custom-scrollbar pr-0.5">
             <template x-for="item in (needsYouExpanded ? needsYouItems : needsYouItems.slice(0, needsYouCollapsedCap))" :key="item.id">
               <div class="bg-gray-900/50 border border-gray-700/50 rounded-lg p-2.5 sm:p-3">
                 <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
@@ -6430,7 +6430,7 @@
               </template>
             </div>
           </div>
-          <div class="space-y-1 max-h-[calc(100vh-16rem)] overflow-y-auto custom-scrollbar">
+          <div class="space-y-1 max-h-[calc(100dvh-16rem)] overflow-y-auto custom-scrollbar">
             <template x-for="t in filteredTraces" :key="t.trace_id">
               <div>
                 <div @click="toggleTraceExpand(t.trace_id)"
@@ -6538,7 +6538,7 @@
               Show technical detail
             </label>
           </div>
-          <div class="space-y-1 max-h-[calc(100vh-16rem)] overflow-y-auto custom-scrollbar"
+          <div class="space-y-1 max-h-[calc(100dvh-16rem)] overflow-y-auto custom-scrollbar"
                data-testid="system-activity-feed">
             <!-- Tech-detail mode: raw event stream (one row per event). -->
             <template x-if="showTechDetail">
@@ -6638,7 +6638,7 @@
             <button @click="fetchSystemLogs()" class="text-xs text-gray-400 hover:text-white transition-colors">Refresh</button>
           </div>
           <div class="bg-gray-900/70 border border-gray-800/60 rounded-md overflow-hidden">
-            <div class="max-h-[calc(100vh-16rem)] overflow-y-auto custom-scrollbar p-3 font-mono text-xs">
+            <div class="max-h-[calc(100dvh-16rem)] overflow-y-auto custom-scrollbar p-3 font-mono text-xs">
               <p x-show="systemLogs.length === 0 && !systemLogsLoading" class="text-gray-500 text-center py-8">No logs available. <button @click="fetchSystemLogs()" class="text-indigo-400 hover:underline">Refresh</button></p>
               <div x-show="systemLogsLoading" class="text-center py-8">
                 <div class="inline-flex items-center gap-2 text-gray-400">


### PR DESCRIPTION
## Problem

Follow-up to #1030. On mobile Chrome, scrolling across the dashboard feels stuck/janky rather than smooth. The locked-shell scroll model (`body: h-[100dvh] overflow-hidden`, `main.overflow-auto` as the per-tab scroller) is structurally sound — the friction comes from a few unit/scope choices.

## Changes (surgical, desktop-safe)

1. **Unscope `overscroll-behavior: contain`** (`dashboard.css`) — it was applied to all **41** `.custom-scrollbar` cards. On touch, a drag usually lands on one of these small boxes, and `contain` swallows the gesture at the card's edge instead of chaining to `main` → the page reads as "stuck". Now scoped to the large primary scrollers only (`main` + the two chat logs). The document is already `overscroll-behavior: none` + `overflow-hidden`, so nothing bounces.

2. **Add momentum** (`dashboard.css`) — `-webkit-overflow-scrolling: touch` on the real scrollers (was only on `.hide-scrollbar`), restoring inertial scroll on WebKit / Chrome-on-iOS.

3. **`dvh` → `svh` on the locked shell** (`index.html`: `<body>`, root flex, chat-tab `min-height`). `dvh` is dynamic — it reflows the whole layout as the URL bar moves and can resolve taller than the visible area, clipping the bottom of a body that can't scroll. `svh` (stable smallest-viewport) always fits. **Desktop unaffected** (svh ≡ vh with no dynamic browser UI). The fixed messenger panel intentionally keeps `dvh` (correct for a viewport-anchored overlay).

4. **Nested caps `vh` → `dvh`** (`index.html`) — `max-h-[calc(100vh-16rem)]` (Settings traces/telemetry/audit) and `max-h-[40vh]` (Work "Needs you") ignored the mobile URL bar and overshot the visible area.

5. **Gate the `visualViewport` listener to iOS** (`app.js`) — that keyboard-recovery handler exists for an iOS Safari bug but ran on all mobile. On Chrome Android the document is never scrolled (`overflow-hidden`), so the reset is a no-op there, yet `visualViewport.resize` fires on URL-bar movement during ordinary scrolling. Now iOS-only (`focusout` reset kept for all — a no-op on Android; teardown already guards `_vvResetHandler`).

## Out of scope (flagged, not touched)

`backdrop-filter` on the sticky "Needs you" panel (compositing jank), browser-preview `<iframe>` touch-capture, and Tailwind-via-CDN — each is a behavior/design or build-system change needing its own review.

## Verification

- `704 passed, 4 skipped` across `test_templates`, `test_dashboard_ui`, `test_dashboard`, `test_dashboard_cookie_import`.
- `node --check app.js` clean; CSS braces balanced; no test asserts on any changed string.
- Desktop layout unchanged (svh==vh there).