### PR TITLE
fix(agent): run memory consolidation off the live turn + read the newest log

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -22,7 +22,7 @@ from src.agent.llm import LLMClient
 from src.agent.loop import AgentLoop
 from src.agent.memory import MemoryStore
 from src.agent.mesh_client import MeshClient
-from src.agent.server import create_agent_app
+from src.agent.server import create_agent_app, run_maintenance_loop
 from src.agent.tools import ToolRegistry
 from src.agent.workspace import WorkspaceManager
 from src.shared.trace import new_trace_id
@@ -258,7 +258,15 @@ def main() -> None:
                     loop.current_task = None
                 logger.warning("Auto-resume check failed: %s", e)
 
+        # Background memory-maintenance pass (consolidation + salience decay),
+        # off the live turn. Internally idle-guarded + 6h-gated.
+        _maintenance_task = asyncio.create_task(run_maintenance_loop(loop))
+
         yield
+
+        _maintenance_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _maintenance_task
         if loop.state == "working":
             loop._cancel_requested = True
             handle = loop._current_task_handle

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -35,6 +35,24 @@ _SUMMARIZATION_INPUT_LIMIT = 20_000  # max chars fed to the summarization LLM ca
 
 _CONSOLIDATION_MIN_INTERVAL_S = 6 * 3600   # at most every 6 hours
 _CONSOLIDATION_MIN_LOG_CHARS = 1_500       # skip if little new material accrued
+_CONSOLIDATION_FAIL_BACKOFF_S = 30 * 60    # after a failed run, wait before retrying
+_DECAY_MIN_INTERVAL_S = 6 * 3600           # salience-decay cadence for the maintenance pass
+
+
+def _tail_on_boundary(text: str, limit: int) -> str:
+    """Return the last ``limit`` chars of ``text``, re-aligned forward to the
+    next ``\\n## `` section boundary so the slice never starts mid-entry.
+
+    The memory log is append-only (oldest first), so the NEWEST entries live
+    at the tail — this is what consolidation must read.
+    """
+    if len(text) <= limit:
+        return text
+    tail = text[-limit:]
+    idx = tail.find("\n## ")
+    if idx != -1:
+        tail = tail[idx + 1:]
+    return tail
 
 
 def _get_tiktoken_encoding(model: str):
@@ -178,6 +196,9 @@ class ContextManager:
         self._flush_triggered = False
         self._flush_lock = asyncio.Lock()
         self._on_memory_update = on_memory_update
+        # Backoff clock for the maintenance pass: set to a future time after a
+        # failed consolidation so a frequent tick doesn't hammer the LLM.
+        self._consolidation_retry_after = 0.0
 
     def reset(self) -> None:
         """Reset per-session state for a new conversation."""
@@ -410,15 +431,49 @@ class ContextManager:
                 f"Context compacted — {count} facts flushed to memory"
             )
 
+    async def run_maintenance(self) -> None:
+        """Off-live-path memory maintenance: re-derive the compiled MEMORY.md
+        head and decay fact salience.
+
+        Driven by the agent's periodic background pass (gbrain "dream cycle" /
+        hermes "Curator"), NOT the live turn — the caller is expected to hold
+        the chat lock so this never races a turn's memory writes. Each step is
+        internally gated (consolidation/decay >=6h), so a frequent tick is
+        cheap when nothing is due. Best-effort: never raises.
+        """
+        await self._maybe_consolidate_memory()
+        await self._maybe_decay_salience()
+
+    async def _maybe_decay_salience(self) -> None:
+        """Decay fact salience at most once per window.
+
+        Gated by the shared ``.memory_decayed`` sentinel that the task path
+        also stamps on every fresh-task decay (loop.py): a busy worker is thus
+        never double-decayed, while an idle agent (e.g. the operator, which
+        runs no tasks) still decays through this pass — the gap this closes.
+        """
+        ws, mem = self.workspace, self.memory
+        if not ws or not mem:
+            return
+        if not ws.decay_due(_DECAY_MIN_INTERVAL_S):
+            return
+        try:
+            await mem.decay_all()
+            ws.mark_decayed()
+        except Exception as e:
+            logger.debug("salience decay failed: %s", e)
+
     async def _maybe_consolidate_memory(self) -> None:
         """Re-derive the compiled MEMORY.md head from the append-only log +
         high-salience facts. Time-gated (>=6h) and material-gated (>=1.5k log
-        chars) so it adds at most one LLM call to the occasional compaction.
-        Best-effort: never raises into the compaction path.
+        chars) so it adds at most one LLM call per cycle. Best-effort: never
+        raises into the caller (compaction or the maintenance pass).
         """
         ws, llm = self.workspace, self.llm
         if not ws or not llm:
             return
