### PR TITLE
feat(memory): dated + sourced facts and inject-head-only option

### DIFF
--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -172,7 +172,9 @@ class MemoryStore:
                 access_count INTEGER DEFAULT 0,
                 last_accessed TEXT,
                 created_at TEXT DEFAULT (datetime('now')),
-                decay_score REAL DEFAULT 1.0
+                decay_score REAL DEFAULT 1.0,
+                source_type TEXT DEFAULT 'conversation',
+                date TEXT DEFAULT (datetime('now'))
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS facts_vec USING vec0(
                 id TEXT PRIMARY KEY,
@@ -241,11 +243,24 @@ class MemoryStore:
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
         """)
-        # Lazy migration: add category_id FK to facts if not present
-        try:
-            self.db.execute("ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)")
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        # Lazy migrations: ADD COLUMN on pre-existing on-disk DBs so a redeploy
+        # against an older schema doesn't crash. Each is idempotent — a
+        # duplicate-column OperationalError on an already-migrated DB is a no-op.
+        for ddl in (
+            "ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)",
+            # Memory v2: dated + sourced facts (enables prefer-recent retrieval).
+            # NOTE: ADD COLUMN cannot carry a non-constant default on a
+            # non-empty table (SQLite "Cannot add a column with non-constant
+            # default"), so `date` is added WITHOUT a default here — pre-existing
+            # rows backfill to NULL (sort last under prefer-recent, acceptable),
+            # and `_store_fact_sync` stamps `date` explicitly on every write.
+            "ALTER TABLE facts ADD COLUMN source_type TEXT DEFAULT 'conversation'",
+            "ALTER TABLE facts ADD COLUMN date TEXT",
+        ):
+            try:
+                self.db.execute(ddl)
+            except sqlite3.OperationalError:
+                pass  # Column already exists
         self.db.commit()
         # Reconcile the dimension the vec0 tables were built at against the
         # configured dimension (rebuilds on an embedding-provider switch).
@@ -266,6 +281,7 @@ class MemoryStore:
     def _store_fact_sync(
         self, key: str, value: str, category: str, source: str,
         confidence: float, embedding: list[float] | None,
+        source_type: str = "conversation",
     ) -> str:
         """Sync DB portion of store_fact. Returns the fact ID."""
         existing = self.db.execute("SELECT id, access_count FROM facts WHERE key = ?", (key,)).fetchone()
@@ -274,11 +290,15 @@ class MemoryStore:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
+            # Re-stamp `date` so a re-asserted fact counts as recent for
+            # prefer-recent retrieval; keep the original source_type unless a
+            # caller overrides it.
             self.db.execute(
                 "UPDATE facts SET value = ?, confidence = ?, "
                 "access_count = ?, last_accessed = datetime('now'), "
-                "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (value, confidence, new_count, boost, fact_id),
+                "decay_score = MIN(?, 10.0), source_type = ?, "
+                "date = datetime('now') WHERE id = ?",
+                (value, confidence, new_count, boost, source_type, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
@@ -288,8 +308,10 @@ class MemoryStore:
         else:
             fact_id = generate_id("fact")
             self.db.execute(
-                "INSERT INTO facts (id, key, value, category, source, confidence) VALUES (?, ?, ?, ?, ?, ?)",
-                (fact_id, key, value, category, source, confidence),
+                "INSERT INTO facts "
+                "(id, key, value, category, source, confidence, source_type, date) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))",
+                (fact_id, key, value, category, source, confidence, source_type),
             )
             self.db.execute(
                 "INSERT INTO facts_fts (fact_id, key, value, category) VALUES (?, ?, ?, ?)",
@@ -309,8 +331,14 @@ class MemoryStore:
         category: str = "general",
         source: str = "agent",
         confidence: float = 1.0,
+        source_type: str = "conversation",
     ) -> str:
-        """Store or update a fact. Returns the fact ID."""
+        """Store or update a fact. Returns the fact ID.
+
+        ``source_type`` records WHERE the fact came from (e.g. "conversation",
+        "context_flush", "consolidation") and is paired with a ``date`` column
+        stamped at write time, enabling prefer-recent retrieval (memory v2).
+        """
         # Compute embedding BEFORE starting DB transaction to avoid
         # yielding control (await) with uncommitted writes.
         embedding = None
@@ -334,7 +362,8 @@ class MemoryStore:
 
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
-            self._store_fact_sync, key, value, category, source, confidence, embedding,
+            self._store_fact_sync, key, value, category, source, confidence,
+            embedding, source_type,
         )
 
         if embedding is not None:
@@ -445,7 +474,7 @@ class MemoryStore:
         row = self.db.execute(
             "SELECT f.id, f.key, f.value, f.category, f.source, f.confidence, "
             "f.access_count, f.last_accessed, f.created_at, f.decay_score, "
-            "c.name "
+            "f.source_type, f.date, c.name "
             "FROM facts f LEFT JOIN categories c ON f.category_id = c.id "
             "WHERE f.id = ?",
             (fact_id,),
@@ -453,7 +482,7 @@ class MemoryStore:
         if not row:
             return None
         # Use category name from categories table if assigned, else text field
-        category = row[10] if row[10] else row[3]
+        category = row[12] if row[12] else row[3]
         return MemoryFact(
             id=row[0],
             key=row[1],
@@ -465,6 +494,8 @@ class MemoryStore:
             last_accessed=row[7],
             created_at=row[8],
             decay_score=row[9],
+            source_type=row[10],
+            date=row[11],
         )
 
     def _get_facts_batch(self, fact_ids: list[str]) -> dict[str, MemoryFact]:
@@ -475,18 +506,19 @@ class MemoryStore:
         rows = self.db.execute(
             f"SELECT f.id, f.key, f.value, f.category, f.source, f.confidence, "
             f"f.access_count, f.last_accessed, f.created_at, f.decay_score, "
-            f"c.name "
+            f"f.source_type, f.date, c.name "
             f"FROM facts f LEFT JOIN categories c ON f.category_id = c.id "
             f"WHERE f.id IN ({placeholders})",
             fact_ids,
         ).fetchall()
         result = {}
         for row in rows:
-            category = row[10] if row[10] else row[3]
+            category = row[12] if row[12] else row[3]
             result[row[0]] = MemoryFact(
                 id=row[0], key=row[1], value=row[2], category=category,
                 source=row[4], confidence=row[5], access_count=row[6],
                 last_accessed=row[7], created_at=row[8], decay_score=row[9],
+                source_type=row[10], date=row[11],
             )
         return result
 
@@ -529,7 +561,13 @@ class MemoryStore:
         await self._run_db(self._decay_all_sync)
 
     def _get_high_salience_facts_sync(self, top_k: int) -> list[MemoryFact]:
-        rows = self.db.execute("SELECT id FROM facts ORDER BY decay_score DESC LIMIT ?", (top_k,)).fetchall()
+        # Prefer-recent (memory v2): salience is the primary signal; `date`
+        # breaks ties toward the newest fact so re-asserted/recent knowledge
+        # ranks above equally-salient stale rows.
+        rows = self.db.execute(
+            "SELECT id FROM facts ORDER BY decay_score DESC, date DESC LIMIT ?",
+            (top_k,),
+        ).fetchall()
         fact_ids = [r[0] for r in rows]
         facts_map = self._get_facts_batch(fact_ids)
         return [facts_map[fid] for fid in fact_ids if fid in facts_map]
@@ -552,7 +590,10 @@ class MemoryStore:
                 continue
             category = fact.get("category", "general")
             try:
-                await self.store_fact(key=key, value=value, category=category, source="context_flush")
+                await self.store_fact(
+                    key=key, value=value, category=category,
+                    source="context_flush", source_type="context_flush",
+                )
                 stored += 1
             except Exception as e:
                 logger.warning(f"Failed to store fact '{key}': {e}")

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -301,14 +301,16 @@ class MemoryStore:
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
             # Re-stamp `date` so a re-asserted fact counts as recent for
-            # prefer-recent retrieval; keep the original source_type unless a
-            # caller overrides it.
+            # prefer-recent retrieval. PRESERVE the original `source_type`
+            # (provenance): a re-store via the conversation loop must not
+            # overwrite a fact first recorded as e.g. "context_flush" with the
+            # caller's default. Only a fresh insert sets source_type.
             self.db.execute(
                 "UPDATE facts SET value = ?, confidence = ?, "
                 "access_count = ?, last_accessed = datetime('now'), "
-                "decay_score = MIN(?, 10.0), source_type = ?, "
+                "decay_score = MIN(?, 10.0), "
                 "date = datetime('now') WHERE id = ?",
-                (value, confidence, new_count, boost, source_type, fact_id),
+                (value, confidence, new_count, boost, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -18,7 +18,6 @@ import hashlib
 import json
 import math
 import re
-import sqlite3
 import struct
 import threading
 from collections.abc import Callable, Coroutine
@@ -244,23 +243,34 @@ class MemoryStore:
             );
         """)
         # Lazy migrations: ADD COLUMN on pre-existing on-disk DBs so a redeploy
