### PR TITLE
fix(dashboard): mobile vertical scroll + responsive Team Hub Work cards

### DIFF
--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1583,6 +1583,32 @@ body {
   overflow-x: hidden;
 }
 
+/* ── Mobile vertical-scroll guarantee ─────────────────
+   The locked-shell model bounds <main> via the flex chain
+   (root `h-[100svh]` → `main flex-1`) so its `overflow-y:auto` becomes the
+   page scroller. On some mobile Chrome builds that flex height chain does
+   NOT constrain <main>: it grows to its full content height, so nothing
+   scrolls vertically and the body's `overflow:hidden` clips everything below
+   the fold. The page reads as frozen — you can pan horizontally (content
+   wider than the viewport) but never scroll down to off-screen content.
+
+   Pin an explicit viewport-relative cap so <main> is ALWAYS a bounded
+   scroller on phones, independent of the flex computation: the mobile shell
+   is the top nav (`--topnav-h`, `.nav-bar` is `flex md:hidden`) plus <main>,
+   so the cap is the remaining viewport. This is a no-op where the flex chain
+   already constrains main (the cap equals the height it already has) and it
+   rescues the case where it doesn't. svh (not dvh) matches the locked shell
+   and avoids URL-bar reflow.
+
+   Mobile-only (<768px): at md+ the layout swaps to the in-flow sidebar
+   (`md:flex-row`) with no top nav, where <main> correctly fills 100svh. */
+@media (max-width: 767px) {
+  main {
+    min-height: 0;
+    max-height: calc(100svh - var(--topnav-h));
+  }
+}
+
 /* iOS Safari auto-zooms on inputs with font-size < 16px.
    Use element selectors to catch ALL form controls regardless of CSS class. */
 @media (max-width: 767px) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2255,7 +2255,7 @@
         <div x-show="artifactPreview" x-cloak
           class="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm"
           @click.self="artifactPreview = null" @keydown.escape.window="artifactPreview = null">
-          <div class="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl w-full max-w-3xl max-h-[80vh] flex flex-col mx-4">
+          <div class="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl w-full max-w-3xl max-h-[80dvh] flex flex-col mx-4">
             <div class="flex items-center justify-between px-4 py-3 border-b border-gray-800">
               <div class="flex items-center gap-2 min-w-0">
                 <span class="text-xs font-mono text-blue-400 truncate" x-text="artifactPreview?.name"></span>
@@ -4511,7 +4511,7 @@
             @keydown.escape.window="closeTaskDrillIn()"
             @keydown.window="handleDrillInKey($event)">
             <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeTaskDrillIn()"></div>
-            <div class="relative w-full max-w-3xl max-h-[90vh] flex flex-col bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden">
+            <div class="relative w-full max-w-3xl max-h-[90dvh] flex flex-col bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden">
               <!-- Header -->
               <div class="flex items-start justify-between gap-3 p-5 border-b border-gray-800">
                 <div class="min-w-0 flex-1">
@@ -9005,7 +9005,7 @@
         <div x-show="showSetup && !loading" x-cloak
              x-init="$watch('showSetup', v => { if (v) { onboardDefaultModel = onboardDefaultModel || (systemSettings && systemSettings.default_model) || ''; onboardOperatorModel = onboardOperatorModel || ((agents.find(a => a.id === 'operator') || {}).model) || ''; } })"
              class="fixed inset-0 z-[160] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm">
-          <div class="w-full max-w-lg bg-gray-900 border border-indigo-800/40 rounded-xl p-6 shadow-2xl max-h-[90vh] overflow-y-auto" data-testid="setup-modal">
+          <div class="w-full max-w-lg bg-gray-900 border border-indigo-800/40 rounded-xl p-6 shadow-2xl max-h-[90dvh] overflow-y-auto" data-testid="setup-modal">
           <h3 class="text-lg font-semibold text-white mb-1">Welcome to OpenLegion</h3>
           <p class="text-xs text-gray-400 mb-5">A couple of quick steps to get your workspace ready.</p>
           <div class="space-y-5">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1820,8 +1820,8 @@
                         <div class="space-y-1">
                           <template x-for="t in teamWork.inflight" :key="t.id">
                             <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg px-3 py-2">