+        if time.time() < self._consolidation_retry_after:
+            return  # backing off after a recent failure
         if not ws.consolidation_due(_CONSOLIDATION_MIN_INTERVAL_S):
             return
         log = ws.load_memory_log()
@@ -442,7 +497,8 @@ class ContextManager:
             "words). Output ONLY the compiled memory markdown — no preamble.\n\n"
             f"## Current compiled memory\n{head[:_SUMMARIZATION_INPUT_LIMIT]}\n\n"
             f"## High-salience facts\n{salient[:4000]}\n\n"
-            f"## Recent activity log (newest last)\n{log[:_SUMMARIZATION_INPUT_LIMIT]}"
+            f"## Recent activity log (newest last)\n"
+            f"{_tail_on_boundary(log, _SUMMARIZATION_INPUT_LIMIT)}"
         )
         try:
             resp = await llm.chat(
@@ -452,12 +508,15 @@ class ContextManager:
             )
         except Exception as e:
             logger.warning("Memory consolidation LLM call failed: %s", e)
+            self._consolidation_retry_after = time.time() + _CONSOLIDATION_FAIL_BACKOFF_S
             return
         new_head = (resp.content or "").strip()
         if not new_head:
+            self._consolidation_retry_after = time.time() + _CONSOLIDATION_FAIL_BACKOFF_S
             return
         ws.write_compiled_memory(sanitize_for_prompt(new_head))
         ws.mark_consolidated()
+        self._consolidation_retry_after = 0.0
         if self._on_memory_update:
             try:
                 await self._on_memory_update()

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -448,9 +448,11 @@ class ContextManager:
         """Decay fact salience at most once per window.
 
         Gated by the shared ``.memory_decayed`` sentinel that the task path
-        also stamps on every fresh-task decay (loop.py): a busy worker is thus
-        never double-decayed, while an idle agent (e.g. the operator, which
-        runs no tasks) still decays through this pass — the gap this closes.
+        also stamps on every fresh-task decay (loop.py). This gating only binds
+        the background maintenance pass: it won't pile an extra decay onto an
+        agent the task path recently decayed. The task path itself stays
+        ungated (it decays per fresh task), so this pass exists to cover an
+        idle agent (e.g. the operator, which runs no tasks) — the gap it closes.
         """
         ws, mem = self.workspace, self.memory
         if not ws or not mem:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1951,7 +1951,16 @@ class AgentLoop:
         if self.state != "idle" or self._chat_lock.locked():
             return
         async with self._chat_lock:
-            await self.context_manager.run_maintenance()
+            # Re-check under the lock, then mark busy so a concurrent POST
+            # /task (which gates on ``state``, not the chat lock) can't start
+            # and race the consolidation's memory writes. Restored in finally.
+            if self.state != "idle":
+                return
+            self.state = "working"
+            try:
+                await self.context_manager.run_maintenance()
+            finally:
+                self.state = "idle"
 
     # ── Heartbeat mode ────────────────────────────────────────
 

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -810,6 +810,8 @@ class AgentLoop:
                 messages = await self._build_initial_context(assignment)
                 if self.memory:
                     await self.memory.decay_all()
