### PR TITLE
Operator memory/context overhaul — Phase 2 (de-flagged, supersedes #1076–#1081)

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -22,7 +22,7 @@ from src.agent.llm import LLMClient
 from src.agent.loop import AgentLoop
 from src.agent.memory import MemoryStore
 from src.agent.mesh_client import MeshClient
-from src.agent.server import create_agent_app
+from src.agent.server import create_agent_app, run_maintenance_loop
 from src.agent.tools import ToolRegistry
 from src.agent.workspace import WorkspaceManager
 from src.shared.trace import new_trace_id
@@ -258,7 +258,15 @@ def main() -> None:
                     loop.current_task = None
                 logger.warning("Auto-resume check failed: %s", e)
 
+        # Background memory-maintenance pass (consolidation + salience decay),
+        # off the live turn. Internally idle-guarded + 6h-gated.
+        _maintenance_task = asyncio.create_task(run_maintenance_loop(loop))
+
         yield
+
+        _maintenance_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _maintenance_task
         if loop.state == "working":
             loop._cancel_requested = True
             handle = loop._current_task_handle

--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 import tempfile
 
 from src.agent.tools import tool
@@ -75,6 +76,12 @@ def _scrubbed_env() -> dict[str, str]:
     Strategy is allowlist-first (only ``_SAFE_ENV_KEYS`` pass through) with a
     sensitive-name denylist applied on top as belt-and-suspenders. The agent's
     full env is never forwarded.
+
+    SCOPE: this scrubs ENVIRONMENT VARIABLES only. It does NOT sandbox the
+    filesystem — a snippet can still read any file the container user owns
+    (e.g. ``~/.netrc``). That is by design and identical to ``run_command``;
+    the Docker container hardening (no host mounts, no host credentials, agents
+    hold no API keys) is the actual boundary, not this scrub.
     """
     env: dict[str, str] = {}
     for key in _SAFE_ENV_KEYS:
@@ -84,6 +91,23 @@ def _scrubbed_env() -> dict[str, str]:
     # Force unbuffered stdout so print() output is captured even on early exit.
     env.setdefault("PYTHONUNBUFFERED", "1")
     return env
+
+
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the child AND any grandchildren it spawned.
+
+    The child is started in its own session (``start_new_session=True``), so it
+    leads a process group. Killing the group reaps any subprocesses the snippet
+    forked — otherwise a snippet that spawns a long-running child leaves orphans
+    that accumulate against the container ``pids_limit``.
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
 
 
 @tool(
@@ -200,7 +224,12 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
         fd, path = tempfile.mkstemp(suffix=".py", prefix="execcode_")
         with os.fdopen(fd, "w") as fh:
             fh.write(code)
+        # Read-only before exec — closes the (already narrow, container-only)
+        # TOCTOU window between write and run.
+        os.chmod(path, 0o400)
 
+        # start_new_session: the child leads its own process group so a timeout
+        # can SIGKILL the whole group (child + any snippet-spawned grandchildren).
         proc = await asyncio.create_subprocess_exec(
             "python3",
             path,
@@ -208,6 +237,7 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
             stderr=asyncio.subprocess.PIPE,
             cwd=workdir,
             env=_scrubbed_env(),
+            start_new_session=True,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             proc.communicate(), timeout=timeout
@@ -222,7 +252,7 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
             "stderr": stderr if proc.returncode != 0 else "",
         }
     except asyncio.TimeoutError:
-        proc.kill()
+        _kill_process_group(proc)
         await proc.wait()
         return {"exit_code": -1, "stdout": "", "stderr": f"Code timed out after {timeout}s"}
     except Exception as e:

--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -8,11 +8,82 @@ from __future__ import annotations
 
 import asyncio
 import os
+import tempfile
 
 from src.agent.tools import tool
 
 _MAX_OUTPUT = 100_000
 _MAX_TIMEOUT = 300
+
+# ── execute_code (code-as-action) — Phase 2 of the operator memory/context
+# overhaul (docs/plans/2026-06-09-operator-memory-context-overhaul.md §7, C2).
+#
+# Lets the model write ONE Python block and get back only what it ``print()``s,
+# collapsing several shell/tool rounds into a single turn. Intermediate values
+# never enter context. v1 is deliberately a pure Python-execution + stdout
+# capture tool — the hermes-style "call agent tools from inside the code" bridge
+# is OUT of scope (see _DEFERRED note below). No recursion into execute_code or
+# delegate.
+#
+# Ships dormant: gated behind OPENLEGION_EXECUTE_CODE (default off). When off
+# the schema is hidden from the worker surface (see _EXECUTE_CODE_TOOLS in
+# loop.py) AND the handler self-rejects (defense-in-depth for the operator
+# allowlist path).
+EXECUTE_CODE_ENABLED_ENV = "OPENLEGION_EXECUTE_CODE"
+
+# Tighter cap than run_command's 100 KB: this is "what the model printed",
+# meant to flow straight back into context, so keep it lean.
+_CODE_MAX_OUTPUT = 20_000
+_CODE_MAX_TIMEOUT = 120
+
+# Env-var name substrings that mark a value as sensitive. Matched
+# case-insensitively against each var NAME (never the value). Agents already
+# never hold API keys (those live mesh-side), but the child gets a scrubbed
+# env regardless — defense-in-depth, and it future-proofs against any var that
+# does leak into the container environment.
+_SENSITIVE_NAME_PARTS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CRED")
+# Whole-name prefixes that are stripped outright (the OpenLegion namespace
+# carries config + per-agent identity we don't want a code snippet reading).
+_SENSITIVE_PREFIXES = ("OPENLEGION_", "OL_")
+# Minimal allowlist of harmless vars the child genuinely needs to behave like a
+# normal Python process (PATH for subprocess lookups, locale, tmp). Everything
+# else is dropped — the child does NOT inherit the agent's full environment.
+_SAFE_ENV_KEYS = (
+    "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR", "TERM",
+    "PYTHONIOENCODING", "PYTHONHASHSEED",
+)
+
+
+def execute_code_enabled() -> bool:
+    """True iff the code-as-action ``execute_code`` tool is opted in."""
+    return os.environ.get(EXECUTE_CODE_ENABLED_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _is_sensitive_env_name(name: str) -> bool:
+    """True iff an env-var name should be scrubbed from the child process."""
+    upper = name.upper()
+    if any(upper.startswith(prefix) for prefix in _SENSITIVE_PREFIXES):
+        return True
+    return any(part in upper for part in _SENSITIVE_NAME_PARTS)
+
+
+def _scrubbed_env() -> dict[str, str]:
+    """Build a minimal, credential-free environment for the child process.
+
+    Strategy is allowlist-first (only ``_SAFE_ENV_KEYS`` pass through) with a
+    sensitive-name denylist applied on top as belt-and-suspenders. The agent's
+    full env is never forwarded.
+    """
+    env: dict[str, str] = {}
+    for key in _SAFE_ENV_KEYS:
+        val = os.environ.get(key)
+        if val is not None and not _is_sensitive_env_name(key):
+            env[key] = val
+    # Force unbuffered stdout so print() output is captured even on early exit.
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    return env
 
 
 @tool(
@@ -73,3 +144,99 @@ async def exec_command(command: str, timeout: int = 30, workdir: str = "/data") 
         return {"exit_code": -1, "stdout": "", "stderr": f"Command timed out after {timeout}s"}
     except Exception as e:
         return {"exit_code": -1, "stdout": "", "stderr": str(e)}
+
+
+@tool(
+    name="execute_code",
+    description=(
+        "Run a Python snippet in your Linux environment and get back ONLY what "
+        "you print(). Use this to collapse several steps into one turn: fetch, "
+        "compute, filter, and print just the final answer — intermediate values "
+        "never come back to you, only your printed output. The snippet runs as a "
+        "fresh `python3` process (no state carries over between calls). On "
+        "failure you get the error (stderr) and a non-zero exit code. "
+        "print() what you need; everything else is discarded."
+    ),
+    parameters={
+        "code": {"type": "string", "description": "Python source to execute"},
+        "timeout": {
+            "type": "integer",
+            "description": "Max seconds to wait (default 30)",
+            "default": 30,
+        },
+    },
+)
+async def execute_code(code: str, timeout: int = 30) -> dict:
+    """Run a Python snippet and return its printed stdout (stderr on failure).
+
+    Reuses run_command's container-exec mechanism (the Docker container IS the
+    security boundary). The snippet is written to a temp file and run with
+    ``python3 <file>`` — temp-file over ``-c`` to sidestep shell/quoting issues
+    — under a SCRUBBED environment (no credentials, no OpenLegion namespace; see
+    ``_scrubbed_env``). Intermediate values stay out of context: only what the
+    snippet print()s is returned.
+    """
+    # Ships dormant. The worker surface hides the schema when the flag is off
+    # (see _EXECUTE_CODE_TOOLS in loop.py); this self-reject also covers the
+    # operator allowlist path, which doesn't go through that exclusion.
+    if not execute_code_enabled():
+        return {
+            "exit_code": -1,
+            "stdout": "",
+            "stderr": (
+                "execute_code is disabled. Set OPENLEGION_EXECUTE_CODE=1 to enable "
+                "it, or use run_command instead."
+            ),
+        }
+    if not isinstance(code, str) or not code.strip():
+        return {"exit_code": -1, "stdout": "", "stderr": "code must be a non-empty string"}
+
+    timeout = min(timeout, _CODE_MAX_TIMEOUT)
+    workdir = "/data" if os.path.isdir("/data") else None
+    path = None
+    try:
+        # Write the snippet to a temp file so we exec `python3 <file>` with no
+        # shell interpolation of the (untrusted, possibly quote-laden) source.
+        fd, path = tempfile.mkstemp(suffix=".py", prefix="execcode_")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(code)
+
+        proc = await asyncio.create_subprocess_exec(
+            "python3",
+            path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=workdir,
+            env=_scrubbed_env(),
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout
+        )
+        stdout = stdout_bytes.decode(errors="replace")[:_CODE_MAX_OUTPUT]
+        stderr = stderr_bytes.decode(errors="replace")[:_CODE_MAX_OUTPUT]
+        return {
+            "exit_code": proc.returncode,
+            "stdout": stdout,
+            # Only surface stderr on failure — keeps the success path to just
+            # what the model printed.
+            "stderr": stderr if proc.returncode != 0 else "",
+        }
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return {"exit_code": -1, "stdout": "", "stderr": f"Code timed out after {timeout}s"}
+    except Exception as e:
+        return {"exit_code": -1, "stdout": "", "stderr": str(e)}
+    finally:
+        if path is not None:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+# DEFERRED (v1 → follow-up): the hermes-style tool-call bridge — letting the
+# executed snippet invoke other agent tools (e.g. a `call_tool(...)` helper in
+# scope) to truly collapse N tool rounds into one — is intentionally NOT built
+# here. It is a larger security surface (tool whitelist, no recursion into
+# execute_code/delegate) and ships as its own PR. v1 is pure Python + stdout.

--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -218,6 +218,7 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
     timeout = min(timeout, _CODE_MAX_TIMEOUT)
     workdir = "/data" if os.path.isdir("/data") else None
     path = None
+    proc: asyncio.subprocess.Process | None = None
     try:
         # Write the snippet to a temp file so we exec `python3 <file>` with no
         # shell interpolation of the (untrusted, possibly quote-laden) source.
@@ -252,8 +253,9 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
             "stderr": stderr if proc.returncode != 0 else "",
         }
     except asyncio.TimeoutError:
-        _kill_process_group(proc)
-        await proc.wait()
+        if proc is not None:
+            _kill_process_group(proc)
+            await proc.wait()
         return {"exit_code": -1, "stdout": "", "stderr": f"Code timed out after {timeout}s"}
     except Exception as e:
         return {"exit_code": -1, "stdout": "", "stderr": str(e)}

--- a/src/agent/builtins/exec_tool.py
+++ b/src/agent/builtins/exec_tool.py
@@ -25,12 +25,6 @@ _MAX_TIMEOUT = 300
 # capture tool — the hermes-style "call agent tools from inside the code" bridge
 # is OUT of scope (see _DEFERRED note below). No recursion into execute_code or
 # delegate.
-#
-# Ships dormant: gated behind OPENLEGION_EXECUTE_CODE (default off). When off
-# the schema is hidden from the worker surface (see _EXECUTE_CODE_TOOLS in
-# loop.py) AND the handler self-rejects (defense-in-depth for the operator
-# allowlist path).
-EXECUTE_CODE_ENABLED_ENV = "OPENLEGION_EXECUTE_CODE"
 
 # Tighter cap than run_command's 100 KB: this is "what the model printed",
 # meant to flow straight back into context, so keep it lean.
@@ -53,13 +47,6 @@ _SAFE_ENV_KEYS = (
     "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR", "TERM",
     "PYTHONIOENCODING", "PYTHONHASHSEED",
 )
-
-
-def execute_code_enabled() -> bool:
-    """True iff the code-as-action ``execute_code`` tool is opted in."""
-    return os.environ.get(EXECUTE_CODE_ENABLED_ENV, "").strip().lower() in (
-        "1", "true", "yes", "on",
-    )
 
 
 def _is_sensitive_env_name(name: str) -> bool:
@@ -200,18 +187,6 @@ async def execute_code(code: str, timeout: int = 30) -> dict:
     ``_scrubbed_env``). Intermediate values stay out of context: only what the
     snippet print()s is returned.
     """
-    # Ships dormant. The worker surface hides the schema when the flag is off
-    # (see _EXECUTE_CODE_TOOLS in loop.py); this self-reject also covers the
-    # operator allowlist path, which doesn't go through that exclusion.
-    if not execute_code_enabled():
-        return {
-            "exit_code": -1,
-            "stdout": "",
-            "stderr": (
-                "execute_code is disabled. Set OPENLEGION_EXECUTE_CODE=1 to enable "
-                "it, or use run_command instead."
-            ),
-        }
     if not isinstance(code, str) or not code.strip():
         return {"exit_code": -1, "stdout": "", "stderr": "code must be a non-empty string"}
 

--- a/src/agent/builtins/tool_search.py
+++ b/src/agent/builtins/tool_search.py
@@ -1,7 +1,7 @@
 """Grouped Tool Search bridge — the ``load_tools`` builtin (Phase 2 / B2).
 
-When grouped tool search is active (``OPENLEGION_GROUPED_TOOLS`` on AND the
-budget gate trips), most non-core tools are advertised cheaply in the system
+When grouped tool search is active (the budget gate trips on a large enough
+tool surface), most non-core tools are advertised cheaply in the system
 prompt's capability index but their full schemas are deferred. ``load_tools``
 is the explicit, always-available bridge that pulls a group's (or a single
 tool's owning group's) full schemas into context for the agent's NEXT turn —

--- a/src/agent/builtins/tool_search.py
+++ b/src/agent/builtins/tool_search.py
@@ -1,0 +1,58 @@
+"""Grouped Tool Search bridge — the ``load_tools`` builtin (Phase 2 / B2).
+
+When grouped tool search is active (``OPENLEGION_GROUPED_TOOLS`` on AND the
+budget gate trips), most non-core tools are advertised cheaply in the system
+prompt's capability index but their full schemas are deferred. ``load_tools``
+is the explicit, always-available bridge that pulls a group's (or a single
+tool's owning group's) full schemas into context for the agent's NEXT turn —
+so a capability is never lost, only its verbose schema is lazy.
+
+The actual schema change is deferred to the next turn boundary by the loop
+(``AgentLoop.request_load_tools`` queues the group; the next system-prompt
+build promotes it) so the toolset never mutates mid-turn — preserving the
+prompt cache. This tool is a thin pass-through to that loop method.
+"""
+
+from __future__ import annotations
+
+from src.agent.tools import tool
+from src.shared.utils import setup_logging
+
+logger = setup_logging("agent.builtins.tool_search")
+
+
+@tool(
+    name="load_tools",
+    description=(
+        "Load the full schemas for a capability group (or a single tool's "
+        "group) so you can call those tools. Use this when the Capability "
+        "Index lists a tool you need but its parameters aren't shown. The "
+        "schemas become available on your NEXT turn — call load_tools, then "
+        "call the tool in a following turn. Pass either 'group' (e.g. "
+        "'fleet_setup', 'scheduling', 'credentials', 'goals_review', "
+        "'audit_undo', 'web_browse') or 'tool' (a specific tool name)."
+    ),
+    parameters={
+        "group": {
+            "type": "string",
+            "description": "Capability group key (or label) to load, e.g. 'fleet_setup'.",
+            "default": "",
+        },
+        "tool": {
+            "type": "string",
+            "description": "A specific tool name to load (its whole group is pulled in).",
+            "default": "",
+        },
+    },
+    loop_exempt=True,
+)
+async def load_tools(group: str = "", tool: str = "", *, agent_loop=None) -> dict:
+    """Queue a capability group's full schemas for the next turn."""
+    if agent_loop is None:
+        return {
+            "loaded": [],
+            "error": "load_tools is unavailable outside an agent loop.",
+        }
+    return agent_loop.request_load_tools(
+        group=group or None, tool=tool or None,
+    )

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -35,6 +35,24 @@ _SUMMARIZATION_INPUT_LIMIT = 20_000  # max chars fed to the summarization LLM ca
 
 _CONSOLIDATION_MIN_INTERVAL_S = 6 * 3600   # at most every 6 hours
 _CONSOLIDATION_MIN_LOG_CHARS = 1_500       # skip if little new material accrued
+_CONSOLIDATION_FAIL_BACKOFF_S = 30 * 60    # after a failed run, wait before retrying
+_DECAY_MIN_INTERVAL_S = 6 * 3600           # salience-decay cadence for the maintenance pass
+
+
+def _tail_on_boundary(text: str, limit: int) -> str:
+    """Return the last ``limit`` chars of ``text``, re-aligned forward to the
+    next ``\\n## `` section boundary so the slice never starts mid-entry.
+
+    The memory log is append-only (oldest first), so the NEWEST entries live
+    at the tail — this is what consolidation must read.
+    """
+    if len(text) <= limit:
+        return text
+    tail = text[-limit:]
+    idx = tail.find("\n## ")
+    if idx != -1:
+        tail = tail[idx + 1:]
+    return tail
 
 
 def _get_tiktoken_encoding(model: str):
@@ -178,6 +196,9 @@ class ContextManager:
         self._flush_triggered = False
         self._flush_lock = asyncio.Lock()
         self._on_memory_update = on_memory_update
+        # Backoff clock for the maintenance pass: set to a future time after a
+        # failed consolidation so a frequent tick doesn't hammer the LLM.
+        self._consolidation_retry_after = 0.0
 
     def reset(self) -> None:
         """Reset per-session state for a new conversation."""
@@ -410,15 +431,49 @@ class ContextManager:
                 f"Context compacted — {count} facts flushed to memory"
             )
 
+    async def run_maintenance(self) -> None:
+        """Off-live-path memory maintenance: re-derive the compiled MEMORY.md
+        head and decay fact salience.
+
+        Driven by the agent's periodic background pass (gbrain "dream cycle" /
+        hermes "Curator"), NOT the live turn — the caller is expected to hold
+        the chat lock so this never races a turn's memory writes. Each step is
+        internally gated (consolidation/decay >=6h), so a frequent tick is
+        cheap when nothing is due. Best-effort: never raises.
+        """
+        await self._maybe_consolidate_memory()
+        await self._maybe_decay_salience()
+
+    async def _maybe_decay_salience(self) -> None:
+        """Decay fact salience at most once per window.
+
+        Gated by the shared ``.memory_decayed`` sentinel that the task path
+        also stamps on every fresh-task decay (loop.py): a busy worker is thus
+        never double-decayed, while an idle agent (e.g. the operator, which
+        runs no tasks) still decays through this pass — the gap this closes.
+        """
+        ws, mem = self.workspace, self.memory
+        if not ws or not mem:
+            return
+        if not ws.decay_due(_DECAY_MIN_INTERVAL_S):
+            return
+        try:
+            await mem.decay_all()
+            ws.mark_decayed()
+        except Exception as e:
+            logger.debug("salience decay failed: %s", e)
+
     async def _maybe_consolidate_memory(self) -> None:
         """Re-derive the compiled MEMORY.md head from the append-only log +
         high-salience facts. Time-gated (>=6h) and material-gated (>=1.5k log
-        chars) so it adds at most one LLM call to the occasional compaction.
-        Best-effort: never raises into the compaction path.
+        chars) so it adds at most one LLM call per cycle. Best-effort: never
+        raises into the caller (compaction or the maintenance pass).
         """
         ws, llm = self.workspace, self.llm
         if not ws or not llm:
             return
+        if time.time() < self._consolidation_retry_after:
+            return  # backing off after a recent failure
         if not ws.consolidation_due(_CONSOLIDATION_MIN_INTERVAL_S):
             return
         log = ws.load_memory_log()
@@ -442,7 +497,8 @@ class ContextManager:
             "words). Output ONLY the compiled memory markdown — no preamble.\n\n"
             f"## Current compiled memory\n{head[:_SUMMARIZATION_INPUT_LIMIT]}\n\n"
             f"## High-salience facts\n{salient[:4000]}\n\n"
-            f"## Recent activity log (newest last)\n{log[:_SUMMARIZATION_INPUT_LIMIT]}"
+            f"## Recent activity log (newest last)\n"
+            f"{_tail_on_boundary(log, _SUMMARIZATION_INPUT_LIMIT)}"
         )
         try:
             resp = await llm.chat(
@@ -452,12 +508,15 @@ class ContextManager:
             )
         except Exception as e:
             logger.warning("Memory consolidation LLM call failed: %s", e)
+            self._consolidation_retry_after = time.time() + _CONSOLIDATION_FAIL_BACKOFF_S
             return
         new_head = (resp.content or "").strip()
         if not new_head:
+            self._consolidation_retry_after = time.time() + _CONSOLIDATION_FAIL_BACKOFF_S
             return
         ws.write_compiled_memory(sanitize_for_prompt(new_head))
         ws.mark_consolidated()
+        self._consolidation_retry_after = 0.0
         if self._on_memory_update:
             try:
                 await self._on_memory_update()

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -448,9 +448,11 @@ class ContextManager:
         """Decay fact salience at most once per window.
 
         Gated by the shared ``.memory_decayed`` sentinel that the task path
-        also stamps on every fresh-task decay (loop.py): a busy worker is thus
-        never double-decayed, while an idle agent (e.g. the operator, which
-        runs no tasks) still decays through this pass — the gap this closes.
+        also stamps on every fresh-task decay (loop.py). This gating only binds
+        the background maintenance pass: it won't pile an extra decay onto an
+        agent the task path recently decayed. The task path itself stays
+        ungated (it decays per fresh task), so this pass exists to cover an
+        idle agent (e.g. the operator, which runs no tasks) — the gap it closes.
         """
         ws, mem = self.workspace, self.memory
         if not ws or not mem:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -42,6 +42,15 @@ _RETRYABLE_STATUS_CODES = {429, 502, 503, 504, 529}  # 529 = Anthropic overloade
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 1  # seconds: 1, 2, 4
 _TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "900"))  # seconds — hard ceiling per tool
+# C3 — cache-prefix stabilization (Phase 2 of the operator memory/context
+# overhaul). When ON, per-turn-volatile prompt fragments (context/round
+# warnings, operator playbooks, 5-min runtime context, the ``## Recent``
+# memory slice) are relocated OUT of the cached system block and appended
+# AFTER the mesh-side cache breakpoint (into the last message) so the stable
+# system prefix stays byte-identical turn-to-turn and #1073's prompt cache
+# actually hits. Default OFF: flag-off rebuilds the exact legacy prompt, so
+# behavior (instruction ordering is weighting-sensitive) is unchanged.
+_STABLE_PREFIX = os.environ.get("OPENLEGION_STABLE_PREFIX", "false").lower() == "true"
 _FLEET_ROSTER_TTL = 600  # seconds — cache TTL for fleet roster
 _GOALS_TTL = 300  # seconds — cache TTL for goals fetch
 _FALLBACK_MAX_TOKENS = 100_000  # context trim fallback when no context manager
@@ -381,6 +390,12 @@ class AgentLoop:
         self._current_task_handle: asyncio.Task | None = None
         self._last_result: TaskResult | None = None
         self._chat_messages: list[dict] = []
+        # C3 — per-turn-volatile prompt fragments relocated out of the cached
+        # system block by ``_build_*_system_prompt`` when ``_STABLE_PREFIX`` is
+        # ON. Re-injected after the cache breakpoint via
+        # ``_messages_with_volatile`` at the LLM call site. Always "" when the
+        # flag is OFF (legacy path leaves these IN the system prompt).
+        self._volatile_prompt_suffix: str = ""
         self._chat_lock = asyncio.Lock()
         self._chat_total_rounds: int = 0
         self._chat_auto_continues: int = 0
@@ -939,18 +954,32 @@ class AgentLoop:
                     return result
 
                 # === DECIDE (LLM call) ===
-                # Refresh system prompt with context warning if applicable
+                # Refresh system prompt with context warning if applicable.
+                # Stable-prefix path: keep ``system_prompt`` byte-stable and
+                # relocate the per-iteration warning below the cache breakpoint
+                # alongside the suffix stashed by ``_build_system_prompt``. The
+                # warning is folded into a LOCAL suffix (not the stashed one) so
+                # it doesn't leak into a later iteration that has no warning.
                 effective_system = system_prompt
-                if self.context_manager:
-                    warning = self.context_manager.context_warning(messages)
+                warning = (
+                    self.context_manager.context_warning(messages)
+                    if self.context_manager else None
+                )
+                if _STABLE_PREFIX:
+                    iter_suffix = "\n\n".join(
+                        p for p in (self._volatile_prompt_suffix, f"## {warning}" if warning else "") if p
+                    )
+                    eff_messages = self._append_volatile_to_messages(messages, iter_suffix)
+                else:
                     if warning:
                         effective_system = system_prompt + f"\n\n## {warning}"
+                    eff_messages = messages
 
                 available_tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat_collect,
                     system=effective_system,
-                    messages=messages,
+                    messages=eff_messages,
                     tools=available_tools,
                 )
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -1715,10 +1744,15 @@ class AgentLoop:
         self, assignment: TaskAssignment, introspect_data: dict | None = None,
     ) -> str:
         parts = []
+        # C3 — see _build_chat_system_prompt. Volatile fragments are stashed on
+        # self._volatile_prompt_suffix and re-injected after the cache
+        # breakpoint when _STABLE_PREFIX is ON; inline (legacy) otherwise.
+        volatile: list[str] = []
+        stable = _STABLE_PREFIX
 
         # Load workspace identity + project files into system prompt
         if self.workspace:
-            bootstrap = self.workspace.get_bootstrap_content()
+            bootstrap = self.workspace.get_bootstrap_content(include_recent=not stable)
             if bootstrap:
                 parts.append(bootstrap)  # pre-sanitized by workspace cache
 
@@ -1762,11 +1796,22 @@ class AgentLoop:
         if tool_history:
             parts.append(sanitize_for_prompt(tool_history))
 
+        # ── Volatile fragments (relocated below the cache breakpoint when ON). ──
+        sink = volatile if stable else parts
+
+        # Relocated ``## Recent`` memory slice (only when stable — otherwise it
+        # is already embedded in the head-inclusive bootstrap above).
+        if stable and self.workspace:
+            recent = self.workspace.get_recent_memory_slice()
+            if recent:
+                sink.append(sanitize_for_prompt(recent))
+
         if introspect_data:
             runtime_ctx = self._format_runtime_context(introspect_data)
             if runtime_ctx:
-                parts.append(runtime_ctx)
+                sink.append(runtime_ctx)
 
+        self._volatile_prompt_suffix = "\n\n".join(volatile)
         return "\n\n".join(parts)
 
     # Round-4 structural fix: hand_off failures are now enforced from
@@ -2003,6 +2048,10 @@ class AgentLoop:
                     )
 
                 parts: list[str] = []
+                # Heartbeat builds its own system prompt (not via
+                # _build_*_system_prompt); clear any suffix stashed by a prior
+                # chat/task build so stale volatile content can't leak in.
+                self._volatile_prompt_suffix = ""
 
                 # 1. Goals — the agent's north star
                 if goals:
@@ -3361,7 +3410,7 @@ class AgentLoop:
             llm_response = await _llm_call_with_retry(
                 self.llm.chat_collect,
                 system=system,
-                messages=self._chat_messages,
+                messages=self._messages_with_volatile(self._chat_messages),
                 tools=None,
             )
         except (LLMAuthError, LLMConfigError):
@@ -3496,7 +3545,7 @@ class AgentLoop:
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat_collect,
                     system=_round_system,
-                    messages=self._chat_messages,
+                    messages=self._messages_with_volatile(self._chat_messages),
                     tools=_iter_tools,
                 )
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -3807,7 +3856,7 @@ class AgentLoop:
             llm_response = await _llm_call_with_retry(
                 self.llm.chat_collect,
                 system=system,
-                messages=self._chat_messages,
+                messages=self._messages_with_volatile(self._chat_messages),
                 tools=None,
             )
             total_tokens += llm_response.tokens_used
