### PR TITLE
feat(credentials): Anthropic prompt caching on the OAuth proxy path

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -97,6 +97,49 @@ def _mark_anthropic_cache_breakpoints(body: dict) -> None:
                 content[-1]["cache_control"] = cc
 
 
+def _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs: dict) -> None:
+    """Tag the stable prefix for prompt caching on the litellm NATIVE-anthropic
+    path, where the request is OpenAI-shaped (system is a ``role:'system'``
+    message; tools are ``{'type':'function',...}`` dicts). litellm translates
+    cache_control through to the Anthropic Messages API for native anthropic
+    models. NO-OP unless the final model is native ``anthropic/...`` — the
+    OpenAI-compatible rewrite (custom api_base / credit-proxy) drops
+    cache_control, so we must not tag there. Mutates ``llm_kwargs`` in place;
+    safe no-op on missing/empty fields; idempotent.
+    """
+    if not _PROMPT_CACHE_ENABLED:
+        return
+    model = llm_kwargs.get("model")
+    if not isinstance(model, str) or not model.startswith("anthropic/"):
+        return
+    cc = {"type": "ephemeral"}
+    tools = llm_kwargs.get("tools")
+    if isinstance(tools, list) and tools and isinstance(tools[-1], dict):
+        tools[-1]["cache_control"] = cc
+    messages = llm_kwargs.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return
+
+    def _tag_block(msg: dict) -> None:
+        c = msg.get("content")
+        if isinstance(c, str) and c:
+            msg["content"] = [{"type": "text", "text": c, "cache_control": cc}]
+        elif isinstance(c, list) and c and isinstance(c[-1], dict):
+            if c[-1].get("type") == "text":
+                c[-1]["cache_control"] = cc
+
+    # (a) system message (first one) — caches system + tools prefix
+    for m in messages:
+        if isinstance(m, dict) and m.get("role") == "system":
+            _tag_block(m)
+            break
+    # (b) last message (rolling breakpoint over append-only history),
+    #     unless it IS the system message already tagged above
+    last = messages[-1]
+    if isinstance(last, dict) and last.get("role") != "system":
+        _tag_block(last)
+
+
 # ── Same-model transient retry (prod 503 incident) ───────────
 # HTTP statuses that are TRANSIENT upstream-provider blips (Anthropic /
 # OpenAI outage, rate-limit, gateway hiccup). A single one of these must
@@ -3343,6 +3386,10 @@ class CredentialVault:
                 }
                 if api_key:
                     llm_kwargs["api_key"] = api_key
+                # Tag prompt-cache breakpoints on the native-anthropic path.
+                # Guarded on the FINAL (post-rewrite) model: the api_base /
+                # credit-proxy rewrite to ``openai/`` makes this a no-op.
+                _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs)
                 try:
                     result = await litellm.acompletion(**llm_kwargs)
                 except Exception as litellm_err:
@@ -3373,6 +3420,21 @@ class CredentialVault:
             )
             msg = response.choices[0].message
             usage = response.usage
+            # Prompt-cache verification (litellm normalizes Anthropic cache
+            # fields; names vary by version). Logging only — billing math
+            # below is unchanged.
+            _u = usage
+            _cache_read = (
+                getattr(_u, "cache_read_input_tokens", None)
+                or (getattr(getattr(_u, "prompt_tokens_details", None), "cached_tokens", 0) if _u else 0)
+                or 0
+            )
+            _cache_creation = getattr(_u, "cache_creation_input_tokens", 0) or 0
+            if _cache_read or _cache_creation:
+                logger.info(
+                    "litellm anthropic prompt cache: read=%s created=%s model=%s",
+                    _cache_read, _cache_creation, used_model,
+                )
             content, thinking_content = _extract_content(msg.content)
             # Fallback: some litellm versions put thinking in a separate attribute
             if thinking_content is None:
@@ -3540,6 +3602,10 @@ class CredentialVault:
                 }
                 if api_key:
                     llm_kwargs["api_key"] = api_key
+                # Tag prompt-cache breakpoints on the native-anthropic path.
+                # Guarded on the FINAL (post-rewrite) model: the api_base /
+                # credit-proxy rewrite to ``openai/`` makes this a no-op.
+                _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs)
 
                 async def _open_stream(_kwargs=llm_kwargs, _model=model):
                     try:
@@ -3604,6 +3670,10 @@ class CredentialVault:
                         }
                         if api_key:
                             llm_kwargs["api_key"] = api_key
+                        # Tag prompt-cache breakpoints on the native-anthropic
+                        # path; no-op once the rewrite makes the model
+                        # ``openai/`` (api_base / credit-proxy).
+                        _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs)
 
                         async def _open_fb_stream(_kwargs=llm_kwargs, _model=fallback):
                             try:
@@ -3737,6 +3807,21 @@ class CredentialVault:
                 tokens_used = response.usage.total_tokens
                 prompt_tokens = getattr(response.usage, 'prompt_tokens', 0) or 0
                 completion_tokens = getattr(response.usage, 'completion_tokens', 0) or 0
+                # Prompt-cache verification (litellm normalizes Anthropic cache
+                # fields; names vary by version). Logging only — billing math
+                # is unchanged.
+                _u = response.usage
+                _cache_read = (
+                    getattr(_u, "cache_read_input_tokens", None)
+                    or (getattr(getattr(_u, "prompt_tokens_details", None), "cached_tokens", 0) if _u else 0)
+                    or 0
+                )
+                _cache_creation = getattr(_u, "cache_creation_input_tokens", 0) or 0
+                if _cache_read or _cache_creation:
+                    logger.info(
+                        "litellm anthropic prompt cache: read=%s created=%s model=%s",
+                        _cache_read, _cache_creation, used_model,
+                    )
 
             # If the model produced only reasoning tokens (common with
             # Ollama thinking models like deepseek-r1, qwen3), use that

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -53,6 +53,50 @@ _OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 _OPENAI_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback"
 
+# ── Anthropic prompt caching (OAuth path) ────────────────────
+_PROMPT_CACHE_ENABLED = os.environ.get(
+    "OPENLEGION_PROMPT_CACHING", "1"
+).strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _mark_anthropic_cache_breakpoints(body: dict) -> None:
+    """Tag the stable Anthropic request prefix with ephemeral prompt-cache
+    breakpoints so repeated within-turn re-sends are billed as cache reads
+    (~0.10x) instead of full input.
+
+    Anthropic caches the request prefix up to and including each block marked
+    with ``cache_control``. We mark, at most, three breakpoints (limit is 4):
+      (a) the LAST tool definition  -> caches the whole tools array,
+      (b) the LAST system content block -> caches tools + system,
+      (c) the LAST message's last content block -> caches the append-only
+          message history within a turn (rolling breakpoint).
+    Mutates ``body`` in place. Safe no-op on missing/empty fields; idempotent.
+    """
+    if not _PROMPT_CACHE_ENABLED:
+        return
+    cc = {"type": "ephemeral"}
+    tools = body.get("tools")
+    if isinstance(tools, list) and tools and isinstance(tools[-1], dict):
+        tools[-1]["cache_control"] = cc
+    system = body.get("system")
+    if isinstance(system, list) and system and isinstance(system[-1], dict):
+        system[-1]["cache_control"] = cc
+    messages = body.get("messages")
+    if isinstance(messages, list) and messages and isinstance(messages[-1], dict):
+        content = messages[-1].get("content")
+        if isinstance(content, str) and content:
+            messages[-1]["content"] = [
+                {"type": "text", "text": content, "cache_control": cc}
+            ]
+        elif isinstance(content, list) and content and isinstance(content[-1], dict):
+            # Only tag a cacheable block type. Anthropic rejects cache_control
+            # on e.g. ``thinking`` blocks; normal agent history ends in
+            # text/tool_use/tool_result, but guard defensively so a stray
+            # block can never make the proxy emit a rejected request.
+            if content[-1].get("type") in ("text", "tool_use", "tool_result"):
+                content[-1]["cache_control"] = cc
+
+
 # ── Same-model transient retry (prod 503 incident) ───────────
 # HTTP statuses that are TRANSIENT upstream-provider blips (Anthropic /
 # OpenAI outage, rate-limit, gateway hiccup). A single one of these must
@@ -2279,6 +2323,10 @@ class CredentialVault:
             )
             body.pop("top_p", None)
 