-        # against an older schema doesn't crash. Each is idempotent — a
-        # duplicate-column OperationalError on an already-migrated DB is a no-op.
-        for ddl in (
-            "ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)",
+        # against an older schema doesn't crash. Each is idempotent — we only run
+        # the ALTER when the column is genuinely absent (checked via
+        # PRAGMA table_info), so a real OperationalError (locked db, disk error,
+        # constraint failure) propagates instead of being silently swallowed.
+        existing_cols = {
+            row[1] for row in self.db.execute("PRAGMA table_info(facts)")
+        }
+        # (column_name, ALTER statement)
+        migrations = (
+            (
+                "category_id",
+                "ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)",
+            ),
             # Memory v2: dated + sourced facts (enables prefer-recent retrieval).
+            (
+                "source_type",
+                "ALTER TABLE facts ADD COLUMN source_type TEXT DEFAULT 'conversation'",
+            ),
             # NOTE: ADD COLUMN cannot carry a non-constant default on a
             # non-empty table (SQLite "Cannot add a column with non-constant
             # default"), so `date` is added WITHOUT a default here — pre-existing
             # rows backfill to NULL (sort last under prefer-recent, acceptable),
             # and `_store_fact_sync` stamps `date` explicitly on every write.
-            "ALTER TABLE facts ADD COLUMN source_type TEXT DEFAULT 'conversation'",
-            "ALTER TABLE facts ADD COLUMN date TEXT",
-        ):
-            try:
+            ("date", "ALTER TABLE facts ADD COLUMN date TEXT"),
+        )
+        for column, ddl in migrations:
+            if column not in existing_cols:
                 self.db.execute(ddl)
