### PR TITLE
fix(streaming): forward agent keepalives to the browser (Phase 0: stop silent operator stalls)

### DIFF
--- a/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
+++ b/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
@@ -1,0 +1,211 @@
+# Operator orchestration: delegate-and-subscribe (no more silent stalls)
+
+**Status:** REVISED after principal-engineer + Codex review (2026-06-10). Phase 0 implemented in the same PR as this revision. Phases 1–3 ready to implement.
+**One-line:** Stop the operator from *blocking* to watch a pipeline. Make watching a durable, origin-aware **system** behavior that **pushes** progress + a **guaranteed terminal outcome** to the user's channel. The operator delegates and releases; it never holds a turn open to babysit a poll loop.
+
+> **Review note (2026-06-10).** The original draft mislocated the root cause and overstated how much of Phase 1 is "just wiring." Both were corrected against the actual code (and an independent Codex pass). The *product direction* — no silent death; delegate-and-release — survived review unchanged. The corrections are folded in below; the superseded claims are called out where they mattered.
+
+---
+
+## 0. TL;DR for the reviewer
+
+- **Symptom (reproduced on cake):** user asks the operator to hand off work through the team; the operator "stops out of nowhere" when a pipeline stage takes a while.
+- **Root cause (CORRECTED):** a streaming hop with a **120s idle timeout that receives no keepalive** kills the turn. It is **NOT** the mesh→agent `transport.py` hop (originally blamed) — that hop is kept alive by the agent's 15s SSE keepalive. The unprotected leg is **dashboard→browser**: `transport.stream_request` strips the agent's `": keepalive"` comments (forwards only `data:` lines), and the dashboard's own SSE generator emits no keepalive — so during a long silent tool call the browser sees zero bytes and its **120s `AbortController`** (`app.js:8610-8619`) fires. That disconnect propagates back (browser→dashboard→agent), cancelling the operator's coroutine → `await_task_event EXIT cancelled (likely tool timeout)` → turn torn down. Then **nothing re-wakes the operator** → stranded.
+- **Why "we improved it" didn't help:** PR #1068 made `await_task_event` poll task status (good — hop 1 worked). But the poll runs inside a blocking tool call, and the *browser idle abort* (not any server-side cap) kills it once a single silent window exceeds 120s. #1068 didn't touch the streaming leg.
+- **The fix has two layers:**
+  1. **Phase 0 (bleeder-stopper, IMPLEMENTED here):** forward the agent's keepalive end-to-end so no streaming hop goes byte-silent. This stops the silent death for **every** long quiet tool (operator `await_task_event`, but also `execute_code`, `run_command`, browser ops), not just this one path. Zero security surface.
+  2. **Phase 1+ (the real product):** even with the connection kept alive, holding a synchronous chat turn open for a 10-minute multi-hop pipeline is wrong — it monopolizes the operator, burns LLM tokens in a poll loop, and dies on operator restart (which we saw on cake). So decouple watching from the turn: **delegate-and-subscribe + push**, with a hard guarantee that every user-initiated chain ends in a user-facing outcome.
+- **Honesty correction:** Phase 1 is **not** "just wiring." Only one reusable primitive exists end-to-end (`_handle_notify_origin` for the chat channels). The chain-level state, the proactive push trigger, and **dashboard delivery** (the exact channel the repro used) must be built. See §4.
+
+---
+
+## 1. Evidence (the cake trace — ground truth)
+
+Operator on cake (`anthropic/claude-opus-4-8`), user-initiated dashboard handoff to test the end-to-end flow:
+
+```
+16:53:00  hand_off → trend-scout              task A = task_1a974ca62a0d   (origin = dashboard human)
+16:53:04  await_task_event task A timeout_s=180 poll=3s
+16:54:19  EXIT terminal_status status=done     ← hop 1: 75s, < 120s, WORKED
+16:54:34  await_task_event task B timeout_s=240 poll=3s   (task_225a797e90fe, next hop)
+16:56:34  EXIT cancelled, last_status_seen='working',
+          reason='await_task_event cancelled (likely tool timeout)'   ← killed at ~120s
+          → turn torn down. Operator idle for 9+ minutes. No re-wake. No user report.
+```
+
+The cancel arrives at ~120s of *silence on the browser leg*, not at any server-side tool ceiling (`_TOOL_TIMEOUT=900`). Hop 1 (75s < 120s) survived; hop 2 (silent > 120s) did not.
+
+---
+
+## 2. Root cause (corrected against the code)
+
+The streaming topology for a dashboard chat is one logical pipe across three legs:
+
+```
+browser  ──fetch+ReadableStream──▶  dashboard (mounted on mesh :8420)  ──transport.stream_request──▶  agent :8400
+   ▲ 120s AbortController                  │ strips ": keepalive", forwards only data:        │ emits ": keepalive" every 15s
+   └──────────────── resets on ANY chunk ──┘ (no keepalive of its own)                         └── (server.py chat_stream)
+```
+
+- **Agent→dashboard leg is protected.** The agent's `chat_stream` generator yields `": keepalive\n\n"` every 15s while a tool runs silently (`src/agent/server.py`). Receiving that line resets httpx's read-idle clock at `aiter_lines()`, so the dashboard→agent hop never idles out — even for a 240s tool. **This is why the originally-blamed `transport.py timeout=120` is NOT the killer.**
+- **Dashboard→browser leg is unprotected.** `transport.stream_request` forwards only lines starting with `data: ` and **drops** the agent's `": keepalive"` comments (`src/host/transport.py`). The dashboard's `api_chat_stream` / `api_broadcast_stream` generators emit no keepalive of their own (`src/dashboard/server.py`). So during a silent tool the browser receives **zero bytes**.
+- **The browser aborts at 120s.** `app.js:8610-8619` arms a 120s `AbortController` that resets on *every* `reader.read()` chunk; with no chunks it fires. The abort closes the fetch → dashboard generator is torn down → its `transport.stream_request` context closes → the agent sees a client disconnect → Starlette cancels the agent's stream coroutine → `CancelledError` lands inside `await_task_event`.
+
+**Two compounding problems remain even if you keep the pipe alive:**
+1. **Synchronous watch can't scale.** A multi-hop, multi-minute pipeline is unbounded async work; a chat turn is a bounded synchronous primitive. No keepalive makes block-watching *correct* — it just stops it *crashing*.
+2. **No resumption.** Once a turn ends (crash, restart, or normal release), nothing re-engages the operator on pipeline progress. The back-edge `task_event` + wake chain did not re-wake it.
+
+---
+
+## 3. Product vision (the north star — unchanged by review)
+
+The operator should behave like a **project manager**, not a security guard:
+- A good PM says "On it," delegates, sets up status reporting, and **goes away** — surfacing only at **milestones, completion, or a blocker**.
+- Today's operator is the guard whose shift is **120 seconds**; when it ends, the feed goes unwatched and nobody tells the user.
+
+**Cardinal rule:** silent death is the one experience we make structurally impossible. Every user-initiated pipeline ends in a user-facing outcome — **done, failed, or stalled** — pushed to the channel the request came from.
+
+**Experience, before → after:**
+> Before: "Do X" → 9-min frozen spinner → silence → user re-asks → operator has forgotten.
+> After: "Do X" → instant "On it — trend-scout researching; I'll keep you posted" → "✅ Research done → drafting" → "✅ Draft → polishing" → "🎉 Done, here's the result." If jammed: "⚠️ Stuck at stage 2, need your call on X."
+
+---
+
+## 4. Architecture: delegate-and-subscribe + push
+
+Three responsibilities, cleanly split:
+
+1. **Operator (LLM, judgment):** hand off → attach the user's `MessageOrigin` to the chain root → reply "On it, I'll report back" → **end the turn**. Re-engaged only for *synthesis* (final result) or *judgment* (a stall needs intervention).
+2. **System (durable, cheap, no LLM):** a chain-level watcher keyed on `root_task_id` observes `task_status_changed` events and **pushes** to the origin channel — milestone on progress, result on completion, nudge on stall/failure. Survives operator restarts.
+3. **Guarantee layer:** every user-originated root chain MUST reach a terminal user notification, exactly once.
+
+`await_task_event` is **demoted**, not deleted: a short, bounded "confirm the first agent picked it up" within a single turn — capped well under the keepalive-survivable window, graceful return. Never the end-to-end watch.
+
+### What actually exists vs what must be built (verified against code)
+
+| Piece | Status | Evidence |
+|---|---|---|
+| System-side, no-LLM, origin-targeted delivery to **chat** channels | **EXISTS — the one true reuse** | `_handle_notify_origin` (`src/cli/runtime.py:889`) → `channel.send_to_user` (telegram/discord/slack/whatsapp). Already wired as the lane's `notify_fn`. |
+| Delivery to the **dashboard** origin | **MISSING — must build** | `_channel_map` has no `dashboard`; `_handle_notify_origin` drops it (`runtime.py:914-920`). Dashboard users are reached via a *separate* `EventBus`/notification path, and the per-chat SSE is **closed** once the operator releases — so terminal delivery must go through the persistent bell store (`src/dashboard/notifications.py`) + `/ws/events`, not the chat stream. **The cake repro is a dashboard chat, so this is on the critical path.** |
+| Chain-level state (know when a multi-hop chain is terminal) | **MISSING — must build** | `lanes.py` is per-single-task; `auto_notify`/`_back_edge_fn` fire on the immediate handoff only. No `root_task_id` grouping anywhere. |
+| Proactive "no-orphan" push from `chain_breaks_24h` | **MISSING — pull-only** | `chain_breaks_24h` (`src/host/orchestration.py:961`) is "observability-only, NO enforcement," called only by `GET /mesh/system/metrics`. Nothing runs it on a timer. A background watcher (or cron target) is new. |
+| Origin on the `task_status_changed` event payload | **PARTIAL** | Origin is persisted on the task row (`orchestration.py` origin_kind/channel/user) but **not** on the event payload — a watcher must `get(task_id)` and walk `parent_task_id` to the root. |
+
+**Conclusion:** Phase 1 builds a small but real durable subsystem: a `chain_watch` table, a restart-recoverable watcher, exactly-once terminal delivery, and a dashboard-capable origin→channel delivery function. Only the chat-channel delivery is genuine reuse.
+
+### Security constraint (load-bearing — do NOT regress)
+
+Per-hop origin is deliberately **downgraded** for worker-originated calls (`_validated_origin`, `src/host/server.py:458-466,506-513`), and the back-edge wake **deliberately skips distant origins where `origin_user != creator`** (`src/host/server.py:5351-5374`). That is an intentional trust boundary: a deep worker must not be able to address an arbitrary human as if it were them.
+
+**Therefore the watcher must NOT trust per-hop origin propagation and must NOT punch a hole in that skip.** Instead:
+- The authoritative **root origin is captured ONCE at chain creation** (the user-originated `hand_off`/`create_task`, where the origin is first-party and trusted) and stored on the `chain_watch` row keyed by `root_task_id`.
+- All terminal/milestone delivery reads the origin **from the `chain_watch` row**, never from a mid-chain task's (possibly downgraded) origin, and never re-opens the back-edge skip.
+- This keeps the existing boundary fully intact while still letting the *system* (not a worker) deliver to the original human.
+
+### Primitives referenced
+- `src/host/orchestration.py` `update_status` — central status-transition point; emits `task_status_changed` + `task_completed_without_handoff`. The watcher's hook.
+- `src/cli/runtime.py:889 _handle_notify_origin` → `channel.send_to_user` — chat-channel delivery (reuse).
+- `src/dashboard/notifications.py` (persistent bell) + `/ws/events` — dashboard delivery (extend).
+- `src/host/user_notifications.py` — observation log (PULL; does not deliver). Useful for audit, not for push.
+- `MessageOrigin` propagation (Constraint #4) for the *creation* stamp only.
+
+---
+
+## 5. Roadmap (re-sequenced: net before trapeze)
+
+> **Ordering rule (review fix):** the operator behavior change (stop block-watching, acknowledge-and-release) is the **LAST** step, gated on a green end-to-end watcher *including dashboard delivery*. Changing operator behavior before the watcher reliably delivers would replace "silent death after 120s" with "silent death immediately" — strictly worse.
+
+### Phase 0 — Bleeder-stopper: keepalive forwarding (IMPLEMENTED in this PR)
+**Goal:** no streaming hop goes byte-silent; long quiet tool calls stop cancelling the turn. General fix, zero security surface, independently shippable.
+**Files:** `src/host/transport.py`, `src/dashboard/server.py` (both stream generators), `src/cli/runtime.py`.
+**Changes (done):**
+- `transport.stream_request` forwards the agent's `": keepalive"` SSE comments as a `{"type": "keepalive"}` liveness sentinel instead of dropping them. (True end-to-end liveness: if the agent loop wedges, keepalives stop and downstream correctly times out.)
+- Dashboard `api_chat_stream` + `api_broadcast_stream` re-emit the sentinel as a real `": keepalive"` SSE comment to the browser (resets `app.js`'s 120s `AbortController`); never a data event, never counted toward completion.
+- CLI `runtime.py` stream consumer drops the sentinel so it can't contaminate a channel's assembled response. (REPL already ignores unknown event types.)
+**Explicitly NOT done (and why):**
+- **Do NOT swallow `CancelledError`** in `await_task_event`. The cancel originates from a client disconnect — by the time it fires the channel is already gone, so returning a value is futile; and the loop intentionally re-raises chat cancellation (`loop.py:3858-3860`). The current re-raise is the safe behavior.
+- **Do NOT add an await re-arm loop.** Keeping the operator spinning in a poll loop under the keepalive window just monopolizes it and burns tokens — Phase 1 removes block-watching entirely.
+**Acceptance:** a 200s+ silent tool call no longer cancels the turn; the browser stays connected (keepalive comments visible on the wire). Unit tests: transport forwards keepalive sentinels; both dashboard generators re-emit them as comments (added).
+**Note:** Phase 0 stops the *crash*. It does NOT make watching scale across many hops/minutes — Phase 1 does. Do not stop here.
+
+### Phase 1 — The guarantee: delegate-and-release + durable terminal outcome
+**Goal:** every user-initiated pipeline ALWAYS produces a final user-facing message (done/failed/stalled), exactly once; the operator stops block-watching.
+
+- **1a (gate — design + schema, tests first):**
+  - Decide the root-origin trust model per §4 security constraint: `chain_watch` row carries the trusted root origin set at chain creation; delivery never trusts per-hop origin and never re-opens the back-edge skip.
+  - Define **"chain terminal"** for fan-out: no non-terminal task remains under `root_task_id` (not merely "a `done` leaf with no child" — that's `chain_breaks`'s weaker per-leaf notion).
+  - `chain_watch` schema (SQLite, WAL): `root_task_id` PK, root origin (kind/channel/user), last-notified status, created_at, terminal_notified flag. **Unique key `(root_task_id, terminal_kind)` for exactly-once.**
+  - Audit/guarantee child←parent origin inheritance through every hop *for attribution only* (root lookup), since per-hop origin is downgraded.
+- **1b (watcher):** a restart-recoverable background watcher subscribed to `update_status` transitions (the `EventBus` is in-memory/ephemeral — the watcher must **re-scan open `chain_watch` rows on boot** to resume/close orphans). On chain terminal, fire exactly-once terminal delivery (idempotent via the unique key; safe against `update_status` re-fires and restart replays).
+- **1c (delivery):** unified system-side delivery covering **both** chat channels (`_handle_notify_origin`) **and** dashboard (persistent bell row + `/ws/events`). Test telegram and dashboard paths.
+- **1d (operator behavior — LAST):** playbook/prompt change in `src/shared/operator_playbooks.py` (+ operator INSTRUCTIONS): when handing off *user-originated* work, acknowledge-and-release; do NOT chain `await_task_event` across hops. Ship only after 1a–1c are green end-to-end.
+
+**Acceptance (the headline test):** a 3-hop pipeline where each hop takes >120s and the whole thing spans multiple turns/minutes ⇒ operator replies instantly, ends its turn, and the user (dashboard AND a paired chat channel) receives exactly one terminal result (or failure/stall) message — with the operator NEVER stranded, including across a mesh restart mid-pipeline.
+
+### Phase 2 — Ambient progress: per-transition milestones
+**Goal:** the "watch it move through the pipeline" feel, cheaply.
+**Decision (confirmed):** **terminal-only for v1.** Per-stage milestone pings re-open a *deliberately removed* behavior (PR-3 of the Work-tab rewrite removed the per-task-completion bell producer; CLAUDE.md `notifications.py` note). Do NOT reintroduce per-stage dings until the terminal path is proven and the noise/throttle policy is agreed. When added: templated milestones on **stage completion only**, debounced/coalesced; LLM only for the final synthesis.
+**Acceptance:** user sees milestone pings as stages complete; fast chains don't flood the channel.
+
+### Phase 3 — Polish: stall watchdog + live pipeline card
+- **Stall watchdog:** if a watched chain has no progress for N minutes, notify the user with a nudge and offer operator intervention (this is the legitimate, system-driven use of the `chain_breaks`/stale-task signal — via the new watcher, not the pull-only metrics path).
+- **Work-tab live pipeline card:** at-a-glance status of in-flight user-originated chains.
+**Acceptance:** a stuck chain pings the user within N minutes; the Work tab shows live pipeline state.
+
+---
+
+## 6. Decisions (confirmed 2026-06-10) + remaining open questions
+
+**Confirmed by the user ("confirm and proceed; do not break our security posture"):**
+- **D1.** Phase 0 ships first as a standalone keepalive fix (this PR). ✅
+- **D2.** Phase 2 is **terminal-only for v1** — no per-stage dings until proven (avoids re-litigating the removed bell producer).
+- **D3.** Dashboard terminal delivery goes through the **persistent bell + `/ws/events`**, not the per-chat SSE.
+- **D4.** Phase 1 is accepted as a small durable subsystem (chain_watch table + watcher + dashboard delivery + origin-trust model), not a wiring task.
+- **D5 (security).** The watcher captures the root origin once at chain creation and delivers system-side; it does **not** loosen `_validated_origin`'s downgrade or the back-edge `origin_user != creator` skip.
+
+**Still open (decide early in Phase 1):**
+- **Q1.** `chain_watch` table vs reuse `task_events` for chain state. (Recommend: dedicated table — durable, survives restarts, clean unique key.)
+- **Q2.** Progress cadence/throttle policy for Phase 2 (debounce window; templated copy).
+- **Q3.** Concurrency: multiple simultaneous pipelines per user/channel — threading/attribution so the user can tell them apart (`root_task_id` in the row + a human-readable chain label).
+- **Q4.** Backwards-compat: chains created without a captured root origin — fall back to a dashboard bell entry keyed by the originating session, and lean on the watcher's boot re-scan to close orphans.
+
+---
+
+## 7. Non-goals / scope guards
+
+- Not rewriting the lane/task system — hook `update_status` events.
+- Not making `await_task_event` block longer; it's demoted to short in-turn confirmations.
+- Not building a generic workflow engine — just reliable, origin-aware **watch + push** for user-initiated chains.
+- Not loosening any origin/permission boundary (D5).
+- Keep the operator's *judgment* role (synthesis, intervention) LLM-driven; keep *plumbing* (progress pings, terminal delivery) system-driven/templated.
+
+---
+
+## 8. Verify on cake after implementation
+
+- **Phase 0:** trigger a long silent tool over a dashboard chat (e.g. an `await_task_event`/`run_command` > 120s). Confirm the browser SSE stays connected (keepalive comments on the wire) and the turn is no longer cancelled; `docker logs openlegion_operator` shows no `await_task_event EXIT cancelled (likely tool timeout)` from the idle path.
+- **Phase 1:** re-run the exact failing flow — multi-hop team pipeline where a stage takes >120s. Confirm: operator replies instantly and ends its turn; user receives a final result/failure/stall message exactly once on the dashboard (and a paired chat channel); operator never strands (no 9-minute idle gap); survives an operator/mesh restart mid-pipeline.
+- Deploy method (this repo → cake): merge to `main`, then on `root@cake.engine.openlegion.ai`: `cd /opt/openlegion/repo && git checkout . && git pull && .venv/bin/pip install -e '.[channels,wallet]' && docker build -t openlegion-agent:latest -f Dockerfile.agent . && systemctl restart openlegion`. The engine rebuilds the browser image at startup (~90s) before the mesh binds `:8420`. Do NOT read `.env`/secrets during verification — health + functional checks only.
+
+---
+
+## 9. Appendix — exact code locations (corrected)
+
+| Concern | Location |
+|---|---|
+| Browser 120s idle abort (the real cliff) | `src/dashboard/static/js/app.js:8608-8620` (`AbortController`, `_resetStreamTimeout` on each chunk) |
+| Agent keepalive (protects only agent→dashboard) | `src/agent/server.py` `chat_stream` `event_generator` — `yield ": keepalive\n\n"` every 15s |
+| Keepalive stripped / now forwarded | `src/host/transport.py` `stream_request` (`aiter_lines`; forwards `data:`, now also `:` comments as `{"type":"keepalive"}`) |
+| Dashboard stream generators (re-emit keepalive) | `src/dashboard/server.py` `api_chat_stream`, `api_broadcast_stream` |
+| Blocking watch tool | `src/agent/builtins/operator_tools.py` `await_task_event` (~1136–1329); `CancelledError` handler re-raises (~1287 — keep as-is) |
+| Per-tool hard ceiling (NOT the killer) | `src/agent/loop.py:44` `_TOOL_TIMEOUT=900`; wrap ~3105 `asyncio.wait_for(..., _TOOL_TIMEOUT)` |
+| Status transition + events (watcher hook) | `src/host/orchestration.py` `update_status`; `task_status_changed`; `task_completed_without_handoff` |
+| Silent-termination detector (pull-only) | `src/host/orchestration.py:961 chain_breaks_24h` (only caller: `GET /mesh/system/metrics`) |
+| Chat-channel delivery (reuse) | `src/cli/runtime.py:889 _handle_notify_origin` → `channel.send_to_user` |
+| Dashboard delivery (extend) | `src/dashboard/notifications.py` (bell) + `/ws/events`; `EventBus` is in-memory (`src/dashboard/events.py`) |
+| Origin downgrade + back-edge skip (do NOT regress) | `src/host/server.py:458-466,506-513` (`_validated_origin`); `src/host/server.py:5351-5374` (`origin_user != creator` skip) |
+| Origin stamp (dashboard) | `src/dashboard/server.py` `api_chat_stream` (`MessageOrigin(kind="human", channel="dashboard")`) |
+
+**Reconciliation note.** This revision merges a principal-engineer review with an independent Codex pass. Both independently concluded: the root cause was mislocated (it's the browser leg, not `transport.py`), "reuse not new machinery" was overstated, and `CancelledError` must not be swallowed. Codex additionally pinned the exact browser-abort site (`app.js:8608-8620`) and surfaced the origin-downgrade / back-edge-skip security collision (`server.py:458-466,5351-5374`) that the §4 trust model now addresses.
+
+**Related prior art:** `docs/plans/2026-05-02-operator-orchestration-roadmap.md`, `docs/plans/2026-06-09-operator-memory-context-overhaul.md`. PR #1068 (await_task_event polling — partial fix this supersedes for the watch path).

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1385,6 +1385,10 @@ class RuntimeContext:
                 agent_name, "POST", "/chat/stream",
                 json={"message": message}, timeout=120,
             ):
+                # Liveness sentinel from the transport keepalive-forwarding —
+                # drop it so it never lands in a channel's assembled response.
+                if isinstance(event, dict) and event.get("type") == "keepalive":
+                    continue
                 if self.event_bus and isinstance(event, dict):
                     etype = event.get("type", "")
                     if etype in ("tool_start", "tool_result"):

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3627,6 +3627,13 @@ def create_dashboard_router(
                     headers=_hdrs,
                 ):
                     if isinstance(event, dict):
+                        if event.get("type") == "keepalive":
+                            # Forward upstream liveness as an SSE comment so the
+                            # browser's idle-abort timer (app.js, 120s) resets
+                            # during long silent tool calls. Not a data event —
+                            # carries no UI state and updates no other session.
+                            yield ": keepalive\n\n"
+                            continue
                         yield f"data: {dumps_safe(event)}\n\n"
                         etype = event.get("type", "")
                         if event_bus:
@@ -3754,6 +3761,12 @@ def create_dashboard_router(
                     headers=bcs_hdrs,
                 ):
                     if isinstance(event, dict):
+                        if event.get("type") == "keepalive":
+                            # Liveness only — forward untagged so the generator
+                            # emits an SSE comment (resets the browser idle
+                            # timer) without counting toward agent completion.
+                            await queue.put({"type": "keepalive"})
+                            continue
                         tagged = {**event, "agent": aid}
                         await queue.put(tagged)
                         if event.get("type") == "done":
@@ -3773,6 +3786,9 @@ def create_dashboard_router(
             try:
                 while done_count < len(agents):
                     event = await queue.get()
+                    if event.get("type") == "keepalive":
+                        yield ": keepalive\n\n"
+                        continue
                     if event.get("type") == "agent_done":
                         done_count += 1
                     yield f"data: {dumps_safe(event)}\n\n"

--- a/src/host/transport.py
+++ b/src/host/transport.py
@@ -183,6 +183,19 @@ class HttpTransport(Transport):
                             yield json_module.loads(line[6:])
                         except json_module.JSONDecodeError:
                             yield {"raw": line[6:]}
+                    elif line.startswith(":"):
+                        # SSE comment. The agent emits ": keepalive" every
+                        # ~15s while a tool runs silently (agent/server.py
+                        # chat_stream). Receiving the line here already resets
+                        # THIS hop's read-idle clock, but historically the
+                        # comment was dropped — so a downstream streaming hop
+                        # (dashboard -> browser) saw zero bytes during a long
+                        # quiet tool call and its own idle-abort fired at 120s,
+                        # cancelling the whole turn. Forward it as a liveness
+                        # sentinel so each hop can reset its timer. It is a true
+                        # end-to-end liveness signal: if the agent's loop wedges
+                        # the keepalive stops and downstream correctly times out.
+                        yield {"type": "keepalive"}
         except httpx.HTTPStatusError as e:
             logger.warning("Stream HTTP %d from agent '%s' %s", e.response.status_code, agent_id, path)
             yield {"type": "error", "message": f"HTTP {e.response.status_code}"}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3145,6 +3145,50 @@ class TestDashboardBroadcastStream:
         delta_agents = {e["agent"] for e in deltas}
         assert delta_agents == {"alpha", "beta"}
 
+    def test_broadcast_stream_forwards_keepalive_as_comment(self):
+        """A keepalive sentinel from the transport is re-emitted as an SSE
+        comment (resets the browser idle timer) — never as a data event and
+        never counted toward agent completion."""
+        async def _mock_stream(aid, method, path, **kwargs):
+            yield {"type": "keepalive"}
+            yield {"type": "text_delta", "content": f"hi {aid}"}
+
+        self.components["transport"].stream_request = _mock_stream
+
+        resp = self.client.post(
+            "/dashboard/api/broadcast/stream",
+            json={"message": "Hello all"},
+        )
+        assert resp.status_code == 200
+        # Emitted on the wire as a comment...
+        assert ": keepalive" in resp.text
+        # ...and NOT as a parsed data event.
+        events = _parse_sse(resp.text)
+        assert all(e.get("type") != "keepalive" for e in events)
+        # Completion accounting is unaffected.
+        types = [e["type"] for e in events]
+        assert types.count("agent_done") == 2
+        assert types[-1] == "all_done"
+
+    def test_chat_stream_forwards_keepalive_as_comment(self):
+        """The single-agent chat stream re-emits a keepalive sentinel as an
+        SSE comment rather than a data event."""
+        async def _mock_stream(agent_id, method, path, **kwargs):
+            yield {"type": "keepalive"}
+            yield {"type": "done", "response": "done"}
+
+        self.components["transport"].stream_request = _mock_stream
+
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat/stream",
+            json={"message": "hi"},
+        )
+        assert resp.status_code == 200
+        assert ": keepalive" in resp.text
+        events = _parse_sse(resp.text)
+        assert all(e.get("type") != "keepalive" for e in events)
+        assert any(e.get("type") == "done" for e in events)
+
     def test_broadcast_stream_empty_message_rejected(self):
         resp = self.client.post(
             "/dashboard/api/broadcast/stream",

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -177,3 +177,64 @@ class TestHttpTransportClientLifecycle:
         await t._get_client()
         await t.close()
         await t.close()  # should not raise
+
+
+class _FakeStreamCtx:
+    """Async-context-manager stand-in for ``client.stream(...)``.
+
+    Yields a response whose ``aiter_lines()`` replays a fixed list of raw
+    SSE lines (data lines and ``:`` comment/keepalive lines).
+    """
+
+    def __init__(self, lines: list[str]):
+        self._lines = lines
+
+    async def __aenter__(self):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        lines = self._lines
+
+        async def _aiter():
+            for ln in lines:
+                yield ln
+
+        resp.aiter_lines = lambda: _aiter()
+        return resp
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestHttpTransportStreamKeepalive:
+    @pytest.mark.asyncio
+    async def test_stream_request_forwards_keepalive_comments(self):
+        """Agent ``: keepalive`` SSE comments are forwarded as
+        ``{"type": "keepalive"}`` sentinels.
+
+        Regression: the comment used to be dropped, so a long silent tool
+        call produced zero bytes on the dashboard->browser leg and the
+        browser's 120s idle-abort cancelled the whole turn. Forwarding the
+        agent's own keepalive lets each downstream hop reset its idle timer.
+        """
+        t = HttpTransport()
+        t.register("a1", "http://agent")
+        lines = [
+            ": keepalive",
+            "",  # blank line that follows an SSE comment — must be ignored
+            'data: {"type": "text_delta", "content": "hi"}',
+            ": keepalive",
+            'data: {"type": "done", "response": "hi"}',
+        ]
+        fake_client = MagicMock()
+        fake_client.stream = MagicMock(return_value=_FakeStreamCtx(lines))
+        with patch.object(t, "_get_client", AsyncMock(return_value=fake_client)):
+            out = [
+                ev
+                async for ev in t.stream_request("a1", "POST", "/chat/stream")
+            ]
+
+        assert out.count({"type": "keepalive"}) == 2
+        assert {"type": "text_delta", "content": "hi"} in out
+        assert out[-1] == {"type": "done", "response": "hi"}
+        # The trailing blank line must NOT have produced a spurious event.
+        assert {"raw": ""} not in out


### PR DESCRIPTION
## What

Forward the agent's SSE keepalive **end-to-end** so a long, quiet tool call no longer cancels the chat turn. This is **Phase 0** of the delegate-and-subscribe plan — the safe, general bleeder-stopper.

## Why

The operator "stops out of nowhere" when a handed-off pipeline stage takes >~120s. Root cause is a streaming hop that goes byte-silent:

```
browser  ──fetch (120s AbortController)──▶  dashboard  ──stream_request──▶  agent
            resets on ANY chunk                 drops ": keepalive"          emits ": keepalive"/15s
```

- The agent emits `": keepalive"` every 15s while a tool runs silently → keeps the **agent→dashboard** leg alive (resets httpx's read clock at `aiter_lines`).
- But `transport.stream_request` forwards only `data:` lines and **strips** the keepalive comments, and the dashboard's SSE generators emit none of their own → the **dashboard→browser** leg sees **zero bytes**.
- The browser's 120s `AbortController` (`app.js:8608-8620`) fires → disconnect propagates browser→dashboard→agent → cancels the operator mid-`await_task_event` (`await_task_event EXIT cancelled (likely tool timeout)`) → turn torn down, no re-wake.

> The originally-suspected `transport.py timeout=120` (mesh→agent) is **not** the killer — that hop is kept alive by the agent keepalive. Confirmed by an independent Codex pass, which also pinned the exact browser-abort site.

## Change

- `transport.stream_request` forwards `:` comment lines as a `{"type": "keepalive"}` liveness sentinel (true end-to-end liveness — if the agent loop wedges, keepalives stop and downstream correctly times out).
- Both dashboard stream generators (`api_chat_stream`, `api_broadcast_stream`) re-emit the sentinel as a real `": keepalive"` SSE comment — never a data event, never counted toward completion.
- CLI stream consumer (`runtime.py`) drops the sentinel so it can't contaminate a channel's assembled response. (REPL already ignores unknown event types.)

General fix — protects **every** long silent tool (`await_task_event`, `execute_code`, `run_command`, browser ops). **Zero security surface** (SSE comment bytes only).

## Explicitly NOT done (by design)
- Does **not** swallow `CancelledError` — the cancel means the channel is already gone; the loop intentionally re-raises chat cancellation.
- Does **not** add an await re-arm loop — Phase 1 removes block-watching entirely (operator delegates-and-releases; a durable system watcher pushes a guaranteed terminal outcome and survives restarts).

## Tests
- `tests/test_transport.py::TestHttpTransportStreamKeepalive` — keepalive comments forwarded as sentinels; trailing blank line ignored.
- `tests/test_dashboard.py` — both stream endpoints re-emit keepalive as a comment, not a data event, and completion accounting is unaffected.
- Full `test_transport.py` + `test_dashboard.py`: **390 passed**. Ruff clean.

## Docs
- Revises `docs/plans/2026-06-10-operator-delegate-and-subscribe.md`: corrected root cause, security-preserving origin-trust model for the Phase 1 watcher (captures the trusted root origin once at chain creation; does not loosen `_validated_origin` or the back-edge `origin_user != creator` skip), and a net-before-trapeze re-sequencing.

## Verify on cake (post-merge)
Trigger a >120s silent tool over a dashboard chat; confirm the SSE stays connected (keepalive comments on the wire) and the turn is no longer cancelled — no `await_task_event EXIT cancelled (likely tool timeout)` from the idle path.