+                    if self.workspace:
+                        self.workspace.mark_decayed()
             else:
                 # Reconcile TokenBudget mutable state
                 if assignment.token_budget:
@@ -852,9 +854,13 @@ class AgentLoop:
             start_iteration = 0
             assignment_json = assignment.model_dump_json()
             messages = await self._build_initial_context(assignment)
-            # Decay salience scores only on fresh start (not resume, to avoid double-decay)
+            # Decay salience scores only on fresh start (not resume, to avoid double-decay).
+            # Stamp the shared decay sentinel so the background maintenance pass
+            # (ContextManager._maybe_decay_salience) won't double-decay a busy agent.
             if self.memory:
                 await self.memory.decay_all()
+                if self.workspace:
+                    self.workspace.mark_decayed()
 
         introspect_data = await self._fetch_introspect_cached()
         system_prompt = self._build_system_prompt(assignment, introspect_data=introspect_data)
@@ -1927,6 +1933,25 @@ class AgentLoop:
             return parsed.get("result", {"raw": content}), parsed.get("promote", {})
         except (json.JSONDecodeError, AttributeError):
             return {"raw": content}, {}
+
+    # ── Background memory maintenance ─────────────────────────
+
+    async def run_maintenance(self) -> None:
+        """Run the off-live-path memory maintenance pass (consolidation +
+        salience decay), driven by the agent's periodic background task.
+
+        Skips while a turn is in flight — same idle/lock guard the heartbeat
+        uses — so it never races a turn's memory writes (``_flush_to_memory``
+        + salience updates) or adds latency to a user-facing turn. The work
+        itself is internally time-gated (>=6h), so a frequent tick is cheap
+        when nothing is due. Best-effort: never raises.
+        """
+        if not self.context_manager:
+            return
+        if self.state != "idle" or self._chat_lock.locked():
+            return
+        async with self._chat_lock:
+            await self.context_manager.run_maintenance()
 
     # ── Heartbeat mode ────────────────────────────────────────
 

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -144,6 +144,14 @@ _MAX_HISTORY_MEMORY_CHARS = 5000
 _MAX_HISTORY_LOGS_CHARS = 16000
 _MAX_HISTORY_LEARNINGS_CHARS = 8000
 
