### PR TITLE
feat(agent): stabilize the cached system-prompt prefix (move volatile content out)

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -42,6 +42,15 @@ _RETRYABLE_STATUS_CODES = {429, 502, 503, 504, 529}  # 529 = Anthropic overloade
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 1  # seconds: 1, 2, 4
 _TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "900"))  # seconds — hard ceiling per tool
+# C3 — cache-prefix stabilization (Phase 2 of the operator memory/context
+# overhaul). When ON, per-turn-volatile prompt fragments (context/round
+# warnings, operator playbooks, 5-min runtime context, the ``## Recent``
+# memory slice) are relocated OUT of the cached system block and appended
+# AFTER the mesh-side cache breakpoint (into the last message) so the stable
+# system prefix stays byte-identical turn-to-turn and #1073's prompt cache
+# actually hits. Default OFF: flag-off rebuilds the exact legacy prompt, so
+# behavior (instruction ordering is weighting-sensitive) is unchanged.
+_STABLE_PREFIX = os.environ.get("OPENLEGION_STABLE_PREFIX", "false").lower() == "true"
 _FLEET_ROSTER_TTL = 600  # seconds — cache TTL for fleet roster
 _GOALS_TTL = 300  # seconds — cache TTL for goals fetch
 _FALLBACK_MAX_TOKENS = 100_000  # context trim fallback when no context manager
@@ -381,6 +390,12 @@ class AgentLoop:
         self._current_task_handle: asyncio.Task | None = None
         self._last_result: TaskResult | None = None
         self._chat_messages: list[dict] = []
+        # C3 — per-turn-volatile prompt fragments relocated out of the cached
+        # system block by ``_build_*_system_prompt`` when ``_STABLE_PREFIX`` is
+        # ON. Re-injected after the cache breakpoint via
+        # ``_messages_with_volatile`` at the LLM call site. Always "" when the
+        # flag is OFF (legacy path leaves these IN the system prompt).
+        self._volatile_prompt_suffix: str = ""
         self._chat_lock = asyncio.Lock()
         self._chat_total_rounds: int = 0
         self._chat_auto_continues: int = 0
@@ -939,18 +954,32 @@ class AgentLoop:
                     return result
 
                 # === DECIDE (LLM call) ===
-                # Refresh system prompt with context warning if applicable
+                # Refresh system prompt with context warning if applicable.
+                # Stable-prefix path: keep ``system_prompt`` byte-stable and
+                # relocate the per-iteration warning below the cache breakpoint
+                # alongside the suffix stashed by ``_build_system_prompt``. The
+                # warning is folded into a LOCAL suffix (not the stashed one) so
+                # it doesn't leak into a later iteration that has no warning.
                 effective_system = system_prompt
-                if self.context_manager:
-                    warning = self.context_manager.context_warning(messages)
+                warning = (
+                    self.context_manager.context_warning(messages)
+                    if self.context_manager else None
+                )
+                if _STABLE_PREFIX:
+                    iter_suffix = "\n\n".join(
+                        p for p in (self._volatile_prompt_suffix, f"## {warning}" if warning else "") if p
+                    )
+                    eff_messages = self._append_volatile_to_messages(messages, iter_suffix)
+                else:
                     if warning:
                         effective_system = system_prompt + f"\n\n## {warning}"
+                    eff_messages = messages
 
                 available_tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat_collect,
                     system=effective_system,
-                    messages=messages,
+                    messages=eff_messages,
                     tools=available_tools,
                 )
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -1715,10 +1744,15 @@ class AgentLoop:
         self, assignment: TaskAssignment, introspect_data: dict | None = None,
     ) -> str:
         parts = []
+        # C3 — see _build_chat_system_prompt. Volatile fragments are stashed on
+        # self._volatile_prompt_suffix and re-injected after the cache
+        # breakpoint when _STABLE_PREFIX is ON; inline (legacy) otherwise.
+        volatile: list[str] = []
+        stable = _STABLE_PREFIX
 
         # Load workspace identity + project files into system prompt
         if self.workspace:
-            bootstrap = self.workspace.get_bootstrap_content()
+            bootstrap = self.workspace.get_bootstrap_content(include_recent=not stable)
             if bootstrap:
                 parts.append(bootstrap)  # pre-sanitized by workspace cache
 
@@ -1762,11 +1796,22 @@ class AgentLoop:
         if tool_history:
             parts.append(sanitize_for_prompt(tool_history))
 
+        # ── Volatile fragments (relocated below the cache breakpoint when ON). ──
+        sink = volatile if stable else parts
+
+        # Relocated ``## Recent`` memory slice (only when stable — otherwise it
+        # is already embedded in the head-inclusive bootstrap above).
+        if stable and self.workspace:
+            recent = self.workspace.get_recent_memory_slice()
+            if recent:
+                sink.append(sanitize_for_prompt(recent))
+
         if introspect_data:
             runtime_ctx = self._format_runtime_context(introspect_data)
             if runtime_ctx:
-                parts.append(runtime_ctx)
+                sink.append(runtime_ctx)
 
