### PR TITLE
feat(agent): grouped tool search — capability index + lazy schema loading

### DIFF
--- a/src/agent/builtins/tool_search.py
+++ b/src/agent/builtins/tool_search.py
@@ -1,0 +1,58 @@
+"""Grouped Tool Search bridge — the ``load_tools`` builtin (Phase 2 / B2).
+
+When grouped tool search is active (``OPENLEGION_GROUPED_TOOLS`` on AND the
+budget gate trips), most non-core tools are advertised cheaply in the system
+prompt's capability index but their full schemas are deferred. ``load_tools``
+is the explicit, always-available bridge that pulls a group's (or a single
+tool's owning group's) full schemas into context for the agent's NEXT turn —
+so a capability is never lost, only its verbose schema is lazy.
+
+The actual schema change is deferred to the next turn boundary by the loop
+(``AgentLoop.request_load_tools`` queues the group; the next system-prompt
+build promotes it) so the toolset never mutates mid-turn — preserving the
+prompt cache. This tool is a thin pass-through to that loop method.
+"""
+
+from __future__ import annotations
+
+from src.agent.tools import tool
+from src.shared.utils import setup_logging
+
+logger = setup_logging("agent.builtins.tool_search")
+
+
+@tool(
+    name="load_tools",
+    description=(
+        "Load the full schemas for a capability group (or a single tool's "
+        "group) so you can call those tools. Use this when the Capability "
+        "Index lists a tool you need but its parameters aren't shown. The "
+        "schemas become available on your NEXT turn — call load_tools, then "
+        "call the tool in a following turn. Pass either 'group' (e.g. "
+        "'fleet_setup', 'scheduling', 'credentials', 'goals_review', "
+        "'audit_undo', 'web_browse') or 'tool' (a specific tool name)."
+    ),
+    parameters={
+        "group": {
+            "type": "string",
+            "description": "Capability group key (or label) to load, e.g. 'fleet_setup'.",
+            "default": "",
+        },
+        "tool": {
+            "type": "string",
+            "description": "A specific tool name to load (its whole group is pulled in).",
+            "default": "",
+        },
+    },
+    loop_exempt=True,
+)
+async def load_tools(group: str = "", tool: str = "", *, agent_loop=None) -> dict:
+    """Queue a capability group's full schemas for the next turn."""
+    if agent_loop is None:
+        return {
+            "loaded": [],
+            "error": "load_tools is unavailable outside an agent loop.",
+        }
+    return agent_loop.request_load_tools(
+        group=group or None, tool=tool or None,
+    )

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -166,6 +166,13 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
 # without it (marketplace tools load at container start, not via runtime reload).
 _TOOL_AUTHORING_TOOLS = frozenset({"create_tool", "reload_tools"})
 
+# Grouped Tool Search (B2) bridge tool. Auto-registers via @tool discovery, but
+# is only meaningful when OPENLEGION_GROUPED_TOOLS is on. Hidden from the worker
+# surface when the flag is off so flag-off == main exactly (the operator path is
+# gated separately in cli/config.py's allowlist). This is also the SOLE tool the
+# registry is permitted to hand the AgentLoop to — see ``_AGENT_LOOP_TOOLS``.
+_GROUPED_TOOLS_BRIDGE = frozenset({"load_tools"})
+
 # Read-only tools allowed during operator heartbeat (unsupervised execution).
 # The full operator allowlist is restricted to this subset so heartbeats
 # cannot mutate fleet state without user approval. ``check_inbox`` is
@@ -428,6 +435,10 @@ class AgentLoop:
             from src.agent.builtins.tool_authoring import tool_authoring_enabled
             if not tool_authoring_enabled():
                 excluded |= _TOOL_AUTHORING_TOOLS
+            # Grouped Tool Search bridge is dead weight when the feature is off;
+            # hide it so the worker surface matches main exactly (flag-off parity).
+            if not grouped_tools_enabled():
+                excluded |= _GROUPED_TOOLS_BRIDGE
             # Operator-only orchestration tools (edit_agent, create_team,
             # manage_*, apply_template, install_skill, …) self-reject for
             # worker callers at call time. Drop their schemas from the worker
@@ -542,14 +553,18 @@ class AgentLoop:
         return kw
 
     # ── Grouped Tool Search (B2) ───────────────────────────────────────────
-    def _refresh_grouped_plan(self) -> str:
-        """Promote pending loads, recompute the grouped-tools plan, return index.
+    def _refresh_grouped_plan(self, *, promote_pending: bool = False) -> str:
+        """Recompute the grouped-tools plan, return the capability-index text.
 
-        Called at each system-prompt build — the TURN BOUNDARY. This is where a
-        ``load_tools`` request made during the previous turn actually takes
-        effect (pending → loaded), so the toolset never changes mid-turn (which
-        would bust the prompt cache; mirrors hermes' "don't change toolsets
-        mid-conversation" invariant).
+        ``promote_pending`` is the turn-boundary switch. A ``load_tools`` request
+        made during a turn is queued in ``_pending_tool_groups``; it only takes
+        effect (pending → loaded) at the start of a NEW external turn, where the
+        caller passes ``promote_pending=True``. MID-turn rebuilds (operator
+        playbook change, tool hot-reload, streaming rebuilds) pass the default
+        ``False`` so the loaded set — and therefore the emitted tool schemas —
+        stay identical to what the turn started with. Promoting mid-turn would
+        flip the toolset and bust the #1073 prompt cache, which is exactly the
+        invariant this feature defers to the next turn boundary.
 
         Returns the capability-index text to append to the system prompt (""
         when the feature is off or the budget gate didn't trip).
@@ -557,8 +572,8 @@ class AgentLoop:
         if not grouped_tools_enabled():
             self._grouped_plan = None
             return ""
-        # Apply deferred loads requested last turn.
-        if self._pending_tool_groups:
+        # Apply deferred loads requested last turn — ONLY at a turn boundary.
+        if promote_pending and self._pending_tool_groups:
             self._loaded_tool_groups |= self._pending_tool_groups
             self._pending_tool_groups.clear()
         # Available = what this agent can actually call this turn, BEFORE the
@@ -955,7 +970,11 @@ class AgentLoop:
                 await self.memory.decay_all()
 
         introspect_data = await self._fetch_introspect_cached()
-        system_prompt = self._build_system_prompt(assignment, introspect_data=introspect_data)
+        # Turn boundary: a new task execution promotes any load_tools requested
+        # on the prior turn (mid-turn rebuilds below pass the default False).
+        system_prompt = self._build_system_prompt(
+            assignment, introspect_data=introspect_data, promote_pending=True,
+        )
 
         # Bug F (codex r4): seed the tool-call counter from messages so a
         # checkpoint-resumed task picks up where it left off; thereafter
@@ -1810,7 +1829,11 @@ class AgentLoop:
         return "## Recent Tool History\n\n" + "\n".join(lines)
 
     def _build_system_prompt(
-        self, assignment: TaskAssignment, introspect_data: dict | None = None,
+        self,
+        assignment: TaskAssignment,
+        introspect_data: dict | None = None,
+        *,
+        promote_pending: bool = False,
     ) -> str:
         parts = []
 
@@ -1865,7 +1888,7 @@ class AgentLoop:
             if runtime_ctx:
                 parts.append(runtime_ctx)
 
-        index_text = self._refresh_grouped_plan()
+        index_text = self._refresh_grouped_plan(promote_pending=promote_pending)
         if index_text:
             parts.append(index_text)
 
@@ -2163,7 +2186,8 @@ class AgentLoop:
                     if runtime_ctx:
                         parts.append(runtime_ctx)
 
-                index_text = self._refresh_grouped_plan()
+                # A heartbeat is a fresh external turn — promote pending loads.
+                index_text = self._refresh_grouped_plan(promote_pending=True)
                 if index_text:
                     parts.append(index_text)
 
@@ -3161,8 +3185,11 @@ class AgentLoop:
                 self._fetch_goals(), self._fetch_fleet_roster(),
                 self._fetch_introspect_cached(),
             )
+        # Turn boundary: a new chat turn promotes any load_tools requested on
+        # the prior turn (the mid-turn rebuilds in the chat loop pass False).
         system = self._build_chat_system_prompt(
             goals=goals, fleet_roster=roster, introspect_data=introspect_data,
+            promote_pending=True,
         )
         return user_message, system
 
@@ -4275,6 +4302,8 @@ class AgentLoop:
         goals: dict | None = None,
         fleet_roster: list[dict] | None = None,
         introspect_data: dict | None = None,
+        *,
+        promote_pending: bool = False,
     ) -> str:
         parts = []
 