-            except sqlite3.OperationalError:
-                pass  # Column already exists
         self.db.commit()
         # Reconcile the dimension the vec0 tables were built at against the
         # configured dimension (rebuilds on an embedding-provider switch).

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import json
 import math
+import os
 import re
 import time
 from datetime import datetime, timedelta, timezone
@@ -104,6 +105,18 @@ MEMORY_COMPILED_END = "<!-- compiled:end -->"
 _MEMORY_FILE_MAX = 64_000
 # Newest slice of the log injected alongside the compiled head.
 _MEMORY_RECENT_LOG_CHARS = 5_000
+
+
+def _inject_head_only() -> bool:
+    """Flag-gated (memory v2): when enabled, ``get_memory_injection`` injects
+    ONLY the compiled head and drops the ``## Recent`` log slice, per gbrain's
+    "inject only the head". Older log entries remain searchable via
+    memory_search. Read per-call so it can be toggled without a process
+    restart. Default OFF — it changes what is injected every turn.
+    """
+    return os.environ.get("OPENLEGION_INJECT_HEAD_ONLY", "").lower() in (
+        "1", "true", "yes", "on",
+    )
 
 # Public mapping for external consumers (tool response, dashboard).
 # Files not listed have no per-file bootstrap cap.
@@ -491,10 +504,16 @@ class WorkspaceManager:
         folds them into the head. Older log entries are recalled via
         memory_search. The head is capped so head + recent fits the per-file
         bootstrap cap.