@@ -4170,12 +4219,22 @@ class AgentLoop:
         introspect_data: dict | None = None,
     ) -> str:
         parts = []
+        # C3 cache-prefix stabilization: when ON, per-turn-volatile fragments
+        # are collected here instead of appended to ``parts``, so the returned
+        # system block stays byte-identical across turns (the cacheable prefix).
+        # They are re-injected after the cache breakpoint via
+        # ``_messages_with_volatile``. When OFF, ``volatile`` is unused and the
+        # fragments stay inline in ``parts`` exactly as before — byte-identical.
+        volatile: list[str] = []
+        stable = _STABLE_PREFIX
 
         if goals:
             parts.append(f"## Your Current Goals\n\n{sanitize_for_prompt(format_dict(goals))}")
 
         if self.workspace:
-            bootstrap = self.workspace.get_bootstrap_content()
+            # Stable path drops the volatile ``## Recent`` memory slice from the
+            # cached bootstrap (head-only) and relocates it below.
+            bootstrap = self.workspace.get_bootstrap_content(include_recent=not stable)
             if bootstrap:
                 parts.append(bootstrap)  # pre-sanitized by workspace cache
 
@@ -4246,6 +4305,17 @@ class AgentLoop:
         if tool_history:
             parts.append(sanitize_for_prompt(tool_history))
 
+        # ── Volatile fragments (relocated below the cache breakpoint when the
+        # stable-prefix flag is ON; inline otherwise — byte-identical legacy). ──
+        sink = volatile if stable else parts
+
+        # Relocated ``## Recent`` memory slice (only when stable — otherwise it
+        # is already embedded in the head-inclusive bootstrap above).
+        if stable and self.workspace:
+            recent = self.workspace.get_recent_memory_slice()
+            if recent:
+                sink.append(sanitize_for_prompt(recent))
+
         # Inject operator playbooks based on tool-call patterns
         if self._is_operator:
             active_playbooks = self._update_operator_playbooks()
@@ -4254,32 +4324,72 @@ class AgentLoop:
 
                 playbook_text = get_playbook_content(active_playbooks)
                 if playbook_text:
-                    parts.append(playbook_text)
+                    sink.append(playbook_text)
 
         if introspect_data:
             runtime_ctx = self._format_runtime_context(
                 introspect_data, exclude_fleet=has_fleet_ctx,
             )
             if runtime_ctx:
-                parts.append(runtime_ctx)
+                sink.append(runtime_ctx)
 
         # Context usage warning at 80%+
         if self.context_manager and self._chat_messages:
             warning = self.context_manager.context_warning(self._chat_messages)
             if warning:
-                parts.append(f"## {warning}")
+                sink.append(f"## {warning}")
 
         # Round-count warning at 80% of checkpoint interval
         if self._chat_total_rounds >= self._CHAT_ROUND_WARNING:
             remaining = self.CHAT_MAX_TOTAL_ROUNDS - self._chat_total_rounds
-            parts.append(
+            sink.append(
                 f"## Session Note\n"
                 f"This session has been running for {self._chat_total_rounds} tool rounds. "
                 f"Context will be auto-refreshed in ~{remaining} rounds. "
                 f"Consider saving important context to memory if you haven't already."
             )
 
+        # Stash the relocated content for re-injection after the cache
+        # breakpoint. Empty string when flag-off or nothing volatile.
+        self._volatile_prompt_suffix = "\n\n".join(volatile)
+
         return "\n\n".join(parts)
+
+    def _messages_with_volatile(self, messages: list[dict]) -> list[dict]:
+        """Return ``messages`` for the LLM call, re-injecting the relocated
+        volatile prompt suffix (stashed by ``_build_*_system_prompt``) AFTER
+        the cache breakpoint. No-op when the flag is off / nothing relocated.
+        """
+        return self._append_volatile_to_messages(messages, self._volatile_prompt_suffix)
+
+    def _append_volatile_to_messages(
+        self, messages: list[dict], suffix: str,
+    ) -> list[dict]:
+        """Append ``suffix`` after the cache breakpoint by folding it into a
+        COPY of the last message's content.
+
+        No-op (returns the same list) when ``_STABLE_PREFIX`` is off or there
+        is nothing to relocate — so the legacy path is untouched. When active,
+        the persistent ``messages``/``_chat_messages`` list is never mutated
+        and NO new message is added — whatever the last message's role is stays
+        the last message's role, so role-alternation (Constraint #7) holds.
+        """
+        if not _STABLE_PREFIX or not suffix or not messages:
+            return messages
+        out = list(messages)
+        last = dict(out[-1])
+        block = f"\n\n[Live context — re-read every turn]\n\n{suffix}"
+        content = last.get("content")
+        if isinstance(content, str):
+            last["content"] = content + block
+        elif isinstance(content, list):
+            # Multimodal/structured content — append a trailing text block.
+            last["content"] = [*content, {"type": "text", "text": block.strip()}]
+        else:
+            # Unexpected shape — leave untouched rather than risk a bad request.
+            return messages
+        out[-1] = last
+        return out
 
     def get_status(self) -> AgentStatus:
         """Return current agent status."""
@@ -4391,9 +4501,10 @@ class AgentLoop:
                 used_streaming = False
                 any_text_streamed = False
                 tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
+                _msgs = self._messages_with_volatile(self._chat_messages)
                 try:
                     async for event in self.llm.chat_stream(
-                        system=system, messages=self._chat_messages, tools=tools,
+                        system=system, messages=_msgs, tools=tools,
                     ):
                         etype = event.get("type", "")
                         if etype == "text_delta":
@@ -4411,7 +4522,7 @@ class AgentLoop:
                     if used_streaming:
                         logger.warning("LLM stream ended without done event, falling back")
                     llm_response = await _llm_call_with_retry(
-                        self.llm.chat, system=system, messages=self._chat_messages, tools=tools,
+                        self.llm.chat, system=system, messages=_msgs, tools=tools,
                     )
 
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -4623,7 +4734,7 @@ class AgentLoop:
             llm_response = await _llm_call_with_retry(
                 self.llm.chat,
                 system=system,
-                messages=self._chat_messages,
+                messages=self._messages_with_volatile(self._chat_messages),
                 tools=None,
             )
             total_tokens += llm_response.tokens_used

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -21,7 +21,6 @@ from src.agent.attachments import enrich_message_with_attachments
 from src.agent.loop_detector import ToolLoopDetector
 from src.agent.tool_groups import (
     GroupedPlan,
-    grouped_tools_enabled,
     plan_grouped_tools,
     resolve_load_request,
 )
@@ -54,9 +53,7 @@ _TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "900"))  # seconds
 # memory slice) are relocated OUT of the cached system block and appended
 # AFTER the mesh-side cache breakpoint (into the last message) so the stable
 # system prefix stays byte-identical turn-to-turn and #1073's prompt cache
-# actually hits. Default OFF: flag-off rebuilds the exact legacy prompt, so
-# behavior (instruction ordering is weighting-sensitive) is unchanged.
-_STABLE_PREFIX = os.environ.get("OPENLEGION_STABLE_PREFIX", "false").lower() == "true"
+# actually hits. Volatile fragments are relocated below the cache breakpoint.
 _FLEET_ROSTER_TTL = 600  # seconds — cache TTL for fleet roster
 _GOALS_TTL = 300  # seconds — cache TTL for goals fetch
 _FALLBACK_MAX_TOKENS = 100_000  # context trim fallback when no context manager
@@ -407,10 +404,8 @@ class AgentLoop:
         self._last_result: TaskResult | None = None
         self._chat_messages: list[dict] = []
         # C3 — per-turn-volatile prompt fragments relocated out of the cached
-        # system block by ``_build_*_system_prompt`` when ``_STABLE_PREFIX`` is
-        # ON. Re-injected after the cache breakpoint via
-        # ``_messages_with_volatile`` at the LLM call site. Always "" when the
-        # flag is OFF (legacy path leaves these IN the system prompt).
+        # system block by ``_build_*_system_prompt``. Re-injected after the cache
+        # breakpoint via ``_messages_with_volatile`` at the LLM call site.
         self._volatile_prompt_suffix: str = ""
         self._chat_lock = asyncio.Lock()
         self._chat_total_rounds: int = 0
@@ -483,7 +478,7 @@ class AgentLoop:
             self._disabled_gates.add("browser")
         self._runtime_disabled_tools: frozenset[str] = frozenset()
         self._recompute_runtime_disabled()
-        # ── Grouped Tool Search (B2, default-OFF via OPENLEGION_GROUPED_TOOLS) ──
+        # ── Grouped Tool Search (budget-gated capability index + lazy schemas) ──
         # ``_loaded_tool_groups`` are groups whose full schemas are present in
         # context. ``_pending_tool_groups`` are groups requested via
         # ``load_tools`` this turn — promoted into ``_loaded_tool_groups`` at the
@@ -576,11 +571,8 @@ class AgentLoop:
         invariant this feature defers to the next turn boundary.
 
         Returns the capability-index text to append to the system prompt (""
-        when the feature is off or the budget gate didn't trip).
+        when the budget gate didn't trip).
         """
-        if not grouped_tools_enabled():
-            self._grouped_plan = None
-            return ""
         # Apply deferred loads requested last turn — ONLY at a turn boundary.
         if promote_pending and self._pending_tool_groups:
             self._loaded_tool_groups |= self._pending_tool_groups
@@ -609,10 +601,10 @@ class AgentLoop:
         deferred to the next system-prompt build (``_refresh_grouped_plan``) so
         the toolset stays stable for the remainder of the current turn.
         """
-        if not grouped_tools_enabled():
+        if self._grouped_plan is None or not self._grouped_plan.active:
             return {
                 "loaded": [],
-                "note": "Grouped tool search is disabled; all tools already loaded.",
+                "note": "All tools are already loaded; no deferral is active.",
             }
         base_kw = {
             k: v for k, v in self._tool_filter_kw.items() if k != "defer"
@@ -1082,15 +1074,10 @@ class AgentLoop:
                     self.context_manager.context_warning(messages)
                     if self.context_manager else None
                 )
-                if _STABLE_PREFIX:
-                    iter_suffix = "\n\n".join(
-                        p for p in (self._volatile_prompt_suffix, f"## {warning}" if warning else "") if p
-                    )
-                    eff_messages = self._append_volatile_to_messages(messages, iter_suffix)
-                else:
-                    if warning:
-                        effective_system = system_prompt + f"\n\n## {warning}"
-                    eff_messages = messages
+                iter_suffix = "\n\n".join(
+                    p for p in (self._volatile_prompt_suffix, f"## {warning}" if warning else "") if p
+                )
+                eff_messages = self._append_volatile_to_messages(messages, iter_suffix)
 
                 available_tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 llm_response = await _llm_call_with_retry(
@@ -1866,14 +1853,14 @@ class AgentLoop:
     ) -> str:
         parts = []
         # C3 — see _build_chat_system_prompt. Volatile fragments are stashed on
-        # self._volatile_prompt_suffix and re-injected after the cache
-        # breakpoint when _STABLE_PREFIX is ON; inline (legacy) otherwise.
+        # self._volatile_prompt_suffix and re-injected after the cache breakpoint
+        # so the cached system prefix stays byte-identical turn-to-turn.
         volatile: list[str] = []
-        stable = _STABLE_PREFIX
 
-        # Load workspace identity + project files into system prompt
+        # Load workspace identity + project files into system prompt. The head is
+        # stable (cached); the ## Recent slice is relocated below the breakpoint.
         if self.workspace:
-            bootstrap = self.workspace.get_bootstrap_content(include_recent=not stable)
+            bootstrap = self.workspace.get_bootstrap_content(include_recent=False)
             if bootstrap:
                 parts.append(bootstrap)  # pre-sanitized by workspace cache
 
@@ -1917,12 +1904,12 @@ class AgentLoop:
         if tool_history:
             parts.append(sanitize_for_prompt(tool_history))
 
-        # ── Volatile fragments (relocated below the cache breakpoint when ON). ──
-        sink = volatile if stable else parts
+        # ── Volatile fragments (relocated below the cache breakpoint). ──
+        sink = volatile
 
-        # Relocated ``## Recent`` memory slice (only when stable — otherwise it
-        # is already embedded in the head-inclusive bootstrap above).
-        if stable and self.workspace:
+        # Relocated ``## Recent`` memory slice (the stable head above is
+        # head-only; the recent slice rides after the cache breakpoint).
+        if self.workspace:
             recent = self.workspace.get_recent_memory_slice()
             if recent:
                 sink.append(sanitize_for_prompt(recent))
@@ -4386,22 +4373,20 @@ class AgentLoop:
         promote_pending: bool = False,
     ) -> str:
         parts = []
-        # C3 cache-prefix stabilization: when ON, per-turn-volatile fragments
-        # are collected here instead of appended to ``parts``, so the returned
-        # system block stays byte-identical across turns (the cacheable prefix).
-        # They are re-injected after the cache breakpoint via
-        # ``_messages_with_volatile``. When OFF, ``volatile`` is unused and the
-        # fragments stay inline in ``parts`` exactly as before — byte-identical.
+        # C3 cache-prefix stabilization: per-turn-volatile fragments are
+        # collected in ``volatile`` instead of appended to ``parts``, so the
+        # returned system block stays byte-identical across turns (the cacheable
+        # prefix). They are re-injected after the cache breakpoint via
+        # ``_messages_with_volatile``.
         volatile: list[str] = []
-        stable = _STABLE_PREFIX
 
         if goals:
             parts.append(f"## Your Current Goals\n\n{sanitize_for_prompt(format_dict(goals))}")
 
         if self.workspace:
-            # Stable path drops the volatile ``## Recent`` memory slice from the
-            # cached bootstrap (head-only) and relocates it below.
-            bootstrap = self.workspace.get_bootstrap_content(include_recent=not stable)
+            # Head-only bootstrap (cached); the volatile ``## Recent`` memory
+            # slice is relocated below the cache breakpoint.
+            bootstrap = self.workspace.get_bootstrap_content(include_recent=False)
             if bootstrap:
                 parts.append(bootstrap)  # pre-sanitized by workspace cache
 
@@ -4472,13 +4457,12 @@ class AgentLoop:
         if tool_history:
             parts.append(sanitize_for_prompt(tool_history))
 
-        # ── Volatile fragments (relocated below the cache breakpoint when the
-        # stable-prefix flag is ON; inline otherwise — byte-identical legacy). ──
-        sink = volatile if stable else parts
+        # ── Volatile fragments (relocated below the cache breakpoint). ──
+        sink = volatile
 
-        # Relocated ``## Recent`` memory slice (only when stable — otherwise it
-        # is already embedded in the head-inclusive bootstrap above).
-        if stable and self.workspace:
+        # Relocated ``## Recent`` memory slice (the stable head above is
+        # head-only; the recent slice rides after the cache breakpoint).
+        if self.workspace:
             recent = self.workspace.get_recent_memory_slice()
             if recent:
                 sink.append(sanitize_for_prompt(recent))
@@ -4540,13 +4524,13 @@ class AgentLoop:
         """Append ``suffix`` after the cache breakpoint by folding it into a
         COPY of the last message's content.
 
-        No-op (returns the same list) when ``_STABLE_PREFIX`` is off or there
-        is nothing to relocate — so the legacy path is untouched. When active,
-        the persistent ``messages``/``_chat_messages`` list is never mutated
-        and NO new message is added — whatever the last message's role is stays
-        the last message's role, so role-alternation (Constraint #7) holds.
+        No-op (returns the same list) when there is nothing to relocate. When
+        active, the persistent ``messages``/``_chat_messages`` list is never
+        mutated and NO new message is added — whatever the last message's role
+        is stays the last message's role, so role-alternation (Constraint #7)
+        holds.
         """
-        if not _STABLE_PREFIX or not suffix or not messages:
+        if not suffix or not messages:
             return messages
         out = list(messages)
         last = dict(out[-1])

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1951,7 +1951,16 @@ class AgentLoop:
         if self.state != "idle" or self._chat_lock.locked():
             return
         async with self._chat_lock:
-            await self.context_manager.run_maintenance()
+            # Re-check under the lock, then mark busy so a concurrent POST
+            # /task (which gates on ``state``, not the chat lock) can't start
+            # and race the consolidation's memory writes. Restored in finally.
+            if self.state != "idle":
+                return
+            self.state = "working"
+            try:
+                await self.context_manager.run_maintenance()
+            finally:
+                self.state = "idle"
 
     # ── Heartbeat mode ────────────────────────────────────────
 

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -166,6 +166,13 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
 # without it (marketplace tools load at container start, not via runtime reload).
 _TOOL_AUTHORING_TOOLS = frozenset({"create_tool", "reload_tools"})
 
+# Grouped Tool Search (B2) bridge tool. Auto-registers via @tool discovery, but
+# is only meaningful when OPENLEGION_GROUPED_TOOLS is on. Hidden from the worker
+# surface when the flag is off so flag-off == main exactly (the operator path is
+# gated separately in cli/config.py's allowlist). This is also the SOLE tool the
+# registry is permitted to hand the AgentLoop to — see ``_AGENT_LOOP_TOOLS``.
+_GROUPED_TOOLS_BRIDGE = frozenset({"load_tools"})
+
 # Read-only tools allowed during operator heartbeat (unsupervised execution).
 # The full operator allowlist is restricted to this subset so heartbeats
 # cannot mutate fleet state without user approval. ``check_inbox`` is
@@ -428,6 +435,10 @@ class AgentLoop:
             from src.agent.builtins.tool_authoring import tool_authoring_enabled
             if not tool_authoring_enabled():
                 excluded |= _TOOL_AUTHORING_TOOLS
+            # Grouped Tool Search bridge is dead weight when the feature is off;
+            # hide it so the worker surface matches main exactly (flag-off parity).
+            if not grouped_tools_enabled():
+                excluded |= _GROUPED_TOOLS_BRIDGE
             # Operator-only orchestration tools (edit_agent, create_team,
             # manage_*, apply_template, install_skill, …) self-reject for
             # worker callers at call time. Drop their schemas from the worker
@@ -542,14 +553,18 @@ class AgentLoop:
         return kw
 
     # ── Grouped Tool Search (B2) ───────────────────────────────────────────
-    def _refresh_grouped_plan(self) -> str:
-        """Promote pending loads, recompute the grouped-tools plan, return index.
+    def _refresh_grouped_plan(self, *, promote_pending: bool = False) -> str:
+        """Recompute the grouped-tools plan, return the capability-index text.
 
-        Called at each system-prompt build — the TURN BOUNDARY. This is where a
-        ``load_tools`` request made during the previous turn actually takes
-        effect (pending → loaded), so the toolset never changes mid-turn (which
-        would bust the prompt cache; mirrors hermes' "don't change toolsets
-        mid-conversation" invariant).
+        ``promote_pending`` is the turn-boundary switch. A ``load_tools`` request
+        made during a turn is queued in ``_pending_tool_groups``; it only takes
+        effect (pending → loaded) at the start of a NEW external turn, where the
+        caller passes ``promote_pending=True``. MID-turn rebuilds (operator
+        playbook change, tool hot-reload, streaming rebuilds) pass the default
+        ``False`` so the loaded set — and therefore the emitted tool schemas —
+        stay identical to what the turn started with. Promoting mid-turn would
+        flip the toolset and bust the #1073 prompt cache, which is exactly the
+        invariant this feature defers to the next turn boundary.
 
         Returns the capability-index text to append to the system prompt (""
         when the feature is off or the budget gate didn't trip).
@@ -557,8 +572,8 @@ class AgentLoop:
         if not grouped_tools_enabled():
             self._grouped_plan = None
             return ""
-        # Apply deferred loads requested last turn.
-        if self._pending_tool_groups:
+        # Apply deferred loads requested last turn — ONLY at a turn boundary.
+        if promote_pending and self._pending_tool_groups:
             self._loaded_tool_groups |= self._pending_tool_groups
             self._pending_tool_groups.clear()
         # Available = what this agent can actually call this turn, BEFORE the
@@ -955,7 +970,11 @@ class AgentLoop:
                 await self.memory.decay_all()
 
         introspect_data = await self._fetch_introspect_cached()
-        system_prompt = self._build_system_prompt(assignment, introspect_data=introspect_data)
+        # Turn boundary: a new task execution promotes any load_tools requested
+        # on the prior turn (mid-turn rebuilds below pass the default False).
+        system_prompt = self._build_system_prompt(
+            assignment, introspect_data=introspect_data, promote_pending=True,
+        )
 
         # Bug F (codex r4): seed the tool-call counter from messages so a
         # checkpoint-resumed task picks up where it left off; thereafter
@@ -1810,7 +1829,11 @@ class AgentLoop:
         return "## Recent Tool History\n\n" + "\n".join(lines)
 
     def _build_system_prompt(
-        self, assignment: TaskAssignment, introspect_data: dict | None = None,
+        self,
+        assignment: TaskAssignment,
+        introspect_data: dict | None = None,
+        *,
+        promote_pending: bool = False,
     ) -> str:
         parts = []
 
@@ -1865,7 +1888,7 @@ class AgentLoop:
             if runtime_ctx:
                 parts.append(runtime_ctx)
 
-        index_text = self._refresh_grouped_plan()
+        index_text = self._refresh_grouped_plan(promote_pending=promote_pending)
         if index_text:
             parts.append(index_text)
 
@@ -2163,7 +2186,8 @@ class AgentLoop:
                     if runtime_ctx:
                         parts.append(runtime_ctx)
 
-                index_text = self._refresh_grouped_plan()
+                # A heartbeat is a fresh external turn — promote pending loads.
+                index_text = self._refresh_grouped_plan(promote_pending=True)
                 if index_text:
                     parts.append(index_text)
 
@@ -3161,8 +3185,11 @@ class AgentLoop:
                 self._fetch_goals(), self._fetch_fleet_roster(),
                 self._fetch_introspect_cached(),
             )
+        # Turn boundary: a new chat turn promotes any load_tools requested on
+        # the prior turn (the mid-turn rebuilds in the chat loop pass False).
         system = self._build_chat_system_prompt(
             goals=goals, fleet_roster=roster, introspect_data=introspect_data,
+            promote_pending=True,
         )
         return user_message, system
 
@@ -4275,6 +4302,8 @@ class AgentLoop:
         goals: dict | None = None,
         fleet_roster: list[dict] | None = None,
         introspect_data: dict | None = None,
+        *,
+        promote_pending: bool = False,
     ) -> str:
         parts = []
 
@@ -4386,7 +4415,7 @@ class AgentLoop:
                 f"Consider saving important context to memory if you haven't already."
             )
 
-        index_text = self._refresh_grouped_plan()
+        index_text = self._refresh_grouped_plan(promote_pending=promote_pending)
         if index_text:
             parts.append(index_text)
 

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -810,6 +810,8 @@ class AgentLoop:
                 messages = await self._build_initial_context(assignment)
                 if self.memory:
                     await self.memory.decay_all()
+                    if self.workspace:
+                        self.workspace.mark_decayed()
             else:
                 # Reconcile TokenBudget mutable state
                 if assignment.token_budget:
@@ -852,9 +854,13 @@ class AgentLoop:
             start_iteration = 0
             assignment_json = assignment.model_dump_json()
             messages = await self._build_initial_context(assignment)
-            # Decay salience scores only on fresh start (not resume, to avoid double-decay)
+            # Decay salience scores only on fresh start (not resume, to avoid double-decay).
+            # Stamp the shared decay sentinel so the background maintenance pass
+            # (ContextManager._maybe_decay_salience) won't double-decay a busy agent.
             if self.memory:
                 await self.memory.decay_all()
+                if self.workspace:
+                    self.workspace.mark_decayed()
 
         introspect_data = await self._fetch_introspect_cached()
         system_prompt = self._build_system_prompt(assignment, introspect_data=introspect_data)
@@ -1927,6 +1933,25 @@ class AgentLoop:
             return parsed.get("result", {"raw": content}), parsed.get("promote", {})
         except (json.JSONDecodeError, AttributeError):
             return {"raw": content}, {}
+
+    # ── Background memory maintenance ─────────────────────────
+
+    async def run_maintenance(self) -> None:
+        """Run the off-live-path memory maintenance pass (consolidation +
+        salience decay), driven by the agent's periodic background task.
+
+        Skips while a turn is in flight — same idle/lock guard the heartbeat
+        uses — so it never races a turn's memory writes (``_flush_to_memory``
+        + salience updates) or adds latency to a user-facing turn. The work
+        itself is internally time-gated (>=6h), so a frequent tick is cheap
+        when nothing is due. Best-effort: never raises.
+        """
+        if not self.context_manager:
+            return
+        if self.state != "idle" or self._chat_lock.locked():
+            return
+        async with self._chat_lock:
+            await self.context_manager.run_maintenance()
 
     # ── Heartbeat mode ────────────────────────────────────────
 

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -583,9 +583,10 @@ class AgentLoop:
             k: v for k, v in self._tool_filter_kw.items() if k != "defer"
         }
         available = set(self.tools.list_tools(**base_kw))
-        context_window = (
-            self.context_manager.max_tokens if self.context_manager else 0
-        )
+        # Degrade to an inactive plan (full surface) if the context window is
+        # unavailable — the capability index is an optimization and must never
+        # hard-fail a turn.
+        context_window = getattr(self.context_manager, "max_tokens", 0) or 0
         self._grouped_plan = plan_grouped_tools(
             available=available,
             loaded_groups=self._loaded_tool_groups,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -160,6 +160,12 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
 # without it (marketplace tools load at container start, not via runtime reload).
 _TOOL_AUTHORING_TOOLS = frozenset({"create_tool", "reload_tools"})
 
+# Code-as-action surface — hidden from the worker tool surface unless the
+# OPENLEGION_EXECUTE_CODE opt-in is set. Ships dormant (Phase 2 of the operator
+# memory/context overhaul, §7 C2). The tool also self-rejects at call time, so
+# the operator allowlist path (which bypasses this exclude) stays gated too.
+_EXECUTE_CODE_TOOLS = frozenset({"execute_code"})
+
 # Read-only tools allowed during operator heartbeat (unsupervised execution).
 # The full operator allowlist is restricted to this subset so heartbeats
 # cannot mutate fleet state without user approval. ``check_inbox`` is
@@ -417,6 +423,10 @@ class AgentLoop:
             from src.agent.builtins.tool_authoring import tool_authoring_enabled
             if not tool_authoring_enabled():
                 excluded |= _TOOL_AUTHORING_TOOLS
+            # Code-as-action ships dormant — hide execute_code unless opted in.
+            from src.agent.builtins.exec_tool import execute_code_enabled
+            if not execute_code_enabled():
+                excluded |= _EXECUTE_CODE_TOOLS
             # Operator-only orchestration tools (edit_agent, create_team,
             # manage_*, apply_template, install_skill, …) self-reject for
             # worker callers at call time. Drop their schemas from the worker

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -19,6 +19,12 @@ import httpx
 
 from src.agent.attachments import enrich_message_with_attachments
 from src.agent.loop_detector import ToolLoopDetector
+from src.agent.tool_groups import (
+    GroupedPlan,
+    grouped_tools_enabled,
+    plan_grouped_tools,
+    resolve_load_request,
+)
 from src.agent.workspace import INTROSPECT_PERM_KEYS
 from src.shared import limits
 from src.shared.errors import LLMAuthError, LLMConfigError
@@ -320,6 +326,11 @@ class AgentLoop:
 
     MAX_ITERATIONS = 20
 
+    # Class-level default so ``_tool_filter_kw`` is safe even when ``__init__``
+    # is bypassed (e.g. ``AgentLoop.__new__`` in tests). None = grouped tool
+    # search inactive (the default); the instance value is set in ``__init__``.
+    _grouped_plan: "GroupedPlan | None" = None
+
     def __init__(
         self,
         agent_id: str,
@@ -452,6 +463,17 @@ class AgentLoop:
             self._disabled_gates.add("browser")
         self._runtime_disabled_tools: frozenset[str] = frozenset()
         self._recompute_runtime_disabled()
+        # ── Grouped Tool Search (B2, default-OFF via OPENLEGION_GROUPED_TOOLS) ──
+        # ``_loaded_tool_groups`` are groups whose full schemas are present in
+        # context. ``_pending_tool_groups`` are groups requested via
+        # ``load_tools`` this turn — promoted into ``_loaded_tool_groups`` at the
+        # NEXT system-prompt build (turn boundary) so the toolset never mutates
+        # mid-conversation (which would bust the prompt cache). The currently
+        # planned defer set is cached so ``_tool_filter_kw`` and the system
+        # prompt stay consistent within a single turn.
+        self._loaded_tool_groups: set[str] = set()
+        self._pending_tool_groups: set[str] = set()
+        self._grouped_plan: GroupedPlan | None = None
         self._tools_reloaded: bool = False
         self._is_operator: bool = allowed_tools is not None
         self._operator_playbook_state: dict[str, int] = {}  # playbook -> turns since trigger
@@ -508,7 +530,83 @@ class AgentLoop:
                 if runtime_disabled
                 else self._allowed_tools
             )
+        # Grouped Tool Search (B2): omit deferred tool schemas for this turn.
+        # The plan is recomputed at each system-prompt build (turn boundary) so
+        # the defer set here stays consistent with the capability index that was
+        # injected into the same turn's system prompt. ``defer`` folds into the
+        # ``get_tool_definitions`` memo cache key, so a different loaded-groups
+        # set yields different definitions (and a fresh cache entry).
+        plan = self._grouped_plan
+        if plan is not None and plan.active and plan.defer:
+            kw["defer"] = plan.defer
         return kw
+
+    # ── Grouped Tool Search (B2) ───────────────────────────────────────────
+    def _refresh_grouped_plan(self) -> str:
+        """Promote pending loads, recompute the grouped-tools plan, return index.
+
+        Called at each system-prompt build — the TURN BOUNDARY. This is where a
+        ``load_tools`` request made during the previous turn actually takes
+        effect (pending → loaded), so the toolset never changes mid-turn (which
+        would bust the prompt cache; mirrors hermes' "don't change toolsets
+        mid-conversation" invariant).
+
+        Returns the capability-index text to append to the system prompt (""
+        when the feature is off or the budget gate didn't trip).
+        """
+        if not grouped_tools_enabled():
+            self._grouped_plan = None
+            return ""
+        # Apply deferred loads requested last turn.
+        if self._pending_tool_groups:
+            self._loaded_tool_groups |= self._pending_tool_groups
+            self._pending_tool_groups.clear()
+        # Available = what this agent can actually call this turn, BEFORE the
+        # grouped defer (so the index reflects every callable capability).
+        base_kw = {
+            k: v for k, v in self._tool_filter_kw.items() if k != "defer"
+        }
+        available = set(self.tools.list_tools(**base_kw))
+        context_window = (
+            self.context_manager.max_tokens if self.context_manager else 0
+        )
+        self._grouped_plan = plan_grouped_tools(
+            available=available,
+            loaded_groups=self._loaded_tool_groups,
+            operator=(self._allowed_tools is not None),
+            context_window=context_window,
+        )
+        return self._grouped_plan.index_text if self._grouped_plan.active else ""
+
+    def request_load_tools(self, *, group: str | None, tool: str | None) -> dict:
+        """Bridge for the ``load_tools`` builtin — queue a group for next turn.
+
+        Does NOT mutate the loaded set immediately: the actual schema change is
+        deferred to the next system-prompt build (``_refresh_grouped_plan``) so
+        the toolset stays stable for the remainder of the current turn.
+        """
+        if not grouped_tools_enabled():
+            return {
+                "loaded": [],
+                "note": "Grouped tool search is disabled; all tools already loaded.",
+            }
+        base_kw = {
+            k: v for k, v in self._tool_filter_kw.items() if k != "defer"
+        }
+        available = set(self.tools.list_tools(**base_kw))
+        keys, error = resolve_load_request(
+            group=group, tool=tool, available=available,
+        )
+        if error:
+            return {"loaded": [], "error": error}
+        self._pending_tool_groups |= keys
+        return {
+            "loaded": sorted(keys),
+            "note": (
+                "Full schemas for these group(s) will be available on your "
+                "NEXT turn. Call the tool then."
+            ),
+        }
 
     def _recompute_runtime_disabled(self) -> None:
         """Rebuild ``_runtime_disabled_tools`` from the active gate set."""
@@ -1767,6 +1865,10 @@ class AgentLoop:
             if runtime_ctx:
                 parts.append(runtime_ctx)
 
+        index_text = self._refresh_grouped_plan()
+        if index_text:
+            parts.append(index_text)
+
         return "\n\n".join(parts)
 
     # Round-4 structural fix: hand_off failures are now enforced from
@@ -2060,6 +2162,10 @@ class AgentLoop:
                     )
                     if runtime_ctx:
                         parts.append(runtime_ctx)
