### PR TITLE
feat(agent): execute_code tool — code-as-action with env scrub

### DIFF
--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 import tempfile
 
 from src.agent.tools import tool
@@ -75,6 +76,12 @@ def _scrubbed_env() -> dict[str, str]:
     Strategy is allowlist-first (only ``_SAFE_ENV_KEYS`` pass through) with a
     sensitive-name denylist applied on top as belt-and-suspenders. The agent's
     full env is never forwarded.
+
+    SCOPE: this scrubs ENVIRONMENT VARIABLES only. It does NOT sandbox the
+    filesystem — a snippet can still read any file the container user owns
+    (e.g. ``~/.netrc``). That is by design and identical to ``run_command``;
+    the Docker container hardening (no host mounts, no host credentials, agents
+    hold no API keys) is the actual boundary, not this scrub.
     """
     env: dict[str, str] = {}
     for key in _SAFE_ENV_KEYS:
@@ -84,6 +91,23 @@ def _scrubbed_env() -> dict[str, str]:
     # Force unbuffered stdout so print() output is captured even on early exit.
     env.setdefault("PYTHONUNBUFFERED", "1")
     return env
+
+
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the child AND any grandchildren it spawned.
+
+    The child is started in its own session (``start_new_session=True``), so it
+    leads a process group. Killing the group reaps any subprocesses the snippet
+    forked — otherwise a snippet that spawns a long-running child leaves orphans
+    that accumulate against the container ``pids_limit``.
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
 
 
 @tool(
@@ -200,7 +224,12 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
         fd, path = tempfile.mkstemp(suffix=".py", prefix="execcode_")
         with os.fdopen(fd, "w") as fh:
             fh.write(code)
+        # Read-only before exec — closes the (already narrow, container-only)
+        # TOCTOU window between write and run.
+        os.chmod(path, 0o400)
 
+        # start_new_session: the child leads its own process group so a timeout
+        # can SIGKILL the whole group (child + any snippet-spawned grandchildren).
         proc = await asyncio.create_subprocess_exec(
             "python3",
             path,
@@ -208,6 +237,7 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
             stderr=asyncio.subprocess.PIPE,
             cwd=workdir,
             env=_scrubbed_env(),
+            start_new_session=True,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             proc.communicate(), timeout=timeout
@@ -222,7 +252,7 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
             "stderr": stderr if proc.returncode != 0 else "",
         }
     except asyncio.TimeoutError:
-        proc.kill()
+        _kill_process_group(proc)
         await proc.wait()
         return {"exit_code": -1, "stdout": "", "stderr": f"Code timed out after {timeout}s"}
     except Exception as e:

--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -8,11 +8,82 @@ from __future__ import annotations
 
 import asyncio
 import os
+import tempfile
 
 from src.agent.tools import tool
 
 _MAX_OUTPUT = 100_000
 _MAX_TIMEOUT = 300
+
+# ── execute_code (code-as-action) — Phase 2 of the operator memory/context
+# overhaul (docs/plans/2026-06-09-operator-memory-context-overhaul.md §7, C2).
+#
+# Lets the model write ONE Python block and get back only what it ``print()``s,
+# collapsing several shell/tool rounds into a single turn. Intermediate values
+# never enter context. v1 is deliberately a pure Python-execution + stdout
+# capture tool — the hermes-style "call agent tools from inside the code" bridge
+# is OUT of scope (see _DEFERRED note below). No recursion into execute_code or
+# delegate.
+#
+# Ships dormant: gated behind OPENLEGION_EXECUTE_CODE (default off). When off
+# the schema is hidden from the worker surface (see _EXECUTE_CODE_TOOLS in
+# loop.py) AND the handler self-rejects (defense-in-depth for the operator
+# allowlist path).
+EXECUTE_CODE_ENABLED_ENV = "OPENLEGION_EXECUTE_CODE"
+
+# Tighter cap than run_command's 100 KB: this is "what the model printed",
+# meant to flow straight back into context, so keep it lean.
+_CODE_MAX_OUTPUT = 20_000
+_CODE_MAX_TIMEOUT = 120
+
+# Env-var name substrings that mark a value as sensitive. Matched
+# case-insensitively against each var NAME (never the value). Agents already
+# never hold API keys (those live mesh-side), but the child gets a scrubbed
+# env regardless — defense-in-depth, and it future-proofs against any var that
+# does leak into the container environment.
+_SENSITIVE_NAME_PARTS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CRED")
+# Whole-name prefixes that are stripped outright (the OpenLegion namespace
+# carries config + per-agent identity we don't want a code snippet reading).
+_SENSITIVE_PREFIXES = ("OPENLEGION_", "OL_")
+# Minimal allowlist of harmless vars the child genuinely needs to behave like a
+# normal Python process (PATH for subprocess lookups, locale, tmp). Everything
+# else is dropped — the child does NOT inherit the agent's full environment.
+_SAFE_ENV_KEYS = (
+    "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR", "TERM",
+    "PYTHONIOENCODING", "PYTHONHASHSEED",
+)
+
+
+def execute_code_enabled() -> bool:
+    """True iff the code-as-action ``execute_code`` tool is opted in."""
+    return os.environ.get(EXECUTE_CODE_ENABLED_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _is_sensitive_env_name(name: str) -> bool:
+    """True iff an env-var name should be scrubbed from the child process."""
+    upper = name.upper()
+    if any(upper.startswith(prefix) for prefix in _SENSITIVE_PREFIXES):
+        return True
+    return any(part in upper for part in _SENSITIVE_NAME_PARTS)
+
+
+def _scrubbed_env() -> dict[str, str]:
+    """Build a minimal, credential-free environment for the child process.
+
+    Strategy is allowlist-first (only ``_SAFE_ENV_KEYS`` pass through) with a
+    sensitive-name denylist applied on top as belt-and-suspenders. The agent's
+    full env is never forwarded.
+    """
+    env: dict[str, str] = {}
+    for key in _SAFE_ENV_KEYS:
+        val = os.environ.get(key)
+        if val is not None and not _is_sensitive_env_name(key):
+            env[key] = val
+    # Force unbuffered stdout so print() output is captured even on early exit.
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    return env
 
 
 @tool(
@@ -73,3 +144,99 @@ async def exec_command(command: str, timeout: int = 30, workdir: str = "/data") 
         return {"exit_code": -1, "stdout": "", "stderr": f"Command timed out after {timeout}s"}
     except Exception as e:
         return {"exit_code": -1, "stdout": "", "stderr": str(e)}
+
+
+@tool(
+    name="execute_code",
+    description=(
+        "Run a Python snippet in your Linux environment and get back ONLY what "
+        "you print(). Use this to collapse several steps into one turn: fetch, "
+        "compute, filter, and print just the final answer — intermediate values "
+        "never come back to you, only your printed output. The snippet runs as a "
+        "fresh `python3` process (no state carries over between calls). On "
+        "failure you get the error (stderr) and a non-zero exit code. "
+        "print() what you need; everything else is discarded."
+    ),
+    parameters={
+        "code": {"type": "string", "description": "Python source to execute"},
+        "timeout": {
+            "type": "integer",
+            "description": "Max seconds to wait (default 30)",
+            "default": 30,
+        },
+    },
+)
+async def execute_code(code: str, timeout: int = 30) -> dict:
+    """Run a Python snippet and return its printed stdout (stderr on failure).
+
+    Reuses run_command's container-exec mechanism (the Docker container IS the
+    security boundary). The snippet is written to a temp file and run with
+    ``python3 <file>`` — temp-file over ``-c`` to sidestep shell/quoting issues
+    — under a SCRUBBED environment (no credentials, no OpenLegion namespace; see
+    ``_scrubbed_env``). Intermediate values stay out of context: only what the
+    snippet print()s is returned.
+    """
+    # Ships dormant. The worker surface hides the schema when the flag is off
+    # (see _EXECUTE_CODE_TOOLS in loop.py); this self-reject also covers the
+    # operator allowlist path, which doesn't go through that exclusion.
+    if not execute_code_enabled():
+        return {
+            "exit_code": -1,
+            "stdout": "",
+            "stderr": (
+                "execute_code is disabled. Set OPENLEGION_EXECUTE_CODE=1 to enable "
+                "it, or use run_command instead."
+            ),
+        }
+    if not isinstance(code, str) or not code.strip():
+        return {"exit_code": -1, "stdout": "", "stderr": "code must be a non-empty string"}
+
+    timeout = min(timeout, _CODE_MAX_TIMEOUT)
+    workdir = "/data" if os.path.isdir("/data") else None
+    path = None
+    try:
+        # Write the snippet to a temp file so we exec `python3 <file>` with no
+        # shell interpolation of the (untrusted, possibly quote-laden) source.
+        fd, path = tempfile.mkstemp(suffix=".py", prefix="execcode_")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(code)
+
+        proc = await asyncio.create_subprocess_exec(
+            "python3",
+            path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=workdir,
+            env=_scrubbed_env(),
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout
+        )
+        stdout = stdout_bytes.decode(errors="replace")[:_CODE_MAX_OUTPUT]
+        stderr = stderr_bytes.decode(errors="replace")[:_CODE_MAX_OUTPUT]
+        return {
+            "exit_code": proc.returncode,
+            "stdout": stdout,
+            # Only surface stderr on failure — keeps the success path to just
+            # what the model printed.
+            "stderr": stderr if proc.returncode != 0 else "",
+        }
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return {"exit_code": -1, "stdout": "", "stderr": f"Code timed out after {timeout}s"}
+    except Exception as e:
+        return {"exit_code": -1, "stdout": "", "stderr": str(e)}
+    finally:
+        if path is not None:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+# DEFERRED (v1 → follow-up): the hermes-style tool-call bridge — letting the
+# executed snippet invoke other agent tools (e.g. a `call_tool(...)` helper in
+# scope) to truly collapse N tool rounds into one — is intentionally NOT built
+# here. It is a larger security surface (tool whitelist, no recursion into
+# execute_code/delegate) and ships as its own PR. v1 is pure Python + stdout.

--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -218,6 +218,7 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
     timeout = min(timeout, _CODE_MAX_TIMEOUT)
     workdir = "/data" if os.path.isdir("/data") else None
     path = None
+    proc: asyncio.subprocess.Process | None = None
     try:
         # Write the snippet to a temp file so we exec `python3 <file>` with no
         # shell interpolation of the (untrusted, possibly quote-laden) source.
@@ -252,8 +253,9 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
             "stderr": stderr if proc.returncode != 0 else "",
         }
     except asyncio.TimeoutError:
-        _kill_process_group(proc)
-        await proc.wait()
+        if proc is not None:
+            _kill_process_group(proc)
+            await proc.wait()
         return {"exit_code": -1, "stdout": "", "stderr": f"Code timed out after {timeout}s"}
     except Exception as e:
         return {"exit_code": -1, "stdout": "", "stderr": str(e)}

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -160,6 +160,12 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
 # without it (marketplace tools load at container start, not via runtime reload).
 _TOOL_AUTHORING_TOOLS = frozenset({"create_tool", "reload_tools"})
 
+# Code-as-action surface — hidden from the worker tool surface unless the
+# OPENLEGION_EXECUTE_CODE opt-in is set. Ships dormant (Phase 2 of the operator
+# memory/context overhaul, §7 C2). The tool also self-rejects at call time, so
+# the operator allowlist path (which bypasses this exclude) stays gated too.
+_EXECUTE_CODE_TOOLS = frozenset({"execute_code"})
+
 # Read-only tools allowed during operator heartbeat (unsupervised execution).
 # The full operator allowlist is restricted to this subset so heartbeats
 # cannot mutate fleet state without user approval. ``check_inbox`` is
@@ -417,6 +423,10 @@ class AgentLoop:
             from src.agent.builtins.tool_authoring import tool_authoring_enabled
             if not tool_authoring_enabled():
                 excluded |= _TOOL_AUTHORING_TOOLS
+            # Code-as-action ships dormant — hide execute_code unless opted in.
+            from src.agent.builtins.exec_tool import execute_code_enabled
+            if not execute_code_enabled():
+                excluded |= _EXECUTE_CODE_TOOLS
             # Operator-only orchestration tools (edit_agent, create_team,
             # manage_*, apply_template, install_skill, …) self-reject for
             # worker callers at call time. Drop their schemas from the worker

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10995,6 +10995,7 @@ function dashboard() {
         browser_solve_captcha: 'solving a CAPTCHA',
         http_request: 'making an HTTP request',
         exec: 'running a command',
+        execute_code: 'running code',
         file_read: 'reading a file',
         file_write: 'writing a file',
         file_list: 'listing files',

--- a/tests/test_execute_code.py
+++ b/tests/test_execute_code.py
@@ -1,0 +1,186 @@
+"""Tests for the execute_code (code-as-action) builtin.
+
+Phase 2 of the operator memory/context overhaul (§7, C2). Covers: stdout
+capture, multi-line snippets, error surfacing, output truncation, the env
+scrub (no credentials reach the child), and flag-off gating (handler self-reject
++ worker-surface exclusion).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agent.builtins import exec_tool
+from src.agent.builtins.exec_tool import (
+    _is_sensitive_env_name,
+    _scrubbed_env,
+    execute_code,
+    execute_code_enabled,
+)
+from src.agent.loop import _EXECUTE_CODE_TOOLS
+from tests.test_loop import _make_loop
+
+ENV = exec_tool.EXECUTE_CODE_ENABLED_ENV
+
+
+# ── flag parsing ──────────────────────────────────────────────────────────
+
+def test_enabled_flag_truthy(monkeypatch):
+    for v in ("1", "true", "TRUE", "yes", "on", " On "):
+        monkeypatch.setenv(ENV, v)
+        assert execute_code_enabled() is True
+
+
+def test_enabled_flag_falsy(monkeypatch):
+    for v in ("", "0", "false", "no", "off", "nope"):
+        monkeypatch.setenv(ENV, v)
+        assert execute_code_enabled() is False
+
+
+def test_disabled_when_unset(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    assert execute_code_enabled() is False
+
+
+# ── flag-off gating ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_self_rejects_when_disabled(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    result = await execute_code(code="print(1)")
+    assert result["exit_code"] == -1
+    assert result["stdout"] == ""
+    assert "disabled" in result["stderr"]
+    assert "OPENLEGION_EXECUTE_CODE" in result["stderr"]
+
+
+def test_worker_hides_execute_code_by_default(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    loop = _make_loop()
+    assert loop._excluded_tools is not None
+    assert _EXECUTE_CODE_TOOLS <= loop._excluded_tools
+
+
+def test_worker_exposes_execute_code_when_enabled(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    loop = _make_loop()
+    assert not loop._excluded_tools or not (_EXECUTE_CODE_TOOLS & loop._excluded_tools)
+
+
+# ── execution (flag on) ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_simple_print(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="print(2 + 2)")
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "4"
+    # Success path keeps stderr empty.
+    assert result["stderr"] == ""
+
+
+@pytest.mark.asyncio
+async def test_multiline_code(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    code = (
+        "total = 0\n"
+        "for i in range(5):\n"
+        "    total += i\n"
+        "print('sum', total)\n"
+    )
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert "sum 10" in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_only_printed_output_returned(monkeypatch):
+    """Intermediate values never leak — only print() reaches the result."""
+    monkeypatch.setenv(ENV, "1")
+    code = "secret = 1234\nprint('answer:', 7 * 6)\n"
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert "42" in result["stdout"]
+    assert "1234" not in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_raise_surfaces_error(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="raise ValueError('boom')")
+    assert result["exit_code"] != 0
+    assert "ValueError" in result["stderr"]
+    assert "boom" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_empty_code_rejected(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="   ")
+    assert result["exit_code"] == -1
+    assert "non-empty" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_timeout(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="import time; time.sleep(10)", timeout=1)
+    assert result["exit_code"] == -1
+    assert "timed out" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_output_truncated(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    # Print way more than the cap; result must be clamped.
+    code = "print('x' * 100000)"
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert len(result["stdout"]) <= exec_tool._CODE_MAX_OUTPUT
+
+
+# ── env scrub ──────────────────────────────────────────────────────────────
+
+def test_is_sensitive_env_name():
+    for name in (
+        "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+        "OPENLEGION_CRED_GITHUB",
+        "OL_INTERNET_ACCESS_ENABLED",
+        "SOME_TOKEN",
+        "my_secret_thing",
+        "DB_PASSWORD",
+        "AWS_ACCESS_KEY_ID",
+    ):
+        assert _is_sensitive_env_name(name) is True, name
+    for name in ("PATH", "HOME", "LANG", "TZ"):
+        assert _is_sensitive_env_name(name) is False, name
+
+
+def test_scrubbed_env_drops_sensitive(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-secret")
+    monkeypatch.setenv("SOME_TOKEN", "tok-123")
+    monkeypatch.setenv("MY_PASSWORD", "hunter2")
+    env = _scrubbed_env()
+    assert "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY" not in env
+    assert "SOME_TOKEN" not in env
+    assert "MY_PASSWORD" not in env
+    # PATH (allowlisted, non-sensitive) survives so subprocess lookups work.
+    assert "PATH" in env
+
+
+@pytest.mark.asyncio
+async def test_child_cannot_read_scrubbed_vars(monkeypatch):
+    """The child process must not see credential-shaped env vars."""
+    monkeypatch.setenv(ENV, "1")
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-LEAKED")
+    monkeypatch.setenv("SOME_TOKEN", "tok-LEAKED")
+    code = (
+        "import os\n"
+        "print(os.environ.get('OPENLEGION_SYSTEM_ANTHROPIC_API_KEY'), "
+        "os.environ.get('SOME_TOKEN'))\n"
+    )
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert "LEAKED" not in result["stdout"]
+    # Scrubbed vars come back as None.
+    assert result["stdout"].strip() == "None None"


### PR DESCRIPTION
## Phase 2 of the operator memory/context overhaul — DO NOT MERGE pending review

Track **C2 — execute_code (code-as-action)** from `docs/plans/2026-06-09-operator-memory-context-overhaul.md` §7. Ships dormant.

## Summary
Adds an `execute_code(code, timeout)` builtin that runs a Python snippet inside the agent container and returns **only its stdout** (what the model `print()`s). Intermediate values never enter context — only printed output flows back. This collapses several shell/tool rounds into one turn, the highest-leverage speed lever for the orchestrator (the operator burns 10+ silent tool rounds per task).

## Security model
- **Reuses `run_command`'s container-exec path** — the Docker container hardening (non-root UID 1000, `cap_drop=ALL`, `no-new-privileges`, read-only root fs, mem/CPU/PID limits) IS the boundary, per CLAUDE.md. No new sandbox invented.
- **Temp-file exec, not shell string interp:** the snippet is written to a temp file and run as `python3 <file>` via `create_subprocess_exec` — no shell, so no quoting/injection surface from the (untrusted) source. Temp file is unlinked in `finally`.
- **Env scrub:** the child runs under a minimal **allowlist-first** environment — only `PATH`/`HOME`/locale/`TMPDIR`/etc. pass through — with a **sensitive-name denylist** on top: any var whose name contains `KEY`/`TOKEN`/`SECRET`/`PASSWORD`/`CRED`, or starts with `OPENLEGION_`/`OL_`, is dropped. The agent's full env is never forwarded. Agents already never hold API keys (those live mesh-side); this is defense-in-depth.
- **Output/timeout caps:** 20 KB stdout cap (tighter than `run_command`'s 100 KB since this flows straight back into context) and a 120 s timeout ceiling. Success path returns empty stderr; failures surface stderr + non-zero exit cleanly.

## Gating (ships dormant)
Behind `OPENLEGION_EXECUTE_CODE` (default off), gated two ways:
1. **Worker surface exclusion** — `_EXECUTE_CODE_TOOLS` hidden from the worker tool surface when off (mirrors `_TOOL_AUTHORING_TOOLS` in `loop.py`), so the schema never bloats a worker's context.
2. **Handler self-reject** — the function self-rejects at call time when off, covering the operator allowlist path (which bypasses the exclude).

## Deferred (follow-up PR)
The hermes-style **tool-call bridge** (invoking agent tools from inside the snippet) is explicitly OUT of scope for v1 — larger security surface (tool whitelist, no recursion into execute_code/delegate). v1 is pure Python execution + stdout capture. No recursion added.

## Deploy zone
Agent code (`src/agent/**`) → baked into `openlegion-agent:latest` → **image rebuild + `systemctl restart openlegion`** (a git pull alone does not update agent code).

## Tests
`tests/test_execute_code.py` — flag parsing; flag-off self-reject + worker-surface exclusion; flag-on `print(2+2)`→"4"; multi-line; only-printed-output (intermediates don't leak); raise→non-zero + error surfaced; empty-code reject; timeout; output truncation cap; env-scrub unit (`_is_sensitive_env_name`/`_scrubbed_env`) + **real-subprocess scrub** (a child can't read `OPENLEGION_SYSTEM_ANTHROPIC_API_KEY`/`SOME_TOKEN` set in the test env → reads back `None None`).

```
tests/test_execute_code.py + tests/test_builtins.py::TestExecTool → 20 passed
tests/test_tool_authoring_gate.py (adjacent loop.py exclusion logic) → 7 passed
ruff check (changed files) → All checks passed!
```