### PR TITLE
feat(memory): semantic fact dedup on the write path

### DIFF
--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -58,6 +58,8 @@ _CATEGORY_RECOMPUTE_INTERVAL = 10
 # distinct facts ("user_name" vs "user_email") are never collapsed — only genuine
 # near-synonym keys ("preferred_language" vs "user_language_preference") merge.
 # Similarity uses the same 1/(1+L2_distance) convention as search/categorization.
+# NOTE: the metric is 1/(1+L2), so 0.93 ≈ ~0.997 cosine for unit-normalized
+# vectors — tune with care; this value is wrong for unnormalized providers.
 _SEMANTIC_DEDUP_SIM_THRESHOLD = 0.93
 
 
@@ -312,36 +314,45 @@ class MemoryStore:
     def _store_fact_sync(
         self, key: str, value: str, category: str, source: str,
         confidence: float, embedding: list[float] | None,
-        merge_into: str | None = None,
+        semantic_dedup: bool = False,
     ) -> str:
         """Sync DB portion of store_fact. Returns the fact ID.
 
-        ``merge_into`` is a fact id resolved by semantic-similarity dedup; when set,
-        that existing row is updated in place (prefer-newer value, bump salience)
-        instead of matching purely on exact key.
+        Probe + conflict-check + write happen in ONE executor call / SQLite
+        transaction (no await gap) so a concurrent store can't mutate the target
+        between the dedup probe and the write.
+
+        ``semantic_dedup`` enables the in-transaction near-duplicate probe (only
+        meaningful when an ``embedding`` is available). The EXACT-key row always
+        wins: a semantic merge only fires when no row already holds ``key``, which
+        guarantees the merge can never rewrite one row's key onto another's and
+        create a duplicate-key orphan.
         """
-        existing = None
-        if merge_into is not None:
-            existing = self.db.execute(
-                "SELECT id, access_count FROM facts WHERE id = ?", (merge_into,),
-            ).fetchone()
-        if existing is None:
-            existing = self.db.execute(
-                "SELECT id, access_count FROM facts WHERE key = ?", (key,),
-            ).fetchone()
+        existing = self.db.execute(
+            "SELECT id, access_count FROM facts WHERE key = ?", (key,),
+        ).fetchone()
+        # Only consider a semantic merge for a genuinely-new key — otherwise the
+        # in-place UPDATE below would rewrite this row's key to equal an existing
+        # row's key, leaving two rows sharing a key (an unreachable orphan).
+        if existing is None and semantic_dedup and embedding is not None:
+            merge_id = self._find_semantic_duplicate(embedding, category)
+            if merge_id is not None:
+                existing = self.db.execute(
+                    "SELECT id, access_count FROM facts WHERE id = ?", (merge_id,),
+                ).fetchone()
 
         if existing:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
-            # Prefer the newer value AND adopt the newer key/category so the
-            # surviving row reflects the latest phrasing (a semantic merge may
-            # have matched a row stored under a different key).
+            # Prefer the newer value AND adopt the newer key/category/source so the
+            # surviving row reflects the latest phrasing + provenance (a semantic
+            # merge may have matched a row stored under a different key).
             self.db.execute(
-                "UPDATE facts SET key = ?, value = ?, category = ?, confidence = ?, "
-                "access_count = ?, last_accessed = datetime('now'), "
+                "UPDATE facts SET key = ?, value = ?, category = ?, source = ?, "
+                "confidence = ?, access_count = ?, last_accessed = datetime('now'), "
                 "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (key, value, category, confidence, new_count, boost, fact_id),
+                (key, value, category, source, confidence, new_count, boost, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
@@ -395,19 +406,15 @@ class MemoryStore:
             )
             embedding = None
 
-        # Semantic dedup (opt-in): if an existing fact is a near-duplicate of this
-        # one, update it in place instead of inserting a near-dup row. Resolved
-        # here (sync probe in executor) so the value reaches _store_fact_sync.
-        merge_into = None
-        if embedding is not None and _semantic_dedup_enabled():
-            merge_into = await self._run_db(
-                self._find_semantic_duplicate, embedding, category,
-            )
+        # Semantic dedup (opt-in): the near-duplicate probe runs INSIDE
+        # _store_fact_sync (same executor call / SQLite transaction as the write)
+        # so the probe + exact-key conflict check + write are atomic.
+        semantic_dedup = embedding is not None and _semantic_dedup_enabled()
 
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
             self._store_fact_sync, key, value, category, source, confidence,
-            embedding, merge_into,
+            embedding, semantic_dedup,
         )
 
         if embedding is not None:

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -334,26 +334,39 @@ class MemoryStore:
         # Only consider a semantic merge for a genuinely-new key — otherwise the
         # in-place UPDATE below would rewrite this row's key to equal an existing
         # row's key, leaving two rows sharing a key (an unreachable orphan).
