### PR TITLE
refactor(agent): hide operator-only tool schemas from worker agents

### DIFF
--- a/src/agent/builtins/fleet_tool.py
+++ b/src/agent/builtins/fleet_tool.py
@@ -14,6 +14,7 @@ def _is_operator() -> bool:
 
 @tool(
     name="list_templates",
+    operator_only=True,
     description=(
         "List available fleet templates that can be used to create agent teams. "
         "Returns template names, descriptions, and agent counts."
@@ -34,6 +35,7 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
 
 @tool(
     name="apply_template",
+    operator_only=True,
     description=(
         "Create a team of agents from a fleet template. Use list_templates first "
         "to see available templates. This creates all agents defined in the template "

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -178,6 +178,7 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
 
 @tool(
     name="read_agent_config",
+    operator_only=True,
     description=(
         "Read an agent's current configuration. Symmetric inverse of "
         "edit_agent — returns the same fields edit_agent can change so you "
@@ -267,6 +268,7 @@ async def read_agent_config(
 
 @tool(
     name="read_user_notifications",
+    operator_only=True,
     description=(
         "Read recent notifications that AGENTS pushed to the human USER's "
         "chat (via notify_user). OBSERVATIONAL / diagnostic only — surfaced "
@@ -334,6 +336,7 @@ async def read_user_notifications(
 
 @tool(
     name="list_peer_artifacts",
+    operator_only=True,
     description=(
         "List a teammate's artifact files. Artifacts are files agents "
         "write via save_artifact — design docs, reports, generated "
@@ -389,6 +392,7 @@ async def list_peer_artifacts(
 
 @tool(
     name="read_peer_artifact",
+    operator_only=True,
     description=(
         "Read a single artifact file written by a teammate. Use this "
         "after list_peer_artifacts to pull the content of a specific "
@@ -473,6 +477,7 @@ async def read_peer_artifact(
 
 @tool(
     name="list_peer_files",
+    operator_only=True,
     description=(
         "List the files in a teammate's workspace/data volume — "
         "operator-only. Unlike list_peer_artifacts (which only sees the "
@@ -538,6 +543,7 @@ async def list_peer_files(
 
 @tool(
     name="read_peer_file",
+    operator_only=True,
     description=(
         "Read the content of any file in a teammate's workspace/data "
         "volume — operator-only. This is how you retrieve a worker's "
@@ -613,6 +619,7 @@ async def read_peer_file(
 
 @tool(
     name="list_available_models",
+    operator_only=True,
     description=(
         "List models currently usable given the active credential setup. "
         "Use this BEFORE edit_agent or create_agent — never memorize the "
@@ -673,6 +680,7 @@ async def list_available_models(
 
 @tool(
     name="edit_agent",
+    operator_only=True,
     description=(
         "Change an agent's configuration. All edits apply IMMEDIATELY and "
         "emit a receipt card with [View diff] [Undo]. No confirmation step "
@@ -807,6 +815,7 @@ async def edit_agent(
 
 @tool(
     name="undo_change",
+    operator_only=True,
     description=(
         "Reverse a recent soft edit by undo_token. Use this if you realize "
         "mid-conversation that an edit you applied was wrong, OR if the user "
@@ -859,6 +868,7 @@ async def undo_change(
 
 @tool(
     name="create_agent",
+    operator_only=True,
     description=(
         "Create a new custom agent with role/model/instructions. "
         "Requires user confirmation."
@@ -959,6 +969,7 @@ def _parse_over_budget(error: Exception) -> dict | None:
 
 @tool(
     name="list_agent_queue",
+    operator_only=True,
     description=(
         "Read an agent's task queue: current and recent tasks grouped by "
         "status (active / blocked / done / failed / cancelled), up to "
@@ -996,6 +1007,7 @@ async def list_agent_queue(
 
 @tool(
     name="get_team_outputs",
+    operator_only=True,
     description=(
         "Completed task artifacts for a project in a time window. "
         "`since` accepts ISO timestamps or duration strings ('24h', '7d'); "
@@ -1033,6 +1045,7 @@ async def get_team_outputs(
 
 @tool(
     name="workflow_snapshot",
+    operator_only=True,
     description=(
         "Read a workflow chain snapshot for a multi-stage handoff. Pass "
         "the kickoff task_id (the root task you created when launching "
@@ -1086,6 +1099,7 @@ _AWAIT_TASK_EVENT_DEFAULT_TIMEOUT_S = 240
 
 @tool(
     name="await_task_event",
+    operator_only=True,
     description=(
         "Block until a specific task reaches a terminal status (done / "
         "failed / blocked / cancelled) or the timeout elapses. Polls "
@@ -1323,6 +1337,7 @@ async def await_task_event(
 
 @tool(
     name="inspect_agents",
+    operator_only=True,
     description=(
         "Read agents. Without agent_id: roster summary. With agent_id: "
         "depth='profile' returns role/capabilities/INTERFACE; "
@@ -1470,6 +1485,7 @@ async def inspect_agents(
 
 @tool(
     name="manage_task",
+    operator_only=True,
     description=(
         "Cancel, reroute, or retry a task. action='cancel' stops the task; "
         "action='reroute' moves it to new_assignee (required); "
@@ -1579,6 +1595,7 @@ async def manage_task(
 
 @tool(
     name="manage_agent",
+    operator_only=True,
     description=(
         "Archive or delete an agent. action='archive' is reversible and "
         "stops scheduling. action='delete' returns a confirmation nonce; "
@@ -1649,6 +1666,7 @@ async def manage_agent(
 
 @tool(
     name="list_pending",
+    operator_only=True,
     description=(
         "List every non-expired pending action awaiting user "
         "confirmation. Returns the nonce, action_kind, target_kind, "
@@ -1674,6 +1692,7 @@ async def list_pending(*, mesh_client=None, **_kw) -> dict:
 
 @tool(
     name="cancel_pending_action",
+    operator_only=True,
     description=(
         "Cancel a pending action by nonce. Use this to clean up stale or "
         "incorrect proposals that the user no longer wants. The action "
@@ -1731,6 +1750,7 @@ async def cancel_pending_action(
 
 @tool(
     name="archive_audit_before",
+    operator_only=True,
     description=(
         "Archive operator audit entries older than the given date. Removes "
         "them from the active audit-log view but preserves them in the "
@@ -1795,6 +1815,7 @@ async def archive_audit_before(
 
 @tool(
     name="inspect_teams",
+    operator_only=True,
     description=(
         "Read team info. detail='names' lists name+description; "
         "detail='status' adds task-count rollups (requires v2). "
@@ -1853,6 +1874,7 @@ async def inspect_teams(
 
 @tool(
     name="create_team",
+    operator_only=True,
     description=(
         "Create a new team and optionally assign agents to it. "
         "Requires user confirmation."
@@ -1892,6 +1914,7 @@ async def create_team(
 
 @tool(
     name="add_agents_to_team",
+    operator_only=True,
     description="Add one or more agents to a team. Requires user confirmation.",
     parameters={
         "team_name": {"type": "string", "description": "Team name"},
@@ -1929,6 +1952,7 @@ async def add_agents_to_team(
 
 @tool(
     name="remove_agents_from_team",
+    operator_only=True,
     description="Remove one or more agents from a team. Requires user confirmation.",
     parameters={
         "team_name": {"type": "string", "description": "Team name"},
@@ -1966,6 +1990,7 @@ async def remove_agents_from_team(
 
 @tool(
     name="update_team_context",
+    operator_only=True,
     description="Update a team's description / shared context.",
     parameters={
         "team_name": {"type": "string", "description": "Team name"},
@@ -1995,6 +2020,7 @@ async def update_team_context(
 
 @tool(
     name="set_team_goal",
+    operator_only=True,
     description="Set a team's north star + success criteria.",
     parameters={
         "team_name": {"type": "string", "description": "Team name"},
@@ -2065,6 +2091,7 @@ async def set_team_goal(
 
 @tool(
     name="summarize_team_progress",
+    operator_only=True,
     description="Synthesised progress summary for a team.",
     parameters={
         "team_id": {"type": "string", "description": "Team id"},
@@ -2091,6 +2118,7 @@ async def summarize_team_progress(
 
 @tool(
     name="compose_work_summary",
+    operator_only=True,
     description=(
         "Compose and persist a work summary for a team or solo agent "
         "(the Work tab's default landing surface). Reads the team's "
@@ -2265,6 +2293,7 @@ async def compose_work_summary(
 
 @tool(
     name="manage_team",
+    operator_only=True,
     description=(
         "Team lifecycle action (archive / unarchive / propose-delete). "
         "Destructive actions require user confirmation."
@@ -2640,6 +2669,7 @@ def _validate_goal_input(goal, *, require_status: bool = True) -> tuple[dict | N
 
 @tool(
     name="manage_goals",
+    operator_only=True,
     description=(
         "Manage tracked business goals shown on the user's Work tab. "
         "Source of truth is GOALS.json (rendered to GOALS.md for humans). "
@@ -2913,6 +2943,7 @@ _MAX_RATE_FEEDBACK_CHARS = 2000
 
 @tool(
     name="rate_delivery",
+    operator_only=True,
     description=(
         "Record outcome for a completed task. Operator's per-task "
         "judgment — preserves the agent-feedback machine loop "

--- a/src/agent/builtins/skill_admin_tool.py
+++ b/src/agent/builtins/skill_admin_tool.py
@@ -20,6 +20,7 @@ def _is_operator() -> bool:
 
 @tool(
     name="install_skill",
+    operator_only=True,
     description=(
         "Install a SKILL.md skill pack from a public git repo so the fleet can "
         "use it. The repo must have a SKILL.md (name + description) at its root. "
@@ -58,6 +59,7 @@ async def install_skill(repo_url: str, ref: str = "", *, mesh_client=None, _mess
 
 @tool(
     name="remove_skill",
+    operator_only=True,
     description=(
         "Remove a previously installed skill pack by name. Operator-only; "
         "requires the user to have asked for it. Bundled skills cannot be removed."
@@ -84,6 +86,7 @@ async def remove_skill(name: str, *, mesh_client=None, _messages=None, **_kw) ->
 
 @tool(
     name="list_skill_assignments",
+    operator_only=True,
     description=(
         "Show which skill packs are assigned where: the fleet-wide list (every "
         "agent sees these) and each agent's per-agent list. Operator-only. Read "
@@ -101,6 +104,7 @@ async def list_skill_assignments(*, mesh_client=None, **_kw) -> dict:
 
 @tool(
     name="assign_skill",
+    operator_only=True,
     description=(
         "Give or take away a skill pack for an agent (or the whole fleet). "
         "Skills are scoped per agent so each agent only sees the procedures it "

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -417,6 +417,15 @@ class AgentLoop:
             from src.agent.builtins.tool_authoring import tool_authoring_enabled
             if not tool_authoring_enabled():
                 excluded |= _TOOL_AUTHORING_TOOLS
+            # Operator-only orchestration tools (edit_agent, create_team,
+            # manage_*, apply_template, install_skill, …) self-reject for
+            # worker callers at call time. Drop their schemas from the worker
+            # surface entirely so they never bloat a worker's LLM context or
+            # tempt it to call a tool it can never use. The operator gets them
+            # via its explicit allowlist, so this exclude never touches it.
+            # ``.update()`` (not ``|=``) so a non-set return can only no-op,
+            # never silently rebind ``excluded`` via the RHS's ``__ror__``.
+            excluded.update(tools.operator_only_tools())
             self._excluded_tools: frozenset[str] | None = (
                 frozenset(excluded) if excluded else None
             )

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -72,6 +72,7 @@ def tool(
     parameters: dict,
     parallel_safe: bool = True,
     loop_exempt: bool = False,
+    operator_only: bool = False,
 ):
     """Decorator to register a function as an agent tool.
 
@@ -82,6 +83,14 @@ def tool(
     *loop_exempt* — when ``True``, the tool is exempt from warn/block
     escalation in the loop detector (but still respects the terminate
     threshold as a hard safety cap).
+
+    *operator_only* — when ``True``, the tool's handler self-rejects for
+    non-operator callers (an ``_is_operator()`` guard in the body). Marking
+    it here lets the worker tool surface drop the schema entirely so it
+    never reaches a worker's LLM context — saving tokens and removing an
+    attractive-nuisance surface (a worker LLM can't be tempted to call a
+    tool it can never use). The operator still receives these via its
+    explicit ``allowed`` allowlist. See ``ToolRegistry.operator_only_tools``.
     """
 
     def decorator(func):
@@ -106,6 +115,7 @@ def tool(
             "_sig_required_params": required_params,
             "_parallel_safe": parallel_safe,
             "_loop_exempt": loop_exempt,
+            "_operator_only": operator_only,
         }
         return func
 
@@ -400,6 +410,22 @@ class ToolRegistry:
         return frozenset(
             name for name, info in self.tools.items()
             if info.get("_loop_exempt", False)
+        )
+
+    def operator_only_tools(self) -> frozenset[str]:
+        """Return the set of tool names marked ``operator_only``.
+
+        These tools self-reject for non-operator callers at call time
+        (``_is_operator()`` guards in their handlers). The worker tool
+        surface unions this set into its exclude list so the schemas are
+        never emitted to a worker's LLM — they would only ever return a
+        permission error if called. The operator receives them via its
+        explicit ``allowed`` allowlist, so this exclusion does not affect
+        the operator.
+        """
+        return frozenset(
+            name for name, info in self.tools.items()
+            if info.get("_operator_only", False)
         )
 
     def list_tools(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -24,6 +24,7 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None) -> AgentLoop:
     tools.list_tools = MagicMock(return_value=[])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
 
     llm = MagicMock()
     if llm_responses:

--- a/tests/test_chat_checkpoint.py
+++ b/tests/test_chat_checkpoint.py
@@ -130,6 +130,7 @@ def _make_loop(tmp_path, *, chat_messages=None):
     tools.get_tool_definitions.return_value = []
     tools.get_descriptions.return_value = ""
     tools.get_loop_exempt_tools.return_value = set()
+    tools.operator_only_tools.return_value = set()
     mesh_client = MagicMock()
     mesh_client.is_standalone = False
     mesh_client.list_agents = AsyncMock(return_value={})
@@ -228,6 +229,7 @@ async def test_no_restore_without_memory(tmp_path):
     tools.get_tool_definitions.return_value = []
     tools.get_descriptions.return_value = ""
     tools.get_loop_exempt_tools.return_value = set()
+    tools.operator_only_tools.return_value = set()
     mesh_client = MagicMock()
     mesh_client.is_standalone = False
 

--- a/tests/test_chat_workspace.py
+++ b/tests/test_chat_workspace.py
@@ -40,6 +40,7 @@ def _make_loop_with_workspace(
     tools.list_tools = MagicMock(return_value=["memory_search", "memory_save"])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
 
     llm = MagicMock()
     if llm_responses:

--- a/tests/test_execute_task_guards.py
+++ b/tests/test_execute_task_guards.py
@@ -57,6 +57,7 @@ def _make_loop(
     tools.list_tools = MagicMock(return_value=[])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
 
     llm = MagicMock()
     if llm_responses:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -61,6 +61,7 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None, *, real_memory: b
     tools.list_tools = MagicMock(return_value=[])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
 
     llm = MagicMock()
     if llm_responses:

--- a/tests/test_operator_allowed_tools.py
+++ b/tests/test_operator_allowed_tools.py
@@ -1,7 +1,9 @@
 """Tests for the allowed_tools allowlist mechanism."""
 import os
 import tempfile
+from unittest.mock import MagicMock
 
+from src.agent.loop import AgentLoop
 from src.agent.tools import ToolRegistry
 
 
@@ -106,3 +108,134 @@ def test_empty_allowed_returns_nothing():
     reg, td = _make_registry_with_tools()
     result = reg.get_tool_definitions(allowed=frozenset())
     assert result == []
+
+
+# --- operator_only flag: keep operator orchestration tools out of worker context ---
+
+def _make_registry_with_operator_tool():
+    """Registry with one operator_only tool and one normal tool."""
+    td = tempfile.mkdtemp()
+    with open(os.path.join(td, "oo_tool.py"), "w") as f:
+        f.write('''
+from src.agent.tools import tool
+
+@tool(name="worker_tool", description="Worker", parameters={})
+async def worker_tool(**kw): return {}
+
+@tool(name="boss_tool", description="Boss", parameters={}, operator_only=True)
+async def boss_tool(**kw): return {}
+''')
+    return ToolRegistry(tools_dir=td), td
+
+
+def test_operator_only_flag_captured():
+    reg, _ = _make_registry_with_operator_tool()
+    assert reg.operator_only_tools() >= {"boss_tool"}
+    assert "worker_tool" not in reg.operator_only_tools()
+
+
+def test_operator_only_defaults_false():
+    """Tools without the flag are never reported as operator-only."""
+    reg, _ = _make_registry_with_tools()
+    assert reg.operator_only_tools().isdisjoint({"tool_a", "tool_b", "tool_c"})
+
+
+def test_real_registry_marks_orchestration_tools_operator_only():
+    """A representative slice of the operator orchestration surface is flagged,
+    and core worker tools are NOT — so the worker exclude drops the former."""
+    reg = ToolRegistry(tools_dir=tempfile.mkdtemp())
+    oo = reg.operator_only_tools()
+    # Orchestration / management tools — must be hidden from workers.
+    for name in (
+        "edit_agent", "create_agent", "create_team", "manage_team",
+        "manage_agent", "manage_task", "apply_template", "list_templates",
+        "install_skill", "assign_skill", "rate_delivery", "workflow_snapshot",
+    ):
+        assert name in oo, f"{name} should be operator_only"
+    # Worker tools — must stay visible to workers.
+    for name in (
+        "read_file", "write_file", "list_files", "run_command",
+        "http_request", "web_search", "skills_list", "skill_view",
+        "memory_save", "memory_search",
+    ):
+        assert name not in oo, f"{name} must NOT be operator_only"
+
+
+def test_operator_only_flag_covers_operator_modules():
+    """Drift guard: every ``@tool`` declared in the operator-only modules is
+    flagged ``operator_only=True`` (so its schema is dropped from workers),
+    and the flag is not set on shared worker builtins.
+
+    Parses the decorator source directly (rather than introspecting the live
+    registry, whose module-global staging dict accumulates tools across tests)
+    so adding a tool to operator_tools.py / fleet_tool.py / skill_admin_tool.py
+    without operator_only=True fails here.
+    """
+    import re
+    from pathlib import Path
+
+    builtins_dir = Path(__file__).resolve().parents[1] / "src" / "agent" / "builtins"
+    declared: set[str] = set()
+    for fname in ("operator_tools.py", "fleet_tool.py", "skill_admin_tool.py"):
+        text = (builtins_dir / fname).read_text()
+        declared |= set(re.findall(r'^\s+name="([^"]+)",\s*$', text, re.MULTILINE))
+    assert declared, "parsed no operator tool names — decorator format changed?"
+
+    oo = ToolRegistry(tools_dir=tempfile.mkdtemp()).operator_only_tools()
+    missing = declared - oo
+    assert not missing, f"operator-module tools missing operator_only=True: {missing}"
+
+    # Shared worker builtins must NOT be flagged — otherwise we'd hide a tool
+    # workers legitimately need.
+    worker_tools = {
+        "read_file", "write_file", "list_files", "run_command",
+        "http_request", "web_search", "skills_list", "skill_view",
+        "memory_save", "memory_search", "notify_user", "check_inbox",
+        "spawn_subagent",
+    }
+    assert worker_tools.isdisjoint(oo), f"worker tools wrongly flagged: {worker_tools & oo}"
+
+
+def _make_loop_with_real_registry(allowed_tools=None):
+    """Build an AgentLoop wired to a REAL ToolRegistry to exercise the
+    schema-build-time tool filtering computed in __init__."""
+    reg = ToolRegistry(tools_dir=tempfile.mkdtemp())
+    mesh = MagicMock()
+    mesh.is_standalone = False
+    loop = AgentLoop(
+        agent_id="operator" if allowed_tools else "worker",
+        role="operator" if allowed_tools else "research",
+        memory=MagicMock(),
+        tools=reg,
+        llm=MagicMock(),
+        mesh_client=mesh,
+        allowed_tools=allowed_tools,
+    )
+    return loop, reg
+
+
+def test_worker_loop_hides_operator_tools_from_schema():
+    """A worker (no allowlist) never receives operator-only tool schemas."""
+    loop, reg = _make_loop_with_real_registry()
+    kw = loop._tool_filter_kw
+    assert "exclude" in kw
+    assert {"edit_agent", "create_team", "apply_template"} <= kw["exclude"]
+    names = {t["function"]["name"] for t in reg.get_tool_definitions(**kw)}
+    assert "edit_agent" not in names
+    assert "create_team" not in names
+    # Worker tools remain visible.
+    assert "read_file" in names
+    assert "run_command" in names
+
+
+def test_operator_loop_still_receives_operator_tools():
+    """The operator path uses the explicit allowlist, so the operator_only
+    exclude never strips its orchestration tools."""
+    allowed = frozenset({"edit_agent", "create_team", "read_file"})
+    loop, reg = _make_loop_with_real_registry(allowed_tools=allowed)
+    kw = loop._tool_filter_kw
+    assert kw.get("allowed") == allowed
+    assert "exclude" not in kw
+    names = {t["function"]["name"] for t in reg.get_tool_definitions(**kw)}
+    assert "edit_agent" in names
+    assert "create_team" in names

--- a/tests/test_operator_e2e.py
+++ b/tests/test_operator_e2e.py
@@ -37,6 +37,7 @@ def _make_mock_tools():
     tools.list_tools = MagicMock(return_value=[])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
     return tools
 
 

--- a/tests/test_task_checkpoint.py
+++ b/tests/test_task_checkpoint.py
@@ -41,6 +41,7 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None, *, real_memory: b
     tools.list_tools = MagicMock(return_value=[])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
 
     llm = MagicMock()
     if llm_responses:
@@ -486,6 +487,7 @@ class TestTaskCheckpointLoop:
         tools.list_tools = MagicMock(return_value=[])
         tools.is_parallel_safe = MagicMock(return_value=True)
         tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+        tools.operator_only_tools = MagicMock(return_value=frozenset())
 
         mesh_client = MagicMock()
         mesh_client.is_standalone = False

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -93,6 +93,7 @@ def _make_loop_with_mocks():
     tools.list_tools = MagicMock(return_value=[])
     tools.is_parallel_safe = MagicMock(return_value=True)
     tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
 
     llm = MagicMock()
     # Default mock returns a STRUCTURED final answer so the chat-path


### PR DESCRIPTION
## Problem

Worker (non-operator) agents were receiving the schemas of **37 operator-only tools** (`operator_tools.py` ×31, `fleet_tool.py` ×2, `skill_admin_tool.py` ×4) in their LLM tool-definitions on **every call**. Those tools already self-reject for non-operators at call time via an `_is_operator()` guard, but their schemas were never stripped from the worker surface:

- **Context bloat** — those tool schemas (rich descriptions + param schemas) were billed on every worker LLM call.
- **Attractive nuisance** — a worker LLM could be tempted to call a tool it can never use.

The operator side was already clean: it runs off an explicit allowlist (`_OPERATOR_ALLOWED_TOOLS`), so it never received worker-only tools like `run_command` / `write_file` / `spawn_subagent` / wallet tools.

## Change

Make "operator-only" a **declared property of the tool** rather than an implicit call-time-only convention:

- Add an `operator_only` flag to the `@tool` decorator + `ToolRegistry.operator_only_tools()` accessor (mirrors the existing `get_loop_exempt_tools()`). Single source of truth — no new hand-synced list.
- Mark all 37 operator tool decorators `operator_only=True`.
- In `AgentLoop.__init__`, the worker exclude path unions in `operator_only_tools()` so the schemas are dropped for workers. Uses `.update()` (not `|=`) so a non-set return can only no-op, never silently rebind the exclude set.
- Call-time `_is_operator()` guards are **kept** as defense-in-depth.

**Operator unaffected** — it uses the `allowed` allowlist path (not exclude), so it still receives all its tools. The daily `compose_work_summary` cron targets the operator and is unaffected.

## Verification

- Full non-Docker suite: **7126 passed, 60 skipped, 0 failed**.
- Ruff: clean on all changed files.
- Independent Codex review: no must-fix; confirmed all four LLM call sites pass `_tool_filter_kw`, and `/capabilities`/`/invoke`/cron/operator/worker paths intact.

New tests in `test_operator_allowed_tools.py`: flag-capture, real-registry coverage, loop-wiring (worker hides / operator keeps), and a source-parsing **drift guard** (adding a tool to an operator module without `operator_only=True` fails CI).

## Flagged as out-of-scope follow-ups (pre-existing, not addressed here)

- `_excluded_tools` is computed once at init (same as the existing `_BLACKBOARD_TOOLS` / `_TOOL_AUTHORING_TOOLS`); builtins don't hot-load.
- Mesh capability registration reports `list_tools()` unfiltered, so a worker still advertises operator tool *names* to the router (metadata, not LLM context). Worth a separate scoped change if discovery should match.