### PR TITLE
fix(orchestration): persist worker result_summary on the task row so await surfaces the deliverable

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1232,7 +1232,15 @@ async def await_task_event(
                             "task_id": task_id,
                             "status": status,
                             "title": record.get("title"),
-                            "summary": "",
+                            # ``result_summary`` is raw worker output crossing
+                            # into the operator's LLM context — sanitize at this
+                            # boundary (mirrors check_inbox's handling of
+                            # back-edge summaries). ``title`` is already
+                            # sanitized at hand_off-creation and ``blocker_note``
+                            # is redacted on write, so only this field is raw.
+                            "summary": sanitize_for_prompt(
+                                record.get("result_summary") or ""
+                            ),
                             "error": blocker,
                             "blocker_note": blocker,
                             "outcome": record.get("outcome"),

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2827,6 +2827,18 @@ class AgentLoop:
                                             "{\"status\": \"noop\", \"reason\": "
                                             "\"...\"}})."
                                         ),
+                                        result_payload=(
+                                            # Capture the worker's answer as the
+                                            # deliverable — but NOT a synthetic
+                                            # ``silent_reply`` marker (mirrors the
+                                            # carve-out above), which is an
+                                            # internal empty-turn placeholder, not
+                                            # a real result.
+                                            {"summary": response_text[:500]}
+                                            if response_text.strip()
+                                            and not result.get("silent_reply")
+                                            else None
+                                        ),
                                     )
                             else:
                                 summary = response_text[:500]

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -381,6 +381,7 @@ class Tasks:
                 ("outcome", "TEXT"),
                 ("feedback_text", "TEXT"),
                 ("previous_task_id", "TEXT"),
+                ("result_summary", "TEXT"),
             )
             for col_name, col_type in outcome_columns:
                 if col_name not in existing:
@@ -479,6 +480,7 @@ class Tasks:
             "feedback_text": row[20],
             "previous_task_id": row[21],
             "outcome_set_at": row[22],
+            "result_summary": row[23],
         }
 
     # ``{team_col}`` is filled in at query time from ``self._team_col``
@@ -490,7 +492,8 @@ class Tasks:
         "assignee, status, priority, dependencies_json, artifact_refs_json, "
         "blocker_note, origin_kind, origin_channel, origin_user, "
         "created_at, updated_at, completed_at, retention_until, "
-        "outcome, feedback_text, previous_task_id, outcome_set_at"
+        "outcome, feedback_text, previous_task_id, outcome_set_at, "
+        "result_summary"
     )
 
     @property
@@ -1201,6 +1204,7 @@ class Tasks:
         actor: str,
         blocker_note: str | None = None,
         extra_payload: dict | None = None,