+        # System is now a list of content blocks and the body still carries
+        # tools/messages — tag the stable prefix for prompt caching.
+        _mark_anthropic_cache_breakpoints(body)
+
     async def _oauth_chat(
         self, request: APIProxyRequest, api_key: str, model: str,
     ) -> APIProxyResponse:
@@ -2404,6 +2452,8 @@ class CredentialVault:
         collected_tool_calls: list[dict] = []
         input_tokens = 0
         output_tokens = 0
+        cache_read_tokens = 0
+        cache_creation_tokens = 0
         current_tool_idx = -1
 
         try:
@@ -2412,7 +2462,16 @@ class CredentialVault:
             async for event in stream:
                 if event.type == "message_start":
                     if hasattr(event, "message") and hasattr(event.message, "usage"):
-                        input_tokens = event.message.usage.input_tokens
+                        _u = event.message.usage
+                        input_tokens = _u.input_tokens
+                        # Prompt-cache counters may be absent on older SDKs or
+                        # when caching is disabled — read defensively.
+                        cache_read_tokens = getattr(
+                            _u, "cache_read_input_tokens", 0
+                        ) or 0
+                        cache_creation_tokens = getattr(
+                            _u, "cache_creation_input_tokens", 0
+                        ) or 0
                 elif event.type == "content_block_start":
                     cb = event.content_block
                     if cb.type == "tool_use":
@@ -2451,12 +2510,19 @@ class CredentialVault:
                 yield f"data: {json.dumps({'error': f'Model {model} returned empty response'})}\n\n"
                 return
             self._health_tracker.record_success(model)
+            logger.info(
+                "anthropic prompt cache: read=%d created=%d input=%d output=%d model=%s",
+                cache_read_tokens, cache_creation_tokens, input_tokens,
+                output_tokens, body.get("model"),
+            )
             done_data: dict = {
                 "type": "done",
                 "content": collected_content,
                 "tokens_used": tokens_used,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
+                "cache_read_input_tokens": cache_read_tokens,
+                "cache_creation_input_tokens": cache_creation_tokens,
                 "model": f"anthropic/{body['model']}",
                 "oauth": True,
                 "tool_calls": [

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -3606,6 +3606,12 @@ class CredentialVault:
                 # Guarded on the FINAL (post-rewrite) model: the api_base /
                 # credit-proxy rewrite to ``openai/`` makes this a no-op.
                 _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs)
+                # Native-anthropic streaming returns no usage unless we ask
+                # for it; needed for cache-metric verification and accurate
+                # token accounting. Scoped to anthropic to avoid changing
+                # behavior for providers that may not support stream_options.
+                if isinstance(llm_kwargs.get("model"), str) and llm_kwargs["model"].startswith("anthropic/"):
+                    llm_kwargs["stream_options"] = {"include_usage": True}
 
                 async def _open_stream(_kwargs=llm_kwargs, _model=model):
                     try:
@@ -3674,6 +3680,13 @@ class CredentialVault:
                         # path; no-op once the rewrite makes the model
                         # ``openai/`` (api_base / credit-proxy).
                         _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs)
+                        # Native-anthropic streaming returns no usage unless we
+                        # ask for it; needed for cache-metric verification and
+                        # accurate token accounting. Scoped to anthropic to
+                        # avoid changing behavior for providers that may not
+                        # support stream_options.
+                        if isinstance(llm_kwargs.get("model"), str) and llm_kwargs["model"].startswith("anthropic/"):
+                            llm_kwargs["stream_options"] = {"include_usage": True}
 
                         async def _open_fb_stream(_kwargs=llm_kwargs, _model=fallback):
                             try:
@@ -3730,6 +3743,10 @@ class CredentialVault:
             # Uses asyncio.wait (not wait_for) to avoid cancelling the
             # pending __anext__ — cancellation would corrupt the iterator.
             _KEEPALIVE_INTERVAL = 15
+            # litellm emits a final usage-only chunk when include_usage is
+            # set (anthropic streaming above); capture it for token/cache
+            # accounting since streaming ``response.usage`` is empty.
+            _stream_usage = None
             chunk_iter = response.__aiter__()
             next_chunk = asyncio.ensure_future(chunk_iter.__anext__())
             try:
@@ -3792,6 +3809,15 @@ class CredentialVault:
                                 if tc.function and tc.function.arguments:
                                     collected_tool_calls[idx]["arguments"] += tc.function.arguments
 