+
+                index_text = self._refresh_grouped_plan()
+                if index_text:
+                    parts.append(index_text)
 
                 system_prompt = "\n\n".join(parts)
 
@@ -3110,6 +3216,7 @@ class AgentLoop:
                     workspace_manager=self.workspace,
                     memory_store=self.memory,
                     _messages=self._current_messages,
+                    agent_loop=self,
                 ),
                 timeout=_TOOL_TIMEOUT,
             )
@@ -4278,6 +4385,10 @@ class AgentLoop:
                 f"Context will be auto-refreshed in ~{remaining} rounds. "
                 f"Consider saving important context to memory if you haven't already."
             )
+
+        index_text = self._refresh_grouped_plan()
+        if index_text:
+            parts.append(index_text)
 
         return "\n\n".join(parts)
 

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -58,6 +58,8 @@ _CATEGORY_RECOMPUTE_INTERVAL = 10
 # distinct facts ("user_name" vs "user_email") are never collapsed — only genuine
 # near-synonym keys ("preferred_language" vs "user_language_preference") merge.
 # Similarity uses the same 1/(1+L2_distance) convention as search/categorization.
+# NOTE: the metric is 1/(1+L2), so 0.93 ≈ ~0.997 cosine for unit-normalized
+# vectors — tune with care; this value is wrong for unnormalized providers.
 _SEMANTIC_DEDUP_SIM_THRESHOLD = 0.93
 
 
@@ -312,36 +314,45 @@ class MemoryStore:
     def _store_fact_sync(
         self, key: str, value: str, category: str, source: str,
         confidence: float, embedding: list[float] | None,
-        merge_into: str | None = None,
+        semantic_dedup: bool = False,
     ) -> str:
         """Sync DB portion of store_fact. Returns the fact ID.
 
-        ``merge_into`` is a fact id resolved by semantic-similarity dedup; when set,
-        that existing row is updated in place (prefer-newer value, bump salience)
-        instead of matching purely on exact key.
+        Probe + conflict-check + write happen in ONE executor call / SQLite
+        transaction (no await gap) so a concurrent store can't mutate the target
+        between the dedup probe and the write.
+
+        ``semantic_dedup`` enables the in-transaction near-duplicate probe (only
+        meaningful when an ``embedding`` is available). The EXACT-key row always
+        wins: a semantic merge only fires when no row already holds ``key``, which
+        guarantees the merge can never rewrite one row's key onto another's and
+        create a duplicate-key orphan.
         """
-        existing = None
-        if merge_into is not None:
-            existing = self.db.execute(
-                "SELECT id, access_count FROM facts WHERE id = ?", (merge_into,),
-            ).fetchone()
-        if existing is None:
-            existing = self.db.execute(
-                "SELECT id, access_count FROM facts WHERE key = ?", (key,),
-            ).fetchone()
+        existing = self.db.execute(
+            "SELECT id, access_count FROM facts WHERE key = ?", (key,),
+        ).fetchone()
+        # Only consider a semantic merge for a genuinely-new key — otherwise the
+        # in-place UPDATE below would rewrite this row's key to equal an existing
+        # row's key, leaving two rows sharing a key (an unreachable orphan).
+        if existing is None and semantic_dedup and embedding is not None:
+            merge_id = self._find_semantic_duplicate(embedding, category)
+            if merge_id is not None:
+                existing = self.db.execute(
+                    "SELECT id, access_count FROM facts WHERE id = ?", (merge_id,),
+                ).fetchone()
 
         if existing:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
-            # Prefer the newer value AND adopt the newer key/category so the
-            # surviving row reflects the latest phrasing (a semantic merge may
-            # have matched a row stored under a different key).
+            # Prefer the newer value AND adopt the newer key/category/source so the
+            # surviving row reflects the latest phrasing + provenance (a semantic
+            # merge may have matched a row stored under a different key).
             self.db.execute(
-                "UPDATE facts SET key = ?, value = ?, category = ?, confidence = ?, "
-                "access_count = ?, last_accessed = datetime('now'), "
+                "UPDATE facts SET key = ?, value = ?, category = ?, source = ?, "
+                "confidence = ?, access_count = ?, last_accessed = datetime('now'), "
                 "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (key, value, category, confidence, new_count, boost, fact_id),
+                (key, value, category, source, confidence, new_count, boost, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
@@ -395,19 +406,15 @@ class MemoryStore:
             )
             embedding = None
 
-        # Semantic dedup (opt-in): if an existing fact is a near-duplicate of this
-        # one, update it in place instead of inserting a near-dup row. Resolved
-        # here (sync probe in executor) so the value reaches _store_fact_sync.
-        merge_into = None
-        if embedding is not None and _semantic_dedup_enabled():
-            merge_into = await self._run_db(
-                self._find_semantic_duplicate, embedding, category,
-            )
+        # Semantic dedup (opt-in): the near-duplicate probe runs INSIDE
+        # _store_fact_sync (same executor call / SQLite transaction as the write)
+        # so the probe + exact-key conflict check + write are atomic.
+        semantic_dedup = embedding is not None and _semantic_dedup_enabled()
 
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
             self._store_fact_sync, key, value, category, source, confidence,
-            embedding, merge_into,
+            embedding, semantic_dedup,
         )
 
         if embedding is not None:

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -334,26 +334,39 @@ class MemoryStore:
         # Only consider a semantic merge for a genuinely-new key — otherwise the
         # in-place UPDATE below would rewrite this row's key to equal an existing
         # row's key, leaving two rows sharing a key (an unreachable orphan).
+        merged = False
         if existing is None and semantic_dedup and embedding is not None:
             merge_id = self._find_semantic_duplicate(embedding, category)
             if merge_id is not None:
                 existing = self.db.execute(
                     "SELECT id, access_count FROM facts WHERE id = ?", (merge_id,),
                 ).fetchone()
+                merged = existing is not None
 
         if existing:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
-            # Prefer the newer value AND adopt the newer key/category/source so the
-            # surviving row reflects the latest phrasing + provenance (a semantic
-            # merge may have matched a row stored under a different key).
-            self.db.execute(
-                "UPDATE facts SET key = ?, value = ?, category = ?, source = ?, "
-                "confidence = ?, access_count = ?, last_accessed = datetime('now'), "
-                "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (key, value, category, source, confidence, new_count, boost, fact_id),
-            )
+            if merged:
+                # Semantic merge: adopt the newer key/category/source so the
+                # surviving row reflects the latest phrasing + provenance (the
+                # matched row may have been stored under a different key/category).
+                self.db.execute(
+                    "UPDATE facts SET key = ?, value = ?, category = ?, source = ?, "
+                    "confidence = ?, access_count = ?, last_accessed = datetime('now'), "
+                    "decay_score = MIN(?, 10.0) WHERE id = ?",
+                    (key, value, category, source, confidence, new_count, boost, fact_id),
+                )
+            else:
+                # Exact-key re-store: byte-identical to the pre-dedup write path
+                # (the flag-off path must match main) — update value/confidence/
+                # salience only; never overwrite the stored key/category/source.
+                self.db.execute(
+                    "UPDATE facts SET value = ?, confidence = ?, "
+                    "access_count = ?, last_accessed = datetime('now'), "
+                    "decay_score = MIN(?, 10.0) WHERE id = ?",
+                    (value, confidence, new_count, boost, fact_id),
+                )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
                 "INSERT INTO facts_fts (fact_id, key, value, category) VALUES (?, ?, ?, ?)",

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -172,7 +172,9 @@ class MemoryStore:
                 access_count INTEGER DEFAULT 0,
                 last_accessed TEXT,
                 created_at TEXT DEFAULT (datetime('now')),
-                decay_score REAL DEFAULT 1.0
+                decay_score REAL DEFAULT 1.0,
+                source_type TEXT DEFAULT 'conversation',
+                date TEXT DEFAULT (datetime('now'))
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS facts_vec USING vec0(
                 id TEXT PRIMARY KEY,
@@ -241,11 +243,24 @@ class MemoryStore:
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
         """)
-        # Lazy migration: add category_id FK to facts if not present
-        try:
-            self.db.execute("ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)")
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        # Lazy migrations: ADD COLUMN on pre-existing on-disk DBs so a redeploy
+        # against an older schema doesn't crash. Each is idempotent — a
+        # duplicate-column OperationalError on an already-migrated DB is a no-op.
+        for ddl in (
+            "ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)",
+            # Memory v2: dated + sourced facts (enables prefer-recent retrieval).
+            # NOTE: ADD COLUMN cannot carry a non-constant default on a
+            # non-empty table (SQLite "Cannot add a column with non-constant
+            # default"), so `date` is added WITHOUT a default here — pre-existing
+            # rows backfill to NULL (sort last under prefer-recent, acceptable),
+            # and `_store_fact_sync` stamps `date` explicitly on every write.
+            "ALTER TABLE facts ADD COLUMN source_type TEXT DEFAULT 'conversation'",
+            "ALTER TABLE facts ADD COLUMN date TEXT",
+        ):
+            try:
+                self.db.execute(ddl)
+            except sqlite3.OperationalError:
+                pass  # Column already exists
         self.db.commit()
         # Reconcile the dimension the vec0 tables were built at against the
         # configured dimension (rebuilds on an embedding-provider switch).
@@ -266,6 +281,7 @@ class MemoryStore:
     def _store_fact_sync(
         self, key: str, value: str, category: str, source: str,
         confidence: float, embedding: list[float] | None,
+        source_type: str = "conversation",
     ) -> str:
         """Sync DB portion of store_fact. Returns the fact ID."""
         existing = self.db.execute("SELECT id, access_count FROM facts WHERE key = ?", (key,)).fetchone()
@@ -274,11 +290,15 @@ class MemoryStore:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
+            # Re-stamp `date` so a re-asserted fact counts as recent for
+            # prefer-recent retrieval; keep the original source_type unless a
+            # caller overrides it.
             self.db.execute(
                 "UPDATE facts SET value = ?, confidence = ?, "
                 "access_count = ?, last_accessed = datetime('now'), "
-                "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (value, confidence, new_count, boost, fact_id),
+                "decay_score = MIN(?, 10.0), source_type = ?, "
+                "date = datetime('now') WHERE id = ?",
+                (value, confidence, new_count, boost, source_type, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
@@ -288,8 +308,10 @@ class MemoryStore:
         else:
             fact_id = generate_id("fact")
             self.db.execute(
-                "INSERT INTO facts (id, key, value, category, source, confidence) VALUES (?, ?, ?, ?, ?, ?)",
-                (fact_id, key, value, category, source, confidence),
+                "INSERT INTO facts "
+                "(id, key, value, category, source, confidence, source_type, date) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))",
+                (fact_id, key, value, category, source, confidence, source_type),
             )
             self.db.execute(
                 "INSERT INTO facts_fts (fact_id, key, value, category) VALUES (?, ?, ?, ?)",
@@ -309,8 +331,14 @@ class MemoryStore:
         category: str = "general",
         source: str = "agent",
         confidence: float = 1.0,
+        source_type: str = "conversation",
     ) -> str:
-        """Store or update a fact. Returns the fact ID."""
+        """Store or update a fact. Returns the fact ID.
+
+        ``source_type`` records WHERE the fact came from (e.g. "conversation",
+        "context_flush", "consolidation") and is paired with a ``date`` column
+        stamped at write time, enabling prefer-recent retrieval (memory v2).
+        """
         # Compute embedding BEFORE starting DB transaction to avoid
         # yielding control (await) with uncommitted writes.
         embedding = None
@@ -334,7 +362,8 @@ class MemoryStore:
 
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
-            self._store_fact_sync, key, value, category, source, confidence, embedding,
+            self._store_fact_sync, key, value, category, source, confidence,
+            embedding, source_type,
         )
 
         if embedding is not None:
@@ -445,7 +474,7 @@ class MemoryStore:
         row = self.db.execute(
             "SELECT f.id, f.key, f.value, f.category, f.source, f.confidence, "
             "f.access_count, f.last_accessed, f.created_at, f.decay_score, "
-            "c.name "
+            "f.source_type, f.date, c.name "
             "FROM facts f LEFT JOIN categories c ON f.category_id = c.id "
             "WHERE f.id = ?",
             (fact_id,),
@@ -453,7 +482,7 @@ class MemoryStore:
         if not row:
             return None
         # Use category name from categories table if assigned, else text field
-        category = row[10] if row[10] else row[3]
+        category = row[12] if row[12] else row[3]
         return MemoryFact(
             id=row[0],
             key=row[1],
@@ -465,6 +494,8 @@ class MemoryStore:
             last_accessed=row[7],
             created_at=row[8],
             decay_score=row[9],
+            source_type=row[10],
+            date=row[11],
         )
 
     def _get_facts_batch(self, fact_ids: list[str]) -> dict[str, MemoryFact]:
@@ -475,18 +506,19 @@ class MemoryStore:
         rows = self.db.execute(
             f"SELECT f.id, f.key, f.value, f.category, f.source, f.confidence, "
             f"f.access_count, f.last_accessed, f.created_at, f.decay_score, "
-            f"c.name "
+            f"f.source_type, f.date, c.name "
             f"FROM facts f LEFT JOIN categories c ON f.category_id = c.id "
             f"WHERE f.id IN ({placeholders})",
             fact_ids,
         ).fetchall()
         result = {}
         for row in rows:
-            category = row[10] if row[10] else row[3]
+            category = row[12] if row[12] else row[3]
             result[row[0]] = MemoryFact(
                 id=row[0], key=row[1], value=row[2], category=category,
                 source=row[4], confidence=row[5], access_count=row[6],
                 last_accessed=row[7], created_at=row[8], decay_score=row[9],
+                source_type=row[10], date=row[11],
             )
         return result
 
@@ -529,7 +561,13 @@ class MemoryStore:
         await self._run_db(self._decay_all_sync)
 
     def _get_high_salience_facts_sync(self, top_k: int) -> list[MemoryFact]:
-        rows = self.db.execute("SELECT id FROM facts ORDER BY decay_score DESC LIMIT ?", (top_k,)).fetchall()
+        # Prefer-recent (memory v2): salience is the primary signal; `date`
+        # breaks ties toward the newest fact so re-asserted/recent knowledge
+        # ranks above equally-salient stale rows.
+        rows = self.db.execute(
+            "SELECT id FROM facts ORDER BY decay_score DESC, date DESC LIMIT ?",
+            (top_k,),
+        ).fetchall()
         fact_ids = [r[0] for r in rows]
         facts_map = self._get_facts_batch(fact_ids)
         return [facts_map[fid] for fid in fact_ids if fid in facts_map]
@@ -552,7 +590,10 @@ class MemoryStore:
                 continue
             category = fact.get("category", "general")
             try:
-                await self.store_fact(key=key, value=value, category=category, source="context_flush")
+                await self.store_fact(
+                    key=key, value=value, category=category,
+                    source="context_flush", source_type="context_flush",
+                )
                 stored += 1
             except Exception as e:
                 logger.warning(f"Failed to store fact '{key}': {e}")

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -301,14 +301,16 @@ class MemoryStore:
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
             # Re-stamp `date` so a re-asserted fact counts as recent for
-            # prefer-recent retrieval; keep the original source_type unless a
-            # caller overrides it.
+            # prefer-recent retrieval. PRESERVE the original `source_type`
+            # (provenance): a re-store via the conversation loop must not
+            # overwrite a fact first recorded as e.g. "context_flush" with the
+            # caller's default. Only a fresh insert sets source_type.
             self.db.execute(
                 "UPDATE facts SET value = ?, confidence = ?, "
                 "access_count = ?, last_accessed = datetime('now'), "
-                "decay_score = MIN(?, 10.0), source_type = ?, "
+                "decay_score = MIN(?, 10.0), "
                 "date = datetime('now') WHERE id = ?",
-                (value, confidence, new_count, boost, source_type, fact_id),
+                (value, confidence, new_count, boost, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -17,6 +17,7 @@ import functools
 import hashlib
 import json
 import math
+import os
 import re
 import sqlite3
 import struct
@@ -51,6 +52,21 @@ _TASK_CHECKPOINT_VERSION = 1
 _CATEGORY_SIM_THRESHOLD = 0.7
 # Recompute category embedding every N new members
 _CATEGORY_RECOMPUTE_INTERVAL = 10
+# Semantic dedup: when storing a fact, an existing fact whose embedding is at or
+# above this similarity (and category-compatible) is treated as the SAME fact and
+# updated in place instead of inserting a near-duplicate row. Deliberately high so
+# distinct facts ("user_name" vs "user_email") are never collapsed — only genuine
+# near-synonym keys ("preferred_language" vs "user_language_preference") merge.
+# Similarity uses the same 1/(1+L2_distance) convention as search/categorization.
+_SEMANTIC_DEDUP_SIM_THRESHOLD = 0.93
+
+
+def _semantic_dedup_enabled() -> bool:
+    """Vector-similarity dedup on the write path is opt-in (embedding path is not
+    always available; ships safe behind a flag, default off)."""
+    return os.environ.get("OPENLEGION_SEMANTIC_DEDUP", "").lower() in (
+        "1", "true", "yes", "on",
+    )
 
 _T = TypeVar("_T")
 
@@ -263,22 +279,69 @@ class MemoryStore:
         recency_factor = max(0.1, 1.0 - days_since_last_access * 0.05)
         return 1.0 + math.log(1 + access_count) * recency_factor
 
+    def _find_semantic_duplicate(
+        self, embedding: list[float], category: str,
+    ) -> str | None:
+        """Return the id of an existing fact that is a near-duplicate of the one
+        being stored (cosine-equivalent similarity at/above the dedup threshold and
+        category-compatible), or None. Conservative by design — only collapses
+        genuine near-synonyms. Used on the write path when the flag is enabled.
+        """
+        blob = serialize_float32(embedding)
+        rows = self.db.execute(
+            "SELECT id, distance FROM facts_vec WHERE embedding MATCH ? "
+            "ORDER BY distance LIMIT ?",
+            (blob, 5),
+        ).fetchall()
+        for fact_id, distance in rows:
+            similarity = 1.0 / (1.0 + distance)
+            if similarity < _SEMANTIC_DEDUP_SIM_THRESHOLD:
+                break  # rows are distance-ordered; first miss ends the scan
+            row = self.db.execute(
+                "SELECT category FROM facts WHERE id = ?", (fact_id,),
+            ).fetchone()
+            if row is None:
+                continue
+            existing_category = row[0] or "general"
+            # Category-compatible = identical, or one side is the catch-all
+            # "general" (so an uncategorized near-dup still merges).
+            if existing_category == category or "general" in (existing_category, category):
+                return fact_id
+        return None
+
     def _store_fact_sync(
         self, key: str, value: str, category: str, source: str,
         confidence: float, embedding: list[float] | None,
+        merge_into: str | None = None,
     ) -> str:
-        """Sync DB portion of store_fact. Returns the fact ID."""
-        existing = self.db.execute("SELECT id, access_count FROM facts WHERE key = ?", (key,)).fetchone()
+        """Sync DB portion of store_fact. Returns the fact ID.
+
+        ``merge_into`` is a fact id resolved by semantic-similarity dedup; when set,
+        that existing row is updated in place (prefer-newer value, bump salience)
+        instead of matching purely on exact key.
+        """
+        existing = None
+        if merge_into is not None:
+            existing = self.db.execute(
+                "SELECT id, access_count FROM facts WHERE id = ?", (merge_into,),
+            ).fetchone()
+        if existing is None:
+            existing = self.db.execute(
+                "SELECT id, access_count FROM facts WHERE key = ?", (key,),
+            ).fetchone()
 
         if existing:
             fact_id = existing[0]
             new_count = existing[1] + 1
             boost = self._compute_boost(new_count)
+            # Prefer the newer value AND adopt the newer key/category so the
+            # surviving row reflects the latest phrasing (a semantic merge may
+            # have matched a row stored under a different key).
             self.db.execute(
-                "UPDATE facts SET value = ?, confidence = ?, "
+                "UPDATE facts SET key = ?, value = ?, category = ?, confidence = ?, "
                 "access_count = ?, last_accessed = datetime('now'), "
                 "decay_score = MIN(?, 10.0) WHERE id = ?",
-                (value, confidence, new_count, boost, fact_id),
+                (key, value, category, confidence, new_count, boost, fact_id),
             )
             self.db.execute("DELETE FROM facts_fts WHERE fact_id = ?", (fact_id,))
             self.db.execute(
@@ -332,9 +395,19 @@ class MemoryStore:
             )
             embedding = None
 
+        # Semantic dedup (opt-in): if an existing fact is a near-duplicate of this
+        # one, update it in place instead of inserting a near-dup row. Resolved
+        # here (sync probe in executor) so the value reaches _store_fact_sync.
+        merge_into = None
+        if embedding is not None and _semantic_dedup_enabled():
+            merge_into = await self._run_db(
+                self._find_semantic_duplicate, embedding, category,
+            )
+
         # Run all DB writes in executor to avoid blocking the event loop
         fact_id = await self._run_db(
-            self._store_fact_sync, key, value, category, source, confidence, embedding,
+            self._store_fact_sync, key, value, category, source, confidence,
+            embedding, merge_into,
         )
 
         if embedding is not None:

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -18,7 +18,6 @@ import hashlib
 import json
 import math
 import re
-import sqlite3
 import struct
 import threading
 from collections.abc import Callable, Coroutine
@@ -244,23 +243,34 @@ class MemoryStore:
             );
         """)
         # Lazy migrations: ADD COLUMN on pre-existing on-disk DBs so a redeploy
-        # against an older schema doesn't crash. Each is idempotent — a
-        # duplicate-column OperationalError on an already-migrated DB is a no-op.
-        for ddl in (
-            "ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)",
+        # against an older schema doesn't crash. Each is idempotent — we only run
+        # the ALTER when the column is genuinely absent (checked via
+        # PRAGMA table_info), so a real OperationalError (locked db, disk error,
+        # constraint failure) propagates instead of being silently swallowed.
+        existing_cols = {
+            row[1] for row in self.db.execute("PRAGMA table_info(facts)")
+        }
+        # (column_name, ALTER statement)
+        migrations = (
+            (
+                "category_id",
+                "ALTER TABLE facts ADD COLUMN category_id INTEGER REFERENCES categories(id)",
+            ),
             # Memory v2: dated + sourced facts (enables prefer-recent retrieval).
+            (
+                "source_type",
+                "ALTER TABLE facts ADD COLUMN source_type TEXT DEFAULT 'conversation'",
+            ),
             # NOTE: ADD COLUMN cannot carry a non-constant default on a
             # non-empty table (SQLite "Cannot add a column with non-constant
             # default"), so `date` is added WITHOUT a default here — pre-existing
             # rows backfill to NULL (sort last under prefer-recent, acceptable),
             # and `_store_fact_sync` stamps `date` explicitly on every write.
-            "ALTER TABLE facts ADD COLUMN source_type TEXT DEFAULT 'conversation'",
-            "ALTER TABLE facts ADD COLUMN date TEXT",
-        ):
-            try:
+            ("date", "ALTER TABLE facts ADD COLUMN date TEXT"),
+        )
+        for column, ddl in migrations:
+            if column not in existing_cols:
                 self.db.execute(ddl)
-            except sqlite3.OperationalError:
-                pass  # Column already exists
         self.db.commit()
         # Reconcile the dimension the vec0 tables were built at against the
         # configured dimension (rebuilds on an embedding-provider switch).

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -144,6 +144,14 @@ _MAX_HISTORY_MEMORY_CHARS = 5000
 _MAX_HISTORY_LOGS_CHARS = 16000
 _MAX_HISTORY_LEARNINGS_CHARS = 8000
 