-                              <div class="flex items-center justify-between gap-2">
-                                <span class="text-sm text-gray-200 truncate" x-text="t.title"></span>
+                              <div class="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+                                <span class="text-sm text-gray-200 truncate min-w-0" x-text="t.title"></span>
                                 <span class="text-[11px] text-gray-500 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
                               </div>
                               <div class="text-[11px] text-gray-600 mt-0.5" x-text="t.status"></div>
@@ -1835,8 +1835,8 @@
                         <div class="space-y-1">
                           <template x-for="t in teamWork.doneToday" :key="t.id">
                             <div class="bg-gray-800/30 border border-gray-800 rounded-lg px-3 py-2">
-                              <div class="flex items-center justify-between gap-2">
-                                <span class="text-sm text-gray-300 truncate" x-text="t.title"></span>
+                              <div class="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+                                <span class="text-sm text-gray-300 truncate min-w-0" x-text="t.title"></span>
                                 <span class="text-[11px] text-gray-600 flex-shrink-0 font-mono" x-text="teamHandoffLabel(t)"></span>
                               </div>
                               <div x-show="t.outcome" class="text-[11px] text-emerald-400/80 mt-0.5" x-text="'✓ ' + (t.outcome || '')"></div>


### PR DESCRIPTION
## Summary

Fixes mobile Chrome dashboard issues reported by a user: **pages could not be scrolled vertically** (content below the fold unreachable on every tab), and the **Team Hub Work cards were not responsive** (task title crushed to nothing on phone widths). Also hardens three modals against mobile viewport overflow.

## 1. Mobile vertical scroll guarantee

**Symptom:** on some mobile Chrome builds, horizontal panning worked but vertical scroll was dead on every page (chat, Teams, Work, Settings) — content below the fold was unreachable.

**Root cause:** the locked-shell scroll model (#1030/#1066) bounds `<main>` *solely* via the flex chain (`root h-[100svh]` → `main flex-1`) so its `overflow-y:auto` becomes the page scroller. On the affected devices that flex height chain does not constrain `<main>`: it grows to its full content height (no vertical overflow to scroll), and the body's `overflow:hidden` then clips everything below the visible viewport. Width stays viewport-bounded, so horizontal overflow is still scrollable — matching the exact symptom.

**Reproduced** with a simulated unbounded flex chain in headless Chromium (Pixel 5): `main.clientHeight` grew to the full content height (`vScroll=false`, last card unreachable); adding the cap restored a bounded `clientHeight` (`vScroll=true`, last card reachable).

**Fix:** pin an explicit viewport-relative cap on `<main>` on phones so it is always a bounded scroller, independent of the flex computation:
```css
@media (max-width: 767px) {
  main { min-height: 0; max-height: calc(100svh - var(--topnav-h)); }
}
```
No-op where the flex chain already constrains main (cap == current height); rescues the case where it doesn't. Mobile-only — at md+ the layout swaps to the in-flow sidebar with no top nav, where main fills 100svh correctly (untouched). Verified the operator chat composer stays reachable under both a working and a broken flex chain.

## 2. Responsive Team Hub Work cards

The In-flight / Delivered-today cards laid the title and the handoff label on a single `justify-between` row. On phone widths the handoff label (e.g. `researcher → writer`) reserved its width and crushed the truncating title to a few characters. Now stacked on mobile (title full width, handoff + status below) with the side-by-side layout restored at `sm+`; added `min-w-0` so truncation resolves inside the flex row. Verified at 360px and 900px.

## 3. Modal viewport units (vh → dvh)

Follow-up to #1066, which converted the locked shell + nested caps to `dvh` but missed three centered modals (first-run setup, task drill-in, artifact preview). Static `vh` resolves to the largest viewport on mobile Chrome, so a tall centered modal could push its top/bottom off-screen with no way to reach it. Converted to `dvh`.

## Testing

Verified the layout/scroll behavior in headless Chromium with mobile emulation (faithful repros of the shell, the chat nesting, nested scrollers, and the simulated flex-chain failure). Desktop layout unaffected (changes are mobile-gated / `dvh == vh` with no dynamic browser UI).

https://claude.ai/code/session_01SW3reXAqdEm9EB9mZ5xyiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SW3reXAqdEm9EB9mZ5xyiu)_