@@ -4386,7 +4415,7 @@ class AgentLoop:
                 f"Consider saving important context to memory if you haven't already."
             )
 
-        index_text = self._refresh_grouped_plan()
+        index_text = self._refresh_grouped_plan(promote_pending=promote_pending)
         if index_text:
             parts.append(index_text)
 

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -19,6 +19,12 @@ import httpx
 
 from src.agent.attachments import enrich_message_with_attachments
 from src.agent.loop_detector import ToolLoopDetector
+from src.agent.tool_groups import (
+    GroupedPlan,
+    grouped_tools_enabled,
+    plan_grouped_tools,
+    resolve_load_request,
+)
 from src.agent.workspace import INTROSPECT_PERM_KEYS
 from src.shared import limits
 from src.shared.errors import LLMAuthError, LLMConfigError
@@ -320,6 +326,11 @@ class AgentLoop:
 
     MAX_ITERATIONS = 20
 
+    # Class-level default so ``_tool_filter_kw`` is safe even when ``__init__``
+    # is bypassed (e.g. ``AgentLoop.__new__`` in tests). None = grouped tool
+    # search inactive (the default); the instance value is set in ``__init__``.
+    _grouped_plan: "GroupedPlan | None" = None
+
     def __init__(
         self,
         agent_id: str,
@@ -452,6 +463,17 @@ class AgentLoop:
             self._disabled_gates.add("browser")
         self._runtime_disabled_tools: frozenset[str] = frozenset()
         self._recompute_runtime_disabled()
+        # ── Grouped Tool Search (B2, default-OFF via OPENLEGION_GROUPED_TOOLS) ──
+        # ``_loaded_tool_groups`` are groups whose full schemas are present in
+        # context. ``_pending_tool_groups`` are groups requested via
+        # ``load_tools`` this turn — promoted into ``_loaded_tool_groups`` at the
+        # NEXT system-prompt build (turn boundary) so the toolset never mutates
+        # mid-conversation (which would bust the prompt cache). The currently
+        # planned defer set is cached so ``_tool_filter_kw`` and the system
+        # prompt stay consistent within a single turn.
+        self._loaded_tool_groups: set[str] = set()
+        self._pending_tool_groups: set[str] = set()
+        self._grouped_plan: GroupedPlan | None = None
         self._tools_reloaded: bool = False
         self._is_operator: bool = allowed_tools is not None
         self._operator_playbook_state: dict[str, int] = {}  # playbook -> turns since trigger
@@ -508,7 +530,83 @@ class AgentLoop:
                 if runtime_disabled
                 else self._allowed_tools
             )
+        # Grouped Tool Search (B2): omit deferred tool schemas for this turn.
+        # The plan is recomputed at each system-prompt build (turn boundary) so
+        # the defer set here stays consistent with the capability index that was
+        # injected into the same turn's system prompt. ``defer`` folds into the
+        # ``get_tool_definitions`` memo cache key, so a different loaded-groups
+        # set yields different definitions (and a fresh cache entry).
+        plan = self._grouped_plan
+        if plan is not None and plan.active and plan.defer:
+            kw["defer"] = plan.defer
         return kw
+
+    # ── Grouped Tool Search (B2) ───────────────────────────────────────────
+    def _refresh_grouped_plan(self) -> str:
+        """Promote pending loads, recompute the grouped-tools plan, return index.
+
+        Called at each system-prompt build — the TURN BOUNDARY. This is where a
+        ``load_tools`` request made during the previous turn actually takes
+        effect (pending → loaded), so the toolset never changes mid-turn (which
+        would bust the prompt cache; mirrors hermes' "don't change toolsets
+        mid-conversation" invariant).
+
+        Returns the capability-index text to append to the system prompt (""
+        when the feature is off or the budget gate didn't trip).
+        """
+        if not grouped_tools_enabled():
+            self._grouped_plan = None
+            return ""
+        # Apply deferred loads requested last turn.
+        if self._pending_tool_groups:
+            self._loaded_tool_groups |= self._pending_tool_groups
+            self._pending_tool_groups.clear()
+        # Available = what this agent can actually call this turn, BEFORE the
+        # grouped defer (so the index reflects every callable capability).
+        base_kw = {
+            k: v for k, v in self._tool_filter_kw.items() if k != "defer"
+        }
+        available = set(self.tools.list_tools(**base_kw))
+        context_window = (
+            self.context_manager.max_tokens if self.context_manager else 0
+        )
+        self._grouped_plan = plan_grouped_tools(
+            available=available,
+            loaded_groups=self._loaded_tool_groups,
+            operator=(self._allowed_tools is not None),
+            context_window=context_window,
+        )
+        return self._grouped_plan.index_text if self._grouped_plan.active else ""
+
+    def request_load_tools(self, *, group: str | None, tool: str | None) -> dict:
+        """Bridge for the ``load_tools`` builtin — queue a group for next turn.
+
+        Does NOT mutate the loaded set immediately: the actual schema change is
+        deferred to the next system-prompt build (``_refresh_grouped_plan``) so
+        the toolset stays stable for the remainder of the current turn.
+        """
+        if not grouped_tools_enabled():
+            return {
+                "loaded": [],
+                "note": "Grouped tool search is disabled; all tools already loaded.",
+            }
+        base_kw = {
+            k: v for k, v in self._tool_filter_kw.items() if k != "defer"
+        }
+        available = set(self.tools.list_tools(**base_kw))
+        keys, error = resolve_load_request(
+            group=group, tool=tool, available=available,
+        )
+        if error:
+            return {"loaded": [], "error": error}
+        self._pending_tool_groups |= keys
+        return {
+            "loaded": sorted(keys),
+            "note": (
+                "Full schemas for these group(s) will be available on your "
+                "NEXT turn. Call the tool then."
+            ),
+        }
 
     def _recompute_runtime_disabled(self) -> None:
         """Rebuild ``_runtime_disabled_tools`` from the active gate set."""
@@ -1767,6 +1865,10 @@ class AgentLoop:
             if runtime_ctx:
                 parts.append(runtime_ctx)
 
+        index_text = self._refresh_grouped_plan()
+        if index_text:
+            parts.append(index_text)
+
         return "\n\n".join(parts)
 
     # Round-4 structural fix: hand_off failures are now enforced from
@@ -2060,6 +2162,10 @@ class AgentLoop:
                     )
                     if runtime_ctx:
                         parts.append(runtime_ctx)