+        merged = False
         if existing is None and semantic_dedup and embedding is not None:
             merge_id = self._find_semantic_duplicate(embedding, category)
             if merge_id is not None:
                 existing = self.db.execute(
                     "SELECT id, access_count FROM facts WHERE id = ?", (merge_id,),
                 ).fetchone()
+                merged = existing is not None
 
         if existing:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
-            # Prefer the newer value AND adopt the newer key/category/source so the
-            # surviving row reflects the latest phrasing + provenance (a semantic
-            # merge may have matched a row stored under a different key).
-            self.db.execute(
-                "UPDATE facts SET key = ?, value = ?, category = ?, source = ?, "
-                "confidence = ?, access_count = ?, last_accessed = datetime('now'), "
-                "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (key, value, category, source, confidence, new_count, boost, fact_id),
-            )
+            if merged:
+                # Semantic merge: adopt the newer key/category/source so the
+                # surviving row reflects the latest phrasing + provenance (the
+                # matched row may have been stored under a different key/category).
+                self.db.execute(
+                    "UPDATE facts SET key = ?, value = ?, category = ?, source = ?, "
+                    "confidence = ?, access_count = ?, last_accessed = datetime('now'), "
+                    "decay_score = MIN(?, 10.0) WHERE id = ?",
+                    (key, value, category, source, confidence, new_count, boost, fact_id),
+                )
+            else:
+                # Exact-key re-store: byte-identical to the pre-dedup write path
+                # (the flag-off path must match main) — update value/confidence/
+                # salience only; never overwrite the stored key/category/source.
+                self.db.execute(
+                    "UPDATE facts SET value = ?, confidence = ?, "
+                    "access_count = ?, last_accessed = datetime('now'), "
+                    "decay_score = MIN(?, 10.0) WHERE id = ?",
+                    (value, confidence, new_count, boost, fact_id),
+                )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
                 "INSERT INTO facts_fts (fact_id, key, value, category) VALUES (?, ?, ?, ?)",

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -17,6 +17,7 @@ import functools
 import hashlib
 import json
 import math
+import os
 import re
 import sqlite3
 import struct
@@ -51,6 +52,21 @@ _TASK_CHECKPOINT_VERSION = 1
 _CATEGORY_SIM_THRESHOLD = 0.7
 # Recompute category embedding every N new members
 _CATEGORY_RECOMPUTE_INTERVAL = 10
+# Semantic dedup: when storing a fact, an existing fact whose embedding is at or
+# above this similarity (and category-compatible) is treated as the SAME fact and
+# updated in place instead of inserting a near-duplicate row. Deliberately high so
+# distinct facts ("user_name" vs "user_email") are never collapsed — only genuine
+# near-synonym keys ("preferred_language" vs "user_language_preference") merge.
+# Similarity uses the same 1/(1+L2_distance) convention as search/categorization.
+_SEMANTIC_DEDUP_SIM_THRESHOLD = 0.93
+
+
+def _semantic_dedup_enabled() -> bool:
+    """Vector-similarity dedup on the write path is opt-in (embedding path is not
+    always available; ships safe behind a flag, default off)."""
+    return os.environ.get("OPENLEGION_SEMANTIC_DEDUP", "").lower() in (
+        "1", "true", "yes", "on",
+    )
 
 _T = TypeVar("_T")
 
@@ -263,22 +279,69 @@ class MemoryStore:
         recency_factor = max(0.1, 1.0 - days_since_last_access * 0.05)
         return 1.0 + math.log(1 + access_count) * recency_factor
 