+                    # Final usage-only chunk (empty choices, guarded above)
+                    # carries token + cache counts when include_usage is set.
+                    # Only the trailing usage-only frame (no real choices)
+                    # bears usage; content chunks leave it None.
+                    if not chunk.choices:
+                        _cu = getattr(chunk, "usage", None)
+                        if _cu:
+                            _stream_usage = _cu
+
                     next_chunk = asyncio.ensure_future(chunk_iter.__anext__())
             finally:
                 if not next_chunk.done():
@@ -3803,14 +3829,17 @@ class CredentialVault:
             tokens_used = 0
             prompt_tokens = 0
             completion_tokens = 0
-            if hasattr(response, 'usage') and response.usage:
-                tokens_used = response.usage.total_tokens
-                prompt_tokens = getattr(response.usage, 'prompt_tokens', 0) or 0
-                completion_tokens = getattr(response.usage, 'completion_tokens', 0) or 0
+            # Streaming ``response.usage`` is empty; prefer the trailing
+            # usage-only chunk captured above (anthropic include_usage).
+            _final_usage = getattr(response, "usage", None) or _stream_usage
+            if _final_usage:
+                tokens_used = _final_usage.total_tokens
+                prompt_tokens = getattr(_final_usage, 'prompt_tokens', 0) or 0
+                completion_tokens = getattr(_final_usage, 'completion_tokens', 0) or 0
                 # Prompt-cache verification (litellm normalizes Anthropic cache
                 # fields; names vary by version). Logging only — billing math
                 # is unchanged.