+        self._volatile_prompt_suffix = "\n\n".join(volatile)
         return "\n\n".join(parts)
 
     # Round-4 structural fix: hand_off failures are now enforced from
@@ -2003,6 +2048,10 @@ class AgentLoop:
                     )
 
                 parts: list[str] = []
+                # Heartbeat builds its own system prompt (not via
+                # _build_*_system_prompt); clear any suffix stashed by a prior
+                # chat/task build so stale volatile content can't leak in.
+                self._volatile_prompt_suffix = ""
 
                 # 1. Goals — the agent's north star
                 if goals:
@@ -3361,7 +3410,7 @@ class AgentLoop:
             llm_response = await _llm_call_with_retry(
                 self.llm.chat_collect,
                 system=system,
-                messages=self._chat_messages,
+                messages=self._messages_with_volatile(self._chat_messages),
                 tools=None,
             )
         except (LLMAuthError, LLMConfigError):
@@ -3496,7 +3545,7 @@ class AgentLoop:
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat_collect,
                     system=_round_system,
-                    messages=self._chat_messages,
+                    messages=self._messages_with_volatile(self._chat_messages),
                     tools=_iter_tools,
                 )
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -3807,7 +3856,7 @@ class AgentLoop:
             llm_response = await _llm_call_with_retry(
                 self.llm.chat_collect,
                 system=system,
-                messages=self._chat_messages,
+                messages=self._messages_with_volatile(self._chat_messages),
                 tools=None,
             )
             total_tokens += llm_response.tokens_used
@@ -4170,12 +4219,22 @@ class AgentLoop:
         introspect_data: dict | None = None,
     ) -> str:
         parts = []
+        # C3 cache-prefix stabilization: when ON, per-turn-volatile fragments
+        # are collected here instead of appended to ``parts``, so the returned
+        # system block stays byte-identical across turns (the cacheable prefix).
+        # They are re-injected after the cache breakpoint via
+        # ``_messages_with_volatile``. When OFF, ``volatile`` is unused and the
+        # fragments stay inline in ``parts`` exactly as before — byte-identical.
+        volatile: list[str] = []
+        stable = _STABLE_PREFIX
 
         if goals:
             parts.append(f"## Your Current Goals\n\n{sanitize_for_prompt(format_dict(goals))}")
 
         if self.workspace:
-            bootstrap = self.workspace.get_bootstrap_content()
+            # Stable path drops the volatile ``## Recent`` memory slice from the
+            # cached bootstrap (head-only) and relocates it below.
+            bootstrap = self.workspace.get_bootstrap_content(include_recent=not stable)
             if bootstrap:
                 parts.append(bootstrap)  # pre-sanitized by workspace cache
 
@@ -4246,6 +4305,17 @@ class AgentLoop:
         if tool_history:
             parts.append(sanitize_for_prompt(tool_history))
 
+        # ── Volatile fragments (relocated below the cache breakpoint when the
+        # stable-prefix flag is ON; inline otherwise — byte-identical legacy). ──
+        sink = volatile if stable else parts
+
+        # Relocated ``## Recent`` memory slice (only when stable — otherwise it
+        # is already embedded in the head-inclusive bootstrap above).
+        if stable and self.workspace:
+            recent = self.workspace.get_recent_memory_slice()
+            if recent:
+                sink.append(sanitize_for_prompt(recent))
+
         # Inject operator playbooks based on tool-call patterns
         if self._is_operator:
             active_playbooks = self._update_operator_playbooks()
@@ -4254,32 +4324,72 @@ class AgentLoop:
 
                 playbook_text = get_playbook_content(active_playbooks)
                 if playbook_text:
-                    parts.append(playbook_text)
+                    sink.append(playbook_text)
 
         if introspect_data:
             runtime_ctx = self._format_runtime_context(
                 introspect_data, exclude_fleet=has_fleet_ctx,
             )
             if runtime_ctx:
-                parts.append(runtime_ctx)
+                sink.append(runtime_ctx)
 
         # Context usage warning at 80%+
         if self.context_manager and self._chat_messages:
             warning = self.context_manager.context_warning(self._chat_messages)
             if warning:
-                parts.append(f"## {warning}")
+                sink.append(f"## {warning}")
 
         # Round-count warning at 80% of checkpoint interval
         if self._chat_total_rounds >= self._CHAT_ROUND_WARNING:
             remaining = self.CHAT_MAX_TOTAL_ROUNDS - self._chat_total_rounds