+
+        When ``OPENLEGION_INJECT_HEAD_ONLY`` is set, the ``## Recent`` log slice
+        is dropped and ONLY the compiled head is injected (gbrain "inject only
+        the head"); the log stays on disk and searchable via memory_search.
         """
         raw = self._read_file(self.MEMORY_FILE) or ""
         head, log = self._split_memory(raw)
         head, log = head.strip(), log.strip()
+        if _inject_head_only():
+            return head
         recent = ""
         if log:
             recent = log[-_MEMORY_RECENT_LOG_CHARS:]

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -619,6 +619,9 @@ class MemoryFact(BaseModel):
     last_accessed: datetime | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     decay_score: float = 1.0
+    # Memory v2: provenance + recency for prefer-recent retrieval.
+    source_type: str = "conversation"
+    date: datetime | None = None
 
 
 class MemoryLog(BaseModel):

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -139,6 +139,40 @@ async def test_migration_is_idempotent_on_reopen(tmp_path):
         s2.close()
 
 
+@pytest.mark.asyncio
+async def test_migration_propagates_real_operational_error(tmp_path, monkeypatch):
+    """A genuine OperationalError during an ALTER (not a duplicate column) must
+    surface, not be silently swallowed — guards against half-applied schemas."""
+    db_path = str(tmp_path / "broken.db")
+    _create_legacy_facts_db(db_path)
+
+    from src.agent import memory as memory_mod
+
+    real_open_db = memory_mod.open_db
+
+    class _FaultyConn:
+        """Wraps a real connection but fails any ALTER TABLE facts statement
+        with a non-duplicate OperationalError (e.g. a locked db)."""
+
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            if isinstance(sql, str) and sql.startswith("ALTER TABLE facts"):
+                raise sqlite3.OperationalError("database is locked")
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    monkeypatch.setattr(
+        memory_mod, "open_db", lambda *a, **k: _FaultyConn(real_open_db(*a, **k))
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        MemoryStore(db_path=db_path)
+
+
 # --- Prefer-recent tie-break -------------------------------------------------
 
 @pytest.mark.asyncio

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -1,0 +1,191 @@
+"""Tests for memory v2: dated + sourced facts and inject-head-only option.
+
+Covers:
+  - new (source_type, date) columns present + populated on store_fact
+  - idempotent migration adds the columns to a pre-existing DB created
+    WITHOUT them (an old on-disk schema) — reopen must not crash
+  - prefer-recent: date breaks decay_score ties in high-salience selection
+  - inject-head-only flag drops the ## Recent slice but keeps the head, and
+    the log stays searchable; flag-off → injection unchanged
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.agent.memory import MemoryStore
+from src.agent.workspace import WorkspaceManager
+
+
+@pytest.fixture
+def memory(tmp_path):
+    store = MemoryStore(db_path=str(tmp_path / "test.db"))
+    yield store
+    store.close()
+
+
+# --- Schema + populate -------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_new_columns_present_and_populated_on_store(memory):
+    fact_id = await memory.store_fact("user_lang", "english", source_type="conversation")
+
+    cols = {r[1] for r in memory.db.execute("PRAGMA table_info(facts)").fetchall()}
+    assert "source_type" in cols
+    assert "date" in cols
+
+    row = memory.db.execute(
+        "SELECT source_type, date FROM facts WHERE id = ?", (fact_id,)
+    ).fetchone()
+    assert row[0] == "conversation"
+    assert row[1]  # date stamped, non-empty
+
+    fact = memory._get_fact(fact_id)
+    assert fact.source_type == "conversation"
+    assert fact.date is not None
+
+
+@pytest.mark.asyncio
+async def test_source_type_default_and_override(memory):
+    default_id = await memory.store_fact("k1", "v1")
+    custom_id = await memory.store_fact("k2", "v2", source_type="consolidation")
+
+    assert memory._get_fact(default_id).source_type == "conversation"
+    assert memory._get_fact(custom_id).source_type == "consolidation"
+
+
+@pytest.mark.asyncio
+async def test_batch_store_tags_context_flush_source_type(memory):
+    await memory.store_facts_batch([{"key": "bk", "value": "bv"}])
+    fact = memory._get_fact_by_key("bk")
+    assert fact is not None
+    assert fact.source_type == "context_flush"
+
+
+# --- Migration on a pre-existing OLD-schema DB -------------------------------
+
+def _create_legacy_facts_db(path: str) -> None:
+    """Create a facts table WITHOUT the v2 columns, mimicking an old on-disk DB
+    that predates the source_type/date migration."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            id TEXT PRIMARY KEY,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            category TEXT DEFAULT 'general',
+            source TEXT DEFAULT 'agent',
+            confidence REAL DEFAULT 1.0,
+            access_count INTEGER DEFAULT 0,
+            last_accessed TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            decay_score REAL DEFAULT 1.0
+        );
+        INSERT INTO facts (id, key, value) VALUES ('fact_old', 'legacy_key', 'legacy_value');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_adds_columns_to_preexisting_db(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _create_legacy_facts_db(db_path)
+
+    # Sanity: old schema lacks the v2 columns.
+    conn = sqlite3.connect(db_path)
+    cols_before = {r[1] for r in conn.execute("PRAGMA table_info(facts)").fetchall()}
+    conn.close()
+    assert "source_type" not in cols_before
+    assert "date" not in cols_before
+
+    # Reopening through MemoryStore must NOT crash and must add the columns.
+    store = MemoryStore(db_path=db_path)
+    try:
+        cols_after = {r[1] for r in store.db.execute("PRAGMA table_info(facts)").fetchall()}
+        assert "source_type" in cols_after
+        assert "date" in cols_after
+
+        # The pre-existing row survives and is readable through the mapper.
+        legacy = store._get_fact_by_key("legacy_key")
+        assert legacy is not None
+        assert legacy.value == "legacy_value"
+
+        # New writes against the migrated DB populate the v2 columns.
+        new_id = await store.store_fact("fresh", "value", source_type="conversation")
+        assert store._get_fact(new_id).source_type == "conversation"
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent_on_reopen(tmp_path):
+    db_path = str(tmp_path / "reopen.db")
+    s1 = MemoryStore(db_path=db_path)
+    await s1.store_fact("k", "v")
+    s1.close()
+    # Reopening an already-migrated DB must not raise on the duplicate ALTER.
+    s2 = MemoryStore(db_path=db_path)
+    try:
+        cols = {r[1] for r in s2.db.execute("PRAGMA table_info(facts)").fetchall()}
+        assert "source_type" in cols and "date" in cols
+    finally:
+        s2.close()
+
+
+# --- Prefer-recent tie-break -------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_high_salience_prefers_recent_on_tie(memory):
+    # Two facts with identical decay_score; the newer date should rank first.
+    old_id = await memory.store_fact("old", "old_val")
+    new_id = await memory.store_fact("new", "new_val")
+    # Force identical decay scores and a clearly older date on `old`.
+    memory.db.execute("UPDATE facts SET decay_score = 1.0")
+    memory.db.execute("UPDATE facts SET date = '2000-01-01 00:00:00' WHERE id = ?", (old_id,))
+    memory.db.execute("UPDATE facts SET date = '2099-01-01 00:00:00' WHERE id = ?", (new_id,))
+    memory.db.commit()
+
+    facts = await memory.get_high_salience_facts(top_k=2)
+    assert facts[0].id == new_id
+
+
+# --- inject-head-only flag ---------------------------------------------------
+
+class TestInjectHeadOnly:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.ws = WorkspaceManager(workspace_dir=self._tmpdir)
+        self.ws.write_compiled_memory("COMPILED_HEAD_MARKER")
+        self.ws.append_memory("## Recent entry\n\nRECENT_LOG_MARKER")
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_flag_off_injects_head_and_recent(self, monkeypatch):
+        monkeypatch.delenv("OPENLEGION_INJECT_HEAD_ONLY", raising=False)
+        injected = self.ws.get_memory_injection()
+        assert "COMPILED_HEAD_MARKER" in injected
+        assert "RECENT_LOG_MARKER" in injected
+        assert "## Recent" in injected
+
+    def test_flag_on_drops_recent_keeps_head(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_INJECT_HEAD_ONLY", "1")
+        injected = self.ws.get_memory_injection()
+        assert "COMPILED_HEAD_MARKER" in injected
+        assert "RECENT_LOG_MARKER" not in injected
+        assert "## Recent" not in injected
+
+    def test_flag_on_log_stays_searchable(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_INJECT_HEAD_ONLY", "1")
+        # Dropped from injection, but still on disk + searchable.
+        assert "RECENT_LOG_MARKER" not in self.ws.get_memory_injection()
+        assert "RECENT_LOG_MARKER" in self.ws.load_memory_log()
+        files = {r["file"] for r in self.ws.search("RECENT_LOG_MARKER")}
+        assert "MEMORY.md" in files

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -59,6 +59,18 @@ async def test_source_type_default_and_override(memory):
 
 
 @pytest.mark.asyncio
+async def test_exact_key_restore_preserves_source_type(memory):
+    """Provenance guard: an exact-key re-store must NOT overwrite the original
+    source_type. A fact first recorded as "context_flush" and later re-asserted
+    by the conversation loop (default source_type) keeps its origin."""
+    fid = await memory.store_fact("k", "v1", source_type="context_flush")
+    await memory.store_fact("k", "v2")  # default source_type="conversation"
+    fact = memory._get_fact(fid)
+    assert fact.value == "v2"                  # value updated
+    assert fact.source_type == "context_flush"  # provenance preserved
+
+
+@pytest.mark.asyncio
 async def test_batch_store_tags_context_flush_source_type(memory):
     await memory.store_facts_batch([{"key": "bk", "value": "bv"}])
     fact = memory._get_fact_by_key("bk")


### PR DESCRIPTION
## Phase 2 of the operator memory/context overhaul — DO NOT MERGE pending review

Implements **A5 — Memory v2: dated + sourced facts, inject-head-only** from `docs/plans/2026-06-09-operator-memory-context-overhaul.md` (§7). KISS, additive, behind a flag where it changes per-turn behavior.

### Design summary
The operator was drowning in stale, contradictory context. Facts had no notion of *when* or *where* they came from, so "prefer recent" was impossible and high-salience selection drifted toward old, frequently-touched rows. gbrain's prior art: date + source facts, inject **only** the compiled head, rank head > log at read time. This PR lands the schema + the head-only injection lever.

### What changed
- **Schema: `facts` gains `(source_type, date)`.** `CREATE TABLE` carries the columns; an **idempotent lazy migration** (alongside the existing `category_id` one) `ALTER`s pre-existing on-disk DBs.
- **`store_fact` / `store_facts_batch` populate provenance.** `source_type` defaults to `"conversation"`; context flushes are tagged `"context_flush"`. `MemoryFact` (types.py) now exposes `source_type` + `date`.
- **Prefer-recent (light, additive):** `get_high_salience_facts` tie-breaks `decay_score` by `date DESC` so re-asserted/recent facts rank above equally-salient stale rows. No ranking rewrite.
- **inject-head-only:** `WorkspaceManager.get_memory_injection` drops the `## Recent` log slice and injects only the compiled head when the flag is set. Older log entries stay on disk and BM25-searchable via memory_search.

### Flag-gating
`OPENLEGION_INJECT_HEAD_ONLY` (default **off** — `1/true/yes/on` to enable), read per-call so it can be toggled without a process restart. It changes what's injected every turn, hence opt-in. Schema + dating are always-on (purely additive columns).

### Migration safety note
SQLite refuses a **non-constant default on a non-empty table** (`Cannot add a column with non-constant default`). So `date` is added via `ALTER` **without** a column default — pre-existing rows backfill to `NULL` (which sorts last under prefer-recent, acceptable) — and `_store_fact_sync` stamps `date` explicitly (`datetime('now')`) on every insert/update instead. The migration loop swallows the duplicate-column `OperationalError` on already-migrated DBs (idempotent). Regression-tested against a simulated old schema created WITHOUT the v2 columns.

### Deploy zone
**Agent code** (`src/agent/**`) → must `docker build -t openlegion-agent:latest -f Dockerfile.agent .` + `systemctl restart openlegion`. A git pull alone does NOT update agent code. `src/shared/types.py` rides along in the same image.

### Tests
New `tests/test_memory_v2_dated_facts.py` (real in-memory `MemoryStore` + `tmp_path` workspace):
- new columns present + populated on store; source_type default + override; batch → `context_flush`
- **migration adds columns to a pre-existing DB created WITHOUT them** (no crash, columns added, legacy row survives, new writes populated); migration idempotent on reopen
- prefer-recent: `date` breaks decay_score ties
- inject-head-only flag **on** drops `## Recent` keeps head; log stays searchable; flag **off** → injection unchanged

Result: `62 passed` across `test_memory_v2_dated_facts.py` + `test_memory.py` + `test_memory_integration.py` + `test_compiled_memory.py`; `test_context.py` 59 passed. Ruff clean on all changed files.

### Merge coordination
Overlaps:
- `src/agent/memory.py` — with **A4 (#1077)** and **#1076**
- `src/agent/workspace.py` — with **#1076**

Coordinate merge order with those PRs to avoid conflicts.