+# Background memory-maintenance pass cadence. The first run is delayed so boot
+# and the first user turn settle; thereafter it ticks periodically. The actual
+# work (consolidation + decay) is internally 6h-gated, so the short delay also
+# gives a frequently-restarted agent (e.g. the operator) a maintenance attempt
+# soon after each boot rather than never reaching a long interval.
+_MAINTENANCE_INITIAL_DELAY_S = 180
+_MAINTENANCE_TICK_S = 30 * 60
+
 
 def _origin_from_mesh_request(request: Request):
     """Parse origin from a host-to-agent request.
@@ -171,7 +179,35 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if os.environ.get("OPENLEGION_ENABLE_DOCS", "").lower() in ("1", "true", "yes", "on")
         else {"docs_url": None, "redoc_url": None, "openapi_url": None}
     )
-    app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}", **_docs_kwargs)
+    @contextlib.asynccontextmanager
+    async def _lifespan(_app: FastAPI):
+        """Run a periodic background memory-maintenance pass for this agent's
+        lifetime (consolidation + salience decay, off the live turn)."""
+        async def _maintenance_loop() -> None:
+            delay = _MAINTENANCE_INITIAL_DELAY_S
+            while True:
+                await asyncio.sleep(delay)
+                delay = _MAINTENANCE_TICK_S
+                try:
+                    await loop.run_maintenance()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning("maintenance pass failed: %s", e)
+
+        task = asyncio.create_task(_maintenance_loop())
+        try:
+            yield
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app = FastAPI(
+        title=f"OpenLegion Agent: {loop.agent_id}",
+        lifespan=_lifespan,
+        **_docs_kwargs,
+    )
     _install_body_size_limit(app)
     _task_accept_lock = asyncio.Lock()
 

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -179,35 +179,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if os.environ.get("OPENLEGION_ENABLE_DOCS", "").lower() in ("1", "true", "yes", "on")
         else {"docs_url": None, "redoc_url": None, "openapi_url": None}
     )
-    @contextlib.asynccontextmanager
-    async def _lifespan(_app: FastAPI):
-        """Run a periodic background memory-maintenance pass for this agent's
-        lifetime (consolidation + salience decay, off the live turn)."""
-        async def _maintenance_loop() -> None:
-            delay = _MAINTENANCE_INITIAL_DELAY_S
-            while True:
-                await asyncio.sleep(delay)
-                delay = _MAINTENANCE_TICK_S
-                try:
-                    await loop.run_maintenance()
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.warning("maintenance pass failed: %s", e)
-
-        task = asyncio.create_task(_maintenance_loop())
-        try:
-            yield
-        finally:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-
-    app = FastAPI(
-        title=f"OpenLegion Agent: {loop.agent_id}",
-        lifespan=_lifespan,
-        **_docs_kwargs,
-    )
+    app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}", **_docs_kwargs)
     _install_body_size_limit(app)
     _task_accept_lock = asyncio.Lock()
 
@@ -1089,3 +1061,23 @@ def _log_task_exception(task: asyncio.Task) -> None:
     exc = task.exception()
     if exc:
         logger.error(f"Background task failed: {exc}", exc_info=exc)
+
+
+async def run_maintenance_loop(loop: AgentLoop) -> None:
+    """Periodic background memory-maintenance pass for an agent's lifetime.
+
+    Launched from the agent process lifespan (``__main__``). The first run is
+    delayed so boot + the first user turn settle; thereafter it ticks
+    periodically. ``loop.run_maintenance`` is internally idle-guarded and
+    6h-gated, so a frequent tick is cheap and never races a live turn.
+    """
+    delay = _MAINTENANCE_INITIAL_DELAY_S
+    while True:
+        await asyncio.sleep(delay)
+        delay = _MAINTENANCE_TICK_S
+        try:
+            await loop.run_maintenance()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("maintenance pass failed: %s", e)

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -252,6 +252,7 @@ class WorkspaceManager:
 
     MEMORY_FILE = "MEMORY.md"
     _CONSOLIDATION_STAMP = ".memory_consolidated"
+    _DECAY_STAMP = ".memory_decayed"
     HEARTBEAT_FILE = "HEARTBEAT.md"
     DAILY_DIR = "memory"
     LEARNINGS_DIR = "learnings"
@@ -686,6 +687,28 @@ class WorkspaceManager:
             (self.root / self._CONSOLIDATION_STAMP).touch()
         except OSError as e:
             logger.debug("Failed to stamp consolidation: %s", e)
+
+    def decay_due(self, min_interval_s: float) -> bool:
+        """True when fact salience hasn't been decayed within the window.
+
+        Shared by the task path (stamps on every fresh-task decay) and the
+        background maintenance pass, so an idle agent still decays and a busy
+        one is never double-decayed.
+        """
+        p = self.root / self._DECAY_STAMP
+        try:
+            if p.exists():
+                return (time.time() - p.stat().st_mtime) >= min_interval_s
+        except OSError:
+            pass
+        return True  # never decayed → due
+
+    def mark_decayed(self) -> None:
+        """Stamp the last salience-decay time (touch the sentinel)."""
+        try:
+            (self.root / self._DECAY_STAMP).touch()
+        except OSError as e:
+            logger.debug("Failed to stamp decay: %s", e)
 
     # Files agents are allowed to update themselves
     AGENT_WRITABLE = frozenset({"HEARTBEAT.md", "USER.md", "SOUL.md", "INSTRUCTIONS.md", "INTERFACE.md"})

--- a/tests/test_compiled_memory.py
+++ b/tests/test_compiled_memory.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.agent.context import ContextManager
+from src.agent.context import (
+    _SUMMARIZATION_INPUT_LIMIT,
+    ContextManager,
+    _tail_on_boundary,
+)
 from src.agent.workspace import (
     _MEMORY_FILE_MAX,
     MEMORY_COMPILED_BEGIN,
@@ -164,6 +168,29 @@ class TestCompiledMemorySplit:
         # Zero interval → always due.
         assert self.ws.consolidation_due(0) is True
 
+    def test_decay_stamp_due_then_not_due(self):
+        # Mirrors the consolidation sentinel: never decayed → due; just
+        # stamped → not due; zero interval → always due.
+        assert self.ws.decay_due(10_000) is True
+        self.ws.mark_decayed()
+        assert self.ws.decay_due(10_000) is False
+        assert self.ws.decay_due(0) is True
+
+
+def test_tail_on_boundary_returns_newest_not_oldest():
+    """The slice-bug regression guard. The log is append-only (oldest first),
+    so consolidation must read the TAIL — the previous ``log[:N]`` read the
+    OLDEST entries and truncated everything recent."""
+    # Under the limit → returned whole.
+    assert _tail_on_boundary("short", 100) == "short"
+
+    entries = [f"## Entry {i}\n\nbody-{i} " + ("x" * 200) for i in range(20)]
+    log = "\n\n".join(entries)
+    out = _tail_on_boundary(log, 1_000)
+    assert "Entry 19" in out            # newest survives
+    assert "Entry 0\n" not in out       # oldest truncated
+    assert out.lstrip().startswith("## ")  # never starts mid-entry
+
 
 def _fake_fact(key: str, value: str):
     f = MagicMock()
@@ -226,3 +253,125 @@ class TestConsolidateMemory:
 
         llm.chat.assert_not_called()
         ws.write_compiled_memory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_consolidation_feeds_newest_log_to_llm(self):
+        """End-to-end slice-bug guard: the consolidation prompt must contain
+        the NEWEST log entry and exclude the oldest when the log exceeds the
+        summarization limit (the bug fed ``log[:N]`` — the oldest)."""
+        oldest = "## OLDEST\n\nOLDEST_LOG_MARKER"
+        newest = "## NEWEST\n\nNEWEST_LOG_MARKER"
+        log = oldest + "\n\n" + ("filler " * 5_000) + "\n\n" + newest
+        assert len(log) > _SUMMARIZATION_INPUT_LIMIT  # forces a tail slice
+        ws = self._make_workspace(due=True, log=log)
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="HEAD", tokens_used=10)
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+
+        prompt = llm.chat.call_args.kwargs["messages"][0]["content"]
+        assert "NEWEST_LOG_MARKER" in prompt
+        assert "OLDEST_LOG_MARKER" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_failed_consolidation_backs_off_and_skips_next(self):
+        """A failed LLM call sets a backoff so the frequent maintenance tick
+        doesn't hammer the model; the next call skips before the LLM."""
+        ws = self._make_workspace(due=True, log="L" * 2_000)
+        llm = MagicMock()
+        llm.chat = AsyncMock(side_effect=RuntimeError("llm down"))
+
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+        assert cm._consolidation_retry_after > 0
+        assert llm.chat.await_count == 1
+        ws.mark_consolidated.assert_not_called()
+
+        # Within the backoff window → no second LLM call.
+        await cm._maybe_consolidate_memory()
+        assert llm.chat.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_consolidation_output_backs_off(self):
+        ws = self._make_workspace(due=True, log="L" * 2_000)
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="   ", tokens_used=1)
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+
+        assert cm._consolidation_retry_after > 0
+        ws.write_compiled_memory.assert_not_called()
+        ws.mark_consolidated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_decay_runs_when_due_and_stamps(self):
+        ws = MagicMock()
+        ws.decay_due.return_value = True
+        mem = MagicMock()
+        mem.decay_all = AsyncMock()
+
+        cm = ContextManager(
+            max_tokens=1000, llm=MagicMock(), workspace=ws, memory=mem,
+        )
+        await cm._maybe_decay_salience()
+
+        mem.decay_all.assert_awaited_once()
+        ws.mark_decayed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_decay_skips_when_not_due(self):
+        ws = MagicMock()
+        ws.decay_due.return_value = False
+        mem = MagicMock()
+        mem.decay_all = AsyncMock()
+
+        cm = ContextManager(
+            max_tokens=1000, llm=MagicMock(), workspace=ws, memory=mem,
+        )
+        await cm._maybe_decay_salience()
+
+        mem.decay_all.assert_not_awaited()
+        ws.mark_decayed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_maintenance_decay_skips_after_task_path_stamp(self):
+        """Double-decay guard with a REAL workspace: the task path stamps the
+        shared ``.memory_decayed`` sentinel on every fresh-task decay, so the
+        maintenance pass must then treat decay as not-due."""
+        d = tempfile.mkdtemp()
+        try:
+            ws = WorkspaceManager(workspace_dir=d)
+            ws.mark_decayed()  # simulate a task-path decay
+            mem = MagicMock()
+            mem.decay_all = AsyncMock()
+            cm = ContextManager(
+                max_tokens=1000, llm=MagicMock(), workspace=ws, memory=mem,
+            )
+            await cm._maybe_decay_salience()
+            mem.decay_all.assert_not_awaited()
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_run_maintenance_consolidates_then_decays(self):
+        ws = self._make_workspace(due=True, log="L" * 2_000)
+        ws.decay_due.return_value = True
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="NEW HEAD", tokens_used=10)
+        )
+        mem = MagicMock()
+        mem.get_high_salience_facts = AsyncMock(return_value=[])
+        mem.decay_all = AsyncMock()
+
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=mem)
+        await cm.run_maintenance()
+
+        ws.write_compiled_memory.assert_called_once()
+        ws.mark_consolidated.assert_called_once()
+        mem.decay_all.assert_awaited_once()
+        ws.mark_decayed.assert_called_once()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2269,6 +2269,34 @@ async def test_heartbeat_skips_when_chat_locked():
 
 
 @pytest.mark.asyncio