+    def _find_semantic_duplicate(
+        self, embedding: list[float], category: str,
+    ) -> str | None:
+        """Return the id of an existing fact that is a near-duplicate of the one
+        being stored (cosine-equivalent similarity at/above the dedup threshold and
+        category-compatible), or None. Conservative by design — only collapses
+        genuine near-synonyms. Used on the write path when the flag is enabled.
+        """
+        blob = serialize_float32(embedding)
+        rows = self.db.execute(
+            "SELECT id, distance FROM facts_vec WHERE embedding MATCH ? "
+            "ORDER BY distance LIMIT ?",
+            (blob, 5),
+        ).fetchall()
+        for fact_id, distance in rows:
+            similarity = 1.0 / (1.0 + distance)
+            if similarity < _SEMANTIC_DEDUP_SIM_THRESHOLD:
+                break  # rows are distance-ordered; first miss ends the scan
+            row = self.db.execute(
+                "SELECT category FROM facts WHERE id = ?", (fact_id,),
+            ).fetchone()
+            if row is None:
+                continue
+            existing_category = row[0] or "general"
+            # Category-compatible = identical, or one side is the catch-all
+            # "general" (so an uncategorized near-dup still merges).
+            if existing_category == category or "general" in (existing_category, category):
+                return fact_id
+        return None
+
     def _store_fact_sync(
         self, key: str, value: str, category: str, source: str,
         confidence: float, embedding: list[float] | None,
+        merge_into: str | None = None,
     ) -> str:
-        """Sync DB portion of store_fact. Returns the fact ID."""
-        existing = self.db.execute("SELECT id, access_count FROM facts WHERE key = ?", (key,)).fetchone()
+        """Sync DB portion of store_fact. Returns the fact ID.
+
+        ``merge_into`` is a fact id resolved by semantic-similarity dedup; when set,
+        that existing row is updated in place (prefer-newer value, bump salience)
+        instead of matching purely on exact key.
+        """
+        existing = None
+        if merge_into is not None:
+            existing = self.db.execute(
+                "SELECT id, access_count FROM facts WHERE id = ?", (merge_into,),
+            ).fetchone()
+        if existing is None:
+            existing = self.db.execute(
+                "SELECT id, access_count FROM facts WHERE key = ?", (key,),
+            ).fetchone()
 
         if existing:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
+            # Prefer the newer value AND adopt the newer key/category so the
+            # surviving row reflects the latest phrasing (a semantic merge may
+            # have matched a row stored under a different key).
             self.db.execute(
-                "UPDATE facts SET value = ?, confidence = ?, "
+                "UPDATE facts SET key = ?, value = ?, category = ?, confidence = ?, "
                 "access_count = ?, last_accessed = datetime('now'), "
                 "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (value, confidence, new_count, boost, fact_id),
+                (key, value, category, confidence, new_count, boost, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
@@ -332,9 +395,19 @@ class MemoryStore:
             )
             embedding = None
 
+        # Semantic dedup (opt-in): if an existing fact is a near-duplicate of this
+        # one, update it in place instead of inserting a near-dup row. Resolved
+        # here (sync probe in executor) so the value reaches _store_fact_sync.
+        merge_into = None
+        if embedding is not None and _semantic_dedup_enabled():
+            merge_into = await self._run_db(
+                self._find_semantic_duplicate, embedding, category,
+            )
+
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
-            self._store_fact_sync, key, value, category, source, confidence, embedding,
+            self._store_fact_sync, key, value, category, source, confidence,
+            embedding, merge_into,
         )
 
         if embedding is not None:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -410,3 +410,131 @@ class TestToolOutcomes:
         ).fetchall()]
         assert "tool_outcomes" in tables
         store.close()