-            parts.append(
+            sink.append(
                 f"## Session Note\n"
                 f"This session has been running for {self._chat_total_rounds} tool rounds. "
                 f"Context will be auto-refreshed in ~{remaining} rounds. "
                 f"Consider saving important context to memory if you haven't already."
             )
 
+        # Stash the relocated content for re-injection after the cache
+        # breakpoint. Empty string when flag-off or nothing volatile.
+        self._volatile_prompt_suffix = "\n\n".join(volatile)
+
         return "\n\n".join(parts)
+
+    def _messages_with_volatile(self, messages: list[dict]) -> list[dict]:
+        """Return ``messages`` for the LLM call, re-injecting the relocated
+        volatile prompt suffix (stashed by ``_build_*_system_prompt``) AFTER
+        the cache breakpoint. No-op when the flag is off / nothing relocated.
+        """
+        return self._append_volatile_to_messages(messages, self._volatile_prompt_suffix)
+
+    def _append_volatile_to_messages(
+        self, messages: list[dict], suffix: str,
+    ) -> list[dict]:
+        """Append ``suffix`` after the cache breakpoint by folding it into a
+        COPY of the last message's content.
+
+        No-op (returns the same list) when ``_STABLE_PREFIX`` is off or there
+        is nothing to relocate — so the legacy path is untouched. When active,
+        the persistent ``messages``/``_chat_messages`` list is never mutated
+        and NO new message is added — whatever the last message's role is stays
+        the last message's role, so role-alternation (Constraint #7) holds.
+        """
+        if not _STABLE_PREFIX or not suffix or not messages:
+            return messages
+        out = list(messages)
+        last = dict(out[-1])
+        block = f"\n\n[Live context — re-read every turn]\n\n{suffix}"
+        content = last.get("content")
+        if isinstance(content, str):
+            last["content"] = content + block
+        elif isinstance(content, list):
+            # Multimodal/structured content — append a trailing text block.
+            last["content"] = [*content, {"type": "text", "text": block.strip()}]
+        else:
+            # Unexpected shape — leave untouched rather than risk a bad request.
+            return messages
+        out[-1] = last
+        return out
 
     def get_status(self) -> AgentStatus:
         """Return current agent status."""
@@ -4391,9 +4501,10 @@ class AgentLoop:
                 used_streaming = False
                 any_text_streamed = False
                 tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
+                _msgs = self._messages_with_volatile(self._chat_messages)
                 try:
                     async for event in self.llm.chat_stream(
-                        system=system, messages=self._chat_messages, tools=tools,
+                        system=system, messages=_msgs, tools=tools,
                     ):
                         etype = event.get("type", "")
                         if etype == "text_delta":
@@ -4411,7 +4522,7 @@ class AgentLoop:
                     if used_streaming:
                         logger.warning("LLM stream ended without done event, falling back")
                     llm_response = await _llm_call_with_retry(
-                        self.llm.chat, system=system, messages=self._chat_messages, tools=tools,
+                        self.llm.chat, system=system, messages=_msgs, tools=tools,
                     )
 
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -4623,7 +4734,7 @@ class AgentLoop:
             llm_response = await _llm_call_with_retry(
                 self.llm.chat,
                 system=system,
-                messages=self._chat_messages,
+                messages=self._messages_with_volatile(self._chat_messages),
                 tools=None,
             )
             total_tokens += llm_response.tokens_used

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -282,7 +282,12 @@ class WorkspaceManager:
         # cache-prefix-stabilization path (MEMORY.md injected WITHOUT the
         # volatile ``## Recent`` slice so the system prefix stays stable).
         self._bootstrap_cache_stable: str | None = None
+        # Each cache slot owns its OWN mtime snapshot. They must NOT be shared:
+        # the lazy mtime-triggered rebuild path only rebuilds the requested
+        # variant, so a shared snapshot would mark the OTHER slot fresh and
+        # serve stale content for the rest of the process lifetime.
         self._bootstrap_mtimes: dict[str, float] = {}
+        self._bootstrap_mtimes_stable: dict[str, float] = {}
         self._learnings_cache: str | None = None
         self._learnings_mtimes: dict[str, float] = {}
 
@@ -599,10 +604,13 @@ class WorkspaceManager:
         and is memoized in a separate cache slot so it can't be conflated with
         the default (recent-included) variant.
         """
-        cache_attr = "_bootstrap_cache" if include_recent else "_bootstrap_cache_stable"
+        if include_recent:
+            cache_attr, mtimes = "_bootstrap_cache", self._bootstrap_mtimes
+        else:
+            cache_attr, mtimes = "_bootstrap_cache_stable", self._bootstrap_mtimes_stable
         cached = getattr(self, cache_attr)
         if cached is not None and not self._check_mtimes(
-            self._BOOTSTRAP_FILES, self._bootstrap_mtimes,
+            self._BOOTSTRAP_FILES, mtimes,
         ):
             return cached
 
@@ -657,7 +665,7 @@ class WorkspaceManager:
         # Pre-sanitize so callers never need to re-sanitize unchanged content
         combined = sanitize_for_prompt(combined)
 
-        self._snapshot_mtimes(self._BOOTSTRAP_FILES, self._bootstrap_mtimes)
+        self._snapshot_mtimes(self._BOOTSTRAP_FILES, mtimes)
         setattr(self, cache_attr, combined)
         return combined
 

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -278,6 +278,10 @@ class WorkspaceManager:
 
         # Caches — invalidated by mtime changes or explicit writes
         self._bootstrap_cache: str | None = None
+        # Separate cache slot for the head-only bootstrap variant used by the
+        # cache-prefix-stabilization path (MEMORY.md injected WITHOUT the
+        # volatile ``## Recent`` slice so the system prefix stays stable).
+        self._bootstrap_cache_stable: str | None = None
         self._bootstrap_mtimes: dict[str, float] = {}
         self._learnings_cache: str | None = None
         self._learnings_mtimes: dict[str, float] = {}
@@ -484,25 +488,56 @@ class WorkspaceManager:
         """Return only the append-only MEMORY.md log tail (BM25-searchable)."""
         return self._split_memory(self._read_file(self.MEMORY_FILE) or "")[1]
 
-    def get_memory_injection(self) -> str:
+    def _recent_log_slice(self) -> str:
+        """Return the bounded NEWEST-log slice (without the ``## Recent``
+        header), or "" if there is no log. Single source of truth for the
+        recent slice shared by ``get_memory_injection`` and
+        ``get_recent_memory_slice``.
+        """
+        raw = self._read_file(self.MEMORY_FILE) or ""
+        _, log = self._split_memory(raw)
+        log = log.strip()
+        if not log:
+            return ""
+        recent = log[-_MEMORY_RECENT_LOG_CHARS:]
+        # Begin at an entry boundary so we never start mid-entry.
+        idx = recent.find("\n## ")
+        if idx != -1:
+            recent = recent[idx + 1:]
+        return recent.strip()
+
+    def get_recent_memory_slice(self) -> str:
+        """Return the volatile ``## Recent`` memory block (header + newest-log
+        slice), or "" if there's nothing recent.
+
+        This is the per-turn-volatile fragment that the cache-prefix
+        stabilization path (loop._STABLE_PREFIX) relocates OUT of the cached
+        system prompt and re-injects after the cache breakpoint. The stable
+        head stays in the system prompt via ``get_memory_injection(
+        include_recent=False)``.
+        """
+        recent = self._recent_log_slice()
+        return f"## Recent\n\n{recent}".strip() if recent else ""
+
+    def get_memory_injection(self, *, include_recent: bool = True) -> str:
         """Compose the MEMORY.md content injected into the system prompt: the
         consolidated compiled head PLUS a bounded slice of the NEWEST log
         entries, so recently-learned facts auto-surface before consolidation
         folds them into the head. Older log entries are recalled via
         memory_search. The head is capped so head + recent fits the per-file
         bootstrap cap.