+async def test_run_maintenance_skips_when_busy_else_runs_under_lock():
+    """The background maintenance pass must skip while a turn is in flight
+    (same idle/lock guard the heartbeat uses) and otherwise run the
+    ContextManager pass under the chat lock."""
+    loop = _make_loop()
+    loop.context_manager = MagicMock()
+    loop.context_manager.run_maintenance = AsyncMock()
+
+    # Busy with a task → skip.
+    loop.state = "working"
+    await loop.run_maintenance()
+    loop.context_manager.run_maintenance.assert_not_awaited()
+
+    # Idle but a chat turn holds the lock → skip.
+    loop.state = "idle"
+    await loop._chat_lock.acquire()
+    try:
+        await loop.run_maintenance()
+    finally:
+        loop._chat_lock.release()
+    loop.context_manager.run_maintenance.assert_not_awaited()
+
+    # Idle and unlocked → runs.
+    await loop.run_maintenance()
+    loop.context_manager.run_maintenance.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_skips_when_no_rules():
     """Heartbeat skips LLM call when HEARTBEAT.md is empty and no goals set."""
     loop = _make_loop()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -8,6 +8,7 @@ Uses mock LLM to verify:
 - Final output parsing
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2291,9 +2292,33 @@ async def test_run_maintenance_skips_when_busy_else_runs_under_lock():
         loop._chat_lock.release()
     loop.context_manager.run_maintenance.assert_not_awaited()
 