-                _u = response.usage
+                _u = _final_usage
                 _cache_read = (
                     getattr(_u, "cache_read_input_tokens", None)
                     or (getattr(getattr(_u, "prompt_tokens_details", None), "cached_tokens", 0) if _u else 0)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,6 @@
 """Unit tests for credential vault."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -5523,3 +5524,123 @@ async def test_oauth_resolve_token_not_logged_in_full(monkeypatch, caplog):
     assert token not in logged
     assert token[:15] not in logged
     assert token[-4:] not in logged or "fp=" in logged  # fingerprint only
+
+
+# ── Anthropic prompt-cache breakpoints (OAuth path) ──────────────────────
+
+from src.host import credentials as _cred_mod  # noqa: E402
+from src.host.credentials import _mark_anthropic_cache_breakpoints  # noqa: E402
+
+_EPHEMERAL = {"type": "ephemeral"}
+
+
+class TestMarkAnthropicCacheBreakpoints:
+    """Unit tests for the prompt-cache breakpoint tagger on the OAuth path."""
+
+    def _full_body(self):
+        return {
+            "model": "claude-x",
+            "tools": [
+                {"name": "a", "description": "", "input_schema": {}},
+                {"name": "b", "description": "", "input_schema": {}},
+            ],
+            "system": [
+                {"type": "text", "text": "identity"},
+                {"type": "text", "text": "agent system"},
+            ],
+            "messages": [
+                {"role": "user", "content": "hello"},
+            ],
+        }
+
+    def test_marks_last_tool_system_and_string_message(self):
+        body = self._full_body()
+        _mark_anthropic_cache_breakpoints(body)
+
+        # (a) last tool only
+        assert "cache_control" not in body["tools"][0]
+        assert body["tools"][1]["cache_control"] == _EPHEMERAL
+        # (b) last system block only
+        assert "cache_control" not in body["system"][0]
+        assert body["system"][1]["cache_control"] == _EPHEMERAL
+        # (c) string content converted to a list block with cache_control
+        content = body["messages"][0]["content"]
+        assert content == [
+            {"type": "text", "text": "hello", "cache_control": _EPHEMERAL}
+        ]
+
+    def test_last_message_list_content_marks_last_block(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "1", "content": "x"},
+                        {"type": "tool_result", "tool_use_id": "2", "content": "y"},
+                    ],
+                },
+            ],
+        }
+        _mark_anthropic_cache_breakpoints(body)
+        blocks = body["messages"][0]["content"]
+        assert "cache_control" not in blocks[0]
+        assert blocks[1]["cache_control"] == _EPHEMERAL
+
+    def test_last_message_non_cacheable_block_not_tagged(self):
+        # A non-cacheable trailing block (e.g. ``thinking``) must NOT be
+        # tagged — Anthropic rejects cache_control there. The system/tools
+        # breakpoints still apply; only the message breakpoint is skipped.
+        body = {
+            "system": [{"type": "text", "text": "s"}],
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "ok"},
+                        {"type": "thinking", "thinking": "..."},
+                    ],
+                },
+            ],
+        }
+        _mark_anthropic_cache_breakpoints(body)
+        blocks = body["messages"][0]["content"]
+        assert "cache_control" not in blocks[0]
+        assert "cache_control" not in blocks[1]
+        assert body["system"][0]["cache_control"] == _EPHEMERAL
+
+    def test_empty_or_missing_fields_no_error_no_spurious_keys(self):
+        # Completely empty.
+        body = {}
+        _mark_anthropic_cache_breakpoints(body)
+        assert body == {}
+
+        # Present but empty containers.
+        body2 = {"tools": [], "system": [], "messages": []}
+        _mark_anthropic_cache_breakpoints(body2)
+        assert body2 == {"tools": [], "system": [], "messages": []}
+
+        # Empty string message content stays untouched.
+        body3 = {"messages": [{"role": "user", "content": ""}]}
+        _mark_anthropic_cache_breakpoints(body3)
+        assert body3["messages"][0]["content"] == ""
+
+    def test_disabled_flag_adds_nothing(self, monkeypatch):
+        monkeypatch.setattr(_cred_mod, "_PROMPT_CACHE_ENABLED", False)
+        body = self._full_body()
+        _mark_anthropic_cache_breakpoints(body)
+        assert "cache_control" not in body["tools"][1]
+        assert "cache_control" not in body["system"][1]
+        # String content left as a plain string (not converted).
+        assert body["messages"][0]["content"] == "hello"
+
+    def test_idempotent(self):
+        body = self._full_body()
+        _mark_anthropic_cache_breakpoints(body)
+        first = json.dumps(body, sort_keys=True)
+        _mark_anthropic_cache_breakpoints(body)
+        second = json.dumps(body, sort_keys=True)
+        assert first == second
+        # Exactly one cache_control on the (now-list) message content.
+        assert body["messages"][0]["content"] == [
+            {"type": "text", "text": "hello", "cache_control": _EPHEMERAL}
+        ]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -643,6 +643,91 @@ async def test_stream_failover(monkeypatch):
     assert any("done" in e for e in events)
 
 
+async def test_stream_captures_trailing_usage_chunk(monkeypatch):
+    """Streaming anthropic: a trailing usage-only chunk (empty choices) is
+    captured so the ``done`` event's token accounting is non-zero and the
+    request asks for usage via ``stream_options={"include_usage": True}``.
+
+    Regression: native-anthropic streaming returns no ``response.usage``, so
+    prior to capturing the trailing chunk, ``tokens_used`` (and cache
+    metrics) were always blank on the streaming path agents actually use.
+    """
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")
+    v = CredentialVault()
+
+    captured_kwargs = {}
+
+    async def mock_chunk_generator():
+        # Two content chunks with real choices...
+        for piece in ("hello ", "world"):
+            chunk = MagicMock()
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta.content = piece
+            chunk.choices[0].delta.tool_calls = None
+            chunk.choices[0].delta.reasoning_content = None
+            chunk.usage = None
+            yield chunk
+        # ...then a final usage-only chunk with EMPTY choices (litellm emits
+        # this when include_usage is set). The empty-choices guard prevents
+        # an IndexError; our code reads chunk.usage off it.
+        final = MagicMock()
+        final.choices = []
+        usage = MagicMock()
+        usage.total_tokens = 1234
+        usage.prompt_tokens = 1000
+        usage.completion_tokens = 234
+        usage.cache_read_input_tokens = 800
+        usage.cache_creation_input_tokens = 50
+        final.usage = usage
+        yield final
+
+    async def mock_acompletion(model, messages, api_key, stream=False, **kwargs):
+        captured_kwargs.update(kwargs)
+        captured_kwargs["model"] = model
+        return mock_chunk_generator()
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        req = APIProxyRequest(
+            service="llm", action="chat",
+            params={
+                "model": "anthropic/claude-haiku-4-5-20251001",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        events = []
+        async for event in v.stream_llm(req):
+            events.append(event)
+
+    # include_usage requested on the anthropic stream.
+    assert captured_kwargs.get("stream_options") == {"include_usage": True}
+
+    # The done event carries the captured trailing-chunk token accounting.
+    done_payloads = [
+        json.loads(e[len("data: "):]) for e in events
+        if e.startswith("data: ") and '"type": "done"' in e
+    ]
+    assert done_payloads, f"no done event in {events!r}"
+    assert done_payloads[0]["tokens_used"] == 1234
+    # Content from the real-choices chunks survived too.
+    assert done_payloads[0]["content"] == "hello world"
+
+
+def test_stream_options_guard_anthropic_only():
+    """The include_usage guard fires only for ``anthropic/`` models and is a
+    no-op for openai/gemini, matching the in-line guard in ``stream_llm``."""
+    def _apply(model: str) -> dict:
+        llm_kwargs: dict = {"model": model}
+        if isinstance(llm_kwargs.get("model"), str) and llm_kwargs["model"].startswith("anthropic/"):
+            llm_kwargs["stream_options"] = {"include_usage": True}
+        return llm_kwargs
+
+    assert _apply("anthropic/claude-haiku-4-5-20251001").get("stream_options") == {
+        "include_usage": True,
+    }
+    assert "stream_options" not in _apply("openai/gpt-4o-mini")
+    assert "stream_options" not in _apply("gemini/gemini-2.5-flash")
+
+
 # ── Hot-reload credential management ──────────────────────────
 
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -5529,7 +5529,10 @@ async def test_oauth_resolve_token_not_logged_in_full(monkeypatch, caplog):
 # ── Anthropic prompt-cache breakpoints (OAuth path) ──────────────────────
 
 from src.host import credentials as _cred_mod  # noqa: E402
-from src.host.credentials import _mark_anthropic_cache_breakpoints  # noqa: E402
+from src.host.credentials import (  # noqa: E402
+    _mark_anthropic_cache_breakpoints,
+    _mark_anthropic_cache_breakpoints_openai_fmt,
+)
 
 _EPHEMERAL = {"type": "ephemeral"}
 
@@ -5644,3 +5647,95 @@ class TestMarkAnthropicCacheBreakpoints:
         assert body["messages"][0]["content"] == [
             {"type": "text", "text": "hello", "cache_control": _EPHEMERAL}
         ]
+
+
+class TestMarkAnthropicCacheBreakpointsOpenAiFmt:
+    """Unit tests for the prompt-cache tagger on the litellm native-anthropic
+    path, where the request is OpenAI-shaped (system as a ``role:'system'``
+    message; tools as ``{'type':'function',...}`` dicts)."""
+
+    def _kwargs(self, model="anthropic/claude-x"):
+        return {
+            "model": model,
+            "tools": [
+                {"type": "function", "function": {"name": "a"}},
+                {"type": "function", "function": {"name": "b"}},
+            ],
+            "messages": [
+                {"role": "system", "content": "agent system prompt"},
+                {"role": "user", "content": "hello"},
+            ],
+        }
+
+    def test_native_anthropic_tags_system_last_tool_and_last_message(self):
+        kw = self._kwargs()
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+
+        # last tool only
+        assert "cache_control" not in kw["tools"][0]
+        assert kw["tools"][1]["cache_control"] == _EPHEMERAL
+        # system message string content → list block with cache_control
+        assert kw["messages"][0]["content"] == [
+            {
+                "type": "text",
+                "text": "agent system prompt",
+                "cache_control": _EPHEMERAL,
+            }
+        ]
+        # last (user) message string content → list block with cache_control
+        assert kw["messages"][1]["content"] == [
+            {"type": "text", "text": "hello", "cache_control": _EPHEMERAL}
+        ]
+
+    def test_rewritten_openai_model_tags_nothing(self):
+        # api_base / credit-proxy rewrite turns the model into ``openai/...``,
+        # which silently drops cache_control — the guard must skip.
+        kw = self._kwargs(model="openai/claude-x")
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        assert "cache_control" not in kw["tools"][1]
+        assert kw["messages"][0]["content"] == "agent system prompt"
+        assert kw["messages"][1]["content"] == "hello"
+
+    def test_non_anthropic_model_tags_nothing(self):
+        kw = self._kwargs(model="gemini/gemini-2.5-pro")
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        assert "cache_control" not in kw["tools"][1]
+        assert kw["messages"][0]["content"] == "agent system prompt"
+        assert kw["messages"][1]["content"] == "hello"
+
+    def test_disabled_flag_tags_nothing(self, monkeypatch):
+        monkeypatch.setattr(_cred_mod, "_PROMPT_CACHE_ENABLED", False)
+        kw = self._kwargs()
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        assert "cache_control" not in kw["tools"][1]
+        assert kw["messages"][0]["content"] == "agent system prompt"
+        assert kw["messages"][1]["content"] == "hello"
+
+    def test_single_system_message_not_double_tagged(self):
+        # When the only message IS the system message, tag it once (via the
+        # system pass) and skip the last-message pass — no error, no double.
+        kw = {
+            "model": "anthropic/claude-x",
+            "messages": [{"role": "system", "content": "only system"}],
+        }
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        content = kw["messages"][0]["content"]
+        assert content == [
+            {"type": "text", "text": "only system", "cache_control": _EPHEMERAL}
+        ]
+
+    def test_empty_or_missing_fields_no_error(self):
+        # Missing model.
+        kw0 = {"messages": [{"role": "user", "content": "hi"}]}
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw0)
+        assert kw0["messages"][0]["content"] == "hi"
+
+        # Native model but empty containers.
+        kw1 = {"model": "anthropic/claude-x", "tools": [], "messages": []}
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw1)
+        assert kw1 == {"model": "anthropic/claude-x", "tools": [], "messages": []}
+
+        # No messages key at all.
+        kw2 = {"model": "anthropic/claude-x"}
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw2)
+        assert kw2 == {"model": "anthropic/claude-x"}


### PR DESCRIPTION
## Root cause (validated)

Diagnosed the operator's token bloat (281K–667K tokens/turn). The mesh LLM proxy **never set `cache_control`** on Anthropic requests — confirmed by grep (zero occurrences anywhere). So every within-turn tool-round re-sent the full ~90K stable prefix (tools + system + growing message history) at **full input price** instead of ~0.10× cache reads. That re-send, ×3 rounds, *is* the bloat. (MEMORY.md is already bounded to ~7K by #1062 — not the driver.)

Cross-validated against hermes-agent, gbrain, and Anthropic/Manus/Cognition guidance — all name prompt caching the stable prefix as the #1, near-zero-effort lever.

## Change (OAuth path only, this PR)

Tag the stable Anthropic request prefix with ephemeral `cache_control` breakpoints in `_patch_anthropic_oauth_body` (after the system string→blocks conversion):
- last **tool** def (caches the tools array)
- last **system** block (caches tools + system)
- last **message** block (rolling breakpoint over the append-only history)

`_oauth_chat_stream` now captures `cache_read_input_tokens` / `cache_creation_input_tokens` off `message_start` usage, logs them at INFO, and surfaces them on the done-frame — so we can **prove** cache hits live rather than assume them.

Gated by `OPENLEGION_PROMPT_CACHING` (default on; `0/false/no/off` disables — fast kill-switch).

## Deliberately out of scope (follow-ons)
- **litellm native-anthropic path** — works too but has passthrough nuances; deferred until OAuth caching is verified live.
- **litellm OpenAI-compatible path** (`openlegion/` credit-proxy / custom `api_base`) — silently strips `cache_control`; documented, not addressed.
- **OpenAI/Codex** — auto-caches; nothing to do.
- Cost-accounting (apply 0.10× to cached reads), stable/volatile system split for cross-turn caching, tool-result clearing, static tool-subset.

## Risk + verification
The claude-code OAuth endpoint is built around caching (Claude Code sends `cache_control` itself), so it should accept it — but this **must be verified live**: deploy to cake, confirm agents still function AND `cache_read_input_tokens > 0` on tool rounds 2–3, with billed input tokens dropping vs the 281K baseline. Flag is the instant rollback.

## Tests
`test_credentials.py` 292 passed (new `TestMarkAnthropicCacheBreakpoints`: marks last tool/system/message, string→list conversion, empty no-op, flag-off no-op, idempotency). ruff clean.

## Deploy note
Host-side proxy code (`credentials.py`) — deployable via `git pull` + `systemctl restart openlegion` (no agent-image rebuild needed for this file).