### PR TITLE
fix(context): resolve Opus 4.8 to its real 1M window, not the 128K default

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -190,6 +190,13 @@ class ContextManager:
     ):
         self.model = model
         self.max_tokens = max_tokens or get_context_window(model)
+        # Surface the resolved budget so a silent fallthrough (model missing
+        # from litellm's registry → 128K default) is visible in agent logs
+        # rather than only showing up as surprisingly-early compaction.
+        logger.info(
+            "context budget resolved: model=%s max_tokens=%d",
+            model or "(unset)", self.max_tokens,
+        )
         self.llm = llm
         self.workspace = workspace
         self.memory = memory

--- a/src/shared/models.py
+++ b/src/shared/models.py
@@ -110,6 +110,7 @@ _FALLBACK_CONTEXT: dict[str, int] = {
     "openai/o3-mini": 200_000,
     "openai/o4-mini": 200_000,
     "anthropic/claude-opus-4-6": 200_000,
+    "anthropic/claude-opus-4-8": 1_000_000,
     "anthropic/claude-sonnet-4-6": 200_000,
     "anthropic/claude-sonnet-4-5-20250929": 200_000,
     "anthropic/claude-haiku-4-5-20251001": 200_000,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -120,6 +120,15 @@ class TestGetContextWindow:
             window = get_context_window("openai/gpt-4o")
             assert window == _FALLBACK_CONTEXT["openai/gpt-4o"]
 
+    def test_opus_4_8_resolves_to_1m_without_litellm(self):
+        """Opus 4.8 has a 1M window; when litellm's registry lacks the model
+        the fallback table must still resolve it, not collapse to the 128K
+        default (which would compact the operator absurdly early)."""
+        with patch("src.shared.models._resolve_litellm_key", return_value=None):
+            window = get_context_window("anthropic/claude-opus-4-8")
+            assert window == 1_000_000
+            assert window != _DEFAULT_CONTEXT_WINDOW
+
 
 class TestGetProviderModels:
     def test_featured_models_first(self):


### PR DESCRIPTION
## What

The operator runs `anthropic/claude-opus-4-8`, which has a genuine **1M** context window on the Anthropic OAuth path. But it has been compacting **absurdly early** (~90K).

## Why

`get_context_window()` resolves the per-agent budget from litellm's `model_cost` registry first, and only consults `_FALLBACK_CONTEXT` when litellm **misses** the model. litellm's coverage of newer Claude models is version-dependent, and `model_cost` ships *inside* the package (it drifts at the patch level). A deployment whose pinned litellm (`>=1.83.0,<1.84.0`) predates `claude-opus-4-8` silently falls through to `_DEFAULT_CONTEXT_WINDOW` (**128K**) → the ContextManager compacts at `0.70 * 128K ≈ 90K`.

## Change

- Add `anthropic/claude-opus-4-8: 1_000_000` to `_FALLBACK_CONTEXT`. This is **only read on a litellm registry miss**, so it's a no-op where litellm already knows the model — safe to ship without first confirming the deployed litellm patch version.
- Log the resolved budget at `ContextManager` init, so a silent fallthrough (model missing from litellm → 128K) is visible in agent logs rather than only surfacing as early compaction. This is also how we confirm the fix took effect on deploy (expect `max_tokens=1000000` for the operator).

## Scope / deliberately not included

- **No family-prefix / blanket-1M logic.** A blanket Claude floor would over-promise on the sub-200K Claude variants in litellm's registry. This adds only the one confirmed model.
- **No compaction-threshold change** (0.70 → 0.80). That's a separate behavior/cost decision and is gated on the now-merged memory/caching work; not in this PR.
- **`claude-sonnet-4-8` not added** — no committed config runs it; add when/if a deployment does.

## Testing

`pytest tests/test_models.py tests/test_context.py` → **96 passed**. New test pins Opus 4.8 → 1M on a litellm miss (would return the 128K default without the entry).

## Verify on deploy

After deploy, check the operator log for `context budget resolved: model=anthropic/claude-opus-4-8 max_tokens=1000000`. If it shows `128000`, the model string differs (e.g. dated suffix) and we add that exact key.