+# Background memory-maintenance pass cadence. The first run is delayed so boot
+# and the first user turn settle; thereafter it ticks periodically. The actual
+# work (consolidation + decay) is internally 6h-gated, so the short delay also
+# gives a frequently-restarted agent (e.g. the operator) a maintenance attempt
+# soon after each boot rather than never reaching a long interval.
+_MAINTENANCE_INITIAL_DELAY_S = 180
+_MAINTENANCE_TICK_S = 30 * 60
+
 
 def _origin_from_mesh_request(request: Request):
     """Parse origin from a host-to-agent request.
@@ -171,7 +179,35 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if os.environ.get("OPENLEGION_ENABLE_DOCS", "").lower() in ("1", "true", "yes", "on")
         else {"docs_url": None, "redoc_url": None, "openapi_url": None}
     )
-    app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}", **_docs_kwargs)
+    @contextlib.asynccontextmanager
+    async def _lifespan(_app: FastAPI):
+        """Run a periodic background memory-maintenance pass for this agent's
+        lifetime (consolidation + salience decay, off the live turn)."""
+        async def _maintenance_loop() -> None:
+            delay = _MAINTENANCE_INITIAL_DELAY_S
+            while True:
+                await asyncio.sleep(delay)
+                delay = _MAINTENANCE_TICK_S
+                try:
+                    await loop.run_maintenance()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning("maintenance pass failed: %s", e)
+
+        task = asyncio.create_task(_maintenance_loop())
+        try:
+            yield
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app = FastAPI(
+        title=f"OpenLegion Agent: {loop.agent_id}",
+        lifespan=_lifespan,
+        **_docs_kwargs,
+    )
     _install_body_size_limit(app)
     _task_accept_lock = asyncio.Lock()
 

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -299,6 +299,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
                 mesh_client=loop.mesh_client,
                 workspace_manager=loop.workspace,
                 memory_store=loop.memory,
+                agent_loop=loop,
             )
             return {"result": result}
         except ValueError as e:

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -179,35 +179,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if os.environ.get("OPENLEGION_ENABLE_DOCS", "").lower() in ("1", "true", "yes", "on")
         else {"docs_url": None, "redoc_url": None, "openapi_url": None}
     )
-    @contextlib.asynccontextmanager
-    async def _lifespan(_app: FastAPI):
-        """Run a periodic background memory-maintenance pass for this agent's
-        lifetime (consolidation + salience decay, off the live turn)."""
-        async def _maintenance_loop() -> None:
-            delay = _MAINTENANCE_INITIAL_DELAY_S
-            while True:
-                await asyncio.sleep(delay)
-                delay = _MAINTENANCE_TICK_S
-                try:
-                    await loop.run_maintenance()
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.warning("maintenance pass failed: %s", e)
-
-        task = asyncio.create_task(_maintenance_loop())
-        try:
-            yield
-        finally:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-
-    app = FastAPI(
-        title=f"OpenLegion Agent: {loop.agent_id}",
-        lifespan=_lifespan,
-        **_docs_kwargs,
-    )
+    app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}", **_docs_kwargs)
     _install_body_size_limit(app)
     _task_accept_lock = asyncio.Lock()
 
@@ -1089,3 +1061,23 @@ def _log_task_exception(task: asyncio.Task) -> None:
     exc = task.exception()
     if exc:
         logger.error(f"Background task failed: {exc}", exc_info=exc)
+
+
+async def run_maintenance_loop(loop: AgentLoop) -> None:
+    """Periodic background memory-maintenance pass for an agent's lifetime.
+
+    Launched from the agent process lifespan (``__main__``). The first run is
+    delayed so boot + the first user turn settle; thereafter it ticks
+    periodically. ``loop.run_maintenance`` is internally idle-guarded and
+    6h-gated, so a frequent tick is cheap and never races a live turn.
+    """
+    delay = _MAINTENANCE_INITIAL_DELAY_S
+    while True:
+        await asyncio.sleep(delay)
+        delay = _MAINTENANCE_TICK_S
+        try:
+            await loop.run_maintenance()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("maintenance pass failed: %s", e)

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -1,0 +1,309 @@
+"""Grouped Tool Search — capability index + lazy schema loading (Phase 2 / B2).
+
+Goal: keep the per-turn tool-schema load lean WITHOUT the agent ever losing
+awareness of a capability ("it knows exactly what to do"). Three layers:
+
+1. **Always-loaded core** — the daily-driver tools, full schemas, unchanged.
+2. **Always-loaded capability INDEX** — names + one-line intent, grouped by
+   job-to-be-done (~300-500 tokens, NO full schemas). A tool's *capability*
+   is never hidden; only its verbose schema is lazy.
+3. **On-demand schema loading** — the ``load_tools(group | tool_name)`` bridge
+   pulls full schemas into context for SUBSEQUENT turns.
+
+This is **budget-gated**: the index + deferral only activate when an agent's
+deferrable schemas exceed a fraction of the context window. Small-toolset
+agents present everything unchanged (no behaviour change). The whole feature
+is **default-OFF** behind ``OPENLEGION_GROUPED_TOOLS`` — see
+``grouped_tools_enabled()``.
+
+Groups are defined here as DATA (a registry mapping group → tool names +
+one-line intent + role-eligibility). Applies to BOTH operator and worker
+scope; a worker simply never sees an operator-only group's tools in its
+allowed/exclude surface, so the index naturally renders only what it can call.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+# Env flag — the entire grouped-tool path is dormant unless this is set.
+GROUPED_TOOLS_ENV = "OPENLEGION_GROUPED_TOOLS"
+
+# Budget gate: only activate index+defer when the deferrable tools' estimated
+# schema cost exceeds this fraction of the model's context window. Mirrors
+# hermes-agent's "~10% of the window" Tool Search activation threshold.
+BUDGET_FRACTION = 0.10
+
+# Rough token estimate per deferred tool schema. Tool schemas vary, but a
+# typical builtin definition (name + description + a few params) lands around
+# 120-180 tokens; we use a conservative midpoint so the gate trips on genuinely
+# large surfaces, not marginal ones. Only used for the gate, never for billing.
+SCHEMA_TOKENS_PER_TOOL = 150
+
+
+def grouped_tools_enabled() -> bool:
+    """True iff the grouped-tool-search path is opted in via env flag.
+
+    Default OFF — the feature ships dormant. When false, every code path in
+    this module no-ops and the agent presents its full tool surface unchanged.
+    """
+    return os.environ.get(GROUPED_TOOLS_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+@dataclass(frozen=True)
+class ToolGroup:
+    """A job-to-be-done grouping of tools for the capability index.
+
+    *intent* is the one-line "when would I reach for this" string shown in the
+    index. *tools* are the tool names whose full schemas are deferred until
+    ``load_tools`` pulls the group in. *operator_only* mirrors the registry's
+    operator-only marking so the index never advertises a group a worker can't
+    use (defensive — the allowed/exclude surface already filters the names).
+    """
+
+    key: str
+    label: str
+    intent: str
+    tools: tuple[str, ...]
+    operator_only: bool = False
+
+
+# ── Group registry (DATA) ──────────────────────────────────────────────────
+# Intent-named (job-to-be-done), NOT module-named. Order here is the order the
+# index renders. Tool names that don't exist in a given agent's surface are
+# simply skipped at render/defer time, so this list can stay a superset.
+TOOL_GROUPS: tuple[ToolGroup, ...] = (
+    ToolGroup(
+        key="fleet_setup",
+        label="Fleet setup",
+        intent="build or restructure a team (create agents/teams, apply templates)",
+        tools=(
+            "create_agent", "create_team", "apply_template", "list_templates",
+            "add_agents_to_team", "remove_agents_from_team", "manage_team",
+            "manage_agent", "edit_agent", "read_agent_config",
+            "update_team_context",
+        ),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="scheduling",
+        label="Scheduling",
+        intent="recurring or timed work (cron jobs)",
+        tools=("set_cron", "list_cron", "remove_cron"),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="credentials",
+        label="Credentials & access",
+        intent="an agent needs to reach a service (vault, credential/login requests)",
+        tools=(
+            "vault_list", "request_credential", "request_browser_login",
+        ),
+    ),
+    ToolGroup(
+        key="goals_review",
+        label="Goals & review",
+        intent="set or review team goals and rate deliveries",
+        tools=(
+            "set_team_goal", "manage_goals", "rate_delivery",
+        ),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="audit_undo",
+        label="Audit & undo",
+        intent="inspect pending actions, undo a change, or trim the audit log",
+        tools=(
+            "list_pending", "cancel_pending_action", "archive_audit_before",
+            "undo_change",
+        ),
+        operator_only=True,
+    ),
+    ToolGroup(
+        key="web_browse",
+        label="Web & browse",
+        intent="research or interact with websites (browser automation)",
+        tools=(
+            "browser_navigate", "browser_warmup", "browser_get_elements",
+            "browser_wait_for", "browser_screenshot", "browser_click",
+            "browser_click_xy", "browser_type", "browser_hover",
+            "browser_scroll", "browser_reset", "browser_press_key",
+            "browser_go_back", "browser_go_forward", "browser_switch_tab",
+            "browser_find_text", "browser_fill_form", "browser_open_tab",
+            "browser_inspect_requests", "browser_detect_captcha",
+            "browser_upload_file", "browser_solve_captcha", "browser_download",
+        ),
+    ),
+)
+
+# Index of group-by-key for O(1) lookup.
+_GROUPS_BY_KEY: dict[str, ToolGroup] = {g.key: g for g in TOOL_GROUPS}
+
+# Every tool name that belongs to *some* group — the deferrable universe.
+_GROUPED_TOOL_NAMES: frozenset[str] = frozenset(
+    name for g in TOOL_GROUPS for name in g.tools
+)
+
+
+def is_grouped_tool(name: str) -> bool:
+    """True iff *name* belongs to a deferrable group (vs. always-loaded core)."""
+    return name in _GROUPED_TOOL_NAMES
+
+
+def groups_for_tool(name: str) -> list[str]:
+    """Return the group keys a tool name belongs to (usually 0 or 1)."""
+    return [g.key for g in TOOL_GROUPS if name in g.tools]
+
+
+@dataclass
+class GroupedPlan:
+    """The resolved grouped-tools plan for one turn.
+
+    *active* — whether the budget gate tripped (index+defer in effect). When
+    false, the agent presents its full surface unchanged.
+    *defer* — tool names whose full schemas to omit this turn (deferred groups
+    minus anything already loaded).
+    *index_text* — the always-present capability index string (or "" when
+    inactive).
+    """
+
+    active: bool = False
+    defer: frozenset[str] = field(default_factory=frozenset)
+    index_text: str = ""
+
+
+def _available_for_role(
+    available: set[str], *, operator: bool,
+) -> list[ToolGroup]:
+    """Groups that have at least one tool in *available* and are role-eligible.
+
+    A non-operator agent never sees operator-only groups (their tools won't be
+    in *available* anyway, but we also skip the group entirely so the index
+    doesn't advertise an empty group).
+    """
+    out: list[ToolGroup] = []
+    for g in TOOL_GROUPS:
+        if g.operator_only and not operator:
+            continue
+        if any(t in available for t in g.tools):
+            out.append(g)
+    return out
+
+
+def _render_index(
+    groups: list[ToolGroup],
+    available: set[str],
+    loaded_groups: set[str],
+) -> str:
+    """Render the always-present capability index (names + intent, no schemas).
+
+    Loaded groups are marked so the model knows their full schemas are already
+    in context (no need to ``load_tools`` them again).
+    """
+    lines = [
+        "## Capability Index",
+        (
+            "These tools are available but their full schemas are loaded "
+            "on demand to keep context lean. The capability is never hidden — "
+            "only its detailed parameters are lazy. Call "
+            "`load_tools(group=\"<group>\")` (or `load_tools(tool=\"<name>\")`) "
+            "to pull a group's full schemas into context for your NEXT turn, "
+            "then call the tool normally."
+        ),
+        "",
+    ]
+    for g in groups:
+        names = [t for t in g.tools if t in available]
+        if not names:
+            continue
+        loaded_mark = " (loaded)" if g.key in loaded_groups else ""
+        lines.append(
+            f"- **{g.label}** [`{g.key}`]{loaded_mark} — {g.intent}: "
+            + ", ".join(names)
+        )
+    return "\n".join(lines)
+
+
+def plan_grouped_tools(
+    *,
+    available: set[str],
+    loaded_groups: set[str],
+    operator: bool,
+    context_window: int,
+) -> GroupedPlan:
+    """Compute the grouped-tools plan for one turn (pure, deterministic).
+
+    Budget gate: only activate when the deferrable schemas' estimated cost
+    exceeds ``BUDGET_FRACTION`` of *context_window*. Below that, return an
+    inactive plan (full surface, no index) so small-toolset agents are
+    unchanged.
+
+    *available* — the tool names this agent can actually call this turn (after
+    allowed/exclude filtering). *loaded_groups* — groups the agent has already
+    pulled in via ``load_tools`` (their schemas stay present). *operator* —
+    role eligibility for operator-only groups.
+    """
+    if not grouped_tools_enabled():
+        return GroupedPlan(active=False)
+
+    groups = _available_for_role(available, operator=operator)
+    # Deferrable universe = grouped tools present in this agent's surface.
+    deferrable = {t for g in groups for t in g.tools if t in available}
+    if not deferrable:
+        return GroupedPlan(active=False)
+
+    # Budget gate — only kick in for genuinely large surfaces.
+    est_tokens = len(deferrable) * SCHEMA_TOKENS_PER_TOOL
+    if context_window <= 0 or est_tokens < context_window * BUDGET_FRACTION:
+        return GroupedPlan(active=False)
+
+    # Tools whose schemas stay loaded: any group the agent has pulled in.
+    loaded_tool_names = {
+        t
+        for key in loaded_groups
+        for t in (_GROUPS_BY_KEY[key].tools if key in _GROUPS_BY_KEY else ())
+    }
+    defer = frozenset(deferrable - loaded_tool_names)
+    index_text = _render_index(groups, available, loaded_groups)
+    return GroupedPlan(active=True, defer=defer, index_text=index_text)
+
+
+def resolve_load_request(
+    *, group: str | None, tool: str | None, available: set[str],
+) -> tuple[set[str], str | None]:
+    """Resolve a ``load_tools`` request to a set of group keys to load.
+
+    Accepts either a group key/label or a single tool name (resolved to its
+    group). Returns ``(group_keys, error)`` — *error* is a human string when
+    the request matched nothing, else None.
+    """
+    keys: set[str] = set()
+    if group:
+        g = group.strip().lower()
+        match = _GROUPS_BY_KEY.get(g)
+        if match is None:
+            # Allow matching by human label too.
+            for grp in TOOL_GROUPS:
+                if grp.label.lower() == g:
+                    match = grp
+                    break
+        if match is None:
+            valid = ", ".join(grp.key for grp in TOOL_GROUPS)
+            return set(), f"Unknown tool group '{group}'. Valid groups: {valid}"
+        keys.add(match.key)
+    if tool:
+        t = tool.strip()
+        owning = groups_for_tool(t)
+        if not owning:
+            if t in available:
+                return set(), (
+                    f"Tool '{t}' is already in your core surface — call it directly."
+                )
+            return set(), f"Tool '{t}' is not a known grouped tool."
+        keys.update(owning)
+    if not keys:
+        return set(), "Specify a 'group' or a 'tool' to load."
+    return keys, None

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -12,9 +12,8 @@ awareness of a capability ("it knows exactly what to do"). Three layers:
 
 This is **budget-gated**: the index + deferral only activate when an agent's
 deferrable schemas exceed a fraction of the context window. Small-toolset
-agents present everything unchanged (no behaviour change). The whole feature
-is **default-OFF** behind ``OPENLEGION_GROUPED_TOOLS`` — see
-``grouped_tools_enabled()``.
+agents present everything unchanged (no behaviour change) — the budget gate is
+the sole activation control.
 
 Groups are defined here as DATA (a registry mapping group → tool names +
 one-line intent + role-eligibility). Applies to BOTH operator and worker
@@ -24,11 +23,7 @@ allowed/exclude surface, so the index naturally renders only what it can call.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
-
-# Env flag — the entire grouped-tool path is dormant unless this is set.
-GROUPED_TOOLS_ENV = "OPENLEGION_GROUPED_TOOLS"
 
 # Budget gate: only activate index+defer when the deferrable tools' estimated
 # schema cost exceeds this fraction of the model's context window. Mirrors
@@ -40,17 +35,6 @@ BUDGET_FRACTION = 0.10
 # 120-180 tokens; we use a conservative midpoint so the gate trips on genuinely
 # large surfaces, not marginal ones. Only used for the gate, never for billing.
 SCHEMA_TOKENS_PER_TOOL = 150
-
-
-def grouped_tools_enabled() -> bool:
-    """True iff the grouped-tool-search path is opted in via env flag.
-
-    Default OFF — the feature ships dormant. When false, every code path in
-    this module no-ops and the agent presents its full tool surface unchanged.
-    """
-    return os.environ.get(GROUPED_TOOLS_ENV, "").strip().lower() in (
-        "1", "true", "yes", "on",
-    )
 
 
 @dataclass(frozen=True)
@@ -246,9 +230,6 @@ def plan_grouped_tools(
     pulled in via ``load_tools`` (their schemas stay present). *operator* —
     role eligibility for operator-only groups.
     """
-    if not grouped_tools_enabled():
-        return GroupedPlan(active=False)
-
     groups = _available_for_role(available, operator=operator)
     # Deferrable universe = grouped tools present in this agent's surface.
     deferrable = {t for g in groups for t in g.tools if t in available}

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -237,6 +237,7 @@ class ToolRegistry:
         workspace_manager: Any = None,
         memory_store: Any = None,
         _messages: list[dict] | None = None,
+        agent_loop: Any = None,
     ) -> Any:
         """Execute a tool by name with given arguments."""
         if self._mcp_client and self._mcp_client.has_tool(name):
@@ -310,6 +311,8 @@ class ToolRegistry:
             call_args["memory_store"] = memory_store
         if "_messages" in sig_params:
             call_args["_messages"] = _messages
+        if "agent_loop" in sig_params:
+            call_args["agent_loop"] = agent_loop
 
         # Filter out LLM-hallucinated parameters that the function doesn't
         # accept.  Without this, an LLM sending e.g. {"raw": ""} to a
@@ -346,7 +349,7 @@ class ToolRegistry:
                 req_parts = []
                 opt_parts = []
                 for k, v in param_schemas.items():
-                    if k in {"mesh_client", "workspace_manager", "memory_store", "_messages"}:
+                    if k in {"mesh_client", "workspace_manager", "memory_store", "_messages", "agent_loop"}:
                         continue
                     ptype = v.get("type", "any")
                     desc = v.get("description", "")
@@ -432,8 +435,15 @@ class ToolRegistry:
         self,
         exclude: frozenset[str] | None = None,
         allowed: frozenset[str] | None = None,
+        defer: frozenset[str] | None = None,
     ) -> list[str]:
-        """Return list of available tool names."""
+        """Return list of available tool names.
+
+        *defer* (Grouped Tool Search) is accepted for call-site symmetry with
+        ``get_tool_definitions`` but intentionally ignored: a deferred tool is
+        still *callable* (only its schema is lazy), so it must remain in the
+        capability/status listing.
+        """
         if allowed is not None:
             return [n for n in self.tools if n in allowed]
         if exclude:
@@ -478,12 +488,20 @@ class ToolRegistry:
         self,
         exclude: frozenset[str] | None = None,
         allowed: frozenset[str] | None = None,
+        defer: frozenset[str] | None = None,
     ) -> list[dict]:
-        """Return OpenAI-compatible tool definitions for LLM function calling (memoized)."""
+        """Return OpenAI-compatible tool definitions for LLM function calling (memoized).
+
+        *defer* — Grouped Tool Search (B2): tool names whose full schemas to
+        OMIT from this build (their capability is still advertised cheaply via
+        the always-present capability index in the system prompt; the schema is
+        pulled in later via ``load_tools``). Folded into the memo cache key so a
+        different loaded-groups set yields different definitions.
+        """
         if self._tool_defs_cache is None:
             self._tool_defs_cache = {}
         cache = self._tool_defs_cache
-        cache_key = (exclude, allowed)
+        cache_key = (exclude, allowed, defer)
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -494,6 +512,8 @@ class ToolRegistry:
                 if name not in allowed:
                     continue
             elif exclude and name in exclude:
+                continue
+            if defer and name in defer:
                 continue
             params = info["parameters"]
 

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -39,6 +39,15 @@ _NON_TOOL_DIRS = frozenset({
 _tool_staging: dict[str, dict] = {}
 _tool_staging_lock = threading.Lock()
 
+# Trust-boundary allowlist for the ``agent_loop`` injection. The AgentLoop is
+# the whole sandboxed-agent runtime; handing it to a tool gives that tool full
+# control over the loop. Only these TRUSTED builtin bridge tools receive it —
+# gated by tool NAME, never by signature inspection alone. Custom / marketplace
+# / self-authored tools load into the SAME registry and could otherwise declare
+# an ``agent_loop`` param to capture the loop, breaking the sandbox model (tools
+# get only mesh_client / workspace_manager / memory_store). See CLAUDE.md.
+_AGENT_LOOP_TOOLS = frozenset({"load_tools"})
+
 
 def _normalize_params_dict(params: object) -> dict:
     """Normalize tool parameters to the canonical dict shape.
@@ -311,7 +320,11 @@ class ToolRegistry:
             call_args["memory_store"] = memory_store
         if "_messages" in sig_params:
             call_args["_messages"] = _messages
-        if "agent_loop" in sig_params:
+        # Trust-boundary gate: inject the AgentLoop ONLY into trusted builtin
+        # bridge tools (gated by NAME), never by signature alone. A custom or
+        # self-authored tool declaring an ``agent_loop`` param must NOT capture
+        # the loop. See ``_AGENT_LOOP_TOOLS``.
+        if name in _AGENT_LOOP_TOOLS and "agent_loop" in sig_params:
             call_args["agent_loop"] = agent_loop
 
         # Filter out LLM-hallucinated parameters that the function doesn't
@@ -501,7 +514,11 @@ class ToolRegistry:
         if self._tool_defs_cache is None:
             self._tool_defs_cache = {}
         cache = self._tool_defs_cache
-        cache_key = (exclude, allowed, defer)
+        # Flag-off parity: when no defer set is in play (Grouped Tool Search off),
+        # emit the LEGACY 2-tuple key so cache behaviour is byte-identical to main
+        # (no cold-miss against pre-existing entries). Only widen to the 3-tuple
+        # when a defer set is actually present.
+        cache_key = (exclude, allowed) if defer is None else (exclude, allowed, defer)
         cached = cache.get(cache_key)
         if cached is not None:
             return cached

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import json
 import math
+import os
 import re
 import time
 from datetime import datetime, timedelta, timezone
@@ -104,6 +105,18 @@ MEMORY_COMPILED_END = "<!-- compiled:end -->"
 _MEMORY_FILE_MAX = 64_000
 # Newest slice of the log injected alongside the compiled head.
 _MEMORY_RECENT_LOG_CHARS = 5_000
+
+
+def _inject_head_only() -> bool:
+    """Flag-gated (memory v2): when enabled, ``get_memory_injection`` injects
+    ONLY the compiled head and drops the ``## Recent`` log slice, per gbrain's
+    "inject only the head". Older log entries remain searchable via
+    memory_search. Read per-call so it can be toggled without a process
+    restart. Default OFF — it changes what is injected every turn.
+    """
+    return os.environ.get("OPENLEGION_INJECT_HEAD_ONLY", "").lower() in (
+        "1", "true", "yes", "on",
+    )
 
 # Public mapping for external consumers (tool response, dashboard).
 # Files not listed have no per-file bootstrap cap.
@@ -491,10 +504,16 @@ class WorkspaceManager:
         folds them into the head. Older log entries are recalled via
         memory_search. The head is capped so head + recent fits the per-file
         bootstrap cap.
+
+        When ``OPENLEGION_INJECT_HEAD_ONLY`` is set, the ``## Recent`` log slice
+        is dropped and ONLY the compiled head is injected (gbrain "inject only
+        the head"); the log stays on disk and searchable via memory_search.
         """
         raw = self._read_file(self.MEMORY_FILE) or ""
         head, log = self._split_memory(raw)
         head, log = head.strip(), log.strip()
+        if _inject_head_only():
+            return head
         recent = ""
         if log:
             recent = log[-_MEMORY_RECENT_LOG_CHARS:]

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -252,6 +252,7 @@ class WorkspaceManager:
 
     MEMORY_FILE = "MEMORY.md"
     _CONSOLIDATION_STAMP = ".memory_consolidated"
+    _DECAY_STAMP = ".memory_decayed"
     HEARTBEAT_FILE = "HEARTBEAT.md"
     DAILY_DIR = "memory"
     LEARNINGS_DIR = "learnings"
@@ -686,6 +687,28 @@ class WorkspaceManager:
             (self.root / self._CONSOLIDATION_STAMP).touch()
         except OSError as e:
             logger.debug("Failed to stamp consolidation: %s", e)
+
+    def decay_due(self, min_interval_s: float) -> bool:
+        """True when fact salience hasn't been decayed within the window.
+
+        Shared by the task path (stamps on every fresh-task decay) and the
+        background maintenance pass, so an idle agent still decays and a busy
+        one is never double-decayed.
+        """
+        p = self.root / self._DECAY_STAMP
+        try:
+            if p.exists():
+                return (time.time() - p.stat().st_mtime) >= min_interval_s
+        except OSError:
+            pass
+        return True  # never decayed → due
+
+    def mark_decayed(self) -> None:
+        """Stamp the last salience-decay time (touch the sentinel)."""
+        try:
+            (self.root / self._DECAY_STAMP).touch()
+        except OSError as e:
+            logger.debug("Failed to stamp decay: %s", e)
 
     # Files agents are allowed to update themselves
     AGENT_WRITABLE = frozenset({"HEARTBEAT.md", "USER.md", "SOUL.md", "INSTRUCTIONS.md", "INTERFACE.md"})

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -282,7 +282,12 @@ class WorkspaceManager:
         # cache-prefix-stabilization path (MEMORY.md injected WITHOUT the
         # volatile ``## Recent`` slice so the system prefix stays stable).
         self._bootstrap_cache_stable: str | None = None
+        # Each cache slot owns its OWN mtime snapshot. They must NOT be shared:
+        # the lazy mtime-triggered rebuild path only rebuilds the requested
+        # variant, so a shared snapshot would mark the OTHER slot fresh and
+        # serve stale content for the rest of the process lifetime.
         self._bootstrap_mtimes: dict[str, float] = {}
+        self._bootstrap_mtimes_stable: dict[str, float] = {}
         self._learnings_cache: str | None = None
         self._learnings_mtimes: dict[str, float] = {}
 
@@ -599,10 +604,13 @@ class WorkspaceManager:
         and is memoized in a separate cache slot so it can't be conflated with
         the default (recent-included) variant.
         """
-        cache_attr = "_bootstrap_cache" if include_recent else "_bootstrap_cache_stable"
+        if include_recent:
+            cache_attr, mtimes = "_bootstrap_cache", self._bootstrap_mtimes
+        else:
+            cache_attr, mtimes = "_bootstrap_cache_stable", self._bootstrap_mtimes_stable
         cached = getattr(self, cache_attr)
         if cached is not None and not self._check_mtimes(
-            self._BOOTSTRAP_FILES, self._bootstrap_mtimes,
+            self._BOOTSTRAP_FILES, mtimes,
         ):
             return cached
 
@@ -657,7 +665,7 @@ class WorkspaceManager:
         # Pre-sanitize so callers never need to re-sanitize unchanged content
         combined = sanitize_for_prompt(combined)
 
-        self._snapshot_mtimes(self._BOOTSTRAP_FILES, self._bootstrap_mtimes)
+        self._snapshot_mtimes(self._BOOTSTRAP_FILES, mtimes)
         setattr(self, cache_attr, combined)
         return combined
 

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -278,6 +278,10 @@ class WorkspaceManager:
 
         # Caches — invalidated by mtime changes or explicit writes
         self._bootstrap_cache: str | None = None
+        # Separate cache slot for the head-only bootstrap variant used by the
+        # cache-prefix-stabilization path (MEMORY.md injected WITHOUT the
+        # volatile ``## Recent`` slice so the system prefix stays stable).
+        self._bootstrap_cache_stable: str | None = None
         self._bootstrap_mtimes: dict[str, float] = {}
         self._learnings_cache: str | None = None
         self._learnings_mtimes: dict[str, float] = {}
@@ -484,25 +488,56 @@ class WorkspaceManager:
         """Return only the append-only MEMORY.md log tail (BM25-searchable)."""
         return self._split_memory(self._read_file(self.MEMORY_FILE) or "")[1]
 
-    def get_memory_injection(self) -> str:
+    def _recent_log_slice(self) -> str:
+        """Return the bounded NEWEST-log slice (without the ``## Recent``
+        header), or "" if there is no log. Single source of truth for the
+        recent slice shared by ``get_memory_injection`` and
+        ``get_recent_memory_slice``.
+        """
+        raw = self._read_file(self.MEMORY_FILE) or ""
+        _, log = self._split_memory(raw)
+        log = log.strip()
+        if not log:
+            return ""
+        recent = log[-_MEMORY_RECENT_LOG_CHARS:]
+        # Begin at an entry boundary so we never start mid-entry.
+        idx = recent.find("\n## ")
+        if idx != -1:
+            recent = recent[idx + 1:]
+        return recent.strip()
+
+    def get_recent_memory_slice(self) -> str:
+        """Return the volatile ``## Recent`` memory block (header + newest-log
+        slice), or "" if there's nothing recent.
+
+        This is the per-turn-volatile fragment that the cache-prefix
+        stabilization path (loop._STABLE_PREFIX) relocates OUT of the cached
+        system prompt and re-injects after the cache breakpoint. The stable
+        head stays in the system prompt via ``get_memory_injection(
+        include_recent=False)``.
+        """
+        recent = self._recent_log_slice()
+        return f"## Recent\n\n{recent}".strip() if recent else ""
+
+    def get_memory_injection(self, *, include_recent: bool = True) -> str:
         """Compose the MEMORY.md content injected into the system prompt: the
         consolidated compiled head PLUS a bounded slice of the NEWEST log
         entries, so recently-learned facts auto-surface before consolidation
         folds them into the head. Older log entries are recalled via
         memory_search. The head is capped so head + recent fits the per-file
         bootstrap cap.
+
+        ``include_recent=False`` returns the STABLE head only — the
+        cache-prefix-stabilization path uses it so the volatile ``## Recent``
+        slice can be relocated out of the cached system block (it is re-injected
+        after the cache breakpoint via ``get_recent_memory_slice``).
         """
         raw = self._read_file(self.MEMORY_FILE) or ""
-        head, log = self._split_memory(raw)
-        head, log = head.strip(), log.strip()
-        recent = ""
-        if log:
-            recent = log[-_MEMORY_RECENT_LOG_CHARS:]
-            # Begin at an entry boundary so we never start mid-entry.
-            idx = recent.find("\n## ")
-            if idx != -1:
-                recent = recent[idx + 1:]
-            recent = recent.strip()
+        head, _ = self._split_memory(raw)
+        head = head.strip()
+        if not include_recent:
+            return head
+        recent = self._recent_log_slice()
         if not recent:
             return head
         # Reserve room for the recent slice so a large head can't crowd it out
@@ -548,7 +583,7 @@ class WorkspaceManager:
         for filename in filenames:
             target[filename] = self._get_mtime(self.root / filename)
 
-    def get_bootstrap_content(self) -> str:
+    def get_bootstrap_content(self, *, include_recent: bool = True) -> str:
         """Load workspace files for system prompt with per-file and total caps.
 
         Loads INSTRUCTIONS.md, SOUL.md, USER.md, MEMORY.md with individual
@@ -558,11 +593,18 @@ class WorkspaceManager:
         Daily logs are NOT included — agents access them via memory_search.
 
         Results are cached with mtime-based invalidation and pre-sanitized.
+
+        ``include_recent=False`` injects MEMORY.md head-only (drops the
+        volatile ``## Recent`` slice) for the cache-prefix-stabilization path,
+        and is memoized in a separate cache slot so it can't be conflated with
+        the default (recent-included) variant.
         """
-        if self._bootstrap_cache is not None and not self._check_mtimes(
+        cache_attr = "_bootstrap_cache" if include_recent else "_bootstrap_cache_stable"
+        cached = getattr(self, cache_attr)
+        if cached is not None and not self._check_mtimes(
             self._BOOTSTRAP_FILES, self._bootstrap_mtimes,
         ):
-            return self._bootstrap_cache
+            return cached
 
         caps = {
             "INSTRUCTIONS.md": _MAX_INSTRUCTIONS,
@@ -593,8 +635,9 @@ class WorkspaceManager:
             if filename == "MEMORY.md":
                 # Inject the consolidated head + a bounded slice of the NEWEST
                 # log entries (recent facts auto-surface); older log entries
-                # are recalled via memory_search/BM25.
-                content = self.get_memory_injection()
+                # are recalled via memory_search/BM25. ``include_recent=False``
+                # drops the volatile slice for the stable-prefix path.
+                content = self.get_memory_injection(include_recent=include_recent)
             else:
                 content = self._read_file(filename)
             if not content or not content.strip():
@@ -615,7 +658,7 @@ class WorkspaceManager:
         combined = sanitize_for_prompt(combined)
 
         self._snapshot_mtimes(self._BOOTSTRAP_FILES, self._bootstrap_mtimes)
-        self._bootstrap_cache = combined
+        setattr(self, cache_attr, combined)
         return combined
 
     def _read_file(self, relative_path: str) -> str | None:
@@ -657,6 +700,7 @@ class WorkspaceManager:
         new_log = self._trim_memory_log(new_log)
         path.write_text(self._render_memory(head, new_log))
         self._bootstrap_cache = None  # MEMORY.md is part of bootstrap
+        self._bootstrap_cache_stable = None
 
     def write_compiled_memory(self, head: str) -> None:
         """Replace the compiled head (consolidation), preserving the log."""
@@ -667,6 +711,7 @@ class WorkspaceManager:
         _, log = self._split_memory(raw)
         path.write_text(self._render_memory(head, log))
         self._bootstrap_cache = None
+        self._bootstrap_cache_stable = None
 
     # ── Consolidation stamp (mirrors seed_bootstrap_greeting's sentinel) ──
 
@@ -723,6 +768,7 @@ class WorkspaceManager:
 
         path.write_text(content)
         self._bootstrap_cache = None  # invalidate — file changed
+        self._bootstrap_cache_stable = None
         self.append_daily_log(f"Updated workspace file: {filename}")
         return {
             "filename": filename,

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -518,10 +518,9 @@ class WorkspaceManager:
         slice), or "" if there's nothing recent.
 
         This is the per-turn-volatile fragment that the cache-prefix
-        stabilization path (loop._STABLE_PREFIX) relocates OUT of the cached
-        system prompt and re-injects after the cache breakpoint. The stable
-        head stays in the system prompt via ``get_memory_injection(
-        include_recent=False)``.
+        stabilization path relocates OUT of the cached system prompt and
+        re-injects after the cache breakpoint. The stable head stays in the
+        system prompt via ``get_memory_injection(include_recent=False)``.
         """
         recent = self._recent_log_slice()
         return f"## Recent\n\n{recent}".strip() if recent else ""

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1780,14 +1780,12 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_download",
 ]
 
-# Grouped Tool Search (B2) bridge — pulls a deferred capability group's full
-# schemas into context for the next turn. Granted ONLY when the feature is
-# opted in via OPENLEGION_GROUPED_TOOLS; with the flag off the operator's tool
-# surface stays byte-identical to main (the bridge would be a dead no-op).
-from src.agent.tool_groups import grouped_tools_enabled as _grouped_tools_enabled  # noqa: E402
-
-if _grouped_tools_enabled():
-    _OPERATOR_ALLOWED_TOOLS.append("load_tools")
+# Grouped Tool Search bridge — pulls a deferred capability group's full schemas
+# into context for the next turn. ``execute_code`` runs a Python snippet in the
+# agent container (code-as-action speed lever). Both are part of the operator's
+# standard surface.
+_OPERATOR_ALLOWED_TOOLS.append("load_tools")
+_OPERATOR_ALLOWED_TOOLS.append("execute_code")
 
 # Reference list documenting the tools operator uses on heartbeat. The
 # loop's actual gate is ``_HEARTBEAT_TOOLS`` in ``src/agent/loop.py`` —

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1684,6 +1684,10 @@ def _setup_agent_wizard(model: str) -> str:
 _OPERATOR_AGENT_ID = "operator"
 
 _OPERATOR_ALLOWED_TOOLS: list[str] = [
+    # Grouped Tool Search (B2) bridge — pulls a deferred capability group's
+    # full schemas into context for the next turn. Always-available core tool;
+    # a no-op when OPENLEGION_GROUPED_TOOLS is off (the default).
+    "load_tools",
     # Monitoring + heartbeat
     "get_system_status", "notify_user",
     "inspect_agents", "inspect_teams",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1684,10 +1684,6 @@ def _setup_agent_wizard(model: str) -> str:
 _OPERATOR_AGENT_ID = "operator"
 
 _OPERATOR_ALLOWED_TOOLS: list[str] = [
-    # Grouped Tool Search (B2) bridge — pulls a deferred capability group's
-    # full schemas into context for the next turn. Always-available core tool;
-    # a no-op when OPENLEGION_GROUPED_TOOLS is off (the default).
-    "load_tools",
     # Monitoring + heartbeat
     "get_system_status", "notify_user",
     "inspect_agents", "inspect_teams",
@@ -1783,6 +1779,15 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_detect_captcha", "browser_upload_file", "browser_solve_captcha",
     "browser_download",
 ]
+
+# Grouped Tool Search (B2) bridge — pulls a deferred capability group's full
+# schemas into context for the next turn. Granted ONLY when the feature is
+# opted in via OPENLEGION_GROUPED_TOOLS; with the flag off the operator's tool
+# surface stays byte-identical to main (the bridge would be a dead no-op).
+from src.agent.tool_groups import grouped_tools_enabled as _grouped_tools_enabled  # noqa: E402
+
+if _grouped_tools_enabled():
+    _OPERATOR_ALLOWED_TOOLS.append("load_tools")
 
 # Reference list documenting the tools operator uses on heartbeat. The
 # loop's actual gate is ``_HEARTBEAT_TOOLS`` in ``src/agent/loop.py`` —

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10995,6 +10995,7 @@ function dashboard() {
         browser_solve_captcha: 'solving a CAPTCHA',
         http_request: 'making an HTTP request',
         exec: 'running a command',
+        execute_code: 'running code',
         file_read: 'reading a file',
         file_write: 'writing a file',
         file_list: 'listing files',

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -619,6 +619,9 @@ class MemoryFact(BaseModel):
     last_accessed: datetime | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     decay_score: float = 1.0
+    # Memory v2: provenance + recency for prefer-recent retrieval.
+    source_type: str = "conversation"
+    date: datetime | None = None
 
 
 class MemoryLog(BaseModel):

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -658,6 +658,7 @@ class TestInvokeTool:
             mesh_client=loop.mesh_client,
             workspace_manager=loop.workspace,
             memory_store=loop.memory,
+            agent_loop=loop,
         )
 
     @pytest.mark.asyncio
@@ -675,6 +676,7 @@ class TestInvokeTool:
             mesh_client=loop.mesh_client,
             workspace_manager=loop.workspace,
             memory_store=loop.memory,
+            agent_loop=loop,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -328,14 +328,19 @@ class TestAutoContinueSession:
         assert loop._chat_total_rounds == 0
 
     @pytest.mark.asyncio
-    async def test_round_warning_in_system_prompt(self):
-        """System prompt includes session note at 80% of round limit."""
+    async def test_round_warning_relocated_to_volatile(self):
+        """Session note at 80% of round limit is emitted as a volatile fragment
+        (relocated below the cache breakpoint), not baked into the cached
+        system prefix."""
         loop = _make_loop()
         loop._chat_total_rounds = loop._CHAT_ROUND_WARNING
 
         prompt = loop._build_chat_system_prompt()
-        assert "Session Note" in prompt
-        assert "auto-refreshed" in prompt
+        # Volatile — kept OUT of the stable/cached system prompt...
+        assert "Session Note" not in prompt
+        # ...and stashed for re-injection after the cache breakpoint.
+        assert "Session Note" in loop._volatile_prompt_suffix
+        assert "auto-refreshed" in loop._volatile_prompt_suffix
 
     @pytest.mark.asyncio
     async def test_no_warning_below_threshold(self):

--- a/tests/test_chat_workspace.py
+++ b/tests/test_chat_workspace.py
@@ -9,6 +9,7 @@ Verifies:
 
 from __future__ import annotations
 
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -198,7 +199,13 @@ class TestCrossSessionMemory:
 
     @pytest.mark.asyncio
     async def test_fact_persists_across_sessions(self):
-        """Session 1 saves a fact. Session 2 sees it in system prompt."""
+        """Session 1 saves a fact. Session 2 sees it in the prompt payload.
+
+        The recently-appended memory rides in the relocated ``## Recent`` slice
+        (volatile, folded into the last message after the cache breakpoint), not
+        the cached system head — so assert against the full system+messages
+        payload, which is what the model actually receives.
+        """
         # Session 1: save a fact
         loop1 = _make_loop_with_workspace(self._tmpdir)
         loop1.workspace.append_daily_log("User's dog is named Biscuit")
@@ -209,10 +216,12 @@ class TestCrossSessionMemory:
         loop2 = _make_loop_with_workspace(self._tmpdir)
         await loop2.chat("What is my dog's name?")
 
-        # Verify system prompt in session 2 contains the fact from session 1
+        # Verify the full payload in session 2 contains the fact from session 1.
         call_args = loop2.llm.chat.call_args
         system_prompt = call_args.kwargs.get("system") or call_args[1].get("system", "")
-        assert "Biscuit" in system_prompt
+        messages = call_args.kwargs.get("messages") or call_args[1].get("messages", [])
+        payload = system_prompt + json.dumps(messages, default=str)
+        assert "Biscuit" in payload
 
     @pytest.mark.asyncio
     async def test_daily_log_accessible_via_search(self):

--- a/tests/test_compiled_memory.py
+++ b/tests/test_compiled_memory.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.agent.context import ContextManager
+from src.agent.context import (
+    _SUMMARIZATION_INPUT_LIMIT,
+    ContextManager,
+    _tail_on_boundary,
+)
 from src.agent.workspace import (
     _MEMORY_FILE_MAX,
     MEMORY_COMPILED_BEGIN,
@@ -164,6 +168,29 @@ class TestCompiledMemorySplit:
         # Zero interval → always due.
         assert self.ws.consolidation_due(0) is True
 
+    def test_decay_stamp_due_then_not_due(self):
+        # Mirrors the consolidation sentinel: never decayed → due; just
+        # stamped → not due; zero interval → always due.
+        assert self.ws.decay_due(10_000) is True
+        self.ws.mark_decayed()
+        assert self.ws.decay_due(10_000) is False
+        assert self.ws.decay_due(0) is True
+
+
+def test_tail_on_boundary_returns_newest_not_oldest():
+    """The slice-bug regression guard. The log is append-only (oldest first),
+    so consolidation must read the TAIL — the previous ``log[:N]`` read the
+    OLDEST entries and truncated everything recent."""
+    # Under the limit → returned whole.
+    assert _tail_on_boundary("short", 100) == "short"
+
+    entries = [f"## Entry {i}\n\nbody-{i} " + ("x" * 200) for i in range(20)]
+    log = "\n\n".join(entries)
+    out = _tail_on_boundary(log, 1_000)
+    assert "Entry 19" in out            # newest survives
+    assert "Entry 0\n" not in out       # oldest truncated
+    assert out.lstrip().startswith("## ")  # never starts mid-entry
+
 
 def _fake_fact(key: str, value: str):
     f = MagicMock()
@@ -226,3 +253,125 @@ class TestConsolidateMemory:
 
         llm.chat.assert_not_called()
         ws.write_compiled_memory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_consolidation_feeds_newest_log_to_llm(self):
+        """End-to-end slice-bug guard: the consolidation prompt must contain
+        the NEWEST log entry and exclude the oldest when the log exceeds the
+        summarization limit (the bug fed ``log[:N]`` — the oldest)."""
+        oldest = "## OLDEST\n\nOLDEST_LOG_MARKER"
+        newest = "## NEWEST\n\nNEWEST_LOG_MARKER"
+        log = oldest + "\n\n" + ("filler " * 5_000) + "\n\n" + newest
+        assert len(log) > _SUMMARIZATION_INPUT_LIMIT  # forces a tail slice
+        ws = self._make_workspace(due=True, log=log)
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="HEAD", tokens_used=10)
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+
+        prompt = llm.chat.call_args.kwargs["messages"][0]["content"]
+        assert "NEWEST_LOG_MARKER" in prompt
+        assert "OLDEST_LOG_MARKER" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_failed_consolidation_backs_off_and_skips_next(self):
+        """A failed LLM call sets a backoff so the frequent maintenance tick
+        doesn't hammer the model; the next call skips before the LLM."""
+        ws = self._make_workspace(due=True, log="L" * 2_000)
+        llm = MagicMock()
+        llm.chat = AsyncMock(side_effect=RuntimeError("llm down"))
+
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+        assert cm._consolidation_retry_after > 0
+        assert llm.chat.await_count == 1
+        ws.mark_consolidated.assert_not_called()
+
+        # Within the backoff window → no second LLM call.
+        await cm._maybe_consolidate_memory()
+        assert llm.chat.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_consolidation_output_backs_off(self):
+        ws = self._make_workspace(due=True, log="L" * 2_000)
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="   ", tokens_used=1)
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+
+        assert cm._consolidation_retry_after > 0
+        ws.write_compiled_memory.assert_not_called()
+        ws.mark_consolidated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_decay_runs_when_due_and_stamps(self):
+        ws = MagicMock()
+        ws.decay_due.return_value = True
+        mem = MagicMock()
+        mem.decay_all = AsyncMock()
+
+        cm = ContextManager(
+            max_tokens=1000, llm=MagicMock(), workspace=ws, memory=mem,
+        )
+        await cm._maybe_decay_salience()
+
+        mem.decay_all.assert_awaited_once()
+        ws.mark_decayed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_decay_skips_when_not_due(self):
+        ws = MagicMock()
+        ws.decay_due.return_value = False
+        mem = MagicMock()
+        mem.decay_all = AsyncMock()
+
+        cm = ContextManager(
+            max_tokens=1000, llm=MagicMock(), workspace=ws, memory=mem,
+        )
+        await cm._maybe_decay_salience()
+
+        mem.decay_all.assert_not_awaited()
+        ws.mark_decayed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_maintenance_decay_skips_after_task_path_stamp(self):
+        """Double-decay guard with a REAL workspace: the task path stamps the
+        shared ``.memory_decayed`` sentinel on every fresh-task decay, so the
+        maintenance pass must then treat decay as not-due."""
+        d = tempfile.mkdtemp()
+        try:
+            ws = WorkspaceManager(workspace_dir=d)
+            ws.mark_decayed()  # simulate a task-path decay
+            mem = MagicMock()
+            mem.decay_all = AsyncMock()
+            cm = ContextManager(
+                max_tokens=1000, llm=MagicMock(), workspace=ws, memory=mem,
+            )
+            await cm._maybe_decay_salience()
+            mem.decay_all.assert_not_awaited()
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_run_maintenance_consolidates_then_decays(self):
+        ws = self._make_workspace(due=True, log="L" * 2_000)
+        ws.decay_due.return_value = True
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="NEW HEAD", tokens_used=10)
+        )
+        mem = MagicMock()
+        mem.get_high_salience_facts = AsyncMock(return_value=[])
+        mem.decay_all = AsyncMock()
+
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=mem)
+        await cm.run_maintenance()
+
+        ws.write_compiled_memory.assert_called_once()
+        ws.mark_consolidated.assert_called_once()
+        mem.decay_all.assert_awaited_once()
+        ws.mark_decayed.assert_called_once()

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1906,6 +1906,9 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "create_tool",
     "reload_tools",
     "update_workspace",
+    # Grouped Tool Search bridge — agent-side meta-tool, not a user-facing
+    # activity verb; the generic "using load tools" fallback reads fine.
+    "load_tools",
     # Misc / external integrations.
     "post_tweet",
     "save_artifact",

--- a/tests/test_execute_code.py
+++ b/tests/test_execute_code.py
@@ -1,0 +1,186 @@
+"""Tests for the execute_code (code-as-action) builtin.
+
+Phase 2 of the operator memory/context overhaul (§7, C2). Covers: stdout
+capture, multi-line snippets, error surfacing, output truncation, the env
+scrub (no credentials reach the child), and flag-off gating (handler self-reject
++ worker-surface exclusion).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agent.builtins import exec_tool
+from src.agent.builtins.exec_tool import (
+    _is_sensitive_env_name,
+    _scrubbed_env,
+    execute_code,
+    execute_code_enabled,
+)
+from src.agent.loop import _EXECUTE_CODE_TOOLS
+from tests.test_loop import _make_loop
+
+ENV = exec_tool.EXECUTE_CODE_ENABLED_ENV
+
+
+# ── flag parsing ──────────────────────────────────────────────────────────
+
+def test_enabled_flag_truthy(monkeypatch):
+    for v in ("1", "true", "TRUE", "yes", "on", " On "):
+        monkeypatch.setenv(ENV, v)
+        assert execute_code_enabled() is True
+
+
+def test_enabled_flag_falsy(monkeypatch):
+    for v in ("", "0", "false", "no", "off", "nope"):
+        monkeypatch.setenv(ENV, v)
+        assert execute_code_enabled() is False
+
+
+def test_disabled_when_unset(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    assert execute_code_enabled() is False
+
+
+# ── flag-off gating ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_self_rejects_when_disabled(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    result = await execute_code(code="print(1)")
+    assert result["exit_code"] == -1
+    assert result["stdout"] == ""
+    assert "disabled" in result["stderr"]
+    assert "OPENLEGION_EXECUTE_CODE" in result["stderr"]
+
+
+def test_worker_hides_execute_code_by_default(monkeypatch):
+    monkeypatch.delenv(ENV, raising=False)
+    loop = _make_loop()
+    assert loop._excluded_tools is not None
+    assert _EXECUTE_CODE_TOOLS <= loop._excluded_tools
+
+
+def test_worker_exposes_execute_code_when_enabled(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    loop = _make_loop()
+    assert not loop._excluded_tools or not (_EXECUTE_CODE_TOOLS & loop._excluded_tools)
+
+
+# ── execution (flag on) ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_simple_print(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="print(2 + 2)")
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "4"
+    # Success path keeps stderr empty.
+    assert result["stderr"] == ""
+
+
+@pytest.mark.asyncio
+async def test_multiline_code(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    code = (
+        "total = 0\n"
+        "for i in range(5):\n"
+        "    total += i\n"
+        "print('sum', total)\n"
+    )
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert "sum 10" in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_only_printed_output_returned(monkeypatch):
+    """Intermediate values never leak — only print() reaches the result."""
+    monkeypatch.setenv(ENV, "1")
+    code = "secret = 1234\nprint('answer:', 7 * 6)\n"
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert "42" in result["stdout"]
+    assert "1234" not in result["stdout"]
+
+
+@pytest.mark.asyncio
+async def test_raise_surfaces_error(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="raise ValueError('boom')")
+    assert result["exit_code"] != 0
+    assert "ValueError" in result["stderr"]
+    assert "boom" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_empty_code_rejected(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="   ")
+    assert result["exit_code"] == -1
+    assert "non-empty" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_timeout(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    result = await execute_code(code="import time; time.sleep(10)", timeout=1)
+    assert result["exit_code"] == -1
+    assert "timed out" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_output_truncated(monkeypatch):
+    monkeypatch.setenv(ENV, "1")
+    # Print way more than the cap; result must be clamped.
+    code = "print('x' * 100000)"
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert len(result["stdout"]) <= exec_tool._CODE_MAX_OUTPUT
+
+
+# ── env scrub ──────────────────────────────────────────────────────────────
+
+def test_is_sensitive_env_name():
+    for name in (
+        "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+        "OPENLEGION_CRED_GITHUB",
+        "OL_INTERNET_ACCESS_ENABLED",
+        "SOME_TOKEN",
+        "my_secret_thing",
+        "DB_PASSWORD",
+        "AWS_ACCESS_KEY_ID",
+    ):
+        assert _is_sensitive_env_name(name) is True, name
+    for name in ("PATH", "HOME", "LANG", "TZ"):
+        assert _is_sensitive_env_name(name) is False, name
+
+
+def test_scrubbed_env_drops_sensitive(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-secret")
+    monkeypatch.setenv("SOME_TOKEN", "tok-123")
+    monkeypatch.setenv("MY_PASSWORD", "hunter2")
+    env = _scrubbed_env()
+    assert "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY" not in env
+    assert "SOME_TOKEN" not in env
+    assert "MY_PASSWORD" not in env
+    # PATH (allowlisted, non-sensitive) survives so subprocess lookups work.
+    assert "PATH" in env
+
+
+@pytest.mark.asyncio
+async def test_child_cannot_read_scrubbed_vars(monkeypatch):
+    """The child process must not see credential-shaped env vars."""
+    monkeypatch.setenv(ENV, "1")
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-LEAKED")
+    monkeypatch.setenv("SOME_TOKEN", "tok-LEAKED")
+    code = (
+        "import os\n"
+        "print(os.environ.get('OPENLEGION_SYSTEM_ANTHROPIC_API_KEY'), "
+        "os.environ.get('SOME_TOKEN'))\n"
+    )
+    result = await execute_code(code=code)
+    assert result["exit_code"] == 0
+    assert "LEAKED" not in result["stdout"]
+    # Scrubbed vars come back as None.
+    assert result["stdout"].strip() == "None None"

--- a/tests/test_execute_code.py
+++ b/tests/test_execute_code.py
@@ -1,9 +1,8 @@
 """Tests for the execute_code (code-as-action) builtin.
 
 Phase 2 of the operator memory/context overhaul (§7, C2). Covers: stdout
-capture, multi-line snippets, error surfacing, output truncation, the env
-scrub (no credentials reach the child), and flag-off gating (handler self-reject
-+ worker-surface exclusion).
+capture, multi-line snippets, error surfacing, output truncation, and the env
+scrub (no credentials reach the child). The tool is always-on (no feature flag).
 """
 
 from __future__ import annotations
@@ -15,63 +14,12 @@ from src.agent.builtins.exec_tool import (
     _is_sensitive_env_name,
     _scrubbed_env,
     execute_code,
-    execute_code_enabled,
 )
-from src.agent.loop import _EXECUTE_CODE_TOOLS
-from tests.test_loop import _make_loop
 
-ENV = exec_tool.EXECUTE_CODE_ENABLED_ENV
-
-
-# ── flag parsing ──────────────────────────────────────────────────────────
-
-def test_enabled_flag_truthy(monkeypatch):
-    for v in ("1", "true", "TRUE", "yes", "on", " On "):
-        monkeypatch.setenv(ENV, v)
-        assert execute_code_enabled() is True
-
-
-def test_enabled_flag_falsy(monkeypatch):
-    for v in ("", "0", "false", "no", "off", "nope"):
-        monkeypatch.setenv(ENV, v)
-        assert execute_code_enabled() is False
-
-
-def test_disabled_when_unset(monkeypatch):
-    monkeypatch.delenv(ENV, raising=False)
-    assert execute_code_enabled() is False
-
-
-# ── flag-off gating ───────────────────────────────────────────────────────
+# ── execution ─────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_self_rejects_when_disabled(monkeypatch):
-    monkeypatch.delenv(ENV, raising=False)
-    result = await execute_code(code="print(1)")
-    assert result["exit_code"] == -1
-    assert result["stdout"] == ""
-    assert "disabled" in result["stderr"]
-    assert "OPENLEGION_EXECUTE_CODE" in result["stderr"]
-
-
-def test_worker_hides_execute_code_by_default(monkeypatch):
-    monkeypatch.delenv(ENV, raising=False)
-    loop = _make_loop()
-    assert loop._excluded_tools is not None
-    assert _EXECUTE_CODE_TOOLS <= loop._excluded_tools
-
-
-def test_worker_exposes_execute_code_when_enabled(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
-    loop = _make_loop()
-    assert not loop._excluded_tools or not (_EXECUTE_CODE_TOOLS & loop._excluded_tools)
-
-
-# ── execution (flag on) ───────────────────────────────────────────────────
-
-@pytest.mark.asyncio
-async def test_simple_print(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
+async def test_simple_print():
     result = await execute_code(code="print(2 + 2)")
     assert result["exit_code"] == 0
     assert result["stdout"].strip() == "4"
@@ -80,8 +28,7 @@ async def test_simple_print(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_multiline_code(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
+async def test_multiline_code():
     code = (
         "total = 0\n"
         "for i in range(5):\n"
@@ -94,9 +41,8 @@ async def test_multiline_code(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_only_printed_output_returned(monkeypatch):
+async def test_only_printed_output_returned():
     """Intermediate values never leak — only print() reaches the result."""
-    monkeypatch.setenv(ENV, "1")
     code = "secret = 1234\nprint('answer:', 7 * 6)\n"
     result = await execute_code(code=code)
     assert result["exit_code"] == 0
@@ -105,8 +51,7 @@ async def test_only_printed_output_returned(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_raise_surfaces_error(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
+async def test_raise_surfaces_error():
     result = await execute_code(code="raise ValueError('boom')")
     assert result["exit_code"] != 0
     assert "ValueError" in result["stderr"]
@@ -114,24 +59,21 @@ async def test_raise_surfaces_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_empty_code_rejected(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
+async def test_empty_code_rejected():
     result = await execute_code(code="   ")
     assert result["exit_code"] == -1
     assert "non-empty" in result["stderr"]
 
 
 @pytest.mark.asyncio
-async def test_timeout(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
+async def test_timeout():
     result = await execute_code(code="import time; time.sleep(10)", timeout=1)
     assert result["exit_code"] == -1
     assert "timed out" in result["stderr"]
 
 
 @pytest.mark.asyncio
-async def test_output_truncated(monkeypatch):
-    monkeypatch.setenv(ENV, "1")
+async def test_output_truncated():
     # Print way more than the cap; result must be clamped.
     code = "print('x' * 100000)"
     result = await execute_code(code=code)
@@ -171,7 +113,6 @@ def test_scrubbed_env_drops_sensitive(monkeypatch):
 @pytest.mark.asyncio
 async def test_child_cannot_read_scrubbed_vars(monkeypatch):
     """The child process must not see credential-shaped env vars."""
-    monkeypatch.setenv(ENV, "1")
     monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-LEAKED")
     monkeypatch.setenv("SOME_TOKEN", "tok-LEAKED")
     code = (

--- a/tests/test_grouped_tools.py
+++ b/tests/test_grouped_tools.py
@@ -323,7 +323,7 @@ def test_loop_flag_off_no_index_no_defer(monkeypatch):
 
 def test_load_tools_defers_to_next_turn(grouped_on):
     loop = _make_grouped_loop()
-    loop._refresh_grouped_plan()  # turn 1 build
+    loop._refresh_grouped_plan(promote_pending=True)  # turn 1 build
     # set_cron is deferred at first.
     assert "set_cron" in loop._grouped_plan.defer
 
@@ -336,10 +336,37 @@ def test_load_tools_defers_to_next_turn(grouped_on):
     assert "set_cron" in loop._grouped_plan.defer
 
     # Next turn boundary: the build promotes pending → loaded.
-    loop._refresh_grouped_plan()
+    loop._refresh_grouped_plan(promote_pending=True)
     assert loop._loaded_tool_groups == {"scheduling"}
     assert loop._pending_tool_groups == set()
     # set_cron's schema is now loaded (no longer deferred).
+    assert "set_cron" not in loop._grouped_plan.defer
+
+
+def test_mid_turn_rebuild_does_not_promote(grouped_on):
+    """A MID-turn rebuild (promote_pending=False) must leave pending untouched.
+
+    Promoting mid-turn would flip the toolset and bust the prompt cache — the
+    whole point of deferring to the next turn boundary.
+    """
+    loop = _make_grouped_loop()
+    loop._refresh_grouped_plan(promote_pending=True)  # turn-entry build
+    assert "set_cron" in loop._grouped_plan.defer
+
+    loop.request_load_tools(group="scheduling", tool=None)
+    assert loop._pending_tool_groups == {"scheduling"}
+
+    # Mid-turn rebuilds (hot reload, playbook change, streaming rebuild) default
+    # to promote_pending=False — pending stays queued, loaded set unchanged.
+    loop._refresh_grouped_plan()
+    assert loop._loaded_tool_groups == set()
+    assert loop._pending_tool_groups == {"scheduling"}
+    # The toolset the turn started with is preserved (set_cron still deferred).
+    assert "set_cron" in loop._grouped_plan.defer
+
+    # Only the next turn boundary actually promotes.
+    loop._refresh_grouped_plan(promote_pending=True)
+    assert loop._loaded_tool_groups == {"scheduling"}
     assert "set_cron" not in loop._grouped_plan.defer
 
 
@@ -349,3 +376,122 @@ def test_load_tools_noop_when_flag_off(monkeypatch):
     res = loop.request_load_tools(group="scheduling", tool=None)
     assert res["loaded"] == []
     assert loop._pending_tool_groups == set()
+
+
+# ── Fix 3b: defer=None uses the LEGACY 2-tuple cache key ────────────────────
+def test_defer_none_uses_legacy_two_tuple_cache_key():
+    """With no defer set, the memo key must be the legacy ``(exclude, allowed)``
+    2-tuple so flag-off cache behaviour is byte-identical to main."""
+    reg = _registry_with("alpha", "beta")
+    reg.get_tool_definitions(exclude=frozenset({"beta"}))
+    # The cache must be keyed by the 2-tuple, NOT a 3-tuple with a trailing None.
+    assert (frozenset({"beta"}), None) in reg._tool_defs_cache
+    assert (frozenset({"beta"}), None, None) not in reg._tool_defs_cache
+
+
+def test_defer_set_uses_three_tuple_cache_key():
+    """A real defer set widens the key to the 3-tuple (separate cache entry)."""
+    reg = _registry_with("alpha", "beta")
+    reg.get_tool_definitions(defer=frozenset({"beta"}))
+    assert (None, None, frozenset({"beta"})) in reg._tool_defs_cache
+
+
+# ── Fix 1: agent_loop injection is gated by tool NAME, not signature ────────
+def _registry_with_agent_loop_tool(name: str) -> ToolRegistry:
+    @tool(name=name, description=f"desc {name}", parameters={})
+    async def _fn(*, agent_loop=None):
+        return {"got_loop": agent_loop is not None}
+
+    reg = ToolRegistry.__new__(ToolRegistry)
+    reg.tools = dict(_tool_staging)
+    reg._mcp_client = None
+    reg._tool_defs_cache = {}
+    reg._descriptions_cache = {}
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_injected_only_for_allowlisted_tool():
+    from src.agent.tools import _AGENT_LOOP_TOOLS
+
+    # The allowlist must be exactly the trusted bridge tool.
+    assert _AGENT_LOOP_TOOLS == frozenset({"load_tools"})
+
+    sentinel = object()
+    reg = _registry_with_agent_loop_tool("load_tools")
+    result = await reg.execute("load_tools", {}, agent_loop=sentinel)
+    assert result == {"got_loop": True}
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_not_injected_for_untrusted_tool():
+    """A non-allowlisted tool declaring ``agent_loop`` must NOT receive it —
+    the loop is the whole sandbox runtime; custom/self-authored tools can't
+    capture it just by naming the param."""
+    sentinel = object()
+    reg = _registry_with_agent_loop_tool("evil_custom_tool")
+    result = await reg.execute("evil_custom_tool", {}, agent_loop=sentinel)
+    assert result == {"got_loop": False}
+
+
+# ── Fix 3a: flag-off → load_tools is NOT in the worker tool surface ─────────
+def test_load_tools_absent_from_worker_surface_when_flag_off(monkeypatch):
+    from src.agent.loop import _GROUPED_TOOLS_BRIDGE
+
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    loop = _make_worker_loop()
+    # The worker's effective exclude set hides the bridge entirely.
+    excluded = loop._excluded_tools or frozenset()
+    assert _GROUPED_TOOLS_BRIDGE <= excluded
+    assert "load_tools" not in loop.tools.list_tools(**loop._tool_filter_kw)
+
+
+def test_load_tools_present_in_worker_surface_when_flag_on(grouped_on):
+    loop = _make_worker_loop()
+    excluded = loop._excluded_tools or frozenset()
+    assert "load_tools" not in excluded
+    assert "load_tools" in loop.tools.list_tools(**loop._tool_filter_kw)
+
+
+def _make_worker_loop():
+    """A worker AgentLoop (exclude-based surface) with load_tools registered."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.agent.loop import AgentLoop
+
+    surface = {"notify_user", "load_tools", "read_file"}
+
+    tools = MagicMock()
+
+    def _list_tools(exclude=None, allowed=None, defer=None):
+        names = list(surface)
+        if exclude:
+            names = [n for n in names if n not in exclude]
+        return names
+
+    tools.list_tools = MagicMock(side_effect=_list_tools)
+    tools.get_tool_definitions = MagicMock(return_value=[])
+    tools.get_descriptions = MagicMock(return_value="")
+    tools.is_parallel_safe = MagicMock(return_value=True)
+    tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
+    tools.tools = {n: {} for n in surface}
+
+    memory = MagicMock()
+    memory.get_high_salience_facts = AsyncMock(return_value=[])
+    memory.search = AsyncMock(return_value=[])
+
+    llm = MagicMock()
+    llm.default_model = "test-model"
+
+    mesh_client = MagicMock()
+    mesh_client.is_standalone = False
+
+    return AgentLoop(
+        agent_id="worker",
+        role="worker",
+        memory=memory,
+        tools=tools,
+        llm=llm,
+        mesh_client=mesh_client,
+    )

--- a/tests/test_grouped_tools.py
+++ b/tests/test_grouped_tools.py
@@ -1,0 +1,351 @@
+"""Unit tests for Grouped Tool Search (B2).
+
+Covers:
+- the budget gate (small toolset → unchanged; large → index+defer),
+- the capability index renders ALL grouped capabilities (names never hidden),
+- ``load_tools`` defers the schema change to the NEXT build (not mid-turn),
+- the loaded-groups state folds into the ``get_tool_definitions`` cache key,
+- flag-off → identical behaviour to today.
+
+The whole feature is default-OFF behind ``OPENLEGION_GROUPED_TOOLS``, so each
+test that exercises the active path sets the env flag explicitly.
+"""
+
+import pytest
+
+from src.agent import tool_groups
+from src.agent.tool_groups import (
+    TOOL_GROUPS,
+    grouped_tools_enabled,
+    plan_grouped_tools,
+    resolve_load_request,
+)
+from src.agent.tools import ToolRegistry, _tool_staging, tool
+
+
+def setup_function():
+    _tool_staging.clear()
+
+
+@pytest.fixture
+def grouped_on(monkeypatch):
+    monkeypatch.setenv(tool_groups.GROUPED_TOOLS_ENV, "1")
+    yield
+
+
+# ── Flag plumbing ───────────────────────────────────────────────────────────
+def test_flag_off_by_default(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    assert grouped_tools_enabled() is False
+
+
+def test_flag_on(monkeypatch):
+    monkeypatch.setenv(tool_groups.GROUPED_TOOLS_ENV, "true")
+    assert grouped_tools_enabled() is True
+
+
+def test_plan_inactive_when_flag_off(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups=set(),
+        operator=True,
+        context_window=1000,  # tiny window → would trip the gate if flag were on
+    )
+    assert plan.active is False
+    assert plan.defer == frozenset()
+    assert plan.index_text == ""
+
+
+# ── Budget gate ─────────────────────────────────────────────────────────────
+def test_budget_gate_small_toolset_unchanged(grouped_on):
+    """A small grouped surface stays under the budget → plan inactive."""
+    available = {"create_agent", "set_cron"}  # only 2 grouped tools
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups=set(),
+        operator=True,
+        context_window=200_000,  # opus-class window — 2 tools is far under 10%
+    )
+    assert plan.active is False
+    assert plan.defer == frozenset()
+
+
+def test_budget_gate_large_toolset_activates(grouped_on):
+    """A large grouped surface exceeding ~10% of the window → index+defer."""
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    # Pick a window small enough that the grouped tools exceed 10%.
+    est = len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL
+    window = int(est / tool_groups.BUDGET_FRACTION) - 1  # just under the gate's denom
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups=set(),
+        operator=True,
+        context_window=window,
+    )
+    assert plan.active is True
+    assert plan.defer  # something is deferred
+    assert plan.index_text
+
+
+def test_budget_gate_zero_window_inactive(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    plan = plan_grouped_tools(
+        available=available, loaded_groups=set(), operator=True, context_window=0,
+    )
+    assert plan.active is False
+
+
+# ── Capability index renders ALL capabilities (names never hidden) ──────────
+def test_index_lists_every_available_grouped_tool(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    window = int(
+        (len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    plan = plan_grouped_tools(
+        available=available, loaded_groups=set(), operator=True, context_window=window,
+    )
+    assert plan.active is True
+    # Every grouped tool that's deferred must still appear by NAME in the index
+    # — the capability is never hidden, only its full schema is lazy.
+    for name in plan.defer:
+        assert name in plan.index_text, f"{name} missing from capability index"
+
+
+def test_index_marks_loaded_groups(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    window = int(
+        (len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    plan = plan_grouped_tools(
+        available=available,
+        loaded_groups={"scheduling"},
+        operator=True,
+        context_window=window,
+    )
+    assert "(loaded)" in plan.index_text
+    # A loaded group's tools are no longer deferred.
+    assert "set_cron" not in plan.defer
+
+
+def test_worker_never_sees_operator_only_group(grouped_on):
+    available = {t for g in TOOL_GROUPS for t in g.tools}
+    # Size the window against the WORKER-eligible deferrable set (operator-only
+    # groups are excluded), else the gate wouldn't trip for a worker.
+    worker_deferrable = {
+        t for g in TOOL_GROUPS if not g.operator_only for t in g.tools
+    }
+    window = int(
+        (len(worker_deferrable) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    plan = plan_grouped_tools(
+        available=available, loaded_groups=set(), operator=False, context_window=window,
+    )
+    # Operator-only group tools must not be deferred/advertised for a worker.
+    assert "create_agent" not in plan.defer
+    assert "Fleet setup" not in plan.index_text
+    # A non-operator-only group (web_browse) still appears.
+    assert "Web & browse" in plan.index_text
+
+
+# ── resolve_load_request ────────────────────────────────────────────────────
+def test_resolve_by_group_key():
+    keys, err = resolve_load_request(group="scheduling", tool=None, available=set())
+    assert err is None
+    assert keys == {"scheduling"}
+
+
+def test_resolve_by_group_label():
+    keys, err = resolve_load_request(group="Fleet setup", tool=None, available=set())
+    assert err is None
+    assert keys == {"fleet_setup"}
+
+
+def test_resolve_by_tool_name():
+    keys, err = resolve_load_request(group=None, tool="create_agent", available=set())
+    assert err is None
+    assert keys == {"fleet_setup"}
+
+
+def test_resolve_unknown_group_errors():
+    keys, err = resolve_load_request(group="nope", tool=None, available=set())
+    assert keys == set()
+    assert "Unknown tool group" in err
+
+
+def test_resolve_core_tool_hint():
+    keys, err = resolve_load_request(
+        group=None, tool="notify_user", available={"notify_user"},
+    )
+    assert keys == set()
+    assert "core surface" in err
+
+
+def test_resolve_empty_errors():
+    keys, err = resolve_load_request(group=None, tool=None, available=set())
+    assert keys == set()
+    assert err
+
+
+# ── get_tool_definitions: defer folds into the memo cache key ───────────────
+def _registry_with(*names: str) -> ToolRegistry:
+    for n in names:
+        @tool(name=n, description=f"desc {n}", parameters={"x": {"type": "string"}})
+        def _fn(x: str):
+            return x
+
+    reg = ToolRegistry.__new__(ToolRegistry)
+    reg.tools = dict(_tool_staging)
+    reg._tool_defs_cache = {}
+    reg._descriptions_cache = {}
+    return reg
+
+
+def test_defer_omits_schema():
+    reg = _registry_with("alpha", "beta", "gamma")
+    full = reg.get_tool_definitions()
+    deferred = reg.get_tool_definitions(defer=frozenset({"beta"}))
+    full_names = {d["function"]["name"] for d in full}
+    deferred_names = {d["function"]["name"] for d in deferred}
+    assert "beta" in full_names
+    assert "beta" not in deferred_names
+    assert deferred_names == full_names - {"beta"}
+
+
+def test_defer_folds_into_cache_key():
+    """Different loaded/deferred sets must yield different cached definitions."""
+    reg = _registry_with("alpha", "beta", "gamma")
+    a = reg.get_tool_definitions(defer=frozenset({"beta", "gamma"}))
+    b = reg.get_tool_definitions(defer=frozenset({"gamma"}))
+    # Different defer set → different result (different cache entry).
+    assert a is not b
+    assert {d["function"]["name"] for d in a} == {"alpha"}
+    assert {d["function"]["name"] for d in b} == {"alpha", "beta"}
+    # Same key returns the memoized object.
+    a2 = reg.get_tool_definitions(defer=frozenset({"beta", "gamma"}))
+    assert a2 is a
+
+
+def test_defer_none_matches_today():
+    """defer=None / absent must be byte-identical to the legacy build."""
+    reg = _registry_with("alpha", "beta")
+    legacy = reg.get_tool_definitions(exclude=frozenset())
+    defer_none = reg.get_tool_definitions(exclude=frozenset(), defer=None)
+    assert legacy == defer_none
+
+
+def test_list_tools_ignores_defer():
+    """A deferred tool is still callable → must remain in list_tools()."""
+    reg = _registry_with("alpha", "beta")
+    names = reg.list_tools(defer=frozenset({"beta"}))
+    assert "beta" in names
+
+
+# ── Loop integration: instance state + next-turn deferral ───────────────────
+def _make_grouped_loop():
+    """Build an AgentLoop whose operator allowlist covers every grouped tool.
+
+    Mirrors tests/test_loop.py:_make_loop but with a tool surface large enough
+    to trip the budget gate and a real (non-mock) ToolRegistry-like ``list_tools``
+    that honours ``allowed``/``defer``.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.agent.loop import AgentLoop
+
+    all_grouped = {t for g in TOOL_GROUPS for t in g.tools}
+    allowed = frozenset(all_grouped | {"load_tools", "notify_user"})
+
+    tools = MagicMock()
+
+    def _list_tools(exclude=None, allowed=None, defer=None):
+        names = list(allowed) if allowed is not None else list(all_grouped)
+        return names
+
+    tools.list_tools = MagicMock(side_effect=_list_tools)
+    tools.get_tool_definitions = MagicMock(return_value=[])
+    tools.get_descriptions = MagicMock(return_value="")
+    tools.is_parallel_safe = MagicMock(return_value=True)
+    tools.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+    tools.operator_only_tools = MagicMock(return_value=frozenset())
+    tools.tools = {n: {} for n in all_grouped}
+
+    memory = MagicMock()
+    memory.get_high_salience_facts = AsyncMock(return_value=[])
+    memory.search = AsyncMock(return_value=[])
+
+    llm = MagicMock()
+    llm.default_model = "test-model"
+
+    mesh_client = MagicMock()
+    mesh_client.is_standalone = False
+
+    loop = AgentLoop(
+        agent_id="operator",
+        role="operator",
+        memory=memory,
+        tools=tools,
+        llm=llm,
+        mesh_client=mesh_client,
+        allowed_tools=allowed,
+    )
+    # A roomy context window — the gate trips on the grouped-tool fraction below.
+    cm = MagicMock()
+    cm.max_tokens = int(
+        (len(all_grouped) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
+        / tool_groups.BUDGET_FRACTION
+    ) - 1
+    loop.context_manager = cm
+    return loop
+
+
+def test_loop_refresh_builds_index_and_defer(grouped_on):
+    loop = _make_grouped_loop()
+    index = loop._refresh_grouped_plan()
+    assert index  # capability index present
+    assert loop._grouped_plan is not None and loop._grouped_plan.active
+    # The defer set is now reflected in the tool-filter kwargs.
+    assert "defer" in loop._tool_filter_kw
+
+
+def test_loop_flag_off_no_index_no_defer(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    loop = _make_grouped_loop()
+    index = loop._refresh_grouped_plan()
+    assert index == ""
+    assert loop._grouped_plan is None
+    assert "defer" not in loop._tool_filter_kw
+
+
+def test_load_tools_defers_to_next_turn(grouped_on):
+    loop = _make_grouped_loop()
+    loop._refresh_grouped_plan()  # turn 1 build
+    # set_cron is deferred at first.
+    assert "set_cron" in loop._grouped_plan.defer
+
+    # Request the scheduling group — must NOT mutate the loaded set mid-turn.
+    res = loop.request_load_tools(group="scheduling", tool=None)
+    assert res["loaded"] == ["scheduling"]
+    assert loop._loaded_tool_groups == set()  # not applied yet (mid-turn)
+    assert loop._pending_tool_groups == {"scheduling"}
+    # The current turn's defer is unchanged (toolset stable within a turn).
+    assert "set_cron" in loop._grouped_plan.defer
+
+    # Next turn boundary: the build promotes pending → loaded.
+    loop._refresh_grouped_plan()
+    assert loop._loaded_tool_groups == {"scheduling"}
+    assert loop._pending_tool_groups == set()
+    # set_cron's schema is now loaded (no longer deferred).
+    assert "set_cron" not in loop._grouped_plan.defer
+
+
+def test_load_tools_noop_when_flag_off(monkeypatch):
+    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+    loop = _make_grouped_loop()
+    res = loop.request_load_tools(group="scheduling", tool=None)
+    assert res["loaded"] == []
+    assert loop._pending_tool_groups == set()

--- a/tests/test_grouped_tools.py
+++ b/tests/test_grouped_tools.py
@@ -4,11 +4,12 @@ Covers:
 - the budget gate (small toolset → unchanged; large → index+defer),
 - the capability index renders ALL grouped capabilities (names never hidden),
 - ``load_tools`` defers the schema change to the NEXT build (not mid-turn),
-- the loaded-groups state folds into the ``get_tool_definitions`` cache key,
-- flag-off → identical behaviour to today.
+- the loaded-groups state folds into the ``get_tool_definitions`` cache key.
 
-The whole feature is default-OFF behind ``OPENLEGION_GROUPED_TOOLS``, so each
-test that exercises the active path sets the env flag explicitly.
+Grouped Tool Search is always-on; the SOLE activation control is the budget
+gate — ``plan_grouped_tools`` returns ``active=False`` when the deferrable
+schemas fall under ``BUDGET_FRACTION`` of the context window (small toolset or
+tiny window).
 """
 
 import pytest
@@ -16,7 +17,6 @@ import pytest
 from src.agent import tool_groups
 from src.agent.tool_groups import (
     TOOL_GROUPS,
-    grouped_tools_enabled,
     plan_grouped_tools,
     resolve_load_request,
 )
@@ -27,40 +27,13 @@ def setup_function():
     _tool_staging.clear()
 
 
-@pytest.fixture
-def grouped_on(monkeypatch):
-    monkeypatch.setenv(tool_groups.GROUPED_TOOLS_ENV, "1")
-    yield
-
-
-# ── Flag plumbing ───────────────────────────────────────────────────────────
-def test_flag_off_by_default(monkeypatch):
-    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
-    assert grouped_tools_enabled() is False
-
-
-def test_flag_on(monkeypatch):
-    monkeypatch.setenv(tool_groups.GROUPED_TOOLS_ENV, "true")
-    assert grouped_tools_enabled() is True
-
-
-def test_plan_inactive_when_flag_off(monkeypatch):
-    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
-    available = {t for g in TOOL_GROUPS for t in g.tools}
-    plan = plan_grouped_tools(
-        available=available,
-        loaded_groups=set(),
-        operator=True,
-        context_window=1000,  # tiny window → would trip the gate if flag were on
-    )
-    assert plan.active is False
-    assert plan.defer == frozenset()
-    assert plan.index_text == ""
-
-
 # ── Budget gate ─────────────────────────────────────────────────────────────
-def test_budget_gate_small_toolset_unchanged(grouped_on):
-    """A small grouped surface stays under the budget → plan inactive."""
+def test_budget_gate_small_toolset_unchanged():
+    """A small grouped surface stays under the budget → plan inactive.
+
+    This is the only "inactive" path now that the feature is always-on: a tiny
+    deferrable surface against an opus-class window stays under the budget gate.
+    """
     available = {"create_agent", "set_cron"}  # only 2 grouped tools
     plan = plan_grouped_tools(
         available=available,
@@ -70,9 +43,10 @@ def test_budget_gate_small_toolset_unchanged(grouped_on):
     )
     assert plan.active is False
     assert plan.defer == frozenset()
+    assert plan.index_text == ""
 
 
-def test_budget_gate_large_toolset_activates(grouped_on):
+def test_budget_gate_large_toolset_activates():
     """A large grouped surface exceeding ~10% of the window → index+defer."""
     available = {t for g in TOOL_GROUPS for t in g.tools}
     # Pick a window small enough that the grouped tools exceed 10%.
@@ -89,7 +63,7 @@ def test_budget_gate_large_toolset_activates(grouped_on):
     assert plan.index_text
 
 
-def test_budget_gate_zero_window_inactive(grouped_on):
+def test_budget_gate_zero_window_inactive():
     available = {t for g in TOOL_GROUPS for t in g.tools}
     plan = plan_grouped_tools(
         available=available, loaded_groups=set(), operator=True, context_window=0,
@@ -98,7 +72,7 @@ def test_budget_gate_zero_window_inactive(grouped_on):
 
 
 # ── Capability index renders ALL capabilities (names never hidden) ──────────
-def test_index_lists_every_available_grouped_tool(grouped_on):
+def test_index_lists_every_available_grouped_tool():
     available = {t for g in TOOL_GROUPS for t in g.tools}
     window = int(
         (len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
@@ -114,7 +88,7 @@ def test_index_lists_every_available_grouped_tool(grouped_on):
         assert name in plan.index_text, f"{name} missing from capability index"
 
 
-def test_index_marks_loaded_groups(grouped_on):
+def test_index_marks_loaded_groups():
     available = {t for g in TOOL_GROUPS for t in g.tools}
     window = int(
         (len(available) * tool_groups.SCHEMA_TOKENS_PER_TOOL)
@@ -131,7 +105,7 @@ def test_index_marks_loaded_groups(grouped_on):
     assert "set_cron" not in plan.defer
 
 
-def test_worker_never_sees_operator_only_group(grouped_on):
+def test_worker_never_sees_operator_only_group():
     available = {t for g in TOOL_GROUPS for t in g.tools}
     # Size the window against the WORKER-eligible deferrable set (operator-only
     # groups are excluded), else the gate wouldn't trip for a worker.
@@ -303,7 +277,7 @@ def _make_grouped_loop():
     return loop
 
 
-def test_loop_refresh_builds_index_and_defer(grouped_on):
+def test_loop_refresh_builds_index_and_defer():
     loop = _make_grouped_loop()
     index = loop._refresh_grouped_plan()
     assert index  # capability index present
@@ -312,16 +286,21 @@ def test_loop_refresh_builds_index_and_defer(grouped_on):
     assert "defer" in loop._tool_filter_kw
 
 
-def test_loop_flag_off_no_index_no_defer(monkeypatch):
-    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+def test_loop_under_budget_no_index_no_defer():
+    """When the agent's deferrable surface is under the budget gate, the plan is
+    inactive: no index, no ``defer`` in the tool-filter kwargs."""
     loop = _make_grouped_loop()
+    # Roomy enough that the grouped tools fall under BUDGET_FRACTION → inactive.
+    cm = loop.context_manager
+    cm.max_tokens = 10_000_000
     index = loop._refresh_grouped_plan()
     assert index == ""
-    assert loop._grouped_plan is None
+    assert loop._grouped_plan is not None
+    assert loop._grouped_plan.active is False
     assert "defer" not in loop._tool_filter_kw
 
 
-def test_load_tools_defers_to_next_turn(grouped_on):
+def test_load_tools_defers_to_next_turn():
     loop = _make_grouped_loop()
     loop._refresh_grouped_plan(promote_pending=True)  # turn 1 build
     # set_cron is deferred at first.
@@ -343,7 +322,7 @@ def test_load_tools_defers_to_next_turn(grouped_on):
     assert "set_cron" not in loop._grouped_plan.defer
 
 
-def test_mid_turn_rebuild_does_not_promote(grouped_on):
+def test_mid_turn_rebuild_does_not_promote():
     """A MID-turn rebuild (promote_pending=False) must leave pending untouched.
 
     Promoting mid-turn would flip the toolset and bust the prompt cache — the
@@ -370,9 +349,14 @@ def test_mid_turn_rebuild_does_not_promote(grouped_on):
     assert "set_cron" not in loop._grouped_plan.defer
 
 
-def test_load_tools_noop_when_flag_off(monkeypatch):
-    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
+def test_load_tools_noop_when_plan_inactive():
+    """When the budget gate hasn't tripped (plan inactive), a load_tools request
+    is a no-op — there is nothing deferred to load."""
     loop = _make_grouped_loop()
+    # Roomy window → grouped tools under budget → plan inactive.
+    loop.context_manager.max_tokens = 10_000_000
+    loop._refresh_grouped_plan()
+    assert loop._grouped_plan is not None and loop._grouped_plan.active is False
     res = loop.request_load_tools(group="scheduling", tool=None)
     assert res["loaded"] == []
     assert loop._pending_tool_groups == set()
@@ -434,19 +418,10 @@ async def test_agent_loop_not_injected_for_untrusted_tool():
     assert result == {"got_loop": False}
 
 
-# ── Fix 3a: flag-off → load_tools is NOT in the worker tool surface ─────────
-def test_load_tools_absent_from_worker_surface_when_flag_off(monkeypatch):
-    from src.agent.loop import _GROUPED_TOOLS_BRIDGE
-
-    monkeypatch.delenv(tool_groups.GROUPED_TOOLS_ENV, raising=False)
-    loop = _make_worker_loop()
-    # The worker's effective exclude set hides the bridge entirely.
-    excluded = loop._excluded_tools or frozenset()
-    assert _GROUPED_TOOLS_BRIDGE <= excluded
-    assert "load_tools" not in loop.tools.list_tools(**loop._tool_filter_kw)
-
-
-def test_load_tools_present_in_worker_surface_when_flag_on(grouped_on):
+# ── load_tools is always in the worker tool surface (always-on) ─────────────
+def test_load_tools_present_in_worker_surface():
+    """The grouped-tools bridge is always available to a worker now that the
+    feature is always-on — it's never hidden from the effective surface."""
     loop = _make_worker_loop()
     excluded = loop._excluded_tools or frozenset()
     assert "load_tools" not in excluded

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1037,7 +1037,8 @@ async def test_steer_interrupt_limit():
 
 
 def test_context_warning_in_chat_system_prompt():
-    """When context >= 80%, _build_chat_system_prompt includes CONTEXT WARNING."""
+    """When context >= 80%, the CONTEXT WARNING is emitted as a VOLATILE fragment
+    (relocated out of the cached system prefix, onto _volatile_prompt_suffix)."""
     from src.agent.context import ContextManager
 
     loop = _make_loop()
@@ -1049,7 +1050,9 @@ def test_context_warning_in_chat_system_prompt():
         {"role": "assistant", "content": "y" * 500},
     ]
     prompt = loop._build_chat_system_prompt()
-    assert "CONTEXT WARNING" in prompt
+    # Volatile fragments live below the cache breakpoint, not in the system prompt.
+    assert "CONTEXT WARNING" not in prompt
+    assert "CONTEXT WARNING" in loop._volatile_prompt_suffix
 
 
 def test_context_warning_absent_below_threshold():
@@ -1786,7 +1789,8 @@ class TestRuntimeContextInjection:
     }
 
     def test_task_mode_includes_runtime_context(self):
-        """_build_system_prompt includes ## Runtime Context with introspect data."""
+        """The ## Runtime Context block is emitted as a VOLATILE fragment
+        (relocated below the cache breakpoint, onto _volatile_prompt_suffix)."""
         from src.shared.types import TaskAssignment
 
         loop = _make_loop()
@@ -1795,17 +1799,22 @@ class TestRuntimeContextInjection:
             input_data={"instruction": "do stuff"},
         )
         prompt = loop._build_system_prompt(assignment, introspect_data=self._INTROSPECT_DATA)
-        assert "## Runtime Context" in prompt
-        assert "Budget: daily $0.50/$5.00" in prompt
-        assert "allowed_credentials: brightdata_*" in prompt
+        # Runtime context lives below the cache breakpoint, not in the prompt.
+        assert "## Runtime Context" not in prompt
+        suffix = loop._volatile_prompt_suffix
+        assert "## Runtime Context" in suffix
+        assert "Budget: daily $0.50/$5.00" in suffix
+        assert "allowed_credentials: brightdata_*" in suffix
 
     def test_chat_mode_includes_runtime_context(self):
-        """_build_chat_system_prompt includes ## Runtime Context."""
+        """The ## Runtime Context block is relocated onto _volatile_prompt_suffix."""
         loop = _make_loop()
         prompt = loop._build_chat_system_prompt(introspect_data=self._INTROSPECT_DATA)
-        assert "## Runtime Context" in prompt
-        assert "Budget: daily $0.50/$5.00" in prompt
-        assert "allowed_credentials: brightdata_*" in prompt
+        assert "## Runtime Context" not in prompt
+        suffix = loop._volatile_prompt_suffix
+        assert "## Runtime Context" in suffix
+        assert "Budget: daily $0.50/$5.00" in suffix
+        assert "allowed_credentials: brightdata_*" in suffix
 
     def test_chat_mode_excludes_fleet_from_runtime_when_fleet_ctx_present(self):
         """When fleet_roster is provided, fleet line is excluded from runtime context."""
@@ -1815,15 +1824,19 @@ class TestRuntimeContextInjection:
             fleet_roster=roster,
             introspect_data=self._INTROSPECT_DATA,
         )
-        # Detailed fleet block should be present
+        # Detailed fleet block should be present in the stable system prompt.
         assert "Your Team" in prompt
-        # Runtime context should NOT duplicate fleet
-        # Split on "## Runtime Context" to check just that section
-        runtime_section = prompt.split("## Runtime Context")[1] if "## Runtime Context" in prompt else ""
+        # The relocated runtime context (now volatile) must NOT duplicate fleet.
+        suffix = loop._volatile_prompt_suffix
+        runtime_section = (
+            suffix.split("## Runtime Context")[1]
+            if "## Runtime Context" in suffix else ""
+        )
         assert "Fleet:" not in runtime_section
 
     def test_task_mode_includes_fleet_in_runtime(self):
-        """Task mode has no detailed fleet block, so fleet shows in runtime context."""
+        """Task mode has no detailed fleet block, so fleet shows in the runtime
+        context — which is now relocated onto _volatile_prompt_suffix."""
         from src.shared.types import TaskAssignment
 
         loop = _make_loop()
@@ -1831,8 +1844,8 @@ class TestRuntimeContextInjection:
             workflow_id="wf1", step_id="s1", task_type="test",
             input_data={"instruction": "do stuff"},
         )
-        prompt = loop._build_system_prompt(assignment, introspect_data=self._INTROSPECT_DATA)
-        assert "Fleet: [test_agent, bob]" in prompt
+        loop._build_system_prompt(assignment, introspect_data=self._INTROSPECT_DATA)
+        assert "Fleet: [test_agent, bob]" in loop._volatile_prompt_suffix
 
     def test_no_introspect_data_no_runtime_context(self):
         """Without introspect data, no runtime context block."""

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2269,6 +2269,34 @@ async def test_heartbeat_skips_when_chat_locked():
 
 
 @pytest.mark.asyncio
+async def test_run_maintenance_skips_when_busy_else_runs_under_lock():
+    """The background maintenance pass must skip while a turn is in flight
+    (same idle/lock guard the heartbeat uses) and otherwise run the
+    ContextManager pass under the chat lock."""
+    loop = _make_loop()
+    loop.context_manager = MagicMock()
+    loop.context_manager.run_maintenance = AsyncMock()
+
+    # Busy with a task → skip.
+    loop.state = "working"
+    await loop.run_maintenance()
+    loop.context_manager.run_maintenance.assert_not_awaited()
+
+    # Idle but a chat turn holds the lock → skip.
+    loop.state = "idle"
+    await loop._chat_lock.acquire()
+    try:
+        await loop.run_maintenance()
+    finally:
+        loop._chat_lock.release()
+    loop.context_manager.run_maintenance.assert_not_awaited()
+
+    # Idle and unlocked → runs.
+    await loop.run_maintenance()
+    loop.context_manager.run_maintenance.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_skips_when_no_rules():
     """Heartbeat skips LLM call when HEARTBEAT.md is empty and no goals set."""
     loop = _make_loop()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -8,6 +8,7 @@ Uses mock LLM to verify:
 - Final output parsing
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2291,9 +2292,33 @@ async def test_run_maintenance_skips_when_busy_else_runs_under_lock():
         loop._chat_lock.release()
     loop.context_manager.run_maintenance.assert_not_awaited()
 
-    # Idle and unlocked → runs.
+    # Idle and unlocked → runs, then restores idle state (so it doesn't
+    # leave the agent stuck "working").
     await loop.run_maintenance()
     loop.context_manager.run_maintenance.assert_awaited_once()
+    assert loop.state == "idle"
+
+
+@pytest.mark.asyncio
+async def test_run_maintenance_loop_invokes_then_cancels(monkeypatch):
+    """The production launch path (server.run_maintenance_loop) ticks
+    loop.run_maintenance and stops cleanly on cancellation."""
+    from src.agent import server
+
+    loop = _make_loop()
+    loop.run_maintenance = AsyncMock()
+    monkeypatch.setattr(server, "_MAINTENANCE_INITIAL_DELAY_S", 0)
+    monkeypatch.setattr(server, "_MAINTENANCE_TICK_S", 0.01)
+
+    task = asyncio.create_task(server.run_maintenance_loop(loop))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert loop.run_maintenance.await_count >= 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -410,3 +410,131 @@ class TestToolOutcomes:
         ).fetchall()]
         assert "tool_outcomes" in tables
         store.close()
+
+
+class TestSemanticDedup:
+    """Vector-similarity dedup on the write path (OPENLEGION_SEMANTIC_DEDUP).
+
+    Uses a controllable stub embedder so near-duplicate vs distinct facts are
+    deterministic and independent of any real embedding provider.
+    """
+
+    @staticmethod
+    def _grouped_embedder(groups):
+        """Return an async embed_fn that maps each key (the part before ': ') to a
+        deterministic vector per ``groups`` membership. Keys in the same group get
+        an identical vector (similarity 1.0); keys in different groups get near-
+        orthogonal vectors (similarity well below the dedup threshold)."""
+        # group_index -> base vector
+        async def _embed(text: str) -> list[float]:
+            key = text.split(":", 1)[0].strip()
+            for gi, members in enumerate(groups):
+                if key in members:
+                    vec = [0.0] * 1536
+                    vec[gi] = 1.0
+                    return vec
+            # Unknown key: unique-ish vector far from the named groups.
+            vec = [0.0] * 1536
+            vec[1535] = 1.0
+            return vec
+        return _embed
+
+    @pytest.fixture
+    def dedup_on(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_SEMANTIC_DEDUP", "1")
+
+    @pytest.fixture
+    def dedup_off(self, monkeypatch):
+        monkeypatch.delenv("OPENLEGION_SEMANTIC_DEDUP", raising=False)
+
+    def _make_store(self, tmp_path, name, groups):
+        embed = self._grouped_embedder(groups)
+        return MemoryStore(db_path=str(tmp_path / name), embed_fn=embed)
+
+    @staticmethod
+    def _count_facts(store) -> int:
+        return store.db.execute("SELECT COUNT(*) FROM facts").fetchone()[0]
+
+    @pytest.mark.asyncio
+    async def test_near_duplicate_keys_merge_into_one_row(self, tmp_path, dedup_on):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "merge.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            # Both near-synonym keys collapse to a single surviving row.
+            assert self._count_facts(store) == 1
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_distinct_facts_stay_separate(self, tmp_path, dedup_on):
+        groups = [{"user_name"}, {"user_email"}]
+        store = self._make_store(tmp_path, "distinct.db", groups)
+        try:
+            await store.store_fact("user_name", "Alice")
+            await store.store_fact("user_email", "alice@example.com")
+            # Clearly-distinct facts (orthogonal vectors) are never collapsed.
+            assert self._count_facts(store) == 2
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_merge_prefers_newer_value(self, tmp_path, dedup_on):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "newer.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            assert self._count_facts(store) == 1
+            # Surviving row reflects the newer value + key.
+            fact = store._get_fact_by_key("user_language_preference")
+            assert fact is not None
+            assert fact.value == "Rust"
+            # Old key no longer resolves (the single row was rewritten).
+            assert store._get_fact_by_key("preferred_language") is None
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_merge_bumps_salience(self, tmp_path, dedup_on):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "salience.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            first = store._get_fact_by_key("preferred_language")
+            assert first is not None
+            await store.store_fact("user_language_preference", "Rust")
+            merged = store._get_fact_by_key("user_language_preference")
+            assert merged is not None
+            assert merged.access_count > first.access_count
+            assert merged.decay_score > first.decay_score
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_keeps_exact_key_behavior(self, tmp_path, dedup_off):
+        groups = [{"preferred_language", "user_language_preference"}]
+        store = self._make_store(tmp_path, "flagoff.db", groups)
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            # Flag off: near-dup keys are NOT merged — two rows, today's behavior.
+            assert self._count_facts(store) == 2
+            # Exact-key update still collapses (unchanged behavior).
+            await store.store_fact("preferred_language", "Go")
+            assert self._count_facts(store) == 2
+            assert store._get_fact_by_key("preferred_language").value == "Go"
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_embedder_unchanged(self, tmp_path, dedup_off):
+        # No embed_fn at all → write path identical to today regardless of flag.
+        store = MemoryStore(db_path=str(tmp_path / "noembed.db"))
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            assert self._count_facts(store) == 2
+        finally:
+            store.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -429,7 +429,7 @@ class TestToolOutcomes:
 
 
 class TestSemanticDedup:
-    """Vector-similarity dedup on the write path (OPENLEGION_SEMANTIC_DEDUP).
+    """Vector-similarity dedup on the write path (always-on).
 
     Uses a controllable stub embedder so near-duplicate vs distinct facts are
     deterministic and independent of any real embedding provider.
@@ -455,14 +455,6 @@ class TestSemanticDedup:
             return vec
         return _embed
 
-    @pytest.fixture
-    def dedup_on(self, monkeypatch):
-        monkeypatch.setenv("OPENLEGION_SEMANTIC_DEDUP", "1")
-
-    @pytest.fixture
-    def dedup_off(self, monkeypatch):
-        monkeypatch.delenv("OPENLEGION_SEMANTIC_DEDUP", raising=False)
-
     def _make_store(self, tmp_path, name, groups):
         embed = self._grouped_embedder(groups)
         return MemoryStore(db_path=str(tmp_path / name), embed_fn=embed)
@@ -472,7 +464,7 @@ class TestSemanticDedup:
         return store.db.execute("SELECT COUNT(*) FROM facts").fetchone()[0]
 
     @pytest.mark.asyncio
-    async def test_near_duplicate_keys_merge_into_one_row(self, tmp_path, dedup_on):
+    async def test_near_duplicate_keys_merge_into_one_row(self, tmp_path):
         groups = [{"preferred_language", "user_language_preference"}]
         store = self._make_store(tmp_path, "merge.db", groups)
         try:
@@ -484,7 +476,7 @@ class TestSemanticDedup:
             store.close()
 
     @pytest.mark.asyncio
-    async def test_distinct_facts_stay_separate(self, tmp_path, dedup_on):
+    async def test_distinct_facts_stay_separate(self, tmp_path):
         groups = [{"user_name"}, {"user_email"}]
         store = self._make_store(tmp_path, "distinct.db", groups)
         try:
@@ -496,7 +488,7 @@ class TestSemanticDedup:
             store.close()
 
     @pytest.mark.asyncio
-    async def test_merge_prefers_newer_value(self, tmp_path, dedup_on):
+    async def test_merge_prefers_newer_value(self, tmp_path):
         groups = [{"preferred_language", "user_language_preference"}]
         store = self._make_store(tmp_path, "newer.db", groups)
         try:
@@ -513,7 +505,7 @@ class TestSemanticDedup:
             store.close()
 
     @pytest.mark.asyncio
-    async def test_merge_bumps_salience(self, tmp_path, dedup_on):
+    async def test_merge_bumps_salience(self, tmp_path):
         groups = [{"preferred_language", "user_language_preference"}]
         store = self._make_store(tmp_path, "salience.db", groups)
         try:
@@ -529,34 +521,40 @@ class TestSemanticDedup:
             store.close()
 
     @pytest.mark.asyncio
-    async def test_flag_off_keeps_exact_key_behavior(self, tmp_path, dedup_off):
+    async def test_merge_restamps_date_and_preserves_source_type(self, tmp_path):
+        # Issue-1 regression (#1077 + #1080 reconciliation): a semantic merge must
+        # re-stamp `date` so the re-asserted fact ranks as recent under
+        # prefer-recent, AND preserve the surviving row's original source_type
+        # (provenance) rather than overwriting it with the caller's default.
         groups = [{"preferred_language", "user_language_preference"}]
-        store = self._make_store(tmp_path, "flagoff.db", groups)
+        store = self._make_store(tmp_path, "datestamp.db", groups)
         try:
-            await store.store_fact("preferred_language", "Python")
+            await store.store_fact(
+                "preferred_language", "Python", source_type="context_flush",
+            )
+            # Backdate the stored row so a successful re-stamp is observable.
+            store.db.execute(
+                "UPDATE facts SET date = '2000-01-01 00:00:00' WHERE key = ?",
+                ("preferred_language",),
+            )
+            store.db.commit()
+            # Near-duplicate key → semantic merge into the same row.
             await store.store_fact("user_language_preference", "Rust")
-            # Flag off: near-dup keys are NOT merged — two rows, today's behavior.
-            assert self._count_facts(store) == 2
-            # Exact-key update still collapses (unchanged behavior).
-            await store.store_fact("preferred_language", "Go")
-            assert self._count_facts(store) == 2
-            assert store._get_fact_by_key("preferred_language").value == "Go"
+            assert self._count_facts(store) == 1
+            date, source_type = store.db.execute(
+                "SELECT date, source_type FROM facts WHERE key = ?",
+                ("user_language_preference",),
+            ).fetchone()
+            # date re-stamped away from the backdated value (counts as recent).
+            assert date is not None and date != "2000-01-01 00:00:00"
+            # source_type provenance preserved from the original row, NOT the
+            # default "conversation" the second store_fact would have applied.
+            assert source_type == "context_flush"
         finally:
             store.close()
 
     @pytest.mark.asyncio
-    async def test_flag_off_no_embedder_unchanged(self, tmp_path, dedup_off):
-        # No embed_fn at all → write path identical to today regardless of flag.
-        store = MemoryStore(db_path=str(tmp_path / "noembed.db"))
-        try:
-            await store.store_fact("preferred_language", "Python")
-            await store.store_fact("user_language_preference", "Rust")
-            assert self._count_facts(store) == 2
-        finally:
-            store.close()
-
-    @pytest.mark.asyncio
-    async def test_no_duplicate_key_orphans_after_semantic_merge(self, tmp_path, dedup_on):
+    async def test_no_duplicate_key_orphans_after_semantic_merge(self, tmp_path):
         # BLOCKER regression: a semantic merge must never rewrite one row's key
         # onto another row's key (which would leave two rows sharing a key — the
         # exact-key dedup path becomes ambiguous and one row is an unreachable
@@ -589,10 +587,11 @@ class TestSemanticDedup:
             store.close()
 
     @pytest.mark.asyncio
-    async def test_dedup_on_no_embedder_graceful(self, tmp_path, dedup_on):
-        # Flag ON but embed_fn is None → no embedding, so the semantic probe is
-        # skipped entirely and the write path falls back to exact-key behavior.
-        store = MemoryStore(db_path=str(tmp_path / "ondnoembed.db"))
+    async def test_no_embedder_falls_back_to_exact_key(self, tmp_path):
+        # embed_fn is None → no embedding, so the semantic probe is skipped
+        # entirely and the write path falls back to exact-key behavior: near-dup
+        # keys stay as two rows; an exact-key re-store still collapses.
+        store = MemoryStore(db_path=str(tmp_path / "noembed.db"))
         try:
             await store.store_fact("preferred_language", "Python")
             await store.store_fact("user_language_preference", "Rust")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -538,3 +538,51 @@ class TestSemanticDedup:
             assert self._count_facts(store) == 2
         finally:
             store.close()
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_key_orphans_after_semantic_merge(self, tmp_path, dedup_on):
+        # BLOCKER regression: a semantic merge must never rewrite one row's key
+        # onto another row's key (which would leave two rows sharing a key — the
+        # exact-key dedup path becomes ambiguous and one row is an unreachable
+        # orphan). lang_a and lang_b share an embedding group (near-duplicates).
+        groups = [{"lang_a", "lang_b"}]
+        store = self._make_store(tmp_path, "orphan.db", groups)
+        try:
+            await store.store_fact("lang_a", "X")
+            # Near-duplicate embedding → merges into the lang_a row, flipping its
+            # key to lang_b. Now a single row, keyed lang_b.
+            await store.store_fact("lang_b", "Y")
+            assert self._count_facts(store) == 1
+            # Re-store lang_a (exact-key path: no row holds lang_a, but its
+            # embedding still matches the lang_b row — must NOT clobber lang_b's
+            # key) and lang_b again (genuine exact-key update).
+            await store.store_fact("lang_a", "Z")
+            await store.store_fact("lang_b", "W")
+            # Invariant: no two rows share a key.
+            dupes = store.db.execute(
+                "SELECT key, COUNT(*) FROM facts GROUP BY key HAVING COUNT(*) > 1",
+            ).fetchall()
+            assert dupes == []
+            # The surviving values are reachable by exact key.
+            for key in ("lang_a", "lang_b"):
+                fact = store._get_fact_by_key(key)
+                if fact is not None:
+                    # Every key that resolves resolves to exactly one row.
+                    assert fact.key == key
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_dedup_on_no_embedder_graceful(self, tmp_path, dedup_on):
+        # Flag ON but embed_fn is None → no embedding, so the semantic probe is
+        # skipped entirely and the write path falls back to exact-key behavior.
+        store = MemoryStore(db_path=str(tmp_path / "ondnoembed.db"))
+        try:
+            await store.store_fact("preferred_language", "Python")
+            await store.store_fact("user_language_preference", "Rust")
+            assert self._count_facts(store) == 2
+            await store.store_fact("preferred_language", "Go")
+            assert self._count_facts(store) == 2
+            assert store._get_fact_by_key("preferred_language").value == "Go"
+        finally:
+            store.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -72,6 +72,22 @@ async def test_update_existing_fact(memory):
 
 
 @pytest.mark.asyncio
+async def test_exact_key_restore_preserves_category_and_source(memory):
+    """Flag-off byte-identical guard: an exact-key re-store updates the value
+    (and salience) but must NOT overwrite the stored category/source — matching
+    the pre-dedup write path. Only a semantic MERGE adopts the newer
+    key/category/source; the exact-key path never does."""
+    fid = await memory.store_fact("k", "v1", category="preference", source="user")
+    await memory.store_fact("k", "v2", category="general", source="agent")
+    row = memory.db.execute(
+        "SELECT value, category, source FROM facts WHERE id = ?", (fid,),
+    ).fetchone()
+    assert row[0] == "v2"            # value updated
+    assert row[1] == "preference"   # category preserved (not clobbered)
+    assert row[2] == "user"         # source preserved
+
+
+@pytest.mark.asyncio
 async def test_keyword_search_returns_results(memory):
     await memory.store_fact("company_name", "Acme Corporation")
     await memory.store_fact("company_size", "500 employees")

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -205,6 +205,11 @@ async def test_high_salience_prefers_recent_on_tie(memory):
 # --- inject-head-only flag ---------------------------------------------------
 
 class TestInjectHeadOnly:
+    """The head-only split is a builder-layer option (``include_recent=``), not
+    an env flag. The default injection still carries the recent slice; the
+    head-only variant drops it while the log stays on disk + searchable.
+    """
+
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
         self.ws = WorkspaceManager(workspace_dir=self._tmpdir)
@@ -214,24 +219,27 @@ class TestInjectHeadOnly:
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    def test_flag_off_injects_head_and_recent(self, monkeypatch):
-        monkeypatch.delenv("OPENLEGION_INJECT_HEAD_ONLY", raising=False)
+    def test_default_injects_head_and_recent(self):
+        # Default (include_recent=True) carries both the head and recent slice.
         injected = self.ws.get_memory_injection()
         assert "COMPILED_HEAD_MARKER" in injected
         assert "RECENT_LOG_MARKER" in injected
         assert "## Recent" in injected
+        # Explicit include_recent=True matches the default.
+        assert self.ws.get_memory_injection(include_recent=True) == injected
 
-    def test_flag_on_drops_recent_keeps_head(self, monkeypatch):
-        monkeypatch.setenv("OPENLEGION_INJECT_HEAD_ONLY", "1")
-        injected = self.ws.get_memory_injection()
+    def test_head_only_drops_recent_keeps_head(self):
+        # include_recent=False returns the stable head WITHOUT the recent slice.
+        injected = self.ws.get_memory_injection(include_recent=False)
         assert "COMPILED_HEAD_MARKER" in injected
         assert "RECENT_LOG_MARKER" not in injected
         assert "## Recent" not in injected
 
-    def test_flag_on_log_stays_searchable(self, monkeypatch):
-        monkeypatch.setenv("OPENLEGION_INJECT_HEAD_ONLY", "1")
-        # Dropped from injection, but still on disk + searchable.
-        assert "RECENT_LOG_MARKER" not in self.ws.get_memory_injection()
+    def test_head_only_log_stays_searchable(self):
+        # Dropped from the head-only injection, but still on disk + searchable.
+        assert "RECENT_LOG_MARKER" not in self.ws.get_memory_injection(
+            include_recent=False,
+        )
         assert "RECENT_LOG_MARKER" in self.ws.load_memory_log()
         files = {r["file"] for r in self.ws.search("RECENT_LOG_MARKER")}
         assert "MEMORY.md" in files

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -139,6 +139,40 @@ async def test_migration_is_idempotent_on_reopen(tmp_path):
         s2.close()
 
 
+@pytest.mark.asyncio
+async def test_migration_propagates_real_operational_error(tmp_path, monkeypatch):
+    """A genuine OperationalError during an ALTER (not a duplicate column) must
+    surface, not be silently swallowed — guards against half-applied schemas."""
+    db_path = str(tmp_path / "broken.db")
+    _create_legacy_facts_db(db_path)
+
+    from src.agent import memory as memory_mod
+
+    real_open_db = memory_mod.open_db
+
+    class _FaultyConn:
+        """Wraps a real connection but fails any ALTER TABLE facts statement
+        with a non-duplicate OperationalError (e.g. a locked db)."""
+
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            if isinstance(sql, str) and sql.startswith("ALTER TABLE facts"):
+                raise sqlite3.OperationalError("database is locked")
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    monkeypatch.setattr(
+        memory_mod, "open_db", lambda *a, **k: _FaultyConn(real_open_db(*a, **k))
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        MemoryStore(db_path=db_path)
+
+
 # --- Prefer-recent tie-break -------------------------------------------------
 
 @pytest.mark.asyncio

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -1,0 +1,191 @@
+"""Tests for memory v2: dated + sourced facts and inject-head-only option.
+
+Covers:
+  - new (source_type, date) columns present + populated on store_fact
+  - idempotent migration adds the columns to a pre-existing DB created
+    WITHOUT them (an old on-disk schema) — reopen must not crash
+  - prefer-recent: date breaks decay_score ties in high-salience selection
+  - inject-head-only flag drops the ## Recent slice but keeps the head, and
+    the log stays searchable; flag-off → injection unchanged
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import tempfile
+
+import pytest
+
+from src.agent.memory import MemoryStore
+from src.agent.workspace import WorkspaceManager
+
+
+@pytest.fixture
+def memory(tmp_path):
+    store = MemoryStore(db_path=str(tmp_path / "test.db"))
+    yield store
+    store.close()
+
+
+# --- Schema + populate -------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_new_columns_present_and_populated_on_store(memory):
+    fact_id = await memory.store_fact("user_lang", "english", source_type="conversation")
+
+    cols = {r[1] for r in memory.db.execute("PRAGMA table_info(facts)").fetchall()}
+    assert "source_type" in cols
+    assert "date" in cols
+
+    row = memory.db.execute(
+        "SELECT source_type, date FROM facts WHERE id = ?", (fact_id,)
+    ).fetchone()
+    assert row[0] == "conversation"
+    assert row[1]  # date stamped, non-empty
+
+    fact = memory._get_fact(fact_id)
+    assert fact.source_type == "conversation"
+    assert fact.date is not None
+
+
+@pytest.mark.asyncio
+async def test_source_type_default_and_override(memory):
+    default_id = await memory.store_fact("k1", "v1")
+    custom_id = await memory.store_fact("k2", "v2", source_type="consolidation")
+
+    assert memory._get_fact(default_id).source_type == "conversation"
+    assert memory._get_fact(custom_id).source_type == "consolidation"
+
+
+@pytest.mark.asyncio
+async def test_batch_store_tags_context_flush_source_type(memory):
+    await memory.store_facts_batch([{"key": "bk", "value": "bv"}])
+    fact = memory._get_fact_by_key("bk")
+    assert fact is not None
+    assert fact.source_type == "context_flush"
+
+
+# --- Migration on a pre-existing OLD-schema DB -------------------------------
+
+def _create_legacy_facts_db(path: str) -> None:
+    """Create a facts table WITHOUT the v2 columns, mimicking an old on-disk DB
+    that predates the source_type/date migration."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            id TEXT PRIMARY KEY,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            category TEXT DEFAULT 'general',
+            source TEXT DEFAULT 'agent',
+            confidence REAL DEFAULT 1.0,
+            access_count INTEGER DEFAULT 0,
+            last_accessed TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            decay_score REAL DEFAULT 1.0
+        );
+        INSERT INTO facts (id, key, value) VALUES ('fact_old', 'legacy_key', 'legacy_value');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_adds_columns_to_preexisting_db(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _create_legacy_facts_db(db_path)
+
+    # Sanity: old schema lacks the v2 columns.
+    conn = sqlite3.connect(db_path)
+    cols_before = {r[1] for r in conn.execute("PRAGMA table_info(facts)").fetchall()}
+    conn.close()
+    assert "source_type" not in cols_before
+    assert "date" not in cols_before
+
+    # Reopening through MemoryStore must NOT crash and must add the columns.
+    store = MemoryStore(db_path=db_path)
+    try:
+        cols_after = {r[1] for r in store.db.execute("PRAGMA table_info(facts)").fetchall()}
+        assert "source_type" in cols_after
+        assert "date" in cols_after
+
+        # The pre-existing row survives and is readable through the mapper.
+        legacy = store._get_fact_by_key("legacy_key")
+        assert legacy is not None
+        assert legacy.value == "legacy_value"
+
+        # New writes against the migrated DB populate the v2 columns.
+        new_id = await store.store_fact("fresh", "value", source_type="conversation")
+        assert store._get_fact(new_id).source_type == "conversation"
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent_on_reopen(tmp_path):
+    db_path = str(tmp_path / "reopen.db")
+    s1 = MemoryStore(db_path=db_path)
+    await s1.store_fact("k", "v")
+    s1.close()
+    # Reopening an already-migrated DB must not raise on the duplicate ALTER.
+    s2 = MemoryStore(db_path=db_path)
+    try:
+        cols = {r[1] for r in s2.db.execute("PRAGMA table_info(facts)").fetchall()}
+        assert "source_type" in cols and "date" in cols
+    finally:
+        s2.close()
+
+
+# --- Prefer-recent tie-break -------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_high_salience_prefers_recent_on_tie(memory):
+    # Two facts with identical decay_score; the newer date should rank first.
+    old_id = await memory.store_fact("old", "old_val")
+    new_id = await memory.store_fact("new", "new_val")
+    # Force identical decay scores and a clearly older date on `old`.
+    memory.db.execute("UPDATE facts SET decay_score = 1.0")
+    memory.db.execute("UPDATE facts SET date = '2000-01-01 00:00:00' WHERE id = ?", (old_id,))
+    memory.db.execute("UPDATE facts SET date = '2099-01-01 00:00:00' WHERE id = ?", (new_id,))
+    memory.db.commit()
+
+    facts = await memory.get_high_salience_facts(top_k=2)
+    assert facts[0].id == new_id
+
+
+# --- inject-head-only flag ---------------------------------------------------
+
+class TestInjectHeadOnly:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.ws = WorkspaceManager(workspace_dir=self._tmpdir)
+        self.ws.write_compiled_memory("COMPILED_HEAD_MARKER")
+        self.ws.append_memory("## Recent entry\n\nRECENT_LOG_MARKER")
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_flag_off_injects_head_and_recent(self, monkeypatch):
+        monkeypatch.delenv("OPENLEGION_INJECT_HEAD_ONLY", raising=False)
+        injected = self.ws.get_memory_injection()
+        assert "COMPILED_HEAD_MARKER" in injected
+        assert "RECENT_LOG_MARKER" in injected
+        assert "## Recent" in injected
+
+    def test_flag_on_drops_recent_keeps_head(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_INJECT_HEAD_ONLY", "1")
+        injected = self.ws.get_memory_injection()
+        assert "COMPILED_HEAD_MARKER" in injected
+        assert "RECENT_LOG_MARKER" not in injected
+        assert "## Recent" not in injected
+
+    def test_flag_on_log_stays_searchable(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_INJECT_HEAD_ONLY", "1")
+        # Dropped from injection, but still on disk + searchable.
+        assert "RECENT_LOG_MARKER" not in self.ws.get_memory_injection()
+        assert "RECENT_LOG_MARKER" in self.ws.load_memory_log()
+        files = {r["file"] for r in self.ws.search("RECENT_LOG_MARKER")}
+        assert "MEMORY.md" in files

--- a/tests/test_memory_v2_dated_facts.py
+++ b/tests/test_memory_v2_dated_facts.py
@@ -59,6 +59,18 @@ async def test_source_type_default_and_override(memory):
 
 
 @pytest.mark.asyncio
+async def test_exact_key_restore_preserves_source_type(memory):
+    """Provenance guard: an exact-key re-store must NOT overwrite the original
+    source_type. A fact first recorded as "context_flush" and later re-asserted
+    by the conversation loop (default source_type) keeps its origin."""
+    fid = await memory.store_fact("k", "v1", source_type="context_flush")
+    await memory.store_fact("k", "v2")  # default source_type="conversation"
+    fact = memory._get_fact(fid)
+    assert fact.value == "v2"                  # value updated
+    assert fact.source_type == "context_flush"  # provenance preserved
+
+
+@pytest.mark.asyncio
 async def test_batch_store_tags_context_flush_source_type(memory):
     await memory.store_facts_batch([{"key": "bk", "value": "bv"}])
     fact = memory._get_fact_by_key("bk")

--- a/tests/test_stable_prefix.py
+++ b/tests/test_stable_prefix.py
@@ -276,6 +276,43 @@ def test_bootstrap_cache_slots_independent(tmp_path):
     assert ws.get_bootstrap_content(include_recent=False) == head_only
 
 
+def test_bootstrap_cache_both_slots_detect_external_mtime_change(tmp_path):
+    """Regression: an mtime-triggered rebuild of ONE variant must not mark the
+    OTHER variant fresh. Each slot owns its own mtime snapshot, so an external
+    write to MEMORY.md (one that does NOT explicitly clear the caches) is picked
+    up by BOTH variants on their next call — neither serves stale content."""
+    import os
+
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    memory = ws.root / "MEMORY.md"
+    memory.write_text(_MEMORY_WITH_RECENT)
+
+    # Warm BOTH cache slots against the original content.
+    assert _HEAD in ws.get_bootstrap_content(include_recent=True)
+    assert _HEAD in ws.get_bootstrap_content(include_recent=False)
+
+    # Simulate an EXTERNAL change: write directly to the file and bump its
+    # mtime, bypassing append_memory/write_compiled_memory/update_file (the
+    # paths that explicitly clear the caches). Only the lazy mtime check applies.
+    new_head = "The user now prefers verbose answers. The live fleet is sales."
+    memory.write_text(
+        "# Long-Term Memory\n\n"
+        "<!-- compiled:begin -->\n"
+        f"{new_head}\n"
+        "<!-- compiled:end -->\n\n"
+        "## 2026-06-09T11:00 flush\n\n"
+        "- learned: the user switched preferences\n"
+    )
+    future = memory.stat().st_mtime + 10
+    os.utime(memory, (future, future))
+
+    # BOTH variants must observe the new content (no stale slot).
+    assert new_head in ws.get_bootstrap_content(include_recent=True)
+    assert new_head in ws.get_bootstrap_content(include_recent=False)
+    assert _HEAD not in ws.get_bootstrap_content(include_recent=True)
+    assert _HEAD not in ws.get_bootstrap_content(include_recent=False)
+
+
 def test_no_recent_slice_when_log_empty(tmp_path, monkeypatch):
     """Flag ON with a head-only MEMORY (no log) stashes nothing extra for the
     recent slice and the head is still present in the system prompt."""

--- a/tests/test_stable_prefix.py
+++ b/tests/test_stable_prefix.py
@@ -1,20 +1,18 @@
-"""Tests for C3 — cache-prefix stabilization (OPENLEGION_STABLE_PREFIX).
+"""Tests for C3 — cache-prefix stabilization.
 
-The flag relocates per-turn-VOLATILE prompt fragments (context/round warnings,
-operator playbooks, 5-min runtime context, the ``## Recent`` memory slice) OUT
-of the cached system block and re-injects them AFTER the mesh-side cache
+Always-on: per-turn-VOLATILE prompt fragments (context/round warnings, operator
+playbooks, 5-min runtime context, the ``## Recent`` memory slice) are relocated
+OUT of the cached system block and re-injected AFTER the mesh-side cache
 breakpoint (into the last message). Goals:
 
-  * flag OFF  → the built system prompt is byte-identical to today's.
-  * flag ON   → volatile fragments are NOT in the system prompt but ARE present
-                later in the message list; role-alternation stays valid.
+  * volatile fragments are NOT in the system prompt but ARE present later in the
+    message list; role-alternation stays valid.
   * the STABLE prefix is byte-identical across two builds that differ ONLY in
-                volatile content (the whole point — prove the prefix is stable).
+    volatile content (the whole point — prove the prefix is stable).
 
 These exercise the prompt BUILDERS directly (no LLM round-trip needed).
 """
 
-import src.agent.loop as loop_mod
 from src.agent.context import ContextManager
 from src.agent.workspace import WorkspaceManager
 from src.shared.types import TaskAssignment
@@ -43,9 +41,8 @@ _RECENT_MARKER = "## Recent"
 _RECENT_BODY = "the user is named Jeff and wants SEO work"
 
 
-def _operator_loop(tmp_path, monkeypatch, *, stable: bool):
+def _operator_loop(tmp_path):
     """A loop with a real workspace + context manager, operator role."""
-    monkeypatch.setattr(loop_mod, "_STABLE_PREFIX", stable)
     ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
     (ws.root / "SOUL.md").write_text("# Identity\n\nI am the operator.\n")
     (ws.root / "INSTRUCTIONS.md").write_text("# Instructions\n\nDo the thing.\n")
@@ -66,50 +63,11 @@ def _chat_prompt(loop, **kw):
     return loop._build_chat_system_prompt(introspect_data=introspect, **kw)
 
 
-# ── Flag OFF: byte-identical to legacy ────────────────────────────────
+# ── Volatile moves out, lands in the message list ─────────────────────
 
 
-def test_flag_off_chat_prompt_byte_identical(tmp_path, monkeypatch):
-    """Flag OFF must rebuild the EXACT legacy prompt (no reordering).
-
-    We assert the two known-volatile fragments (the ``## Recent`` slice and the
-    CONTEXT WARNING) are INLINE in the system prompt, exactly as before, and
-    that no relocation suffix is stashed.
-    """
-    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
-    # Force a CONTEXT WARNING by stuffing the chat history past 80% of 200 tok.
-    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
-
-    prompt = _chat_prompt(loop)
-
-    assert _RECENT_MARKER in prompt
-    assert _RECENT_BODY in prompt
-    assert "CONTEXT WARNING" in prompt
-    # Nothing relocated when the flag is off.
-    assert loop._volatile_prompt_suffix == ""
-    # And the message list is returned untouched (same object).
-    msgs = loop._chat_messages
-    assert loop._messages_with_volatile(msgs) is msgs
-
-
-def test_flag_off_matches_head_inclusive_bootstrap(tmp_path, monkeypatch):
-    """The flag-off system prompt is exactly the legacy one: the bootstrap is
-    head+recent-inclusive and the prompt equals a freshly rebuilt copy."""
-    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
-    p1 = _chat_prompt(loop)
-    # Rebuild again — deterministic, byte-identical.
-    p2 = _chat_prompt(loop)
-    assert p1 == p2
-    # The recent slice lives inside the (head-inclusive) bootstrap block.
-    assert loop.workspace.get_bootstrap_content(include_recent=True) ==  \
-        loop.workspace.get_bootstrap_content()
-
-
-# ── Flag ON: volatile moves out, lands in the message list ────────────
-
-
-def test_flag_on_recent_slice_leaves_system_prompt(tmp_path, monkeypatch):
-    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+def test_recent_slice_leaves_system_prompt(tmp_path):
+    loop = _operator_loop(tmp_path)
     prompt = _chat_prompt(loop)
 
     # The volatile ``## Recent`` slice is NO LONGER in the system prompt …
@@ -121,8 +79,8 @@ def test_flag_on_recent_slice_leaves_system_prompt(tmp_path, monkeypatch):
     assert _RECENT_BODY in loop._volatile_prompt_suffix
 
 
-def test_flag_on_context_warning_leaves_system_prompt(tmp_path, monkeypatch):
-    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+def test_context_warning_leaves_system_prompt(tmp_path):
+    loop = _operator_loop(tmp_path)
     loop._chat_messages = [{"role": "user", "content": "x " * 400}]
 
     prompt = _chat_prompt(loop)
@@ -131,10 +89,10 @@ def test_flag_on_context_warning_leaves_system_prompt(tmp_path, monkeypatch):
     assert "CONTEXT WARNING" in loop._volatile_prompt_suffix
 
 
-def test_flag_on_volatile_reinjected_into_last_message(tmp_path, monkeypatch):
+def test_volatile_reinjected_into_last_message(tmp_path):
     """Relocated content must still REACH the model — appended to the last
     message, after the cache breakpoint, without adding a message."""
-    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop = _operator_loop(tmp_path)
     loop._chat_messages = [{"role": "user", "content": "Hello operator " * 60}]
     _chat_prompt(loop)
 
@@ -149,10 +107,10 @@ def test_flag_on_volatile_reinjected_into_last_message(tmp_path, monkeypatch):
     assert "CONTEXT WARNING" in out[-1]["content"]
 
 
-def test_flag_on_reinjection_handles_multimodal_last_message(tmp_path, monkeypatch):
+def test_reinjection_handles_multimodal_last_message(tmp_path):
     """A list-content (multimodal) last message gets a trailing text block, not
     a clobbered string — and no extra message."""
-    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop = _operator_loop(tmp_path)
     loop._chat_messages = [
         {"role": "user", "content": [{"type": "text", "text": "pic " * 30}]},
     ]
@@ -172,15 +130,15 @@ def test_flag_on_reinjection_handles_multimodal_last_message(tmp_path, monkeypat
 # ── The whole point: the STABLE prefix is stable ──────────────────────
 
 
-def test_stable_prefix_identical_across_volatile_change(tmp_path, monkeypatch):
+def test_stable_prefix_identical_across_volatile_change(tmp_path):
     """Two builds that differ ONLY in volatile content must yield a
-    byte-identical system prefix when the flag is ON.
+    byte-identical system prefix.
 
     Build A: low context (no warning). Build B: high context (CONTEXT WARNING
-    fires) AND the recent log grows. With the flag ON both must produce the
-    SAME system prompt — that's what makes #1073's cached prefix hit.
+    fires) AND the recent log grows. Both must produce the SAME system prompt —
+    that's what makes #1073's cached prefix hit.
     """
-    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop = _operator_loop(tmp_path)
 
     # Build A — minimal volatile content.
     loop._chat_messages = [{"role": "user", "content": "hi"}]
@@ -199,36 +157,11 @@ def test_stable_prefix_identical_across_volatile_change(tmp_path, monkeypatch):
     assert "CONTEXT WARNING" in loop._volatile_prompt_suffix  # B had a warning
 
 
-def test_stable_prefix_control_flag_off_prefix_changes(tmp_path, monkeypatch):
-    """Control: with the flag OFF the SAME two builds DO differ (volatile is
-    inline) — proving the stability above is the flag's doing, not a no-op."""
-    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
-
-    loop._chat_messages = [{"role": "user", "content": "hi"}]
-    a = _chat_prompt(loop)
-    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
-    b = _chat_prompt(loop)
-
-    assert a != b  # warning is inline → prompt changes turn-to-turn
-
-
 # ── Task-path builder ─────────────────────────────────────────────────
 
 
-def test_task_builder_flag_off_byte_identical(tmp_path, monkeypatch):
-    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
-    assignment = TaskAssignment(
-        workflow_id="wf", step_id="s", task_type="research", input_data={},
-    )
-    introspect = {"permissions": {}, "budget": None, "fleet": [{"id": "a"}]}
-    prompt = loop._build_system_prompt(assignment, introspect_data=introspect)
-    assert _RECENT_MARKER in prompt
-    assert "## Runtime Context" in prompt
-    assert loop._volatile_prompt_suffix == ""
-
-
-def test_task_builder_flag_on_relocates_runtime_and_recent(tmp_path, monkeypatch):
-    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+def test_task_builder_relocates_runtime_and_recent(tmp_path):
+    loop = _operator_loop(tmp_path)
     assignment = TaskAssignment(
         workflow_id="wf", step_id="s", task_type="research", input_data={},
     )
@@ -313,10 +246,9 @@ def test_bootstrap_cache_both_slots_detect_external_mtime_change(tmp_path):
     assert _HEAD not in ws.get_bootstrap_content(include_recent=False)
 
 
-def test_no_recent_slice_when_log_empty(tmp_path, monkeypatch):
-    """Flag ON with a head-only MEMORY (no log) stashes nothing extra for the
-    recent slice and the head is still present in the system prompt."""
-    monkeypatch.setattr(loop_mod, "_STABLE_PREFIX", True)
+def test_no_recent_slice_when_log_empty(tmp_path):
+    """A head-only MEMORY (no log) stashes nothing extra for the recent slice
+    and the head is still present in the system prompt."""
     ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
     (ws.root / "MEMORY.md").write_text(_MEMORY_HEAD_ONLY)
     assert ws.get_recent_memory_slice() == ""

--- a/tests/test_stable_prefix.py
+++ b/tests/test_stable_prefix.py
@@ -1,0 +1,294 @@
+"""Tests for C3 — cache-prefix stabilization (OPENLEGION_STABLE_PREFIX).
+
+The flag relocates per-turn-VOLATILE prompt fragments (context/round warnings,
+operator playbooks, 5-min runtime context, the ``## Recent`` memory slice) OUT
+of the cached system block and re-injects them AFTER the mesh-side cache
+breakpoint (into the last message). Goals:
+
+  * flag OFF  → the built system prompt is byte-identical to today's.
+  * flag ON   → volatile fragments are NOT in the system prompt but ARE present
+                later in the message list; role-alternation stays valid.
+  * the STABLE prefix is byte-identical across two builds that differ ONLY in
+                volatile content (the whole point — prove the prefix is stable).
+
+These exercise the prompt BUILDERS directly (no LLM round-trip needed).
+"""
+
+import src.agent.loop as loop_mod
+from src.agent.context import ContextManager
+from src.agent.workspace import WorkspaceManager
+from src.shared.types import TaskAssignment
+from tests.test_loop import _make_loop
+
+# A compiled head + an append-only log so get_memory_injection() produces a
+# real ``## Recent`` slice. The head is the STABLE part; the log tail is the
+# VOLATILE ``## Recent`` slice that must move out of the cached prefix.
+_HEAD = "The user prefers concise answers. The live fleet is content-seo."
+_MEMORY_WITH_RECENT = (
+    "# Long-Term Memory\n\n"
+    "<!-- compiled:begin -->\n"
+    f"{_HEAD}\n"
+    "<!-- compiled:end -->\n\n"
+    "## 2026-06-09T10:00 flush\n\n"
+    "- learned: the user is named Jeff and wants SEO work\n"
+)
+_MEMORY_HEAD_ONLY = (
+    "# Long-Term Memory\n\n"
+    "<!-- compiled:begin -->\n"
+    f"{_HEAD}\n"
+    "<!-- compiled:end -->\n"
+)
+
+_RECENT_MARKER = "## Recent"
+_RECENT_BODY = "the user is named Jeff and wants SEO work"
+
+
+def _operator_loop(tmp_path, monkeypatch, *, stable: bool):
+    """A loop with a real workspace + context manager, operator role."""
+    monkeypatch.setattr(loop_mod, "_STABLE_PREFIX", stable)
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "SOUL.md").write_text("# Identity\n\nI am the operator.\n")
+    (ws.root / "INSTRUCTIONS.md").write_text("# Instructions\n\nDo the thing.\n")
+    (ws.root / "MEMORY.md").write_text(_MEMORY_WITH_RECENT)
+
+    loop = _make_loop()
+    loop.workspace = ws
+    # Operator: allowed_tools is the signal _is_operator keys off.
+    loop._is_operator = True
+    loop._allowed_tools = frozenset({"notify_user"})
+    loop.context_manager = ContextManager(max_tokens=200, model="test-model")
+    return loop
+
+
+def _chat_prompt(loop, **kw):
+    """Build a chat system prompt with a default introspect payload."""
+    introspect = kw.pop("introspect_data", {"permissions": {}, "budget": None})
+    return loop._build_chat_system_prompt(introspect_data=introspect, **kw)
+
+
+# ── Flag OFF: byte-identical to legacy ────────────────────────────────
+
+
+def test_flag_off_chat_prompt_byte_identical(tmp_path, monkeypatch):
+    """Flag OFF must rebuild the EXACT legacy prompt (no reordering).
+
+    We assert the two known-volatile fragments (the ``## Recent`` slice and the
+    CONTEXT WARNING) are INLINE in the system prompt, exactly as before, and
+    that no relocation suffix is stashed.
+    """
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+    # Force a CONTEXT WARNING by stuffing the chat history past 80% of 200 tok.
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+
+    prompt = _chat_prompt(loop)
+
+    assert _RECENT_MARKER in prompt
+    assert _RECENT_BODY in prompt
+    assert "CONTEXT WARNING" in prompt
+    # Nothing relocated when the flag is off.
+    assert loop._volatile_prompt_suffix == ""
+    # And the message list is returned untouched (same object).
+    msgs = loop._chat_messages
+    assert loop._messages_with_volatile(msgs) is msgs
+
+
+def test_flag_off_matches_head_inclusive_bootstrap(tmp_path, monkeypatch):
+    """The flag-off system prompt is exactly the legacy one: the bootstrap is
+    head+recent-inclusive and the prompt equals a freshly rebuilt copy."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+    p1 = _chat_prompt(loop)
+    # Rebuild again — deterministic, byte-identical.
+    p2 = _chat_prompt(loop)
+    assert p1 == p2
+    # The recent slice lives inside the (head-inclusive) bootstrap block.
+    assert loop.workspace.get_bootstrap_content(include_recent=True) ==  \
+        loop.workspace.get_bootstrap_content()
+
+
+# ── Flag ON: volatile moves out, lands in the message list ────────────
+
+
+def test_flag_on_recent_slice_leaves_system_prompt(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    prompt = _chat_prompt(loop)
+
+    # The volatile ``## Recent`` slice is NO LONGER in the system prompt …
+    assert _RECENT_MARKER not in prompt
+    assert _RECENT_BODY not in prompt
+    # … but the STABLE head still is.
+    assert _HEAD in prompt
+    # … and the recent slice is stashed for re-injection.
+    assert _RECENT_BODY in loop._volatile_prompt_suffix
+
+
+def test_flag_on_context_warning_leaves_system_prompt(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+
+    prompt = _chat_prompt(loop)
+
+    assert "CONTEXT WARNING" not in prompt
+    assert "CONTEXT WARNING" in loop._volatile_prompt_suffix
+
+
+def test_flag_on_volatile_reinjected_into_last_message(tmp_path, monkeypatch):
+    """Relocated content must still REACH the model — appended to the last
+    message, after the cache breakpoint, without adding a message."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop._chat_messages = [{"role": "user", "content": "Hello operator " * 60}]
+    _chat_prompt(loop)
+
+    out = loop._messages_with_volatile(loop._chat_messages)
+    # No new message added (role-alternation preserved).
+    assert len(out) == len(loop._chat_messages)
+    assert out[-1]["role"] == "user"
+    # Persistent list NOT mutated.
+    assert "Live context" not in loop._chat_messages[-1]["content"]
+    # Volatile content present in the transient copy's last message.
+    assert _RECENT_BODY in out[-1]["content"]
+    assert "CONTEXT WARNING" in out[-1]["content"]
+
+
+def test_flag_on_reinjection_handles_multimodal_last_message(tmp_path, monkeypatch):
+    """A list-content (multimodal) last message gets a trailing text block, not
+    a clobbered string — and no extra message."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    loop._chat_messages = [
+        {"role": "user", "content": [{"type": "text", "text": "pic " * 30}]},
+    ]
+    _chat_prompt(loop)
+
+    out = loop._messages_with_volatile(loop._chat_messages)
+    assert len(out) == len(loop._chat_messages)
+    last = out[-1]["content"]
+    assert isinstance(last, list)
+    assert last[-1]["type"] == "text"
+    assert _RECENT_BODY in last[-1]["text"]
+    # Original blocks untouched.
+    assert loop._chat_messages[-1]["content"][0]["text"].startswith("pic ")
+    assert len(loop._chat_messages[-1]["content"]) == 1
+
+
+# ── The whole point: the STABLE prefix is stable ──────────────────────
+
+
+def test_stable_prefix_identical_across_volatile_change(tmp_path, monkeypatch):
+    """Two builds that differ ONLY in volatile content must yield a
+    byte-identical system prefix when the flag is ON.
+
+    Build A: low context (no warning). Build B: high context (CONTEXT WARNING
+    fires) AND the recent log grows. With the flag ON both must produce the
+    SAME system prompt — that's what makes #1073's cached prefix hit.
+    """
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+
+    # Build A — minimal volatile content.
+    loop._chat_messages = [{"role": "user", "content": "hi"}]
+    prefix_a = _chat_prompt(loop)
+
+    # Build B — change ONLY volatile inputs: blow up the context (→ warning)
+    # and append a NEW recent log entry (→ different ## Recent slice).
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+    loop.workspace.append_memory("brand-new volatile fact " * 5)
+    prefix_b = _chat_prompt(loop)
+
+    assert prefix_a == prefix_b, "stable prefix drifted across volatile change"
+    # Sanity: the volatile suffixes DID differ (so we actually changed volatile
+    # inputs, not nothing).
+    # Rebuild A's suffix to compare against B's stash.
+    assert "CONTEXT WARNING" in loop._volatile_prompt_suffix  # B had a warning
+
+
+def test_stable_prefix_control_flag_off_prefix_changes(tmp_path, monkeypatch):
+    """Control: with the flag OFF the SAME two builds DO differ (volatile is
+    inline) — proving the stability above is the flag's doing, not a no-op."""
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+
+    loop._chat_messages = [{"role": "user", "content": "hi"}]
+    a = _chat_prompt(loop)
+    loop._chat_messages = [{"role": "user", "content": "x " * 400}]
+    b = _chat_prompt(loop)
+
+    assert a != b  # warning is inline → prompt changes turn-to-turn
+
+
+# ── Task-path builder ─────────────────────────────────────────────────
+
+
+def test_task_builder_flag_off_byte_identical(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=False)
+    assignment = TaskAssignment(
+        workflow_id="wf", step_id="s", task_type="research", input_data={},
+    )
+    introspect = {"permissions": {}, "budget": None, "fleet": [{"id": "a"}]}
+    prompt = loop._build_system_prompt(assignment, introspect_data=introspect)
+    assert _RECENT_MARKER in prompt
+    assert "## Runtime Context" in prompt
+    assert loop._volatile_prompt_suffix == ""
+
+
+def test_task_builder_flag_on_relocates_runtime_and_recent(tmp_path, monkeypatch):
+    loop = _operator_loop(tmp_path, monkeypatch, stable=True)
+    assignment = TaskAssignment(
+        workflow_id="wf", step_id="s", task_type="research", input_data={},
+    )
+    introspect = {"permissions": {}, "budget": None, "fleet": [{"id": "a"}]}
+    prompt = loop._build_system_prompt(assignment, introspect_data=introspect)
+    # Volatile out of the system prompt …
+    assert _RECENT_MARKER not in prompt
+    assert "## Runtime Context" not in prompt
+    # … stashed for re-injection.
+    assert _RECENT_BODY in loop._volatile_prompt_suffix
+    assert "## Runtime Context" in loop._volatile_prompt_suffix
+    # Stable identity content stays.
+    assert "Operating Rules" in prompt
+
+
+# ── Workspace memory-injection split ──────────────────────────────────
+
+
+def test_get_memory_injection_head_only(tmp_path):
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "MEMORY.md").write_text(_MEMORY_WITH_RECENT)
+    full = ws.get_memory_injection(include_recent=True)
+    head_only = ws.get_memory_injection(include_recent=False)
+    assert _RECENT_MARKER in full
+    assert _RECENT_MARKER not in head_only
+    assert _HEAD in head_only
+    # The relocated slice is exactly what get_recent_memory_slice returns.
+    slice_ = ws.get_recent_memory_slice()
+    assert slice_.startswith(_RECENT_MARKER)
+    assert _RECENT_BODY in slice_
+
+
+def test_bootstrap_cache_slots_independent(tmp_path):
+    """The head-only bootstrap variant is memoized separately from the default
+    (recent-inclusive) one — calling one must not poison the other."""
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "MEMORY.md").write_text(_MEMORY_WITH_RECENT)
+    with_recent = ws.get_bootstrap_content(include_recent=True)
+    head_only = ws.get_bootstrap_content(include_recent=True) is not None and \
+        ws.get_bootstrap_content(include_recent=False)
+    assert _RECENT_MARKER in with_recent
+    assert _RECENT_MARKER not in head_only
+    # Re-fetch from cache — still correct (no cross-contamination).
+    assert ws.get_bootstrap_content(include_recent=True) == with_recent
+    assert ws.get_bootstrap_content(include_recent=False) == head_only
+
+
+def test_no_recent_slice_when_log_empty(tmp_path, monkeypatch):
+    """Flag ON with a head-only MEMORY (no log) stashes nothing extra for the
+    recent slice and the head is still present in the system prompt."""
+    monkeypatch.setattr(loop_mod, "_STABLE_PREFIX", True)
+    ws = WorkspaceManager(workspace_dir=str(tmp_path / "ws"))
+    (ws.root / "MEMORY.md").write_text(_MEMORY_HEAD_ONLY)
+    assert ws.get_recent_memory_slice() == ""
+    loop = _make_loop()
+    loop.workspace = ws
+    loop._is_operator = False
+    loop.context_manager = None
+    prompt = loop._build_chat_system_prompt(
+        introspect_data=None,
+    )
+    assert _HEAD in prompt
+    assert _RECENT_MARKER not in loop._volatile_prompt_suffix


### PR DESCRIPTION
## Operator memory/context overhaul — Phase 2, landed as one clean (de-flagged) system

Supersedes #1076 #1077 #1078 #1079 #1080 #1081. All six were reviewed, merged together, **de-flagged** (no feature flags, no legacy path — the new system is the only path), and the two real cross-PR interaction issues were reconciled with regression coverage.

### What's included
- **#1076** background memory maintenance (consolidation + salience decay outside compaction; lifespan task)
- **#1077** semantic fact dedup on the memory write path
- **#1078** grouped tool search / lazy schema loading (budget-gated)
- **#1079** `execute_code` builtin (all agents + operator)
- **#1080** memory v2: dated + sourced facts, prefer-recent
- **#1081** cache-prefix stabilization (volatile fragments relocated below the cache breakpoint)

### Flags removed (always-on now)
`OPENLEGION_SEMANTIC_DEDUP`, `OPENLEGION_INJECT_HEAD_ONLY`, `OPENLEGION_STABLE_PREFIX`, `OPENLEGION_GROUPED_TOOLS`, `OPENLEGION_EXECUTE_CODE` — plus their gate functions and dead legacy branches.

### Interaction issues reconciled
1. **#1077 × #1080** — the semantic-merge UPDATE now stamps `date` + preserves `source_type`, so a re-asserted near-duplicate ranks recent instead of sinking under prefer-recent. Regression: `test_merge_restamps_date_and_preserves_source_type`.
2. **#1078 × #1081** — the capability index lives in the stable cached block (busts only on an explicit `load_tools`); volatile fragments always relocate below the breakpoint. `#1080`'s redundant `_inject_head_only` path was cut in favor of `#1081`'s `include_recent` mechanism.

### Robustness
`_refresh_grouped_plan` reads the context window defensively — a missing/partial context manager yields an inactive plan (full tool surface) instead of hard-failing a chat turn.

### Tests
Full suite: **7228 passed, 49 skipped, 0 failed**. Ruff clean. Flag-OFF legacy tests removed; new always-on contract asserted directly.