+
+        ``include_recent=False`` returns the STABLE head only — the
+        cache-prefix-stabilization path uses it so the volatile ``## Recent``
+        slice can be relocated out of the cached system block (it is re-injected
+        after the cache breakpoint via ``get_recent_memory_slice``).
         """
         raw = self._read_file(self.MEMORY_FILE) or ""
-        head, log = self._split_memory(raw)
-        head, log = head.strip(), log.strip()
-        recent = ""
-        if log:
-            recent = log[-_MEMORY_RECENT_LOG_CHARS:]
-            # Begin at an entry boundary so we never start mid-entry.
-            idx = recent.find("\n## ")
-            if idx != -1:
-                recent = recent[idx + 1:]
-            recent = recent.strip()
+        head, _ = self._split_memory(raw)
+        head = head.strip()
+        if not include_recent:
+            return head
+        recent = self._recent_log_slice()
         if not recent:
             return head
         # Reserve room for the recent slice so a large head can't crowd it out
@@ -548,7 +583,7 @@ class WorkspaceManager:
         for filename in filenames:
             target[filename] = self._get_mtime(self.root / filename)
 
-    def get_bootstrap_content(self) -> str:
+    def get_bootstrap_content(self, *, include_recent: bool = True) -> str:
         """Load workspace files for system prompt with per-file and total caps.
 
         Loads INSTRUCTIONS.md, SOUL.md, USER.md, MEMORY.md with individual
@@ -558,11 +593,18 @@ class WorkspaceManager:
         Daily logs are NOT included — agents access them via memory_search.
 
         Results are cached with mtime-based invalidation and pre-sanitized.