-    # Idle and unlocked → runs.
+    # Idle and unlocked → runs, then restores idle state (so it doesn't
+    # leave the agent stuck "working").
     await loop.run_maintenance()
     loop.context_manager.run_maintenance.assert_awaited_once()
+    assert loop.state == "idle"
+
+
+@pytest.mark.asyncio
+async def test_run_maintenance_loop_invokes_then_cancels(monkeypatch):
+    """The production launch path (server.run_maintenance_loop) ticks
+    loop.run_maintenance and stops cleanly on cancellation."""
+    from src.agent import server
+
+    loop = _make_loop()
+    loop.run_maintenance = AsyncMock()
+    monkeypatch.setattr(server, "_MAINTENANCE_INITIAL_DELAY_S", 0)
+    monkeypatch.setattr(server, "_MAINTENANCE_TICK_S", 0.01)
+
+    task = asyncio.create_task(server.run_maintenance_loop(loop))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert loop.run_maintenance.await_count >= 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

The compiled-`MEMORY.md` consolidation (#1062) only ran **inside compaction**, which fires at 70% of the context window. A large-window, frequently-restarted agent like the **operator** sits at ~28% of opus's window and **never reached it** — so its compiled head was never re-derived and it read a stale, bloated, self-contradictory `MEMORY.md` every turn. This is the root cause of "operator is slow / doesn't understand": context pollution, not capability.

Three compounding faults (all verified against `origin/main`):

1. **Consolidation never fired** off the compaction path.
2. When it did, it read `log[:20000]` — the **OLDEST** entries (the log is append-only / oldest-first), so the newest activity was truncated off the very input meant to refresh the head.
3. **Salience never decayed in the chat path** — `decay_all` ran only on fresh *task* starts, so an agent that runs no tasks (the operator) never decayed; high-salience facts drifted toward old, frequently-touched items that feed both consolidation and task initial-context.

## What

- **`ContextManager.run_maintenance()`** — consolidation + salience decay, runnable outside compaction. Driven by a per-agent **background pass** (gbrain "dream cycle" / hermes "Curator") started in the agent-server **lifespan**: first run ~3 min after boot, then every 30 min; each step is internally **6h-gated** so a frequent tick is cheap. Runs **under the chat lock** with the heartbeat's idle/lock guard, so it never races a turn's memory writes (`_flush_to_memory` + salience updates) or adds user-turn latency. A frequently-restarted agent still gets an attempt soon after each boot.
- **Slice fix** — read the **newest** log tail via `_tail_on_boundary`, re-aligned to a `\n## ` section boundary so it never starts mid-entry.
- **Chat-path decay** — runs in the maintenance pass, gated by a shared `.memory_decayed` sentinel that the **task path now also stamps**. A busy worker (decays every fresh task) is never double-decayed; an idle operator still decays.
- **Failure backoff** — a failed or empty consolidation sets a 30-min backoff so the frequent tick doesn't hammer the LLM.

The existing compaction-path trigger is **kept** as a high-activity safety net. **No tool or model changes; agent-only** (no host/cron/cli changes).

### Scope notes
- Trigger mechanism is an **in-agent background pass**, not mesh-cron→/invoke: builtin tools cannot reach the `ContextManager`/LLM/`_chat_lock` (all live on `AgentLoop`), which the cron path would have required opening a new tool-injection surface for. The background pass is the pattern originally cited for this work and keeps the change agent-only.
- **Log-trim was dropped from the original plan** on inspection: the on-disk log is already bounded (`_trim_memory_log`, 64K cap) and injection is already capped at the newest 5K — extra trimming would only reduce BM25 search recall.

## Tests
`tests/test_compiled_memory.py` + `tests/test_loop.py`: slice reads newest not oldest, consolidation feeds the newest log to the LLM, failure/empty backoff, decay gating + the shared-sentinel double-decay guard (real workspace), `run_maintenance` consolidates-then-decays, and `AgentLoop.run_maintenance` idle/lock busy-skip. **307 passed**, ruff clean.

## Deploy
Agent code (`src/agent/**`) → rebuild `openlegion-agent:latest` + restart. After deploy, inspect the operator's first re-derived head: `docker exec openlegion_operator cat /data/workspace/MEMORY.md` (the consolidation *prompt* is unchanged from #1062 — only the slice that feeds it was wrong — but it has never actually run for this operator, so eyeball the first output).