+
+
+class TestSemanticDedup:
+    """Vector-similarity dedup on the write path (OPENLEGION_SEMANTIC_DEDUP).
+
+    Uses a controllable stub embedder so near-duplicate vs distinct facts are
+    deterministic and independent of any real embedding provider.
+    """
+
+    @staticmethod
+    def _grouped_embedder(groups):
+        """Return an async embed_fn that maps each key (the part before ': ') to a
+        deterministic vector per ``groups`` membership. Keys in the same group get
+        an identical vector (similarity 1.0); keys in different groups get near-
+        orthogonal vectors (similarity well below the dedup threshold)."""
+        # group_index -> base vector
+        async def _embed(text: str) -> list[float]:
+            key = text.split(":", 1)[0].strip()
+            for gi, members in enumerate(groups):
+                if key in members:
+                    vec = [0.0] * 1536
+                    vec[gi] = 1.0
+                    return vec
+            # Unknown key: unique-ish vector far from the named groups.
+            vec = [0.0] * 1536
+            vec[1535] = 1.0
+            return vec
+        return _embed
+
+    @pytest.fixture
+    def dedup_on(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_SEMANTIC_DEDUP", "1")
+
+    @pytest.fixture
+    def dedup_off(self, monkeypatch):
+        monkeypatch.delenv("OPENLEGION_SEMANTIC_DEDUP", raising=False)
+
+    def _make_store(self, tmp_path, name, groups):
+        embed = self._grouped_embedder(groups)
+        return MemoryStore(db_path=str(tmp_path / name), embed_fn=embed)
+
+    @staticmethod
+    def _count_facts(store) -> int:
+        return store.db.execute("SELECT COUNT(*) FROM facts").fetchone()[0]
+
+    @pytest.mark.asyncio
+    async def test_near_duplicate_keys_merge_into_one_row(self, tmp_path, dedup_on):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "merge.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            # Both near-synonym keys collapse to a single surviving row.
+            assert self._count_facts(store) == 1
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_distinct_facts_stay_separate(self, tmp_path, dedup_on):
+        groups = [{"user_name"}, {"user_email"}]
+        store = self._make_store(tmp_path, "distinct.db", groups)
+        try:
+            await store.store_fact("user_name", "Alice")
+            await store.store_fact("user_email", "alice@example.com")
+            # Clearly-distinct facts (orthogonal vectors) are never collapsed.
+            assert self._count_facts(store) == 2
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_merge_prefers_newer_value(self, tmp_path, dedup_on):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "newer.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            assert self._count_facts(store) == 1
+            # Surviving row reflects the newer value + key.
+            fact = store._get_fact_by_key("user_language_preference")
+            assert fact is not None
+            assert fact.value == "Rust"
+            # Old key no longer resolves (the single row was rewritten).
+            assert store._get_fact_by_key("preferred_language") is None
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_merge_bumps_salience(self, tmp_path, dedup_on):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "salience.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            first = store._get_fact_by_key("preferred_language")
+            assert first is not None
+            await store.store_fact("user_language_preference", "Rust")
+            merged = store._get_fact_by_key("user_language_preference")
+            assert merged is not None
+            assert merged.access_count > first.access_count
+            assert merged.decay_score > first.decay_score
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_keeps_exact_key_behavior(self, tmp_path, dedup_off):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "flagoff.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            # Flag off: near-dup keys are NOT merged — two rows, today's behavior.
+            assert self._count_facts(store) == 2
+            # Exact-key update still collapses (unchanged behavior).
+            await store.store_fact("preferred_language", "Go")
+            assert self._count_facts(store) == 2
+            assert store._get_fact_by_key("preferred_language").value == "Go"
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_embedder_unchanged(self, tmp_path, dedup_off):
+        # No embed_fn at all → write path identical to today regardless of flag.
+        store = MemoryStore(db_path=str(tmp_path / "noembed.db"))
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            assert self._count_facts(store) == 2
+        finally:
+            store.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -538,3 +538,51 @@ class TestSemanticDedup:
             assert self._count_facts(store) == 2
         finally:
             store.close()
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_key_orphans_after_semantic_merge(self, tmp_path, dedup_on):
+        # BLOCKER regression: a semantic merge must never rewrite one row's key
+        # onto another row's key (which would leave two rows sharing a key — the
+        # exact-key dedup path becomes ambiguous and one row is an unreachable
+        # orphan). lang_a and lang_b share an embedding group (near-duplicates).
+        groups = [{"lang_a", "lang_b"}]
+        store = self._make_store(tmp_path, "orphan.db", groups)
+        try:
+            await store.store_fact("lang_a", "X")
+            # Near-duplicate embedding → merges into the lang_a row, flipping its
+            # key to lang_b. Now a single row, keyed lang_b.
+            await store.store_fact("lang_b", "Y")
+            assert self._count_facts(store) == 1
+            # Re-store lang_a (exact-key path: no row holds lang_a, but its
+            # embedding still matches the lang_b row — must NOT clobber lang_b's
+            # key) and lang_b again (genuine exact-key update).
+            await store.store_fact("lang_a", "Z")
+            await store.store_fact("lang_b", "W")
+            # Invariant: no two rows share a key.
+            dupes = store.db.execute(
+                "SELECT key, COUNT(*) FROM facts GROUP BY key HAVING COUNT(*) > 1",
+            ).fetchall()
+            assert dupes == []
+            # The surviving values are reachable by exact key.
+            for key in ("lang_a", "lang_b"):
+                fact = store._get_fact_by_key(key)
+                if fact is not None:
+                    # Every key that resolves resolves to exactly one row.
+                    assert fact.key == key
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_dedup_on_no_embedder_graceful(self, tmp_path, dedup_on):
+        # Flag ON but embed_fn is None → no embedding, so the semantic probe is
+        # skipped entirely and the write path falls back to exact-key behavior.
+        store = MemoryStore(db_path=str(tmp_path / "ondnoembed.db"))
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            assert self._count_facts(store) == 2
+            await store.store_fact("preferred_language", "Go")
+            assert self._count_facts(store) == 2
+            assert store._get_fact_by_key("preferred_language").value == "Go"
+        finally:
+            store.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -72,6 +72,22 @@ async def test_update_existing_fact(memory):
 
 
 @pytest.mark.asyncio
+async def test_exact_key_restore_preserves_category_and_source(memory):
+    """Flag-off byte-identical guard: an exact-key re-store updates the value
+    (and salience) but must NOT overwrite the stored category/source — matching
+    the pre-dedup write path. Only a semantic MERGE adopts the newer
+    key/category/source; the exact-key path never does."""
+    fid = await memory.store_fact("k", "v1", category="preference", source="user")
+    await memory.store_fact("k", "v2", category="general", source="agent")
+    row = memory.db.execute(
+        "SELECT value, category, source FROM facts WHERE id = ?", (fid,),
+    ).fetchone()
+    assert row[0] == "v2"            # value updated
+    assert row[1] == "preference"   # category preserved (not clobbered)
+    assert row[2] == "user"         # source preserved
+
+
+@pytest.mark.asyncio
 async def test_keyword_search_returns_results(memory):
     await memory.store_fact("company_name", "Acme Corporation")
     await memory.store_fact("company_size", "500 employees")


### PR DESCRIPTION
## Phase 2 of the operator memory/context overhaul — DO NOT MERGE pending review

This is track **A4 — Semantic fact dedup** (§7 of `docs/plans/2026-06-09-operator-memory-context-overhaul.md`).

### Problem
Fact dedup today is **exact-key only** (`store_fact`, `WHERE key = ?`). Free-form LLM-chosen keys (`preferred_language` vs `user_language_preference`) create separate near-duplicate rows. Those near-dups bloat the operator's high-salience set and the consolidation input, contributing to the "stale, contradictory context" diagnosed in §3.

### Change
Add **opt-in vector-similarity dedup on the write path**:
- When storing a fact (with an embedding available), probe `facts_vec` for an existing fact at/above a conservative similarity threshold **and** category-compatible.
- On a hit, **update that existing row in place** — prefer the newer key/value, bump salience (access_count + decay boost) — instead of inserting a near-duplicate. The surviving row's embedding/FTS are rewritten to the newest phrasing.
- On a miss, behavior is unchanged (exact-key match, else insert).

Reuses the existing embedding + `facts_vec` infrastructure (same `1/(1+L2_distance)` similarity convention as search/categorization). **No new embedding provider.**

### Flag-gated
Behind `OPENLEGION_SEMANTIC_DEDUP` (**default off**) so it ships safe when the embedding path isn't available. Flag off ⇒ today's exact-key behavior, byte-for-byte.

### Guard rails
- Threshold is a **high constant** `_SEMANTIC_DEDUP_SIM_THRESHOLD = 0.93` — conservative so distinct facts (`user_name` vs `user_email`) are never collapsed.
- Category-compatible = identical category, or one side is the catch-all `general`.

### Independence
Hooks the **write path** (`store_fact`; `store_facts_batch` delegates to it), which exists on `origin/main`. Deliberately **independent of the unmerged A2 `run_maintenance` pass (#1076)**.

### Deferred (documented follow-up)
The full gbrain contradiction judge (date pre-filter → small-model judge w/ confidence floor 0.7 → content-hash cache → severity tiers) is a larger build. Per the KISS scope for v1, this PR ships the **similarity-merge only**; the contradiction judge is a follow-up.

### Deploy zone
**Agent code** (`src/agent/memory.py`) → baked into `openlegion-agent:latest` → **Docker image rebuild + restart** (a git-pull alone does NOT update agent code).

### Overlap warning
Touches `src/agent/memory.py`, which overlaps other in-flight Phase-2 PRs (**A5 memory v2**) and **#1076** (A2). Expect to rebase/coordinate on merge order.

### Tests
New `TestSemanticDedup` in `tests/test_memory.py` (controllable stub embedder, no network):
- near-duplicate keys merge into one row
- clearly-distinct facts stay separate
- prefer-newer value/key on merge
- merge bumps salience
- flag-off → exact-key behavior unchanged (with and without an embedder)

`pytest tests/test_memory.py tests/test_memory_integration.py -q` → **46 passed**. `ruff check` → clean.