+
+        ``include_recent=False`` injects MEMORY.md head-only (drops the
+        volatile ``## Recent`` slice) for the cache-prefix-stabilization path,
+        and is memoized in a separate cache slot so it can't be conflated with
+        the default (recent-included) variant.
         """
-        if self._bootstrap_cache is not None and not self._check_mtimes(
+        cache_attr = "_bootstrap_cache" if include_recent else "_bootstrap_cache_stable"
+        cached = getattr(self, cache_attr)
+        if cached is not None and not self._check_mtimes(
             self._BOOTSTRAP_FILES, self._bootstrap_mtimes,
         ):
-            return self._bootstrap_cache
+            return cached
 
         caps = {
             "INSTRUCTIONS.md": _MAX_INSTRUCTIONS,
@@ -593,8 +635,9 @@ class WorkspaceManager:
             if filename == "MEMORY.md":
                 # Inject the consolidated head + a bounded slice of the NEWEST
                 # log entries (recent facts auto-surface); older log entries
-                # are recalled via memory_search/BM25.
-                content = self.get_memory_injection()
+                # are recalled via memory_search/BM25. ``include_recent=False``
+                # drops the volatile slice for the stable-prefix path.
+                content = self.get_memory_injection(include_recent=include_recent)
             else:
                 content = self._read_file(filename)
             if not content or not content.strip():
@@ -615,7 +658,7 @@ class WorkspaceManager:
         combined = sanitize_for_prompt(combined)
 
         self._snapshot_mtimes(self._BOOTSTRAP_FILES, self._bootstrap_mtimes)
-        self._bootstrap_cache = combined
+        setattr(self, cache_attr, combined)
         return combined
 
     def _read_file(self, relative_path: str) -> str | None:
@@ -657,6 +700,7 @@ class WorkspaceManager:
         new_log = self._trim_memory_log(new_log)
         path.write_text(self._render_memory(head, new_log))
         self._bootstrap_cache = None  # MEMORY.md is part of bootstrap
+        self._bootstrap_cache_stable = None
 
     def write_compiled_memory(self, head: str) -> None:
         """Replace the compiled head (consolidation), preserving the log."""
@@ -667,6 +711,7 @@ class WorkspaceManager:
         _, log = self._split_memory(raw)
         path.write_text(self._render_memory(head, log))
         self._bootstrap_cache = None
+        self._bootstrap_cache_stable = None
 
     # ── Consolidation stamp (mirrors seed_bootstrap_greeting's sentinel) ──
 
@@ -723,6 +768,7 @@ class WorkspaceManager:
 
         path.write_text(content)
         self._bootstrap_cache = None  # invalidate — file changed
+        self._bootstrap_cache_stable = None
         self.append_daily_log(f"Updated workspace file: {filename}")
         return {
             "filename": filename,

--- a/tests/test_stable_prefix.py
+++ b/tests/test_stable_prefix.py
@@ -276,6 +276,43 @@ def test_bootstrap_cache_slots_independent(tmp_path):
     assert ws.get_bootstrap_content(include_recent=False) == head_only
 
 
+def test_bootstrap_cache_both_slots_detect_external_mtime_change(tmp_path):
+    """Regression: an mtime-triggered rebuild of ONE variant must not mark the
+    OTHER variant fresh. Each slot owns its own mtime snapshot, so an external
+    write to MEMORY.md (one that does NOT explicitly clear the caches) is picked
+    up by BOTH variants on their next call — neither serves stale content."""
+    import os
+
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    memory = ws.root / "MEMORY.md"
+    memory.write_text(_MEMORY_WITH_RECENT)
+
+    # Warm BOTH cache slots against the original content.
+    assert _HEAD in ws.get_bootstrap_content(include_recent=True)
+    assert _HEAD in ws.get_bootstrap_content(include_recent=False)
+
+    # Simulate an EXTERNAL change: write directly to the file and bump its
+    # mtime, bypassing append_memory/write_compiled_memory/update_file (the
+    # paths that explicitly clear the caches). Only the lazy mtime check applies.
+    new_head = "The user now prefers verbose answers. The live fleet is sales."
+    memory.write_text(
+        "# Long-Term Memory\n\n"
+        "<!-- compiled:begin -->\n"
+        f"{new_head}\n"
+        "<!-- compiled:end -->\n\n"
+        "## 2026-06-09T11:00 flush\n\n"
+        "- learned: the user switched preferences\n"
+    )
+    future = memory.stat().st_mtime + 10
+    os.utime(memory, (future, future))
+
+    # BOTH variants must observe the new content (no stale slot).
+    assert new_head in ws.get_bootstrap_content(include_recent=True)
+    assert new_head in ws.get_bootstrap_content(include_recent=False)
+    assert _HEAD not in ws.get_bootstrap_content(include_recent=True)
+    assert _HEAD not in ws.get_bootstrap_content(include_recent=False)
+
+
 def test_no_recent_slice_when_log_empty(tmp_path, monkeypatch):
     """Flag ON with a head-only MEMORY (no log) stashes nothing extra for the
     recent slice and the head is still present in the system prompt."""

--- a/tests/test_stable_prefix.py
+++ b/tests/test_stable_prefix.py
@@ -1,0 +1,294 @@
+"""Tests for C3 — cache-prefix stabilization (OPENLEGION_STABLE_PREFIX).
+
+The flag relocates per-turn-VOLATILE prompt fragments (context/round warnings,
+operator playbooks, 5-min runtime context, the ``## Recent`` memory slice) OUT
+of the cached system block and re-injects them AFTER the mesh-side cache
+breakpoint (into the last message). Goals:
+
+  * flag OFF  → the built system prompt is byte-identical to today's.
+  * flag ON   → volatile fragments are NOT in the system prompt but ARE present
+                later in the message list; role-alternation stays valid.
+  * the STABLE prefix is byte-identical across two builds that differ ONLY in
+                volatile content (the whole point — prove the prefix is stable).
+
+These exercise the prompt BUILDERS directly (no LLM round-trip needed).
+"""
+
+import src.agent.loop as loop_mod
+from src.agent.context import ContextManager
+from src.agent.workspace import WorkspaceManager
+from src.shared.types import TaskAssignment
+from tests.test_loop import _make_loop
+
+# A compiled head + an append-only log so get_memory_injection() produces a
+# real ``## Recent`` slice. The head is the STABLE part; the log tail is the
+# VOLATILE ``## Recent`` slice that must move out of the cached prefix.
+_HEAD = "The user prefers concise answers. The live fleet is content-seo."
+_MEMORY_WITH_RECENT = (
+    "# Long-Term Memory\n\n"
+    "<!-- compiled:begin -->\n"
+    f"{_HEAD}\n"
+    "<!-- compiled:end -->\n\n"
+    "## 2026-06-09T10:00 flush\n\n"
+    "- learned: the user is named Jeff and wants SEO work\n"
+)
+_MEMORY_HEAD_ONLY = (
+    "# Long-Term Memory\n\n"
+    "<!-- compiled:begin -->\n"
+    f"{_HEAD}\n"
+    "<!-- compiled:end -->\n"
+)
+
+_RECENT_MARKER = "## Recent"
+_RECENT_BODY = "the user is named Jeff and wants SEO work"
+
+
+def _operator_loop(tmp_path, monkeypatch, *, stable: bool):
+    """A loop with a real workspace + context manager, operator role."""
+    monkeypatch.setattr(loop_mod, "_STABLE_PREFIX", stable)
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "SOUL.md").write_text("# Identity\n\nI am the operator.\n")
+    (ws.root / "INSTRUCTIONS.md").write_text("# Instructions\n\nDo the thing.\n")
+    (ws.root / "MEMORY.md").write_text(_MEMORY_WITH_RECENT)
+
+    loop = _make_loop()
+    loop.workspace = ws
+    # Operator: allowed_tools is the signal _is_operator keys off.
+    loop._is_operator = True
+    loop._allowed_tools = frozenset({"notify_user"})
+    loop.context_manager = ContextManager(max_tokens=200, model="test-model")
+    return loop
+
+
+def _chat_prompt(loop, **kw):
+    """Build a chat system prompt with a default introspect payload."""
+    introspect = kw.pop("introspect_data", {"permissions": {}, "budget": None})
+    return loop._build_chat_system_prompt(introspect_data=introspect, **kw)
+
+
+# ── Flag OFF: byte-identical to legacy ────────────────────────────────
+
+
+def test_flag_off_chat_prompt_byte_identical(tmp_path, monkeypatch):
+    """Flag OFF must rebuild the EXACT legacy prompt (no reordering).
+
+    We assert the two known-volatile fragments (the ``## Recent`` slice and the
+    CONTEXT WARNING) are INLINE in the system prompt, exactly as before, and
+    that no relocation suffix is stashed.
+    """
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+    # Force a CONTEXT WARNING by stuffing the chat history past 80% of 200 tok.
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+
+    prompt = _chat_prompt(loop)
+
+    assert _RECENT_MARKER in prompt
+    assert _RECENT_BODY in prompt
+    assert "CONTEXT WARNING" in prompt
+    # Nothing relocated when the flag is off.
+    assert loop._volatile_prompt_suffix == ""
+    # And the message list is returned untouched (same object).
+    msgs = loop._chat_messages
+    assert loop._messages_with_volatile(msgs) is msgs
+
+
+def test_flag_off_matches_head_inclusive_bootstrap(tmp_path, monkeypatch):
+    """The flag-off system prompt is exactly the legacy one: the bootstrap is
+    head+recent-inclusive and the prompt equals a freshly rebuilt copy."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+    p1 = _chat_prompt(loop)
+    # Rebuild again — deterministic, byte-identical.
+    p2 = _chat_prompt(loop)
+    assert p1 == p2
+    # The recent slice lives inside the (head-inclusive) bootstrap block.
+    assert loop.workspace.get_bootstrap_content(include_recent=True) ==  \
+        loop.workspace.get_bootstrap_content()
+
+
+# ── Flag ON: volatile moves out, lands in the message list ────────────
+
+
+def test_flag_on_recent_slice_leaves_system_prompt(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    prompt = _chat_prompt(loop)
+
+    # The volatile ``## Recent`` slice is NO LONGER in the system prompt …
+    assert _RECENT_MARKER not in prompt
+    assert _RECENT_BODY not in prompt
+    # … but the STABLE head still is.
+    assert _HEAD in prompt
+    # … and the recent slice is stashed for re-injection.
+    assert _RECENT_BODY in loop._volatile_prompt_suffix
+
+
+def test_flag_on_context_warning_leaves_system_prompt(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+
+    prompt = _chat_prompt(loop)
+
+    assert "CONTEXT WARNING" not in prompt
+    assert "CONTEXT WARNING" in loop._volatile_prompt_suffix
+
+
+def test_flag_on_volatile_reinjected_into_last_message(tmp_path, monkeypatch):
+    """Relocated content must still REACH the model — appended to the last
+    message, after the cache breakpoint, without adding a message."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop._chat_messages = [{"role": "user", "content": "Hello operator " * 60}]
+    _chat_prompt(loop)
+
+    out = loop._messages_with_volatile(loop._chat_messages)
+    # No new message added (role-alternation preserved).
+    assert len(out) == len(loop._chat_messages)
+    assert out[-1]["role"] == "user"
+    # Persistent list NOT mutated.
+    assert "Live context" not in loop._chat_messages[-1]["content"]
+    # Volatile content present in the transient copy's last message.
+    assert _RECENT_BODY in out[-1]["content"]
+    assert "CONTEXT WARNING" in out[-1]["content"]
+
+
+def test_flag_on_reinjection_handles_multimodal_last_message(tmp_path, monkeypatch):
+    """A list-content (multimodal) last message gets a trailing text block, not
+    a clobbered string — and no extra message."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop._chat_messages = [
+        {"role": "user", "content": [{"type": "text", "text": "pic " * 30}]},
+    ]
+    _chat_prompt(loop)
+
+    out = loop._messages_with_volatile(loop._chat_messages)
+    assert len(out) == len(loop._chat_messages)
+    last = out[-1]["content"]
+    assert isinstance(last, list)
+    assert last[-1]["type"] == "text"
+    assert _RECENT_BODY in last[-1]["text"]
+    # Original blocks untouched.
+    assert loop._chat_messages[-1]["content"][0]["text"].startswith("pic ")
+    assert len(loop._chat_messages[-1]["content"]) == 1
+
+
+# ── The whole point: the STABLE prefix is stable ──────────────────────
+
+
+def test_stable_prefix_identical_across_volatile_change(tmp_path, monkeypatch):
+    """Two builds that differ ONLY in volatile content must yield a
+    byte-identical system prefix when the flag is ON.
+
+    Build A: low context (no warning). Build B: high context (CONTEXT WARNING
+    fires) AND the recent log grows. With the flag ON both must produce the
+    SAME system prompt — that's what makes #1073's cached prefix hit.
+    """
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+
+    # Build A — minimal volatile content.
+    loop._chat_messages = [{"role": "user", "content": "hi"}]
+    prefix_a = _chat_prompt(loop)
+
+    # Build B — change ONLY volatile inputs: blow up the context (→ warning)
+    # and append a NEW recent log entry (→ different ## Recent slice).
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+    loop.workspace.append_memory("brand-new volatile fact " * 5)
+    prefix_b = _chat_prompt(loop)
+
+    assert prefix_a == prefix_b, "stable prefix drifted across volatile change"
+    # Sanity: the volatile suffixes DID differ (so we actually changed volatile
+    # inputs, not nothing).
+    # Rebuild A's suffix to compare against B's stash.
+    assert "CONTEXT WARNING" in loop._volatile_prompt_suffix  # B had a warning
+
+
+def test_stable_prefix_control_flag_off_prefix_changes(tmp_path, monkeypatch):
+    """Control: with the flag OFF the SAME two builds DO differ (volatile is
+    inline) — proving the stability above is the flag's doing, not a no-op."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+
+    loop._chat_messages = [{"role": "user", "content": "hi"}]
+    a = _chat_prompt(loop)
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+    b = _chat_prompt(loop)
+
+    assert a != b  # warning is inline → prompt changes turn-to-turn
+
+
+# ── Task-path builder ─────────────────────────────────────────────────
+
+
+def test_task_builder_flag_off_byte_identical(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+    assignment = TaskAssignment(
+        workflow_id="wf", step_id="s", task_type="research", input_data={},
+    )
+    introspect = {"permissions": {}, "budget": None, "fleet": [{"id": "a"}]}
+    prompt = loop._build_system_prompt(assignment, introspect_data=introspect)
+    assert _RECENT_MARKER in prompt
+    assert "## Runtime Context" in prompt
+    assert loop._volatile_prompt_suffix == ""
+
+
+def test_task_builder_flag_on_relocates_runtime_and_recent(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    assignment = TaskAssignment(
+        workflow_id="wf", step_id="s", task_type="research", input_data={},
+    )
+    introspect = {"permissions": {}, "budget": None, "fleet": [{"id": "a"}]}
+    prompt = loop._build_system_prompt(assignment, introspect_data=introspect)
+    # Volatile out of the system prompt …
+    assert _RECENT_MARKER not in prompt
+    assert "## Runtime Context" not in prompt
+    # … stashed for re-injection.
+    assert _RECENT_BODY in loop._volatile_prompt_suffix
+    assert "## Runtime Context" in loop._volatile_prompt_suffix
+    # Stable identity content stays.
+    assert "Operating Rules" in prompt
+
+
+# ── Workspace memory-injection split ──────────────────────────────────
+
+
+def test_get_memory_injection_head_only(tmp_path):
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "MEMORY.md").write_text(_MEMORY_WITH_RECENT)
+    full = ws.get_memory_injection(include_recent=True)
+    head_only = ws.get_memory_injection(include_recent=False)
+    assert _RECENT_MARKER in full
+    assert _RECENT_MARKER not in head_only
+    assert _HEAD in head_only
+    # The relocated slice is exactly what get_recent_memory_slice returns.
+    slice_ = ws.get_recent_memory_slice()
+    assert slice_.startswith(_RECENT_MARKER)
+    assert _RECENT_BODY in slice_
+
+
+def test_bootstrap_cache_slots_independent(tmp_path):
+    """The head-only bootstrap variant is memoized separately from the default
+    (recent-inclusive) one — calling one must not poison the other."""
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "MEMORY.md").write_text(_MEMORY_WITH_RECENT)
+    with_recent = ws.get_bootstrap_content(include_recent=True)
+    head_only = ws.get_bootstrap_content(include_recent=True) is not None and \
+        ws.get_bootstrap_content(include_recent=False)
+    assert _RECENT_MARKER in with_recent
+    assert _RECENT_MARKER not in head_only
+    # Re-fetch from cache — still correct (no cross-contamination).
+    assert ws.get_bootstrap_content(include_recent=True) == with_recent
+    assert ws.get_bootstrap_content(include_recent=False) == head_only
+
+
+def test_no_recent_slice_when_log_empty(tmp_path, monkeypatch):
+    """Flag ON with a head-only MEMORY (no log) stashes nothing extra for the
+    recent slice and the head is still present in the system prompt."""
+    monkeypatch.setattr(loop_mod, "_STABLE_PREFIX", True)
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "MEMORY.md").write_text(_MEMORY_HEAD_ONLY)
+    assert ws.get_recent_memory_slice() == ""
+    loop = _make_loop()
+    loop.workspace = ws
+    loop._is_operator = False
+    loop.context_manager = None
+    prompt = loop._build_chat_system_prompt(
+        introspect_data=None,
+    )
+    assert _HEAD in prompt
+    assert _RECENT_MARKER not in loop._volatile_prompt_suffix


### PR DESCRIPTION
## ⚠️ Phase 2 of the operator memory/context overhaul — DO NOT MERGE pending review

Track **C3 — Cache-prefix stabilization** from `docs/plans/2026-06-09-operator-memory-context-overhaul.md` (§7). This is the lowest-priority Phase-2 item; it protects the value of #1073.

## Why

PR #1073 (merged) marks Anthropic `cache_control` on the stable system-prompt prefix mesh-side. But the agent's system prompt embeds **per-turn-volatile** content:
- the `## CONTEXT WARNING …%` / round-budget "Session Note" text,
- operator playbooks (change between turns),
- the 5-min runtime context (ticks),
- the shifting `## Recent` MEMORY slice (grows as the log grows).

Any of these mutating busts the cached system block → the prompt cache we just shipped never hits on the operator chat path. This moves the volatile fragments OUT of the cached system block so the stable prefix stays **byte-identical** across turns and actually gets a cache hit.

## What it does

- **`workspace.py`**: `get_memory_injection(include_recent=...)` + new `get_recent_memory_slice()` split the volatile `## Recent` slice from the stable compiled head. `get_bootstrap_content(include_recent=...)` gains a head-only variant memoized in a **separate cache slot** (`_bootstrap_cache_stable`) so the two variants can't poison each other.
- **`loop.py`**: `_build_chat_system_prompt` and `_build_system_prompt` collect the volatile fragments into `self._volatile_prompt_suffix` instead of the system string when the flag is on. `_messages_with_volatile` / `_append_volatile_to_messages` re-inject that suffix **after** the cache breakpoint by folding it into a **copy** of the last message's content — no message is added, the persistent message list is never mutated, so role-alternation (Constraint #7) holds. Wired into every chat + task LLM call site (incl. streaming + force-compose). Heartbeat clears the suffix (it builds its own prompt).

## Default OFF behind a flag — flag-off is byte-identical

Reordering instructions is behavior-sensitive (changes the model's weighting), so the whole change is gated behind **`OPENLEGION_STABLE_PREFIX` (default `false`)**. Flag-off rebuilds the **exact legacy prompt** — proven byte-identical by test. Volatile content is never dropped; flag-on just relocates it after the cached prefix.

## Tests (`tests/test_stable_prefix.py`, 13 new)

- flag-off → system prompt byte-identical to today (volatile fragments stay inline; nothing stashed; message list returned unchanged).
- flag-on → the `## Recent` slice and the `CONTEXT WARNING` are **NOT** in the system prompt but **ARE** present later in the message list.
- role-alternation stays valid (no new message; last-message role unchanged; string + multimodal content both handled; persistent list untouched).
- **the point**: the stable prefix is byte-identical across two builds that differ only in volatile content (context warning fires + recent log grows), with a flag-off control proving the prefix *does* drift without the flag.
- task-path builder relocation; workspace head-only split + independent cache slots.

`pytest tests/test_stable_prefix.py` → **13 passed**. `tests/test_loop.py tests/test_workspace.py tests/test_compiled_memory.py` → **332 passed**. `ruff check` clean on all changed files. (The 27 failures in the full sweep are pre-existing in `test_credentials.py` / `test_templates.py` — they fail identically on pristine `origin/main` with this branch stashed; unrelated to prompt building.)

## Deploy zone

Agent code (`src/agent/**`) → **`openlegion-agent:latest` image rebuild + restart**. A git-pull alone does NOT update agent code.

## Merge coordination

- **Overlaps `src/agent/loop.py` with B2 (#1078)** — both touch the builders / LLM call sites. Coordinate merge order.
- **Reads `get_memory_injection`**, which **A5** touches (inject-head-only). C3 pairs naturally with A5; sequence accordingly.

## Risks / follow-ups

- Behavior risk from instruction reordering is the reason for the flag; needs live before/after behavior validation on cake before flipping on.
- Task/heartbeat paths are covered structurally but are less cache-sensitive than the operator chat path (the primary target).