### PR TITLE
feat(dashboard): close live-update gaps + fix Team Hub responsiveness

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -782,6 +782,21 @@ def create_dashboard_router(
         except Exception as e:
             logger.debug("%s emit failed: %s", team_event, e)
 
+    def _emit_config_changed(scope: str, **extra: Any) -> None:
+        """Emit a generic ``config_changed`` event for a System-tab panel.
+
+        One discriminated event covers every settings/integrations/storage
+        mutation: ``data.scope`` tells the SPA which panel to re-fetch (e.g.
+        ``browser_settings`` / ``channels`` / ``webhooks`` / ``integrations``).
+        Best-effort — never raises into the request handler.
+        """
+        if event_bus is None:
+            return
+        try:
+            event_bus.emit("config_changed", data={"scope": scope, **extra})
+        except Exception as e:
+            logger.debug("config_changed emit failed (scope=%s): %s", scope, e)
+
     async def _csrf_check(request: Request) -> None:
         """Require X-Requested-With header on state-changing requests.
 
@@ -2219,6 +2234,7 @@ def create_dashboard_router(
         perms["fleet_skills"] = skills
         _save_permissions(perms)
         permissions.reload()
+        _emit_config_changed("skills")
         return {"fleet_skills": skills}
 
     @api_router.post("/api/skills/install")
@@ -2240,6 +2256,7 @@ def create_dashboard_router(
         )
         if "error" in result:
             raise HTTPException(400, result["error"])
+        _emit_config_changed("skills")
         return result
 
     @api_router.post("/api/skills/remove")
@@ -2259,6 +2276,7 @@ def create_dashboard_router(
         if "error" in result:
             status = 404 if "not found" in result["error"].lower() else 400
             raise HTTPException(status, result["error"])
+        _emit_config_changed("skills")
         return result
 
     @api_router.post("/api/agents")
@@ -3325,6 +3343,8 @@ def create_dashboard_router(
                 os.environ["OPENLEGION_SYSTEM_PROXY"] = full_url
                 updated.append("system_proxy")
 
+        if updated:
+            _emit_config_changed("network_proxy")
         return {"updated": updated, "restart_required": bool(updated)}
 
     @api_router.put("/api/agents/{agent_id}/proxy")
@@ -3378,6 +3398,7 @@ def create_dashboard_router(
         # browser resets pick up the change without a full agent restart.
         await _push_browser_proxy_for_agent(agent_id)
 
+        _emit_config_changed("network_proxy", agent=agent_id)
         return {"updated": ["proxy"], "restart_required": True}
 
     @api_router.get("/api/agents/{agent_id}/permissions")
@@ -4504,6 +4525,7 @@ def create_dashboard_router(
             raise HTTPException(400, "client_id and client_secret are required")
         credential_vault.add_credential(p.client_id_key, client_id, system=True)
         credential_vault.add_credential(p.client_secret_key, client_secret, system=True)
+        _emit_config_changed("integrations", provider=provider)
         return {
             "configured": True,
             "provider": provider,
@@ -4595,6 +4617,7 @@ def create_dashboard_router(
         logger.info(
             "Integration connected: %s (%s)", pending.connection_name, provider,
         )
+        _emit_config_changed("integrations", name=pending.connection_name, provider=provider)
         return _back(f"integration_connected={pending.connection_name}")
 
     @api_router.post("/api/integrations/{name}/disconnect")
@@ -4606,6 +4629,7 @@ def create_dashboard_router(
         existed = credential_vault.remove_credential(name)
         if not existed:
             raise HTTPException(404, f"Connection '{name}' not found")
+        _emit_config_changed("integrations", name=name)
         return {"removed": True, "name": name}
 
     # ── External API key management ─────────────────────────
@@ -4636,6 +4660,7 @@ def create_dashboard_router(
             key_id, raw_key = api_key_manager.create_key(name)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        _emit_config_changed("api_keys", id=key_id)
         return {"id": key_id, "name": name, "key": raw_key}
 
     @api_router.delete("/api/external-api-keys/{key_id}")
@@ -4646,6 +4671,7 @@ def create_dashboard_router(
             raise HTTPException(status_code=503, detail="API key manager not available")
         if not api_key_manager.revoke_key(key_id):
             raise HTTPException(status_code=404, detail=f"API key not found: {key_id}")
+        _emit_config_changed("api_keys", id=key_id)
         return {"revoked": True, "id": key_id}
 
     # ── Dashboard telemetry (Phase -1 onboarding wizard) ────────
@@ -4748,6 +4774,7 @@ def create_dashboard_router(
         except Exception as e:
             logger.warning("WalletService init failed: %s", e)
 
+        _emit_config_changed("wallet")
         from starlette.responses import JSONResponse
         return JSONResponse(
             content={"initialized": True, "seed": words, "sample_addresses": addresses},
@@ -4853,6 +4880,7 @@ def create_dashboard_router(
         perms_data.setdefault("permissions", {})[agent_id] = agent_perms
         _save_permissions(perms_data)
         permissions.reload()
+        _emit_config_changed("wallet", agent=agent_id)
         return {"enabled": True, "agent_id": agent_id}
 
     @api_router.get("/api/wallet/rpc")
@@ -4912,6 +4940,7 @@ def create_dashboard_router(
             _ws_local._evm_providers.pop(chain_id, None)
             _ws_local._solana_clients.pop(chain_id, None)
 
+        _emit_config_changed("wallet", chain_id=chain_id)
         return {"updated": True, "chain_id": chain_id}
 
     # ── Cost detail per agent ────────────────────────────────
@@ -6100,6 +6129,7 @@ def create_dashboard_router(
                 logger.debug("Failed to push browser settings: %s", e)
 
         settings = _load_settings()
+        _emit_config_changed("browser_settings")
         return {
             "speed": settings.get("browser_speed", 1.0),
             "delay": settings.get("browser_delay", 0.0),
@@ -6140,6 +6170,7 @@ def create_dashboard_router(
 
         settings = _load_settings()
         stored_key = settings.get("captcha_solver_key", "")
+        _emit_config_changed("captcha_solver")
         return {
             "provider": settings.get("captcha_solver_provider", ""),
             "key_masked": f"...{stored_key[-4:]}" if len(stored_key) >= 4 else "",
@@ -6154,6 +6185,7 @@ def create_dashboard_router(
             settings.pop("captcha_solver_provider", None)
             settings.pop("captcha_solver_key", None)
             _save_settings(settings)
+        _emit_config_changed("captcha_solver")
         return {"removed": True}
 
     # ── System settings (consolidated) ────────────────────────
@@ -6300,6 +6332,8 @@ def create_dashboard_router(
                     setattr(health_monitor, attr, settings[cfg_key])
 
         restart_required = bool(set(updated) & _RESTART_REQUIRED_SETTINGS)
+        if updated:
+            _emit_config_changed("system_settings")
         return {"updated": updated, "restart_required": restart_required}
 
     @api_router.post("/api/default-model")
@@ -6323,6 +6357,7 @@ def create_dashboard_router(
         with open(config_path, "w") as f:
             yaml.dump(mesh_cfg, f, default_flow_style=False, sort_keys=False)
 
+        _emit_config_changed("system_settings")
         return {"model": model}
 
     @api_router.post("/api/embedding-model")
@@ -6382,6 +6417,7 @@ def create_dashboard_router(
         with open(config_path, "w") as f:
             yaml.dump(mesh_cfg, f, default_flow_style=False, sort_keys=False)
 
+        _emit_config_changed("system_settings")
         return {"value": value, "embedding_model": stored}
 
     # ── Restart agents ────────────────────────────────────────
@@ -6831,7 +6867,9 @@ def create_dashboard_router(
 
             return {"purged": True, "deleted_records": total_deleted}
 
-        return await asyncio.get_running_loop().run_in_executor(None, _do_purge)
+        result = await asyncio.get_running_loop().run_in_executor(None, _do_purge)
+        _emit_config_changed("storage", db_id=db_id)
+        return result
 
     # ── Messages log ─────────────────────────────────────────
 
@@ -6879,6 +6917,7 @@ def create_dashboard_router(
         # secret once so the user can copy it at creation time.
         result = dict(hook)
         result["url"] = f"{base}/webhook/hook/{hook['id']}"
+        _emit_config_changed("webhooks", hook_id=hook["id"])
         return {"created": True, "hook": result}
 
     @api_router.delete("/api/webhooks/{hook_id}")
@@ -6888,6 +6927,7 @@ def create_dashboard_router(
         removed = webhook_manager.remove_hook(hook_id)
         if not removed:
             raise HTTPException(status_code=404, detail=f"Webhook '{hook_id}' not found")
+        _emit_config_changed("webhooks", hook_id=hook_id)
         return {"removed": True, "id": hook_id}
 
     @api_router.patch("/api/webhooks/{hook_id}")
@@ -6913,6 +6953,7 @@ def create_dashboard_router(
             raise HTTPException(status_code=404, detail=f"Webhook '{hook_id}' not found")
         base = str(request.base_url).rstrip("/")
         updated["url"] = f"{base}/webhook/hook/{updated['id']}"
+        _emit_config_changed("webhooks", hook_id=hook_id)
         return {"updated": True, "hook": updated}
 
     @api_router.post("/api/webhooks/{hook_id}/test")
@@ -6972,6 +7013,7 @@ def create_dashboard_router(
             if routers:
                 for ch_router in routers:
                     request.app.include_router(ch_router)
+            _emit_config_changed("channels", channel=channel_type)
             return {"connected": True, "type": channel_type}
         except ValueError as e:
             _rollback_credentials()
@@ -6996,6 +7038,7 @@ def create_dashboard_router(
             for _token_key, env_name in _CHANNEL_TOKEN_KEYS[channel_type]:
                 with contextlib.suppress(Exception):
                     credential_vault.remove_credential(env_name)
+        _emit_config_changed("channels", channel=channel_type)
         return {"disconnected": True, "type": channel_type}
 
     # ── Agent Workspace (proxy to agent) ─────────────────────
@@ -7257,6 +7300,7 @@ def create_dashboard_router(
         if len(body) > _MAX_UPLOAD_BYTES:
             raise HTTPException(413, f"File too large (max {_MAX_UPLOAD_BYTES // (1024 * 1024)} MB)")
         dest.write_bytes(body)
+        _emit_config_changed("uploads", name=name)
         return {"uploaded": True, "name": name, "size": len(body)}
 
     @api_router.get("/api/uploads/{name:path}/download")
@@ -7288,6 +7332,7 @@ def create_dashboard_router(
         while parent != root and not any(parent.iterdir()):
             parent.rmdir()
             parent = parent.parent
+        _emit_config_changed("uploads", name=name)
         return {"deleted": True, "name": name}
 
     # ── Task 9 — Workplace tab + pending-action review ──────────────

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1560,8 +1560,10 @@ select:focus-visible,
 
 /* When chat panel is open on medium screens, hide desktop tab pills
    and show the mobile scrolling tab strip instead — available content
-   is too narrow for six inline pill buttons. */
-@media (min-width: 768px) and (max-width: 1599px) {
+   is too narrow for six inline pill buttons. Desktop pills only render at
+   ≥1024px (lg:flex); below that the mobile strip is already shown, so this
+   override is only meaningful in the 1024–1599px side-chat-open band. */
+@media (min-width: 1024px) and (max-width: 1599px) {
   main.chat-side-open .project-hub-desktop-tabs {
     display: none !important;
   }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -276,7 +276,7 @@ function dashboard() {
     // load on the dashboard process modest when the panel is left open.
     platformSuccessData: { platforms: [], since: null },
     platformSuccessLoading: false,
-    _platformSuccessTimer: null,
+    _platformSuccessDebounce: null,
 
     // System settings
     systemSettings: null,
@@ -745,7 +745,7 @@ function dashboard() {
     _ws: null,
     _refreshInterval: null,
     _fleetDebounce: null,
-    _queuePollInterval: null,
+    _queueRefreshDebounce: null,
     _cronDebounce: null,
     _seenEventIds: new Set(),
 
@@ -1298,6 +1298,9 @@ function dashboard() {
               if (this._chatAborts && this._chatAborts[agentId]) continue;
               this._loadChatHistory(agentId);
             }
+            // Queue state is WS-driven (no poll) — re-seed it on reconnect so
+            // any transitions missed during the outage are reflected.
+            this.fetchQueues();
           }
         },
         onDisconnect: () => { this.connected = false; },
@@ -1314,7 +1317,8 @@ function dashboard() {
       this.fetchQueues();
       this._refreshInterval = setInterval(() => this.fetchAgents(), 15000);
       this._modelHealthInterval = setInterval(() => this.fetchModelHealth(), 60000);
-      this._queuePollInterval = setInterval(() => this.fetchQueues(), 2000);
+      // Queue depth/busy is now pushed live via the ``queue_changed`` WS event
+      // (see onWsEvent); the one-shot fetchQueues() above seeds initial state.
 
       // Renew session cookie every 6 hours (sliding window).
       // The auth gate issues 24h cookies; renew when <12h remaining.
@@ -1592,7 +1596,6 @@ function dashboard() {
       document.addEventListener('visibilitychange', () => {
         if (document.hidden) {
           if (this._refreshInterval) { clearInterval(this._refreshInterval); this._refreshInterval = null; }
-          if (this._queuePollInterval) { clearInterval(this._queuePollInterval); this._queuePollInterval = null; }
           if (this._cronDebounce) { clearTimeout(this._cronDebounce); this._cronDebounce = null; }
           if (this._modelHealthInterval) { clearInterval(this._modelHealthInterval); this._modelHealthInterval = null; }
           this._stopActivityRefresh();
@@ -1621,8 +1624,8 @@ function dashboard() {
           // Resume model health + queue polling
           this.fetchModelHealth();
           this._modelHealthInterval = setInterval(() => this.fetchModelHealth(), 60000);
+          // Re-seed queue state on tab-return; live updates flow via WS.
           this.fetchQueues();
-          this._queuePollInterval = setInterval(() => this.fetchQueues(), 2000);
           // Refresh agent detail if we're viewing one
           if (this.detailAgent) {
             this.fetchAgentDetail(this.detailAgent);
@@ -1722,7 +1725,7 @@ function dashboard() {
     destroy() {
       if (this._ws) this._ws.disconnect();
       if (this._refreshInterval) clearInterval(this._refreshInterval);
-      if (this._queuePollInterval) clearInterval(this._queuePollInterval);
+      if (this._queueRefreshDebounce) clearTimeout(this._queueRefreshDebounce);
       if (this._cronDebounce) clearTimeout(this._cronDebounce);
       if (this._modelHealthInterval) clearInterval(this._modelHealthInterval);
       if (this._cookieRenewalInterval) clearInterval(this._cookieRenewalInterval);
@@ -2472,7 +2475,7 @@ function dashboard() {
           this.fetchBrowserSettings();
           this.fetchSystemSettings();
           this.fetchCaptchaSolver();
-          this.startPlatformSuccessRefresh();
+          this.fetchPlatformSuccess();
         }
         if (this.systemTab === 'activity') {
           if (this.activityView === 'traces') {
@@ -2496,8 +2499,7 @@ function dashboard() {
       if (tabId === 'skills') { this.loadSkillsCatalog(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
-      if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); this.startPlatformSuccessRefresh(); }
-      if (tabId !== 'browser') { this.stopPlatformSuccessRefresh(); }
+      if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); this.fetchPlatformSuccess(); }
       if (tabId === 'operator') {
         this.fetchAuditLog();
       }
@@ -4519,6 +4521,47 @@ function dashboard() {
           if (this._teamsRefreshDebounce) clearTimeout(this._teamsRefreshDebounce);
           this._teamsRefreshDebounce = setTimeout(() => this.fetchTeams(), 250);
         }
+        // Brief (TEAM.md) edited elsewhere — live-reload the content for the
+        // active team unless the user is mid-edit (don't clobber their buffer).
+        const d = evt.data || {};
+        const changedTeam = d.team_name || d.name || d.team_id || d.project_id;
+        if (d.field === 'project_md' && changedTeam === this.activeTeam &&
+            !this.teamEditing && typeof this.fetchTeamContent === 'function') {
+          this.fetchTeamContent();
+        }
+      }
+
+      // Lane queue depth/busy changed — debounced refetch of /api/queues
+      // (replaces the old 2s poll). The endpoint merges with the agent
+      // registry so idle agents keep their zero rows; chat-recovery reads
+      // the same ``queueStatus`` this keeps fresh.
+      if (evt.type === 'queue_changed') {
+        if (this._queueRefreshDebounce) clearTimeout(this._queueRefreshDebounce);
+        this._queueRefreshDebounce = setTimeout(() => this.fetchQueues(), 300);
+      }
+
+      // System-tab settings/integrations/storage changed elsewhere — re-fetch
+      // just the affected panel, and only while the System tab is on screen
+      // (off-screen panels re-sync on their next open). ``data.scope`` maps to
+      // the panel's existing loader(s); unknown scopes are ignored.
+      if (evt.type === 'config_changed' && this.activeTab === 'system') {
+        const _configLoaders = {
+          browser_settings: ['fetchBrowserSettings'],
+          system_settings: ['fetchSystemSettings'],
+          captcha_solver: ['fetchCaptchaSolver'],
+          channels: ['fetchChannels'],
+          webhooks: ['fetchWebhooks'],
+          api_keys: ['fetchApiKeys'],
+          integrations: ['loadIntegrations'],
+          network_proxy: ['loadNetworkProxy'],
+          storage: ['fetchStorage', 'fetchDatabaseDetails'],
+          uploads: ['fetchUploads'],
+          skills: ['loadSkillsCatalog'],
+          wallet: ['fetchWallet', 'fetchWalletRpc'],
+        };
+        for (const fn of (_configLoaders[evt.data?.scope] || [])) {
+          if (typeof this[fn] === 'function') this[fn]();
+        }
       }
 
       // Credential stored — flip the matching credential_request
@@ -4610,6 +4653,17 @@ function dashboard() {
         // the detail panel can render trend sparklines without an extra
         // fetch round-trip per tick.
         this._appendBrowserMetricsHistory(evt.agent, evt.data);
+        // Platform-success rollup is driven off this same event (replaces the
+        // old 30s poll). The server-side aggregate is updated synchronously by
+        // this emit, so a refetch here is fresh. Only the captcha/fingerprint/
+        // pre-nav sub-types change the rollup, and only refetch when the panel
+        // is on screen.
+        const _psKinds = ['captcha_gate', 'fingerprint_event', 'fingerprint_burn', 'platform_pre_nav_delay'];
+        if (_psKinds.includes(evt.data.type) &&
+            this.activeTab === 'system' && this.systemTab === 'browser') {
+          if (this._platformSuccessDebounce) clearTimeout(this._platformSuccessDebounce);
+          this._platformSuccessDebounce = setTimeout(() => this.fetchPlatformSuccess(), 500);
+        }
       }
 
       // §6.3 navigator self-test result (one-shot per browser start).
@@ -7554,25 +7608,6 @@ function dashboard() {
         }
       } catch (e) { console.warn('fetchPlatformSuccess failed:', e); }
       this.platformSuccessLoading = false;
-    },
-
-    startPlatformSuccessRefresh() {
-      // Idempotent — calling twice will not stack timers.  30s polling
-      // matches the panel's "operator-glance" use case; the live
-      // EventBus already streams the underlying signals to the
-      // browser metrics + fingerprint cards on faster cadences.
-      if (this._platformSuccessTimer) return;
-      this.fetchPlatformSuccess();
-      this._platformSuccessTimer = setInterval(() => {
-        this.fetchPlatformSuccess();
-      }, 30000);
-    },
-
-    stopPlatformSuccessRefresh() {
-      if (this._platformSuccessTimer) {
-        clearInterval(this._platformSuccessTimer);
-        this._platformSuccessTimer = null;
-      }
     },
 
     platformSuccessBarClass(rate) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1732,6 +1732,7 @@ function dashboard() {
       if (this._ws) this._ws.disconnect();
       if (this._refreshInterval) clearInterval(this._refreshInterval);
       if (this._queueRefreshDebounce) clearTimeout(this._queueRefreshDebounce);
+      if (this._platformSuccessDebounce) clearTimeout(this._platformSuccessDebounce);
       if (this._cronDebounce) clearTimeout(this._cronDebounce);
       if (this._modelHealthInterval) clearInterval(this._modelHealthInterval);
       if (this._cookieRenewalInterval) clearInterval(this._cookieRenewalInterval);
@@ -4273,9 +4274,16 @@ function dashboard() {
         }
       }
 
-      // Append to event feed (newest first, cap at 500)
-      this.events.unshift(evt);
-      if (this.events.length > 500) this.events.splice(500);
+      // Append to event feed (newest first, cap at 500). queue_changed is a
+      // high-frequency, contentless refetch trigger (≈3 per task) with no
+      // human-readable rendering — keep it out of the bounded activity buffer
+      // so it neither crowds real events out of the 500-slot history nor
+      // inflates the "+N coordination events" counter. Its handler still runs
+      // below; dedup above already recorded its id.
+      if (evt.type !== 'queue_changed') {
+        this.events.unshift(evt);
+        if (this.events.length > 500) this.events.splice(500);
+      }
 
       // Update agent activity state
       const agent = evt.agent;

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1301,6 +1301,12 @@ function dashboard() {
             // Queue state is WS-driven (no poll) — re-seed it on reconnect so
             // any transitions missed during the outage are reflected.
             this.fetchQueues();
+            // Platform success is browser_metrics-driven (no poll); if the
+            // operator is on the Browser panel, re-seed it too so a blip
+            // doesn't leave the rollup frozen until the next metrics event.
+            if (this.activeTab === 'system' && this.systemTab === 'browser') {
+              this.fetchPlatformSuccess();
+            }
           }
         },
         onDisconnect: () => { this.connected = false; },
@@ -1621,10 +1627,10 @@ function dashboard() {
               this.fetchSystemLogs();
             }
           }
-          // Resume model health + queue polling
+          // Resume model-health polling; queue state is WS-driven now, so
+          // just re-seed it once on tab-return.
           this.fetchModelHealth();
           this._modelHealthInterval = setInterval(() => this.fetchModelHealth(), 60000);
-          // Re-seed queue state on tab-return; live updates flow via WS.
           this.fetchQueues();
           // Refresh agent detail if we're viewing one
           if (this.detailAgent) {
@@ -4540,24 +4546,28 @@ function dashboard() {
         this._queueRefreshDebounce = setTimeout(() => this.fetchQueues(), 300);
       }
 
-      // System-tab settings/integrations/storage changed elsewhere — re-fetch
-      // just the affected panel, and only while the System tab is on screen
-      // (off-screen panels re-sync on their next open). ``data.scope`` maps to
-      // the panel's existing loader(s); unknown scopes are ignored.
+      // System-tab config changed elsewhere — re-fetch just the affected
+      // panel, and only while the System tab is on screen (off-screen panels
+      // re-sync on their next open). ``data.scope`` maps to the panel's
+      // read-only list loader; unknown scopes are ignored.
+      //
+      // NOTE: only the display-list panels are auto-refetched. The edit-FORM
+      // panels (browser_settings / system_settings / captcha_solver /
+      // network_proxy / wallet) are deliberately excluded — their loaders
+      // overwrite the same state the form inputs bind to (e.g.
+      // loadNetworkProxy resets networkProxy.form), so a background reload
+      // would clobber an operator's in-progress edit. Those panels already
+      // refresh on tab-open, which is sufficient for rarely-changed,
+      // single-operator settings.
       if (evt.type === 'config_changed' && this.activeTab === 'system') {
         const _configLoaders = {
-          browser_settings: ['fetchBrowserSettings'],
-          system_settings: ['fetchSystemSettings'],
-          captcha_solver: ['fetchCaptchaSolver'],
           channels: ['fetchChannels'],
           webhooks: ['fetchWebhooks'],
           api_keys: ['fetchApiKeys'],
           integrations: ['loadIntegrations'],
-          network_proxy: ['loadNetworkProxy'],
           storage: ['fetchStorage', 'fetchDatabaseDetails'],
           uploads: ['fetchUploads'],
           skills: ['loadSkillsCatalog'],
-          wallet: ['fetchWallet', 'fetchWalletRpc'],
         };
         for (const fn of (_configLoaders[evt.data?.scope] || [])) {
           if (typeof this[fn] === 'function') this[fn]();

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1691,7 +1691,7 @@
                 :title="'Goal: ' + (activeTeamData?.north_star || '')"
                 x-text="'🎯 ' + (activeTeamData?.north_star || '')"></span>
               <!-- Tab pills — desktop only, click stops propagation to header toggle -->
-              <div class="project-hub-desktop-tabs seg-group hidden md:flex ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">
+              <div class="project-hub-desktop-tabs seg-group hidden lg:flex ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">
                 <button @click="teamHubExpanded = true; teamHubTab = 'work'; _ensureWorkplaceTasks()"
                   class="seg-tab seg-tab-sm"
                   :class="teamHubExpanded && teamHubTab === 'work' ? 'seg-tab-active' : ''"
@@ -1730,7 +1730,7 @@
                 </button>
               </div>
               <!-- Team options kebab menu -->
-              <div class="project-hub-kebab relative flex-shrink-0 ml-auto md:ml-0" x-data="{ open: false }" @click.stop @keydown.escape.window="open = false">
+              <div class="project-hub-kebab relative flex-shrink-0 ml-auto lg:ml-0" x-data="{ open: false }" @click.stop @keydown.escape.window="open = false">
                 <button @click="open = !open"
                   class="p-1.5 rounded-md text-gray-500 hover:text-gray-300 hover:bg-gray-800 transition-colors"
                   aria-label="Team options">
@@ -1752,7 +1752,7 @@
             <!-- Hub body — collapsible -->
             <div x-show="teamHubExpanded" x-transition class="border-t border-gray-800/60">
               <!-- Mobile tab strip (sm:hidden) -->
-              <div class="project-hub-tabs project-hub-mobile-tabs md:hidden" role="tablist" aria-label="Team sections">
+              <div class="project-hub-tabs project-hub-mobile-tabs lg:hidden" role="tablist" aria-label="Team sections">
                 <button @click="teamHubTab = 'work'; _ensureWorkplaceTasks()"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
                   :class="teamHubTab === 'work' ? 'text-white border-indigo-500' : 'text-gray-400 border-transparent hover:text-gray-300'"

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1751,7 +1751,7 @@
 
             <!-- Hub body — collapsible -->
             <div x-show="teamHubExpanded" x-transition class="border-t border-gray-800/60">
-              <!-- Mobile tab strip (sm:hidden) -->
+              <!-- Mobile tab strip (shown below lg; desktop pills take over at lg) -->
               <div class="project-hub-tabs project-hub-mobile-tabs lg:hidden" role="tablist" aria-label="Team sections">
                 <button @click="teamHubTab = 'work'; _ensureWorkplaceTasks()"
                   class="px-4 py-2.5 text-xs font-medium transition-colors border-b-2"
@@ -7127,7 +7127,7 @@
                 <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/></svg>
                 <h3 class="text-base font-medium text-gray-200">Per-Platform Success</h3>
               </div>
-              <span class="text-[11px] text-gray-500">last 24h · updates live</span>
+              <span class="text-[11px] text-gray-500">last 24h</span>
             </div>
             <p class="text-[11px] text-gray-400 mb-4 leading-relaxed">
               Aggregated per host across the fleet. <span class="text-gray-400">Success</span> is the share of CAPTCHA gates that solved cleanly. <span class="text-amber-400">Burns</span> are fingerprints rejected after a solve — the cue to rotate the profile. Hosts without any CAPTCHA activity show "—" for success rate.

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -7127,7 +7127,7 @@
                 <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/></svg>
                 <h3 class="text-base font-medium text-gray-200">Per-Platform Success</h3>
               </div>
-              <span class="text-[11px] text-gray-500">last 24h · refreshes 30s</span>
+              <span class="text-[11px] text-gray-500">last 24h · updates live</span>
             </div>
             <p class="text-[11px] text-gray-400 mb-4 leading-relaxed">
               Aggregated per host across the fleet. <span class="text-gray-400">Success</span> is the share of CAPTCHA gates that solved cleanly. <span class="text-amber-400">Burns</span> are fingerprints rejected after a solve — the cue to rotate the profile. Hosts without any CAPTCHA activity show "—" for success rate.

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -134,6 +134,36 @@ class LaneManager:
         # ``create_task(_forward())`` can be garbage-collected mid-flight
         # per the Python docs warning.
         self._forward_tasks: set[asyncio.Task] = set()
+        # Dashboard EventBus, wired post-construction (the bus is created
+        # inside ``create_mesh_app``). When set, lane state transitions emit
+        # ``queue_changed`` so the dashboard refreshes queue badges live
+        # instead of polling. ``None`` (the default) means no-op — the lane
+        # works identically without it.
+        self._event_bus: Any = None
+
+    def set_event_bus(self, bus: Any) -> None:
+        """Wire the dashboard EventBus after construction.
+
+        The bus is created inside ``create_mesh_app`` (after this
+        ``LaneManager`` is built in runtime.py), so it is injected post-hoc,
+        mirroring ``set_tasks_store``. Pass ``None`` to clear.
+        """
+        self._event_bus = bus
+
+    def _emit_queue_changed(self, agent: str) -> None:
+        """Emit a ``queue_changed`` event for ``agent`` (best-effort).
+
+        Called from lane state transitions. Safe from the dispatch-loop
+        thread — ``EventBus.emit`` marshals cross-thread internally. Never
+        raises into the lane: a broken bus must not wedge the worker.
+        """
+        bus = self._event_bus
+        if bus is None:
+            return
+        try:
+            bus.emit("queue_changed", agent=agent, data={"agent": agent})
+        except Exception as exc:  # pragma: no cover - observability only
+            logger.debug("queue_changed emit failed for %s: %s", agent, exc)
 
     def set_tasks_store(self, store: Any) -> None:
         """Wire the durable tasks store after construction.
@@ -290,6 +320,7 @@ class LaneManager:
             )
         self._pending[agent].append(task)
         logger.debug(f"Queued task {task.id} for agent '{agent}' (depth: {self._queues[agent].qsize()})")