+        result_summary: str | None = None,
     ) -> dict:
         """Atomically transition a task to a new status.
 
@@ -1250,6 +1254,18 @@ class Tasks:
                 if current == status:
                     # No-op transition. Record the event so the audit
                     # trail still shows the call, but skip the row update.
+                    # Exception: a same-status re-transition may still carry
+                    # a worker ``result_summary`` (e.g. the loop's post-turn
+                    # auto-close fires ``done`` after the worker already
+                    # self-closed ``done`` via complete_task) — persist it so
+                    # the deliverable isn't lost to the no-op path.
+                    if result_summary is not None:
+                        conn.execute(
+                            "UPDATE tasks SET "
+                            "result_summary=COALESCE(?, result_summary) "
+                            "WHERE id=?",
+                            (result_summary, task_id),
+                        )
                     self._emit_event(
                         conn, task_id, "status_unchanged", actor,
                         {"status": status},
@@ -1272,7 +1288,8 @@ class Tasks:
                     "UPDATE tasks SET status=?, updated_at=?, "
                     "completed_at=COALESCE(?, completed_at), "
                     "retention_until=COALESCE(?, retention_until), "
-                    "blocker_note=? WHERE id=?",
+                    "blocker_note=?, "
+                    "result_summary=COALESCE(?, result_summary) WHERE id=?",
                     (
                         status, now, completed_at, retention_until,
                         # ``blocker_note`` is the canonical non-success
@@ -1283,6 +1300,10 @@ class Tasks:
                         # cancellation isn't an error, the user has the
                         # context. ``done`` clears whatever was there.
                         blocker_note if status in ("blocked", "failed") else None,
+                        # ``result_summary`` is the worker's deliverable.
+                        # COALESCE preserves a previously-captured summary
+                        # when a later (non-summary) transition lands.
+                        result_summary,
                         task_id,
                     ),
                 )

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5780,6 +5780,17 @@ def create_mesh_app(
             _err = body.get("error")
             if isinstance(_err, str) and _err.strip():
                 blocker_note = _err.strip()
+        # Persist the worker's result summary on the task row so it
+        # surfaces via await_task_event / GET (today it only reaches the
+        # back-edge inbox event, which doesn't fire for human/cron-
+        # originated handoffs). Length-bounded; matches the existing
+        # (unredacted) back-edge summary handling.
+        _raw_result = body.get("result")
+        _result_summary = None
+        if isinstance(_raw_result, dict):
+            _s = _raw_result.get("summary")
+            if isinstance(_s, str) and _s.strip():
+                _result_summary = _s.strip()[:1000]
         if status not in VALID_STATUSES:
             raise HTTPException(
                 400,
@@ -5800,6 +5811,7 @@ def create_mesh_app(
         try:
             updated = store.update_status(
                 task_id, status, actor=caller, blocker_note=blocker_note,
+                result_summary=_result_summary,
             )
         except InvalidStatusTransition as e:
             raise HTTPException(400, str(e))

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1339,6 +1339,7 @@ class TestAwaitTaskEventTool:
             "title": "stage 1",
             "blocker_note": None,
             "outcome": "accepted",
+            "result_summary": "ok",
             "completed_at": 1000,
             "updated_at": 1000,
         })
@@ -1349,6 +1350,54 @@ class TestAwaitTaskEventTool:
         assert result["event"]["kind"] == "task_completed"
         assert result["event"]["task_id"] == "task_abc"
         assert result["event"]["status"] == "done"
+        assert result["event"]["summary"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_returns_result_summary(self):
+        """The worker's deliverable (persisted on the task row as
+        ``result_summary``) surfaces in the event envelope's ``summary``
+        field — previously hollow (``""``)."""
+        from src.agent.builtins.operator_tools import await_task_event
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.get_task = AsyncMock(return_value={
+            "status": "done",
+            "title": "t",
+            "result_summary": "the deliverable",
+            "completed_at": 1,
+        })
+        result = await await_task_event(
+            "task_abc", timeout_s=60, poll_interval_s=1, mesh_client=mc,
+        )
+        assert result["event"]["summary"] == "the deliverable"
+
+    @pytest.mark.asyncio
+    async def test_result_summary_is_sanitized(self):
+        """The worker's ``result_summary`` is untrusted text and must pass
+        through ``sanitize_for_prompt`` before landing in the event envelope —
+        otherwise injected invisible/line-separator chars reach the LLM."""
+        from src.agent.builtins.operator_tools import await_task_event
+        from src.shared.utils import sanitize_for_prompt
+
+        # U+2028 (LINE SEPARATOR) is rewritten to "\n" by sanitize_for_prompt,
+        # so the sanitized form differs from the raw input.
+        raw = "deliver\u2028able"
+        assert sanitize_for_prompt(raw) != raw
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.get_task = AsyncMock(return_value={
+            "status": "done",
+            "title": "t",
+            "result_summary": raw,
+            "completed_at": 1,
+        })
+        result = await await_task_event(
+            "task_abc", timeout_s=60, poll_interval_s=1, mesh_client=mc,
+        )
+        assert result["event"]["summary"] == sanitize_for_prompt(raw)
+        assert result["event"]["summary"] != raw
 
     @pytest.mark.asyncio
     async def test_returns_timed_out_when_non_terminal(self, monkeypatch):

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -336,6 +336,24 @@ def test_terminal_transition_sets_completed_and_retention(tmp_path):
     )
 
 
+def test_same_status_noop_persists_result_summary(tmp_path):
+    """A same-status ``done``→``done`` no-op transition must still persist a
+    ``result_summary`` carried on the re-transition (e.g. the loop's post-turn
+    auto-close fires ``done`` after the worker already self-closed via
+    complete_task) — otherwise the deliverable is lost to the no-op branch."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="c", assignee="a", title="t")
+    t.update_status(rec["id"], "working", actor="a")
+    # First reach terminal ``done`` with no summary.
+    t.update_status(rec["id"], "done", actor="a")
+    assert t.get(rec["id"])["result_summary"] is None
+    # Same-status re-transition carrying a summary — the no-op branch.
+    t.update_status(
+        rec["id"], "done", actor="a", result_summary="captured-on-noop",
+    )
+    assert t.get(rec["id"])["result_summary"] == "captured-on-noop"
+
+
 def test_blocker_note_clears_on_non_persisting_transition(tmp_path):
     """Transitions OUT of (blocked|failed) — i.e. to working/done/cancelled
     — clear the column. Both ``blocked`` (recoverable) and ``failed``
@@ -397,6 +415,35 @@ def test_update_status_cancelled_does_not_carry_blocker_note(tmp_path):
         blocker_note="should not stick",
     )
     assert result["blocker_note"] is None
+
+
+def test_update_status_persists_result_summary(tmp_path):
+    """The worker's deliverable rides ``result_summary`` onto the task row
+    so it surfaces via await_task_event / GET (not just the origin-gated
+    back-edge inbox event)."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="c", assignee="a", title="t")
+    t.update_status(rec["id"], "working", actor="a")
+    result = t.update_status(
+        rec["id"], "done", actor="a", result_summary="hello",
+    )
+    assert result["result_summary"] == "hello"
+    assert t.get(rec["id"])["result_summary"] == "hello"
+
+
+def test_update_status_result_summary_coalesce_non_clobber(tmp_path):
+    """COALESCE: a later transition WITHOUT ``result_summary`` preserves
+    the previously-captured summary rather than wiping it to NULL."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="c", assignee="a", title="t")
+    t.update_status(
+        rec["id"], "working", actor="a", result_summary="captured",
+    )
+    assert t.get(rec["id"])["result_summary"] == "captured"
+    # Subsequent transition carries no summary — stored value is unchanged.
+    result = t.update_status(rec["id"], "done", actor="a")
+    assert result["result_summary"] == "captured"
+    assert t.get(rec["id"])["result_summary"] == "captured"
 
 
 def test_repeat_status_is_recorded_as_event_but_no_op(tmp_path):

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -534,6 +534,41 @@ async def test_failed_status_promotes_error_to_blocker_note(v2_app):
 
 
 @pytest.mark.asyncio
+async def test_done_status_persists_result_summary(v2_app):
+    """``POST /mesh/tasks/{id}/status`` with a ``result.summary`` body
+    persists the worker's deliverable onto the task row (via
+    ``result_summary``) so ``await_task_event`` / GET surface it — not
+    only the origin-gated back-edge inbox event."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "summary check"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        tid = r.json()["id"]
+        await c.post(
+            f"/mesh/tasks/{tid}/status",
+            json={"status": "working"},
+            headers={"X-Agent-ID": "analyst"},
+        )
+        r = await c.post(
+            f"/mesh/tasks/{tid}/status",
+            json={"status": "done", "result": {"summary": "done-summary"}},
+            headers={"X-Agent-ID": "analyst"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["result_summary"] == "done-summary"
+        # GET reflects the persisted value too.
+        r = await c.get(
+            f"/mesh/tasks/{tid}",
+            headers={"X-Agent-ID": "analyst"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["result_summary"] == "done-summary"
+
+
+@pytest.mark.asyncio
 async def test_failed_status_explicit_blocker_note_wins_over_error(v2_app):
     """Explicit ``blocker_note`` in the body wins over ``error`` — the
     promotion only fires when blocker_note is missing/empty."""


### PR DESCRIPTION
## Problem

After #1068, the operator's `await_task_event` returns the task **status** but not the worker's **deliverable**. When the operator delegates a task and awaits it, it only learns *done/failed* — not *what the worker produced* — so it has to dig through the worker's transcript to report anything useful (observed live: a content-seo delegation where trend-scout answered correctly but the operator had to reconstruct the answer from logs).

Root cause: the worker's result summary **is** produced and sent to `POST /mesh/tasks/{id}/status`, but `server.py` diverts it **only into the back-edge inbox event** — which doesn't fire for human/cron-originated operator handoffs — so it never reaches the task row that `await_task_event` (via `get_task`) reads.

## Fix (capture + surface; guard untouched)

Persist the worker's result summary on the task row:
- **`orchestration.py`** — new idempotent `result_summary TEXT` column (migration tuple + `_SELECT_COLS` + `_row_to_dict`); `update_status` gains a keyword-only `result_summary` param written via `result_summary=COALESCE(?, result_summary)` so a later non-summary transition can't clobber a captured summary. The same-status no-op branch also persists it (covers the worker-self-closes-then-loop-re-closes path).
- **`server.py`** — the status endpoint extracts `body["result"]["summary"]` (length-bounded) before `update_status` and threads it through. Back-edge block untouched.
- **`loop.py`** — the chat `no_outbound_effects` failed-close now forwards the worker's answer as `result_payload` (previously discarded). **The guard's done/failed/deferred verdict logic is intentionally unchanged** — we surface the deliverable so the operator reports accurately, rather than weakening ghost-completion protection.
- **`operator_tools.py`** — `await_task_event` surfaces `result_summary` in the (previously hollow) `summary` field, **sanitized via `sanitize_for_prompt`** since it's raw worker output crossing into the operator's LLM context (mirrors `check_inbox`'s handling).

Result: the operator's `await` returns **status + blocker_note + the worker's actual deliverable** — accurate "what happened" reports with no transcript-digging.

## Review

Independent Codex pass found two issues, both fixed + regression-tested:
1. Raw worker `result_summary` reaching the operator LLM unsanitized → now `sanitize_for_prompt`'d at the await boundary.
2. Same-status `update_status` no-op skipped the summary write → now persists it in the no-op branch.

Additive throughout: optional keyword-only param, additive column (existing rows → NULL), additive dict key, no `SELECT *` positional mappings affected.

## Tests
New: orchestration persistence + COALESCE non-clobber + same-status persistence; endpoint POST `/status` → row persistence; await returns + sanitizes summary. Local: await 11 passed, orchestration 208 passed, ruff clean.

## Deploy note
Touches agent-side (`loop.py`, `operator_tools.py`) + host-side code — fleet rollout needs an agent-image rebuild + restart, not just `git pull`.