+
+                index_text = self._refresh_grouped_plan()
+                if index_text:
+                    parts.append(index_text)
 
                 system_prompt = "\n\n".join(parts)
 
@@ -3110,6 +3216,7 @@ class AgentLoop:
                     workspace_manager=self.workspace,
                     memory_store=self.memory,
                     _messages=self._current_messages,
+                    agent_loop=self,
                 ),
                 timeout=_TOOL_TIMEOUT,
             )
@@ -4278,6 +4385,10 @@ class AgentLoop:
                 f"Context will be auto-refreshed in ~{remaining} rounds. "
                 f"Consider saving important context to memory if you haven't already."
             )
+
+        index_text = self._refresh_grouped_plan()
+        if index_text:
+            parts.append(index_text)
 
         return "\n\n".join(parts)
 

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -299,6 +299,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
                 mesh_client=loop.mesh_client,
                 workspace_manager=loop.workspace,
                 memory_store=loop.memory,
+                agent_loop=loop,
             )
             return {"result": result}
         except ValueError as e:

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -1,0 +1,309 @@
+"""Grouped Tool Search — capability index + lazy schema loading (Phase 2 / B2).
+
+Goal: keep the per-turn tool-schema load lean WITHOUT the agent ever losing
+awareness of a capability ("it knows exactly what to do"). Three layers:
+
+1. **Always-loaded core** — the daily-driver tools, full schemas, unchanged.
+2. **Always-loaded capability INDEX** — names + one-line intent, grouped by
+   job-to-be-done (~300-500 tokens, NO full schemas). A tool's *capability*
+   is never hidden; only its verbose schema is lazy.
+3. **On-demand schema loading** — the ``load_tools(group | tool_name)`` bridge
+   pulls full schemas into context for SUBSEQUENT turns.
+
+This is **budget-gated**: the index + deferral only activate when an agent's
+deferrable schemas exceed a fraction of the context window. Small-toolset
+agents present everything unchanged (no behaviour change). The whole feature
+is **default-OFF** behind ``OPENLEGION_GROUPED_TOOLS`` — see
+``grouped_tools_enabled()``.
+
+Groups are defined here as DATA (a registry mapping group → tool names +
+one-line intent + role-eligibility). Applies to BOTH operator and worker
+scope; a worker simply never sees an operator-only group's tools in its
+allowed/exclude surface, so the index naturally renders only what it can call.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+# Env flag — the entire grouped-tool path is dormant unless this is set.
+GROUPED_TOOLS_ENV = "OPENLEGION_GROUPED_TOOLS"
+
+# Budget gate: only activate index+defer when the deferrable tools' estimated
+# schema cost exceeds this fraction of the model's context window. Mirrors
+# hermes-agent's "~10% of the window" Tool Search activation threshold.
+BUDGET_FRACTION = 0.10
+
+# Rough token estimate per deferred tool schema. Tool schemas vary, but a
+# typical builtin definition (name + description + a few params) lands around
+# 120-180 tokens; we use a conservative midpoint so the gate trips on genuinely
+# large surfaces, not marginal ones. Only used for the gate, never for billing.
+SCHEMA_TOKENS_PER_TOOL = 150
+
+
+def grouped_tools_enabled() -> bool:
+    """True iff the grouped-tool-search path is opted in via env flag.
+
+    Default OFF — the feature ships dormant. When false, every code path in
+    this module no-ops and the agent presents its full tool surface unchanged.
+    """
+    return os.environ.get(GROUPED_TOOLS_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+@dataclass(frozen=True)
+class ToolGroup:
+    """A job-to-be-done grouping of tools for the capability index.
+
+    *intent* is the one-line "when would I reach for this" string shown in the
+    index. *tools* are the tool names whose full schemas are deferred until
+    ``load_tools`` pulls the group in. *operator_only* mirrors the registry's
+    operator-only marking so the index never advertises a group a worker can't
+    use (defensive — the allowed/exclude surface already filters the names).
+    """
+
+    key: str
+    label: str
+    intent: str
+    tools: tuple[str, ...]
+    operator_only: bool = False
+
+
+# ── Group registry (DATA) ──────────────────────────────────────────────────
+# Intent-named (job-to-be-done), NOT module-named. Order here is the order the
+# index renders. Tool names that don't exist in a given agent's surface are
+# simply skipped at render/defer time, so this list can stay a superset.
+TOOL_GROUPS: tuple[ToolGroup, ...] = (
+    ToolGroup(
+        key="fleet_setup",
+        label="Fleet setup",
+        intent="build or restructure a team (create agents/teams, apply templates)",
+        tools=(
+            "create_agent", "create_team", "apply_template", "list_templates",
+            "add_agents_to_team", "remove_agents_from_team", "manage_team",
+            "manage_agent", "edit_agent", "read_agent_config",
+            "update_team_context",
+        ),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="scheduling",
+        label="Scheduling",
+        intent="recurring or timed work (cron jobs)",
+        tools=("set_cron", "list_cron", "remove_cron"),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="credentials",
+        label="Credentials & access",
+        intent="an agent needs to reach a service (vault, credential/login requests)",
+        tools=(
+            "vault_list", "request_credential", "request_browser_login",
+        ),
+    ),
+    ToolGroup(
+        key="goals_review",
+        label="Goals & review",
+        intent="set or review team goals and rate deliveries",
+        tools=(
+            "set_team_goal", "manage_goals", "rate_delivery",
+        ),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="audit_undo",
+        label="Audit & undo",
+        intent="inspect pending actions, undo a change, or trim the audit log",
+        tools=(
+            "list_pending", "cancel_pending_action", "archive_audit_before",
+            "undo_change",
+        ),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="web_browse",
+        label="Web & browse",
+        intent="research or interact with websites (browser automation)",
+        tools=(
+            "browser_navigate", "browser_warmup", "browser_get_elements",
+            "browser_wait_for", "browser_screenshot", "browser_click",
+            "browser_click_xy", "browser_type", "browser_hover",
+            "browser_scroll", "browser_reset", "browser_press_key",
+            "browser_go_back", "browser_go_forward", "browser_switch_tab",
+            "browser_find_text", "browser_fill_form", "browser_open_tab",
+            "browser_inspect_requests", "browser_detect_captcha",
+            "browser_upload_file", "browser_solve_captcha", "browser_download",
+        ),
+    ),
+)
+
+# Index of group-by-key for O(1) lookup.
+_GROUPS_BY_KEY: dict[str, ToolGroup] = {g.key: g for g in TOOL_GROUPS}
+
+# Every tool name that belongs to *some* group — the deferrable universe.
+_GROUPED_TOOL_NAMES: frozenset[str] = frozenset(
+    name for g in TOOL_GROUPS for name in g.tools
+)
+
+
+def is_grouped_tool(name: str) -> bool:
+    """True iff *name* belongs to a deferrable group (vs. always-loaded core)."""
+    return name in _GROUPED_TOOL_NAMES
+
+
+def groups_for_tool(name: str) -> list[str]:
+    """Return the group keys a tool name belongs to (usually 0 or 1)."""
+    return [g.key for g in TOOL_GROUPS if name in g.tools]
+
+
+@dataclass
+class GroupedPlan:
+    """The resolved grouped-tools plan for one turn.
+
+    *active* — whether the budget gate tripped (index+defer in effect). When
+    false, the agent presents its full surface unchanged.
+    *defer* — tool names whose full schemas to omit this turn (deferred groups
+    minus anything already loaded).
+    *index_text* — the always-present capability index string (or "" when
+    inactive).
+    """
+
+    active: bool = False
+    defer: frozenset[str] = field(default_factory=frozenset)
+    index_text: str = ""
+
+
+def _available_for_role(
+    available: set[str], *, operator: bool,
+) -> list[ToolGroup]:
+    """Groups that have at least one tool in *available* and are role-eligible.
+
+    A non-operator agent never sees operator-only groups (their tools won't be
+    in *available* anyway, but we also skip the group entirely so the index
+    doesn't advertise an empty group).
+    """
+    out: list[ToolGroup] = []
+    for g in TOOL_GROUPS:
+        if g.operator_only and not operator:
+            continue
+        if any(t in available for t in g.tools):
+            out.append(g)
+    return out
+
+
+def _render_index(
+    groups: list[ToolGroup],
+    available: set[str],
+    loaded_groups: set[str],
+) -> str:
+    """Render the always-present capability index (names + intent, no schemas).
+
+    Loaded groups are marked so the model knows their full schemas are already
+    in context (no need to ``load_tools`` them again).
+    """
+    lines = [
+        "## Capability Index",
+        (
+            "These tools are available but their full schemas are loaded "
+            "on demand to keep context lean. The capability is never hidden — "
+            "only its detailed parameters are lazy. Call "
+            "`load_tools(group=\"<group>\")` (or `load_tools(tool=\"<name>\")`) "
+            "to pull a group's full schemas into context for your NEXT turn, "
+            "then call the tool normally."
+        ),
+        "",
+    ]
+    for g in groups:
+        names = [t for t in g.tools if t in available]
+        if not names:
+            continue
+        loaded_mark = " (loaded)" if g.key in loaded_groups else ""
+        lines.append(
+            f"- **{g.label}** [`{g.key}`]{loaded_mark} — {g.intent}: "
+            + ", ".join(names)
+        )
+    return "\n".join(lines)
+
+
+def plan_grouped_tools(
+    *,
+    available: set[str],
+    loaded_groups: set[str],
+    operator: bool,
+    context_window: int,
+) -> GroupedPlan:
+    """Compute the grouped-tools plan for one turn (pure, deterministic).
+
+    Budget gate: only activate when the deferrable schemas' estimated cost
+    exceeds ``BUDGET_FRACTION`` of *context_window*. Below that, return an
+    inactive plan (full surface, no index) so small-toolset agents are
+    unchanged.
+
+    *available* — the tool names this agent can actually call this turn (after
+    allowed/exclude filtering). *loaded_groups* — groups the agent has already
+    pulled in via ``load_tools`` (their schemas stay present). *operator* —
+    role eligibility for operator-only groups.
+    """
+    if not grouped_tools_enabled():
+        return GroupedPlan(active=False)
+
+    groups = _available_for_role(available, operator=operator)
+    # Deferrable universe = grouped tools present in this agent's surface.
+    deferrable = {t for g in groups for t in g.tools if t in available}
+    if not deferrable:
+        return GroupedPlan(active=False)
+
+    # Budget gate — only kick in for genuinely large surfaces.
+    est_tokens = len(deferrable) * SCHEMA_TOKENS_PER_TOOL
+    if context_window <= 0 or est_tokens < context_window * BUDGET_FRACTION:
+        return GroupedPlan(active=False)
+
+    # Tools whose schemas stay loaded: any group the agent has pulled in.
+    loaded_tool_names = {
+        t
+        for key in loaded_groups
+        for t in (_GROUPS_BY_KEY[key].tools if key in _GROUPS_BY_KEY else ())
+    }
+    defer = frozenset(deferrable - loaded_tool_names)
+    index_text = _render_index(groups, available, loaded_groups)
+    return GroupedPlan(active=True, defer=defer, index_text=index_text)
+
+
+def resolve_load_request(
+    *, group: str | None, tool: str | None, available: set[str],
+) -> tuple[set[str], str | None]:
+    """Resolve a ``load_tools`` request to a set of group keys to load.
+
+    Accepts either a group key/label or a single tool name (resolved to its
+    group). Returns ``(group_keys, error)`` — *error* is a human string when
+    the request matched nothing, else None.
+    """
+    keys: set[str] = set()
+    if group:
+        g = group.strip().lower()
+        match = _GROUPS_BY_KEY.get(g)
+        if match is None:
+            # Allow matching by human label too.
+            for grp in TOOL_GROUPS:
+                if grp.label.lower() == g:
+                    match = grp
+                    break
+        if match is None:
+            valid = ", ".join(grp.key for grp in TOOL_GROUPS)
+            return set(), f"Unknown tool group '{group}'. Valid groups: {valid}"
+        keys.add(match.key)
+    if tool:
+        t = tool.strip()
+        owning = groups_for_tool(t)
+        if not owning:
+            if t in available:
+                return set(), (
+                    f"Tool '{t}' is already in your core surface — call it directly."
+                )
+            return set(), f"Tool '{t}' is not a known grouped tool."
+        keys.update(owning)
+    if not keys:
+        return set(), "Specify a 'group' or a 'tool' to load."
+    return keys, None

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -237,6 +237,7 @@ class ToolRegistry:
         workspace_manager: Any = None,
         memory_store: Any = None,
         _messages: list[dict] | None = None,
+        agent_loop: Any = None,
     ) -> Any:
         """Execute a tool by name with given arguments."""
         if self._mcp_client and self._mcp_client.has_tool(name):
@@ -310,6 +311,8 @@ class ToolRegistry:
             call_args["memory_store"] = memory_store
         if "_messages" in sig_params:
             call_args["_messages"] = _messages
+        if "agent_loop" in sig_params:
+            call_args["agent_loop"] = agent_loop
 
         # Filter out LLM-hallucinated parameters that the function doesn't
         # accept.  Without this, an LLM sending e.g. {"raw": ""} to a
@@ -346,7 +349,7 @@ class ToolRegistry:
                 req_parts = []
                 opt_parts = []
                 for k, v in param_schemas.items():
-                    if k in {"mesh_client", "workspace_manager", "memory_store", "_messages"}:
+                    if k in {"mesh_client", "workspace_manager", "memory_store", "_messages", "agent_loop"}:
                         continue
                     ptype = v.get("type", "any")
                     desc = v.get("description", "")
@@ -432,8 +435,15 @@ class ToolRegistry:
         self,
         exclude: frozenset[str] | None = None,
         allowed: frozenset[str] | None = None,
+        defer: frozenset[str] | None = None,
     ) -> list[str]:
-        """Return list of available tool names."""
+        """Return list of available tool names.
+
+        *defer* (Grouped Tool Search) is accepted for call-site symmetry with
+        ``get_tool_definitions`` but intentionally ignored: a deferred tool is
+        still *callable* (only its schema is lazy), so it must remain in the
+        capability/status listing.
+        """
         if allowed is not None:
             return [n for n in self.tools if n in allowed]
         if exclude:
@@ -478,12 +488,20 @@ class ToolRegistry:
         self,
         exclude: frozenset[str] | None = None,
         allowed: frozenset[str] | None = None,
+        defer: frozenset[str] | None = None,
     ) -> list[dict]:
-        """Return OpenAI-compatible tool definitions for LLM function calling (memoized)."""
+        """Return OpenAI-compatible tool definitions for LLM function calling (memoized).
+
+        *defer* — Grouped Tool Search (B2): tool names whose full schemas to
+        OMIT from this build (their capability is still advertised cheaply via
+        the always-present capability index in the system prompt; the schema is
+        pulled in later via ``load_tools``). Folded into the memo cache key so a
+        different loaded-groups set yields different definitions.
+        """
         if self._tool_defs_cache is None:
             self._tool_defs_cache = {}
         cache = self._tool_defs_cache
-        cache_key = (exclude, allowed)
+        cache_key = (exclude, allowed, defer)
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -494,6 +512,8 @@ class ToolRegistry:
                 if name not in allowed:
                     continue
             elif exclude and name in exclude:
+                continue
+            if defer and name in defer:
                 continue
             params = info["parameters"]
 

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -39,6 +39,15 @@ _NON_TOOL_DIRS = frozenset({
 _tool_staging: dict[str, dict] = {}
 _tool_staging_lock = threading.Lock()
 
+# Trust-boundary allowlist for the ``agent_loop`` injection. The AgentLoop is
+# the whole sandboxed-agent runtime; handing it to a tool gives that tool full
+# control over the loop. Only these TRUSTED builtin bridge tools receive it —
+# gated by tool NAME, never by signature inspection alone. Custom / marketplace
+# / self-authored tools load into the SAME registry and could otherwise declare
+# an ``agent_loop`` param to capture the loop, breaking the sandbox model (tools
+# get only mesh_client / workspace_manager / memory_store). See CLAUDE.md.
+_AGENT_LOOP_TOOLS = frozenset({"load_tools"})
+
 
 def _normalize_params_dict(params: object) -> dict:
     """Normalize tool parameters to the canonical dict shape.
@@ -311,7 +320,11 @@ class ToolRegistry:
             call_args["memory_store"] = memory_store
         if "_messages" in sig_params:
             call_args["_messages"] = _messages
-        if "agent_loop" in sig_params:
+        # Trust-boundary gate: inject the AgentLoop ONLY into trusted builtin
+        # bridge tools (gated by NAME), never by signature alone. A custom or
+        # self-authored tool declaring an ``agent_loop`` param must NOT capture
+        # the loop. See ``_AGENT_LOOP_TOOLS``.
+        if name in _AGENT_LOOP_TOOLS and "agent_loop" in sig_params:
             call_args["agent_loop"] = agent_loop
 
         # Filter out LLM-hallucinated parameters that the function doesn't
@@ -501,7 +514,11 @@ class ToolRegistry:
         if self._tool_defs_cache is None:
             self._tool_defs_cache = {}
         cache = self._tool_defs_cache
-        cache_key = (exclude, allowed, defer)
+        # Flag-off parity: when no defer set is in play (Grouped Tool Search off),
+        # emit the LEGACY 2-tuple key so cache behaviour is byte-identical to main
+        # (no cold-miss against pre-existing entries). Only widen to the 3-tuple
+        # when a defer set is actually present.
+        cache_key = (exclude, allowed) if defer is None else (exclude, allowed, defer)
         cached = cache.get(cache_key)
         if cached is not None:
             return cached

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1684,6 +1684,10 @@ def _setup_agent_wizard(model: str) -> str:
 _OPERATOR_AGENT_ID = "operator"
 
 _OPERATOR_ALLOWED_TOOLS: list[str] = [
+    # Grouped Tool Search (B2) bridge — pulls a deferred capability group's
+    # full schemas into context for the next turn. Always-available core tool;
+    # a no-op when OPENLEGION_GROUPED_TOOLS is off (the default).
+    "load_tools",
     # Monitoring + heartbeat
     "get_system_status", "notify_user",
     "inspect_agents", "inspect_teams",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1684,10 +1684,6 @@ def _setup_agent_wizard(model: str) -> str:
 _OPERATOR_AGENT_ID = "operator"
 
 _OPERATOR_ALLOWED_TOOLS: list[str] = [
-    # Grouped Tool Search (B2) bridge — pulls a deferred capability group's
-    # full schemas into context for the next turn. Always-available core tool;
-    # a no-op when OPENLEGION_GROUPED_TOOLS is off (the default).
-    "load_tools",
     # Monitoring + heartbeat
     "get_system_status", "notify_user",
     "inspect_agents", "inspect_teams",
@@ -1783,6 +1779,15 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_detect_captcha", "browser_upload_file", "browser_solve_captcha",
     "browser_download",
 ]
+
+# Grouped Tool Search (B2) bridge — pulls a deferred capability group's full
+# schemas into context for the next turn. Granted ONLY when the feature is
+# opted in via OPENLEGION_GROUPED_TOOLS; with the flag off the operator's tool
+# surface stays byte-identical to main (the bridge would be a dead no-op).
+from src.agent.tool_groups import grouped_tools_enabled as _grouped_tools_enabled  # noqa: E402
+
+if _grouped_tools_enabled():
+    _OPERATOR_ALLOWED_TOOLS.append("load_tools")
 
 # Reference list documenting the tools operator uses on heartbeat. The
 # loop's actual gate is ``_HEARTBEAT_TOOLS`` in ``src/agent/loop.py`` —

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -658,6 +658,7 @@ class TestInvokeTool:
             mesh_client=loop.mesh_client,
             workspace_manager=loop.workspace,
             memory_store=loop.memory,
+            agent_loop=loop,
         )
 
     @pytest.mark.asyncio
@@ -675,6 +676,7 @@ class TestInvokeTool:
             mesh_client=loop.mesh_client,
             workspace_manager=loop.workspace,
             memory_store=loop.memory,
+            agent_loop=loop,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1906,6 +1906,9 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "create_tool",
     "reload_tools",
     "update_workspace",
+    # Grouped Tool Search bridge — agent-side meta-tool, not a user-facing
+    # activity verb; the generic "using load tools" fallback reads fine.
+    "load_tools",
     # Misc / external integrations.
     "post_tweet",
     "save_artifact",

--- a/tests/test_grouped_tools.py
+++ b/tests/test_grouped_tools.py
@@ -323,7 +323,7 @@ def test_loop_flag_off_no_index_no_defer(monkeypatch):
 
 def test_load_tools_defers_to_next_turn(grouped_on):
     loop = _make_grouped_loop()
-    loop._refresh_grouped_plan()  # turn 1 build
+    loop._refresh_grouped_plan(promote_pending=True)  # turn 1 build
     # set_cron is deferred at first.
     assert "set_cron" in loop._grouped_plan.defer
 
@@ -336,10 +336,37 @@ def test_load_tools_defers_to_next_turn(grouped_on):
     assert "set_cron" in loop._grouped_plan.defer
 
     # Next turn boundary: the build promotes pending → loaded.
-    loop._refresh_grouped_plan()
+    loop._refresh_grouped_plan(promote_pending=True)
     assert loop._loaded_tool_groups == {"scheduling"}
     assert loop._pending_tool_groups == set()
     # set_cron's schema is now loaded (no longer deferred).
+    assert "set_cron" not in loop._grouped_plan.defer
+
+
+def test_mid_turn_rebuild_does_not_promote(grouped_on):
+    """A MID-turn rebuild (promote_pending=False) must leave pending untouched.
+
+    Promoting mid-turn would flip the toolset and bust the prompt cache — the
+    whole point of deferring to the next turn boundary.
+    """
+    loop = _make_grouped_loop()
+    loop._refresh_grouped_plan(promote_pending=True)  # turn-entry build
+    assert "set_cron" in loop._grouped_plan.defer
+
+    loop.request_load_tools(group="scheduling", tool=None)
+    assert loop._pending_tool_groups == {"scheduling"}
+
+    # Mid-turn rebuilds (hot reload, playbook change, streaming rebuild) default
+    # to promote_pending=False — pending stays queued, loaded set unchanged.
+    loop._refresh_grouped_plan()
+    assert loop._loaded_tool_groups == set()
+    assert loop._pending_tool_groups == {"scheduling"}
+    # The toolset the turn started with is preserved (set_cron still deferred).
+    assert "set_cron" in loop._grouped_plan.defer
+
+    # Only the next turn boundary actually promotes.
+    loop._refresh_grouped_plan(promote_pending=True)
+    assert loop._loaded_tool_groups == {"scheduling"}
     assert "set_cron" not in loop._grouped_plan.defer
 
 
@@ -349,3 +376,122 @@ def test_load_tools_noop_when_flag_off(monkeypatch):
     res = loop.request_load_tools(group="scheduling", tool=None)
     assert res["loaded"] == []
     assert loop._pending_tool_groups == set()
+
+
+# ── Fix 3b: defer=None uses the LEGACY 2-tuple cache key ────────────────────
+def test_defer_none_uses_legacy_two_tuple_cache_key():
+    """With no defer set, the memo key must be the legacy ``(exclude, allowed)``
+    2-tuple so flag-off cache behaviour is byte-identical to main."""
+    reg = _registry_with("alpha", "beta")
+    reg.get_tool_definitions(exclude=frozenset({"beta"}))
+    # The cache must be keyed by the 2-tuple, NOT a 3-tuple with a trailing None.
+    assert (frozenset({"beta"}), None) in reg._tool_defs_cache
+    assert (frozenset({"beta"}), None, None) not in reg._tool_defs_cache
+
+
+def test_defer_set_uses_three_tuple_cache_key():
+    """A real defer set widens the key to the 3-tuple (separate cache entry)."""
+    reg = _registry_with("alpha", "beta")
+    reg.get_tool_definitions(defer=frozenset({"beta"}))
+    assert (None, None, frozenset({"beta"})) in reg._tool_defs_cache
+
+
+# ── Fix 1: agent_loop injection is gated by tool NAME, not signature ────────
+def _registry_with_agent_loop_tool(name: str) -> ToolRegistry:
+    @tool(name=name, description=f"desc {name}", parameters={})
+    async def _fn(*, agent_loop=None):
+        return {"got_loop": agent_loop is not None}
+
+    reg = ToolRegistry.__new__(ToolRegistry)
+    reg.tools = dict(_tool_staging)
+    reg._mcp_client = None
+    reg._tool_defs_cache = {}
+    reg._descriptions_cache = {}
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_injected_only_for_allowlisted_tool():
+    from src.agent.tools import _AGENT_LOOP_TOOLS
+
+    # The allowlist must be exactly the trusted bridge tool.
+    assert _AGENT_LOOP_TOOLS == frozenset({"load_tools"})
+
+    sentinel = object()
+    reg = _registry_with_agent_loop_tool("load_tools")
+    result = await reg.execute("load_tools", {}, agent_loop=sentinel)
+    assert result == {"got_loop": True}
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_not_injected_for_untrusted_tool():
+    """A non-allowlisted tool declaring ``agent_loop`` must NOT receive it —
+    the loop is the whole sandbox runtime; custom/self-authored tools can't
+    capture it just by naming the param."""
+    sentinel = object()
+    reg = _registry_with_agent_loop_tool("evil_custom_tool")
+    result = await reg.execute("evil_custom_tool", {}, agent_loop=sentinel)
+    assert result == {"got_loop": False}
+
+
+# ── Fix 3a: flag-off → load_tools is NOT in the worker tool surface ─────────
+def test_load_tools_absent_from_worker_surface_when_flag_off(monkeypatch):
+    from src.agent.loop import _GROUPED_TOOLS_BRIDGE
+
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    loop = _make_worker_loop()
+    # The worker's effective exclude set hides the bridge entirely.
+    excluded = loop._excluded_tools or frozenset()
+    assert _GROUPED_TOOLS_BRIDGE <= excluded
+    assert "load_tools" not in loop.tools.list_tools(**loop._tool_filter_kw)
+
+
+def test_load_tools_present_in_worker_surface_when_flag_on(grouped_on):
+    loop = _make_worker_loop()
+    excluded = loop._excluded_tools or frozenset()
+    assert "load_tools" not in excluded
+    assert "load_tools" in loop.tools.list_tools(**loop._tool_filter_kw)
+
+
+def _make_worker_loop():
+    """A worker AgentLoop (exclude-based surface) with load_tools registered."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.agent.loop import AgentLoop
+
+    surface = {"notify_user", "load_tools", "read_file"}
+
+    tools = MagicMock()
+
+    def _list_tools(exclude=None, allowed=None, defer=None):
+        names = list(surface)
+        if exclude:
+            names = [n for n in names if n not in exclude]
+        return names
+
+    tools.list_tools = MagicMock(side_effect=_list_tools)
+    tools.get_tool_definitions = MagicMock(return_value=[])
+    tools.get_descriptions = MagicMock(return_value="")
+    tools.is_parallel_safe = MagicMock(return_value=True)
+    tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
+    tools.tools = {n: {} for n in surface}
+
+    memory = MagicMock()
+    memory.get_high_salience_facts = AsyncMock(return_value=[])
+    memory.search = AsyncMock(return_value=[])
+
+    llm = MagicMock()
+    llm.default_model = "test-model"
+
+    mesh_client = MagicMock()
+    mesh_client.is_standalone = False
+
+    return AgentLoop(
+        agent_id="worker",
+        role="worker",
+        memory=memory,
+        tools=tools,
+        llm=llm,
+        mesh_client=mesh_client,
+    )

--- a/tests/test_grouped_tools.py
+++ b/tests/test_grouped_tools.py
@@ -1,0 +1,351 @@
+"""Unit tests for Grouped Tool Search (B2).
+
+Covers:
+- the budget gate (small toolset → unchanged; large → index+defer),
+- the capability index renders ALL grouped capabilities (names never hidden),
+- ``load_tools`` defers the schema change to the NEXT build (not mid-turn),
+- the loaded-groups state folds into the ``get_tool_definitions`` cache key,
+- flag-off → identical behaviour to today.
+
+The whole feature is default-OFF behind ``OPENLEGION_GROUPED_TOOLS``, so each
+test that exercises the active path sets the env flag explicitly.
+"""
+
+import pytest
+
+from src.agent import tool_groups
+from src.agent.tool_groups import (
+    TOOL_GROUPS,
+    grouped_tools_enabled,
+    plan_grouped_tools,
+    resolve_load_request,
+)
+from src.agent.tools import ToolRegistry, _tool_staging, tool
+
+
+def setup_function():
+    _tool_staging.clear()
+
+
+@pytest.fixture
+def grouped_on(monkeypatch):
+    monkeypatch.setenv(tool_groups.GROUPED_TOOLS_ENV, "1")
+    yield
+
+
+# ── Flag plumbing ───────────────────────────────────────────────────────────
+def test_flag_off_by_default(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    assert grouped_tools_enabled() is False
+
+
+def test_flag_on(monkeypatch):
+    monkeypatch.setenv(tool_groups.GROUPED_TOOLS_ENV, "true")
+    assert grouped_tools_enabled() is True
+
+
+def test_plan_inactive_when_flag_off(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups=set(),
+        operator=True,
+        context_window=1000,  # tiny window → would trip the gate if flag were on
+    )
+    assert plan.active is False
+    assert plan.defer == frozenset()
+    assert plan.index_text == ""
+
+
+# ── Budget gate ─────────────────────────────────────────────────────────────
+def test_budget_gate_small_toolset_unchanged(grouped_on):
+    """A small grouped surface stays under the budget → plan inactive."""
+    available = {"create_agent", "set_cron"}  # only 2 grouped tools
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups=set(),
+        operator=True,
+        context_window=200_000,  # opus-class window — 2 tools is far under 10%
+    )
+    assert plan.active is False
+    assert plan.defer == frozenset()
+
+
+def test_budget_gate_large_toolset_activates(grouped_on):
+    """A large grouped surface exceeding ~10% of the window → index+defer."""
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    # Pick a window small enough that the grouped tools exceed 10%.
+    est = len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL
+    window = int(est / tool_groups.BUDGET_FRACTION) - 1  # just under the gate's denom
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups=set(),
+        operator=True,
+        context_window=window,
+    )
+    assert plan.active is True
+    assert plan.defer  # something is deferred
+    assert plan.index_text
+
+
+def test_budget_gate_zero_window_inactive(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    plan = plan_grouped_tools(
+        available=available, loaded_groups=set(), operator=True, context_window=0,
+    )
+    assert plan.active is False
+
+
+# ── Capability index renders ALL capabilities (names never hidden) ──────────
+def test_index_lists_every_available_grouped_tool(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    window = int(
+        (len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    plan = plan_grouped_tools(
+        available=available, loaded_groups=set(), operator=True, context_window=window,
+    )
+    assert plan.active is True
+    # Every grouped tool that's deferred must still appear by NAME in the index
+    # — the capability is never hidden, only its full schema is lazy.
+    for name in plan.defer:
+        assert name in plan.index_text, f"{name} missing from capability index"
+
+
+def test_index_marks_loaded_groups(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    window = int(
+        (len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups={"scheduling"},
+        operator=True,
+        context_window=window,
+    )
+    assert "(loaded)" in plan.index_text
+    # A loaded group's tools are no longer deferred.
+    assert "set_cron" not in plan.defer
+
+
+def test_worker_never_sees_operator_only_group(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    # Size the window against the WORKER-eligible deferrable set (operator-only
+    # groups are excluded), else the gate wouldn't trip for a worker.
+    worker_deferrable = {
+        t for g in TOOL_GROUPS if not g.operator_only for t in g.tools
+    }
+    window = int(
+        (len(worker_deferrable) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    plan = plan_grouped_tools(
+        available=available, loaded_groups=set(), operator=False, context_window=window,
+    )
+    # Operator-only group tools must not be deferred/advertised for a worker.
+    assert "create_agent" not in plan.defer
+    assert "Fleet setup" not in plan.index_text
+    # A non-operator-only group (web_browse) still appears.
+    assert "Web & browse" in plan.index_text
+
+
+# ── resolve_load_request ────────────────────────────────────────────────────
+def test_resolve_by_group_key():
+    keys, err = resolve_load_request(group="scheduling", tool=None, available=set())
+    assert err is None
+    assert keys == {"scheduling"}
+
+
+def test_resolve_by_group_label():
+    keys, err = resolve_load_request(group="Fleet setup", tool=None, available=set())
+    assert err is None
+    assert keys == {"fleet_setup"}
+
+
+def test_resolve_by_tool_name():
+    keys, err = resolve_load_request(group=None, tool="create_agent", available=set())
+    assert err is None
+    assert keys == {"fleet_setup"}
+
+
+def test_resolve_unknown_group_errors():
+    keys, err = resolve_load_request(group="nope", tool=None, available=set())
+    assert keys == set()
+    assert "Unknown tool group" in err
+
+
+def test_resolve_core_tool_hint():
+    keys, err = resolve_load_request(
+        group=None, tool="notify_user", available={"notify_user"},
+    )
+    assert keys == set()
+    assert "core surface" in err
+
+
+def test_resolve_empty_errors():
+    keys, err = resolve_load_request(group=None, tool=None, available=set())
+    assert keys == set()
+    assert err
+
+
+# ── get_tool_definitions: defer folds into the memo cache key ───────────────
+def _registry_with(*names: str) -> ToolRegistry:
+    for n in names:
+        @tool(name=n, description=f"desc {n}", parameters={"x": {"type": "string"}})
+        def _fn(x: str):
+            return x
+
+    reg = ToolRegistry.__new__(ToolRegistry)
+    reg.tools = dict(_tool_staging)
+    reg._tool_defs_cache = {}
+    reg._descriptions_cache = {}
+    return reg
+
+
+def test_defer_omits_schema():
+    reg = _registry_with("alpha", "beta", "gamma")
+    full = reg.get_tool_definitions()
+    deferred = reg.get_tool_definitions(defer=frozenset({"beta"}))
+    full_names = {d["function"]["name"] for d in full}
+    deferred_names = {d["function"]["name"] for d in deferred}
+    assert "beta" in full_names
+    assert "beta" not in deferred_names
+    assert deferred_names == full_names - {"beta"}
+
+
+def test_defer_folds_into_cache_key():
+    """Different loaded/deferred sets must yield different cached definitions."""
+    reg = _registry_with("alpha", "beta", "gamma")
+    a = reg.get_tool_definitions(defer=frozenset({"beta", "gamma"}))
+    b = reg.get_tool_definitions(defer=frozenset({"gamma"}))
+    # Different defer set → different result (different cache entry).
+    assert a is not b
+    assert {d["function"]["name"] for d in a} == {"alpha"}
+    assert {d["function"]["name"] for d in b} == {"alpha", "beta"}
+    # Same key returns the memoized object.
+    a2 = reg.get_tool_definitions(defer=frozenset({"beta", "gamma"}))
+    assert a2 is a
+
+
+def test_defer_none_matches_today():
+    """defer=None / absent must be byte-identical to the legacy build."""
+    reg = _registry_with("alpha", "beta")
+    legacy = reg.get_tool_definitions(exclude=frozenset())
+    defer_none = reg.get_tool_definitions(exclude=frozenset(), defer=None)
+    assert legacy == defer_none
+
+
+def test_list_tools_ignores_defer():
+    """A deferred tool is still callable → must remain in list_tools()."""
+    reg = _registry_with("alpha", "beta")
+    names = reg.list_tools(defer=frozenset({"beta"}))
+    assert "beta" in names
+
+
+# ── Loop integration: instance state + next-turn deferral ───────────────────
+def _make_grouped_loop():
+    """Build an AgentLoop whose operator allowlist covers every grouped tool.
+
+    Mirrors tests/test_loop.py:_make_loop but with a tool surface large enough
+    to trip the budget gate and a real (non-mock) ToolRegistry-like ``list_tools``
+    that honours ``allowed``/``defer``.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.agent.loop import AgentLoop
+
+    all_grouped = {t for g in TOOL_GROUPS for t in g.tools}
+    allowed = frozenset(all_grouped | {"load_tools", "notify_user"})
+
+    tools = MagicMock()
+
+    def _list_tools(exclude=None, allowed=None, defer=None):
+        names = list(allowed) if allowed is not None else list(all_grouped)
+        return names
+
+    tools.list_tools = MagicMock(side_effect=_list_tools)
+    tools.get_tool_definitions = MagicMock(return_value=[])
+    tools.get_descriptions = MagicMock(return_value="")
+    tools.is_parallel_safe = MagicMock(return_value=True)
+    tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
+    tools.tools = {n: {} for n in all_grouped}
+
+    memory = MagicMock()
+    memory.get_high_salience_facts = AsyncMock(return_value=[])
+    memory.search = AsyncMock(return_value=[])
+
+    llm = MagicMock()
+    llm.default_model = "test-model"
+
+    mesh_client = MagicMock()
+    mesh_client.is_standalone = False
+
+    loop = AgentLoop(
+        agent_id="operator",
+        role="operator",
+        memory=memory,
+        tools=tools,
+        llm=llm,
+        mesh_client=mesh_client,
+        allowed_tools=allowed,
+    )
+    # A roomy context window — the gate trips on the grouped-tool fraction below.
+    cm = MagicMock()
+    cm.max_tokens = int(
+        (len(all_grouped) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    loop.context_manager = cm
+    return loop
+
+
+def test_loop_refresh_builds_index_and_defer(grouped_on):
+    loop = _make_grouped_loop()
+    index = loop._refresh_grouped_plan()
+    assert index  # capability index present
+    assert loop._grouped_plan is not None and loop._grouped_plan.active
+    # The defer set is now reflected in the tool-filter kwargs.
+    assert "defer" in loop._tool_filter_kw
+
+
+def test_loop_flag_off_no_index_no_defer(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    loop = _make_grouped_loop()
+    index = loop._refresh_grouped_plan()
+    assert index == ""
+    assert loop._grouped_plan is None
+    assert "defer" not in loop._tool_filter_kw
+
+
+def test_load_tools_defers_to_next_turn(grouped_on):
+    loop = _make_grouped_loop()
+    loop._refresh_grouped_plan()  # turn 1 build
+    # set_cron is deferred at first.
+    assert "set_cron" in loop._grouped_plan.defer
+
+    # Request the scheduling group — must NOT mutate the loaded set mid-turn.
+    res = loop.request_load_tools(group="scheduling", tool=None)
+    assert res["loaded"] == ["scheduling"]
+    assert loop._loaded_tool_groups == set()  # not applied yet (mid-turn)
+    assert loop._pending_tool_groups == {"scheduling"}
+    # The current turn's defer is unchanged (toolset stable within a turn).
+    assert "set_cron" in loop._grouped_plan.defer
+
+    # Next turn boundary: the build promotes pending → loaded.
+    loop._refresh_grouped_plan()
+    assert loop._loaded_tool_groups == {"scheduling"}
+    assert loop._pending_tool_groups == set()
+    # set_cron's schema is now loaded (no longer deferred).
+    assert "set_cron" not in loop._grouped_plan.defer
+
+
+def test_load_tools_noop_when_flag_off(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    loop = _make_grouped_loop()
+    res = loop.request_load_tools(group="scheduling", tool=None)
+    assert res["loaded"] == []
+    assert loop._pending_tool_groups == set()


### PR DESCRIPTION
## Phase 2 (B2) of the operator memory & context overhaul — DO NOT MERGE pending review

> **DO NOT MERGE** — this is Phase 2 of the operator memory/context overhaul and needs review first. It ships **default-OFF behind a flag** so it can merge later without changing default behaviour, but hold for review.

### Design summary

Keep the per-turn tool-schema load lean WITHOUT the agent ever losing awareness of a capability ("it knows exactly what to do"). Removing tools was rejected (trades capability-awareness for leanness); this separates **capability awareness** (always present, cheap) from **schema loading** (lazy). Three layers:

1. **Always-loaded core** — the daily-driver tools, full schemas, unchanged.
2. **Always-loaded capability INDEX** — names + one-line intent, grouped by job-to-be-done (*Fleet setup / Scheduling / Credentials & access / Goals & review / Audit & undo / Web & browse*). ~300-500 tokens, **no full schemas**. A tool's capability is never hidden — only its verbose schema is lazy.
3. **On-demand schema loading** — `load_tools(group | tool)` bridge pulls a group's full schemas into context for **subsequent** turns.

Honors the plan's Codex notes (PT2b/PT2d):
- **Budget-gated** — index+defer only activate when an agent's deferrable schemas exceed ~10% of the context window. Small-toolset agents present everything unchanged (no behaviour change).
- **Extends the existing filter model** — `get_tool_definitions(exclude, allowed)` gains a `defer` arg folded into the `(exclude, allowed, defer)` memo cache key (a different loaded-groups set → different definitions / fresh cache entry). No parallel path.
- **Loaded-group state lives on the `AgentLoop` instance** and is recomputed at each system-prompt build (the **turn boundary**). `load_tools` queues a group into a *pending* set; the change applies on the **next** build — never mid-turn (which would bust the #1073 prompt cache; mirrors hermes' "don't change toolsets mid-conversation").
- **Groups defined as DATA** (`src/agent/tool_groups.py`) with per-group role-eligibility (operator vs worker). Applies to both scopes.

### Default-OFF behind a flag

The entire path is dormant unless `OPENLEGION_GROUPED_TOOLS` is set (default off). Flag off → byte-identical to today (`defer=None` build equals the legacy build; no index injected).

### Deferred to follow-ups
- **Intent-prefetch** (map a new user message → likely group, pre-load so the operator acts without a visible search round-trip) — explicitly deferred for v1 to avoid misclassification risk. `load_tools` is the always-available explicit fallback, so capability is never lost without it.
- **Per-path (task/heartbeat) prefetch** design — deferred.

### Deploy zone
Agent code (`src/agent/**`) → **image rebuild** (`docker build -t openlegion-agent:latest -f Dockerfile.agent .`) **then** `systemctl restart openlegion`. `src/cli/config.py` (operator allowlist) is host-side (git pull + restart). Ship together.

### Files
- `src/agent/tool_groups.py` (new) — group registry (DATA), budget gate, index renderer, `GroupedPlan`, `resolve_load_request`, `grouped_tools_enabled()`.
- `src/agent/builtins/tool_search.py` (new) — `load_tools` bridge builtin.
- `src/agent/tools.py` — `get_tool_definitions`/`list_tools` gain `defer` (folded into cache key); `execute` injects `agent_loop`.
- `src/agent/loop.py` — instance state (`_loaded_tool_groups`/`_pending_tool_groups`/`_grouped_plan`), `_refresh_grouped_plan()` (turn-boundary promote+recompute, injects index into all three system-prompt builds), `request_load_tools()`, `defer` folded into `_tool_filter_kw`.
- `src/agent/server.py` / `src/cli/config.py` — `agent_loop` injection on `/invoke`; `load_tools` added to operator allowlist.

### Test summary
`pytest tests/test_tools.py tests/test_grouped_tools.py tests/test_loop.py -q` → **280 passed**. New `tests/test_grouped_tools.py` covers: budget gate (small→unchanged, large→index+defer), index renders every available capability, `load_tools` defers to the **next** build (not mid-turn), loaded-groups folds into the cache key, worker never sees operator-only groups, flag-off → identical to today. Updated `test_agent_server`/`test_dashboard_ui` for the new `agent_loop` kwarg + `load_tools` builtin. `ruff check` clean on all changed files.

(One pre-existing failure `test_templates::test_creates_tools_dir` is environment-dependent — local OAuth creds reject `gpt-4o`; fails identically on pristine `origin/main`, unrelated to this PR.)

### Overlap note
This PR overlaps `src/agent/loop.py` + `src/agent/tools.py` with other in-flight Phase-2 PRs — expect to rebase/reconcile the `_tool_filter_kw` / `get_tool_definitions` regions.