+        self._emit_queue_changed(agent)
         return await task.future
 
     async def _handle_steer(self, agent: str, message: str) -> str:
@@ -394,9 +425,11 @@ class LaneManager:
                 except ValueError:
                     pass
                 queue.task_done()
+                self._emit_queue_changed(agent)
                 continue
             async with lock:
                 self._busy[agent] = True
+            self._emit_queue_changed(agent)
             current_trace_id.set(task.trace_id)
             t0 = time.time()
             if task.trace_id and self._trace_store:
@@ -596,6 +629,9 @@ class LaneManager:
                     if task in pending:
                         pending.remove(task)
                 queue.task_done()
+                # Terminal transition (complete / timeout / error) — queue
+                # depth dropped and the agent went idle, so refresh badges.
+                self._emit_queue_changed(agent)
 
     def get_status(self) -> dict[str, dict]:
         """Return queue depth, pending task count, and busy flag per agent."""
@@ -634,6 +670,7 @@ class LaneManager:
         self._busy.pop(agent, None)
         self._state_locks.pop(agent, None)
         self._steer_wakeup_ts.pop(agent, None)
+        self._emit_queue_changed(agent)
 
     async def stop(self) -> None:
         """Cancel all worker tasks and any in-flight auto-notify forwards."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -865,6 +865,11 @@ def create_mesh_app(
     # ``task_*`` events to the dashboard.
     if event_bus is not None:
         tasks_store.set_event_bus(event_bus)
+        # Wire the bus into the lane manager so queue depth/busy transitions
+        # emit ``queue_changed`` — the dashboard refreshes queue badges live
+        # instead of polling ``/api/queues`` every 2s.
+        if lane_manager is not None:
+            lane_manager.set_event_bus(event_bus)
 
     # Durable work-summaries store. One row per (scope, period_start);
     # operator generates via the ``compose_work_summary`` tool or the

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -848,6 +848,18 @@ class DashboardEvent(BaseModel):
         # Blackboard delete — mirror of ``blackboard_write`` for the
         # delete endpoint so the SPA can reflect removals live.
         "blackboard_delete",
+        # Lane queue depth/busy changed — emitted by ``host/lanes.LaneManager``
+        # on enqueue / dequeue / quarantine / terminal completion so the SPA
+        # refreshes queue badges live instead of polling ``/api/queues`` every
+        # 2s. Payload: ``{"agent": <agent_id>}``.
+        "queue_changed",
+        # System-tab config changed — single generic event emitted by the
+        # dashboard settings mutation endpoints. ``data.scope`` discriminates
+        # the panel (e.g. browser_settings / channels / integrations / webhooks
+        # / api_keys / network_proxy / captcha_solver / system_settings /
+        # storage / uploads / skills / wallet) so the SPA re-fetches just that
+        # panel without polling.
+        "config_changed",
     ]
     agent: str = ""
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -254,6 +254,42 @@ async def test_status_reports_busy_and_queue_depth():
     await task1
 
 
+# ── EventBus integration (queue_changed) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_queue_changed_emitted_when_bus_wired():
+    """A wired EventBus receives queue_changed on enqueue, dequeue, and completion."""
+    dispatch = AsyncMock(return_value="ok")
+    bus = MagicMock()
+    lm = LaneManager(dispatch_fn=dispatch)
+    lm.set_event_bus(bus)
+
+    await lm.enqueue("agent1", "hi")
+    await asyncio.sleep(0.05)  # let the worker's finally block run
+
+    queue_emits = [
+        c for c in bus.emit.call_args_list
+        if c.args and c.args[0] == "queue_changed"
+    ]
+    # enqueue + busy=True + terminal-finally → at least 3 emits for one task
+    assert len(queue_emits) >= 3
+    for c in queue_emits:
+        assert c.kwargs.get("agent") == "agent1"
+        assert c.kwargs.get("data") == {"agent": "agent1"}
+
+
+@pytest.mark.asyncio
+async def test_no_bus_wired_does_not_break_lane():
+    """Without an EventBus the lane works identically (emits are no-ops)."""
+    dispatch = AsyncMock(return_value="ok")
+    lm = LaneManager(dispatch_fn=dispatch)  # no set_event_bus
+
+    result = await lm.enqueue("agent1", "hi")
+    assert result == "ok"
+    dispatch.assert_awaited_once_with("agent1", "hi")
+
+
 # ── Stop ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Two related dashboard improvements, scoped surgically (KISS, no regressions). Review found the eventbus is already ~95% live — this closes the remaining gaps and fixes the one real responsiveness bug.

### A. Team Hub responsiveness (fleet/"Teams" tab)
The six desktop tab pills (`Work · Files · Brief · Members · Broadcast · Advanced`) are `flex-shrink-0`, so in the **768–1023px band** (tablet portrait, no side chat) the header row overflowed; `body{overflow-x:hidden}` then clipped the **kebab (Delete-team) and right-most pills off-screen**. Fix: bump the desktop/mobile tab breakpoint `md`→`lg`, reusing the existing scrolling mobile strip below 1024px. Inner cards already truncate (`truncate` + `min-w-0` + `flex-shrink-0`) — verified, unchanged.

### B. Live-update gaps closed
| Surface | Before | After |
|---|---|---|
| **Brief (TEAM.md)** | fetch-only | reloads on the existing `team_updated{field:project_md}` event (skipped mid-edit) |
| **Queues** | `/api/queues` polled **every 2s** | new `queue_changed` event from `LaneManager` (enqueue/dequeue/quarantine/terminal); debounced refetch |
| **Platform success** | polled every 30s | driven off the existing `browser_metrics` event |
| **System settings/integrations/storage** | fetch-on-tab-click | one generic `config_changed{scope}` event per settings mutation; SPA refetches just that panel |

New event literals: `queue_changed`, `config_changed` (in `DashboardEvent.type`).

## Safety / no-regression notes
- `/api/queues` endpoint and the `_chatRecoveryPolls` loop are **untouched** — chat recovery still keys off `queueStatus[agent].busy`, which the new handler keeps fresh; reconnect re-seeds queue state.
- `LaneManager` bus is best-effort (`set_event_bus`); emits never raise into the worker, and cross-thread emits are marshalled by `EventBus`.
- `config_changed` refetch is gated to `activeTab === 'system'`; the originating session's refetch is idempotent.

## Testing
- `node --check` on app.js/websocket.js, `ruff check` on changed Python: clean.
- Full suite (minus e2e): **7112 passed, 60 skipped, 0 failures**; `test_lanes.py` 45 passed.
- Manual verification checklist (resize 360/768/820/1024/1440; two-session TEAM.md edit; queue badge w/o 2s poll; reconnect re-sync; cross-session settings change) in the plan.