### PR TITLE
fix(context): defense-in-depth against the operator context-window wedge

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -849,30 +849,10 @@ class ContextManager:
         if len(groups) <= 5:
             return messages
 
-        # Keep first group + last 4 groups
-        kept = groups[:1] + groups[-4:]
-        pruned = [msg for group in kept for msg in group]
-
-        # Prevent consecutive same-role messages across pruning gaps
-        i = 0
-        while i < len(pruned) - 1:
-            role_a = pruned[i].get("role")
-            role_b = pruned[i + 1].get("role")
-            if role_a == role_b == "user":
-                pruned.insert(i + 1, {
-                    "role": "assistant",
-                    "content": "Understood, continuing from above.",
-                })
-                i += 2  # skip past the bridge
-            elif role_a == role_b == "assistant":
-                pruned.insert(i + 1, {
-                    "role": "user",
-                    "content": "Continue.",
-                })
-                i += 2
-            else:
-                i += 1
-
+        # Keep first group + last 4 groups, bridging role-alternation gaps so
+        # the dropped middle can't leave a user->user / assistant->assistant
+        # seam. Shared with ``prune_to_fit`` via ``_merge_groups_alternating``.
+        pruned = self._merge_groups_alternating(groups[:1] + groups[-4:])
         logger.warning(f"Hard-pruned {len(messages)} -> {len(pruned)} messages (group-aware)")
         return pruned
 

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -264,7 +264,14 @@ class ContextManager:
                 [{"role": "system", "content": system_prompt}], self.model,
             )
         if tools:
-            total += len(json.dumps(tools)) // 3
+            # Tool schemas come from @tool-decorated functions and are
+            # JSON-safe, but this runs on every turn's pre-flight path now, so
+            # fall back rather than crash the turn if a schema is ever not
+            # serializable.
+            try:
+                total += len(json.dumps(tools)) // 3
+            except (TypeError, ValueError):
+                total += len(str(tools)) // 4
         return total
 
     def prune_to_fit(
@@ -305,8 +312,9 @@ class ContextManager:
         groups = group_messages_by_tool_call(messages)
         # Keep first group + at least the most-recent group. We drop the OLDEST
         # non-first group repeatedly: kept = [first] + groups[drop_start:].
-        # ``drop_start`` walks forward from index 1 toward the tail.
-        drop_start = 1
+        # ``drop_start`` walks forward from index 2 (index 1 would re-test the
+        # full unmodified list — guaranteed over ceiling since ``before`` was).
+        drop_start = 2
         while drop_start < len(groups):
             # Candidate: first group + everything from drop_start onward.
             kept_groups = groups[:1] + groups[drop_start:]

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -236,6 +236,138 @@ class ContextManager:
     def should_compact(self, messages: list[dict]) -> bool:
         return self.usage(messages) >= _COMPACT_THRESHOLD
 
+    def estimate_request_tokens(
+        self,
+        messages: list[dict],
+        system_prompt: str = "",
+        tools: list[dict] | None = None,
+    ) -> int:
+        """Estimate the TRUE size of the request the LLM client will send.
+
+        ``usage()`` / ``should_compact()`` count only ``messages`` — they are
+        blind to the system prompt, the tool schemas, and the per-turn volatile
+        suffix that ``llm.py`` prepends/appends at the call site. On a model
+        with a large nominal window (e.g. Opus 4.8's 1M) a fat tool schema +
+        system prompt is a large fixed overhead; ignoring it lets the message
+        list grow until the assembled request exceeds the hard model limit and
+        every call 400s. This returns the conservative full-request estimate so
+        the pre-flight guard / emergency prune can act on the real number.
+
+        The tool-schema estimate intentionally errs slightly HIGH
+        (``len(json.dumps(tools)) // 3``, a tighter divisor than the 4-chars/tok
+        message default) — overshooting the budget is safe; undershooting
+        re-wedges.
+        """
+        total = estimate_tokens(messages, self.model)
+        if system_prompt:
+            total += estimate_tokens(
+                [{"role": "system", "content": system_prompt}], self.model,
+            )
+        if tools:
+            total += len(json.dumps(tools)) // 3
+        return total
+
+    def prune_to_fit(
+        self,
+        messages: list[dict],
+        system_prompt: str = "",
+        tools: list[dict] | None = None,
+        *,
+        ceiling_frac: float = 0.90,
+    ) -> list[dict]:
+        """Emergency hard safety net: drop oldest tool-call groups until the
+        FULL request (messages + system + tools) fits under a fraction of the
+        model window.
+
+        This is NOT a threshold change — the 0.60/0.70/0.80 compaction
+        thresholds are untouched. This is a separate last-resort guard for the
+        case where a turn STARTS already over the model limit (inherited fat
+        context, restored fat checkpoint) so the first LLM call would 400 with
+        "prompt is too long" before reactive compaction ever runs.
+
+        Group-aware (via :func:`group_messages_by_tool_call`): always keeps the
+        FIRST group (initial user/context) and at least the most-recent group,
+        and prunes only at group boundaries so a tool result is never orphaned
+        from its parent assistant. Reuses the same role-alternation bridge logic
+        as :meth:`_hard_prune` / ``AgentLoop._trim_context`` so it never emits
+        consecutive same-role messages.
+
+        Returns the (possibly) pruned list; a no-op when already under ceiling.
+        """
+        if not messages:
+            return messages
+
+        ceiling = int(self.max_tokens * ceiling_frac)
+        before = self.estimate_request_tokens(messages, system_prompt, tools)
+        if before <= ceiling:
+            return messages
+
+        groups = group_messages_by_tool_call(messages)
+        # Keep first group + at least the most-recent group. We drop the OLDEST
+        # non-first group repeatedly: kept = [first] + groups[drop_start:].
+        # ``drop_start`` walks forward from index 1 toward the tail.
+        drop_start = 1
+        while drop_start < len(groups):
+            # Candidate: first group + everything from drop_start onward.
+            kept_groups = groups[:1] + groups[drop_start:]
+            candidate = self._merge_groups_alternating(kept_groups)
+            if self.estimate_request_tokens(candidate, system_prompt, tools) <= ceiling:
+                after = self.estimate_request_tokens(candidate, system_prompt, tools)
+                logger.info(
+                    "prune_to_fit: dropped %d oldest group(s), %s->%s est tokens "
+                    "(ceiling=%s, frac=%.2f)",
+                    drop_start - 1, f"{before:,}", f"{after:,}",
+                    f"{ceiling:,}", ceiling_frac,
+                )
+                return candidate
+            # Don't shed past [first, last]: leave the most-recent group intact.
+            if drop_start >= len(groups) - 1:
+                break
+            drop_start += 1
+
+        # Couldn't get under the ceiling even at the minimal kept set
+        # (system + tools alone, or first+last group, already too big). Return
+        # the minimal kept set — the pre-flight guard re-checks and the LLM
+        # self-heal retry will still surface a clear failure if even this 400s.
+        minimal_groups = groups[:1] + groups[-1:] if len(groups) > 1 else groups
+        pruned = self._merge_groups_alternating(minimal_groups)
+        after = self.estimate_request_tokens(pruned, system_prompt, tools)
+        logger.warning(
+            "prune_to_fit: could not fit under ceiling=%s even at minimal kept "
+            "set (%s est tokens); system+tools overhead may exceed budget. "
+            "before=%s groups=%d kept=%d",
+            f"{ceiling:,}", f"{after:,}", f"{before:,}",
+            len(groups), len(minimal_groups),
+        )
+        return pruned
+
+    @staticmethod
+    def _merge_groups_alternating(groups: list[list[dict]]) -> list[dict]:
+        """Flatten tool-call groups into a message list, inserting bridge
+        messages so no two consecutive messages share a role (user/assistant).
+
+        Mirrors the bridge logic in :meth:`_hard_prune` so a prune that drops a
+        middle group can't create a ``user → user`` / ``assistant → assistant``
+        seam across the gap (which the LLM API rejects).
+        """
+        merged = [m for g in groups for m in g]
+        i = 0
+        while i < len(merged) - 1:
+            role_a = merged[i].get("role")
+            role_b = merged[i + 1].get("role")
+            if role_a == role_b == "user":
+                merged.insert(i + 1, {
+                    "role": "assistant",
+                    "content": "Understood, continuing from above.",
+                })
+                i += 2
+            elif role_a == role_b == "assistant":
+                merged.insert(i + 1, {"role": "user", "content": "Continue."})
+                i += 2
+            else:
+                i += 1
+        return merged
+
     async def maybe_compact(
         self, system_prompt: str, messages: list[dict],
     ) -> tuple[list[dict], bool]:
@@ -564,6 +696,22 @@ class ContextManager:
         keep_n = min(4, len(groups) - 1)
         older_groups = groups[:-keep_n]
         recent_groups = groups[-keep_n:]
+
+        # P4 tail cap: a few huge tool-result groups in the retained tail can
+        # defeat compaction (the summary shrinks the OLD context but the kept
+        # recent groups are still over budget). Drop the OLDEST of the kept
+        # groups (group-aware, keep >=1) until the retained tail is under
+        # ~0.5 * max_tokens. The dropped groups still feed the summary because
+        # ``older_groups`` is recomputed to include them.
+        _tail_cap = int(self.max_tokens * 0.5)
+        while (
+            len(recent_groups) > 1
+            and estimate_tokens(
+                [m for g in recent_groups for m in g], self.model,
+            ) > _tail_cap
+        ):
+            recent_groups = recent_groups[1:]
+        older_groups = groups[: len(groups) - len(recent_groups)]
 
         older_messages = [m for g in older_groups for m in g]
         conversation_text = self._messages_to_text(older_messages)

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -26,6 +26,34 @@ class LLMRetryableError(RuntimeError):
     pass
 
 
+class LLMContextOverflowError(RuntimeError):
+    """The assembled request exceeded the model's context window.
+
+    Distinct from the generic non-retryable ``RuntimeError`` so the chat loop
+    can SELF-HEAL: emergency-prune the conversation to fit and retry, instead of
+    aborting the turn (which would leave the over-limit context in place and
+    permanently wedge — every subsequent call 400s the same way). NOT a plain
+    retryable error: re-issuing the identical request would 400 again — the
+    caller MUST shrink the context before retrying.
+    """
+
+    pass
+
+
+# Substrings (matched case-insensitively against the error message) that
+# identify a context-length / "prompt is too long" 400 across providers
+# (Anthropic, OpenAI, OpenRouter passthrough). Used by ``_raise_classified_error``
+# to route to ``LLMContextOverflowError`` so the loop's prune-and-retry self-heal
+# fires instead of a generic turn abort.
+_CONTEXT_OVERFLOW_MARKERS = (
+    "prompt is too long",
+    "context length",
+    "context_length_exceeded",
+    "input length and max_tokens exceed",
+    "maximum context length",
+)
+
+
 class LLMClient:
     """LLM interface that routes all calls through the mesh API proxy."""
 
@@ -179,6 +207,14 @@ class LLMClient:
                 allowed_models=set(error_meta.get("allowed_models", [])),
                 http_status=error_meta.get("http_status"),
             )
+        # Context-overflow 400 ("prompt is too long" / "context length
+        # exceeded"). Route to the distinct overflow type BEFORE the transient /
+        # retryable checks so the chat loop's prune-and-retry self-heal fires
+        # rather than a generic, un-recoverable turn abort. Detected by
+        # substring because the mesh proxy does not yet tag a distinct
+        # ``error_type`` for it.
+        if any(kw in error_msg.lower() for kw in _CONTEXT_OVERFLOW_MARKERS):
+            raise LLMContextOverflowError(f"{prefix}: {error_msg}")
         if error_type == "transient":
             # Mesh-tagged transient (Claude subscription throttle, stream
             # interruption, empty-choices response). The mesh already
@@ -415,8 +451,8 @@ class LLMClient:
             async for chunk in self.chat_stream(system, messages, **_passthru):
                 if chunk.get("type") == "done":
                     final = chunk.get("response")
-        except (LLMRetryableError, LLMAuthError, LLMConfigError):
-            raise  # classified errors -> _llm_call_with_retry handles backoff
+        except (LLMRetryableError, LLMContextOverflowError, LLMAuthError, LLMConfigError):
+            raise  # classified errors -> caller (retry / prune-and-retry) handles them
         except httpx.HTTPError as e:
             # Only genuine transport/HTTP failures fall back to non-streaming.
             # Everything else propagates untouched: non-retryable application

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -200,8 +200,12 @@ class LLMClient:
         # proxy-set ``error_type`` — the mesh proxy masks the raw 400 detail
         # across the trust boundary ("Upstream service call failed (HTTP 400)."),
         # so the agent can't substring-match it; the proxy tags the type from the
-        # detail it can see. ``is_context_overflow(error_msg)`` is a backstop for
-        # any path that does forward the raw text (e.g. local/non-masked).
+        # detail it can see. ``is_context_overflow(error_msg)`` is a LIVE
+        # backstop (not dead code): the STREAMING path's SSE error frames
+        # currently forward the raw provider text un-masked, so the substring
+        # match is what fires the self-heal there. Do NOT remove it without
+        # first tagging ``error_type="context_overflow"`` on the proxy's
+        # streaming emit sites (see PR follow-up).
         from src.shared.errors import is_context_overflow
         if error_type == "context_overflow" or is_context_overflow(error_msg):
             raise LLMContextOverflowError(f"{prefix}: {error_msg}")

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -40,20 +40,6 @@ class LLMContextOverflowError(RuntimeError):
     pass
 
 
-# Substrings (matched case-insensitively against the error message) that
-# identify a context-length / "prompt is too long" 400 across providers
-# (Anthropic, OpenAI, OpenRouter passthrough). Used by ``_raise_classified_error``
-# to route to ``LLMContextOverflowError`` so the loop's prune-and-retry self-heal
-# fires instead of a generic turn abort.
-_CONTEXT_OVERFLOW_MARKERS = (
-    "prompt is too long",
-    "context length",
-    "context_length_exceeded",
-    "input length and max_tokens exceed",
-    "maximum context length",
-)
-
-
 class LLMClient:
     """LLM interface that routes all calls through the mesh API proxy."""
 
@@ -210,10 +196,14 @@ class LLMClient:
         # Context-overflow 400 ("prompt is too long" / "context length
         # exceeded"). Route to the distinct overflow type BEFORE the transient /
         # retryable checks so the chat loop's prune-and-retry self-heal fires
-        # rather than a generic, un-recoverable turn abort. Detected by
-        # substring because the mesh proxy does not yet tag a distinct
-        # ``error_type`` for it.
-        if any(kw in error_msg.lower() for kw in _CONTEXT_OVERFLOW_MARKERS):
+        # rather than a generic, un-recoverable turn abort. PRIMARY signal is the
+        # proxy-set ``error_type`` — the mesh proxy masks the raw 400 detail
+        # across the trust boundary ("Upstream service call failed (HTTP 400)."),
+        # so the agent can't substring-match it; the proxy tags the type from the
+        # detail it can see. ``is_context_overflow(error_msg)`` is a backstop for
+        # any path that does forward the raw text (e.g. local/non-masked).
+        from src.shared.errors import is_context_overflow
+        if error_type == "context_overflow" or is_context_overflow(error_msg):
             raise LLMContextOverflowError(f"{prefix}: {error_msg}")
         if error_type == "transient":
             # Mesh-tagged transient (Claude subscription throttle, stream

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3465,6 +3465,31 @@ class AgentLoop:
                 "output": result,
             })
 
+    def _emergency_prune(self, system: str, tools) -> bool:
+        """Emergency-prune ``self._chat_messages`` to ~0.75 of the window after
+        a context-overflow 400, and report whether it made progress.
+
+        Returns True if the prune reduced the estimated request size (the caller
+        may retry), False if we're already at the minimal kept set (retrying
+        would 400 identically — the caller should surface the failure). Progress
+        is measured in TOKENS, not message count: dropping a 1-message group
+        while the role-alternation bridge inserts 1 leaves the count unchanged
+        though tokens fell, so a count check would bail prematurely on
+        text-heavy (no-tool) operator chats. Callers guard ``context_manager``.
+        """
+        cm = self.context_manager
+        before_msgs = len(self._chat_messages)
+        before_tokens = cm.estimate_request_tokens(self._chat_messages, system, tools)
+        self._chat_messages = cm.prune_to_fit(
+            self._chat_messages, system_prompt=system, tools=tools, ceiling_frac=0.75,
+        )
+        after_tokens = cm.estimate_request_tokens(self._chat_messages, system, tools)
+        logger.warning(
+            "context overflow: emergency-pruned %d->%d messages (%d->%d est tokens)",
+            before_msgs, len(self._chat_messages), before_tokens, after_tokens,
+        )
+        return after_tokens < before_tokens
+
     async def _chat_call_self_healing(
         self, *, system: str, tools, **kwargs,
     ):
@@ -3493,34 +3518,15 @@ class AgentLoop:
                     **kwargs,
                 )
             except LLMContextOverflowError:
-                if attempt >= 2 or not self.context_manager:
-                    raise
-                before_msgs = len(self._chat_messages)
-                before_tokens = self.context_manager.estimate_request_tokens(
-                    self._chat_messages, system, tools,
-                )
-                self._chat_messages = self.context_manager.prune_to_fit(
-                    self._chat_messages,
-                    system_prompt=system,
-                    tools=tools,
-                    ceiling_frac=0.75,
-                )
-                after_tokens = self.context_manager.estimate_request_tokens(
-                    self._chat_messages, system, tools,
-                )
-                logger.warning(
-                    "chat call overflowed context window; emergency-pruned "
-                    "%d->%d messages (%d->%d est tokens), retrying (attempt %d/2)",
-                    before_msgs, len(self._chat_messages),
-                    before_tokens, after_tokens, attempt + 1,
-                )
-                if after_tokens >= before_tokens:
-                    # No TOKEN progress (already at the minimal kept set);
-                    # retrying would 400 identically. Surface the failure.
-                    # Token-based, not message-count: dropping a 1-message group
-                    # while the role-alternation bridge adds 1 leaves the count
-                    # unchanged though tokens fell — a count check would bail
-                    # prematurely on text-heavy (no-tool) operator chats.
+                # Last attempt, no context manager, or the prune can't shrink it
+                # any further → surface the failure instead of looping on the
+                # same 400. (``or`` short-circuits, so we don't prune on the
+                # final attempt.)
+                if (
+                    attempt >= 2
+                    or not self.context_manager
+                    or not self._emergency_prune(system, tools)
+                ):
                     raise
 
     async def _compact_chat_context(self, system: str) -> None:
@@ -4777,17 +4783,10 @@ class AgentLoop:
                 streamed = llm_response is not None
                 if llm_response is None:
                     if _overflowed and self.context_manager:
-                        before = len(self._chat_messages)
-                        self._chat_messages = self.context_manager.prune_to_fit(
-                            self._chat_messages,
-                            system_prompt=system,
-                            tools=tools,
-                            ceiling_frac=0.75,
-                        )
-                        logger.warning(
-                            "emergency-pruned %d->%d messages after stream overflow",
-                            before, len(self._chat_messages),
-                        )
+                        # First prune before falling back to non-streaming; the
+                        # fallback loop below self-heals further if it overflows
+                        # again. (Progress bool ignored — this is the 1st pass.)
+                        self._emergency_prune(system, tools)
                         _msgs = self._messages_with_volatile(self._chat_messages)
                     elif used_streaming:
                         logger.warning("LLM stream ended without done event, falling back")
@@ -4802,30 +4801,13 @@ class AgentLoop:
                             )
                             break
                         except LLMContextOverflowError:
-                            if _heal_attempt >= 2 or not self.context_manager:
+                            if (
+                                _heal_attempt >= 2
+                                or not self.context_manager
+                                or not self._emergency_prune(system, tools)
+                            ):
                                 raise
-                            before_msgs = len(self._chat_messages)
-                            before_tokens = self.context_manager.estimate_request_tokens(
-                                self._chat_messages, system, tools,
-                            )
-                            self._chat_messages = self.context_manager.prune_to_fit(
-                                self._chat_messages,
-                                system_prompt=system,
-                                tools=tools,
-                                ceiling_frac=0.75,
-                            )
-                            after_tokens = self.context_manager.estimate_request_tokens(
-                                self._chat_messages, system, tools,
-                            )
-                            if after_tokens >= before_tokens:
-                                raise  # no token progress — surface the failure
                             _msgs = self._messages_with_volatile(self._chat_messages)
-                            logger.warning(
-                                "non-streaming fallback overflowed; pruned "
-                                "%d->%d messages (%d->%d est tokens), retrying (attempt %d/2)",
-                                before_msgs, len(self._chat_messages),
-                                before_tokens, after_tokens, _heal_attempt + 1,
-                            )
 
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
                 # a single deep-research call can run >5 min, and bumping

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2710,6 +2710,15 @@ class AgentLoop:
         self._chat_auto_continues = cp["auto_continues"]
         if self.context_manager:
             self.context_manager._flush_triggered = cp["flush_triggered"]
+            # Restore guard: a fat checkpoint reloaded VERBATIM would re-wedge
+            # the agent on the first call after restart (it was likely saved
+            # at/over the window that caused the wedge). Prune on
+            # messages+max_tokens alone here (system/tools aren't known at
+            # restore time) as a floor — the pre-flight guard re-checks against
+            # the true request size before the first send.
+            self._chat_messages = self.context_manager.prune_to_fit(
+                self._chat_messages,
+            )
         logger.info(
             "chat-session-restored messages=%d rounds=%d continues=%d",
             len(self._chat_messages),
@@ -3456,6 +3465,53 @@ class AgentLoop:
                 "output": result,
             })
 
+    async def _chat_call_self_healing(
+        self, *, system: str, tools, **kwargs,
+    ):
+        """Run the FIRST (non-streaming) chat call of a round with context-
+        overflow self-heal.
+
+        If the assembled request still overflows the model window (the
+        pre-flight ``prune_to_fit`` undershot, or the volatile suffix pushed it
+        over), emergency-prune ``self._chat_messages`` more aggressively
+        (``ceiling_frac=0.75``) and retry — up to twice — instead of letting the
+        turn abort and re-wedge. Re-raises if it still overflows at the minimal
+        kept set so the user sees a clear failure rather than a silent hang.
+
+        Other error types (retryable / auth / config / generic) flow through
+        ``_llm_call_with_retry`` untouched — this only wraps the overflow case.
+        """
+        from src.agent.llm import LLMContextOverflowError
+
+        for attempt in range(3):  # initial + up to 2 prune-and-retry passes
+            try:
+                return await _llm_call_with_retry(
+                    self.llm.chat_collect,
+                    system=system,
+                    messages=self._messages_with_volatile(self._chat_messages),
+                    tools=tools,
+                    **kwargs,
+                )
+            except LLMContextOverflowError:
+                if attempt >= 2 or not self.context_manager:
+                    raise
+                before = len(self._chat_messages)
+                self._chat_messages = self.context_manager.prune_to_fit(
+                    self._chat_messages,
+                    system_prompt=system,
+                    tools=tools,
+                    ceiling_frac=0.75,
+                )
+                logger.warning(
+                    "chat call overflowed context window; emergency-pruned "
+                    "%d->%d messages and retrying (attempt %d/2)",
+                    before, len(self._chat_messages), attempt + 1,
+                )
+                if len(self._chat_messages) >= before:
+                    # Prune made no progress (already at the minimal kept set);
+                    # retrying would loop on the same 400. Surface the failure.
+                    raise
+
     async def _compact_chat_context(self, system: str) -> None:
         """Run context compaction and drain any pending steer messages."""
         if self.context_manager:
@@ -3607,6 +3663,20 @@ class AgentLoop:
         try:
             user_message, system = await self._prepare_chat_turn(user_message)
 
+            # Pre-flight wedge guard (defense-in-depth). Reactive compaction
+            # only runs at the BOTTOM of the round loop, so a turn that STARTS
+            # over the model limit (inherited fat context / restored fat
+            # checkpoint) would 400 on the FIRST call and abort before
+            # compaction ever ran — permanently wedged. Shrink the inherited
+            # context to fit the TRUE request size (messages + system + tools)
+            # before the first send. Threshold-independent hard safety net.
+            if self.context_manager:
+                self._chat_messages = self.context_manager.prune_to_fit(
+                    self._chat_messages,
+                    system_prompt=system,
+                    tools=self.tools.get_tool_definitions(**self._tool_filter_kw) or None,
+                )
+
             if self._chat_total_rounds >= self.CHAT_MAX_TOTAL_ROUNDS:
                 if self._chat_auto_continues >= self._MAX_SESSION_CONTINUES:
                     self.state = "idle"
@@ -3695,10 +3765,8 @@ class AgentLoop:
                 _iter_tools = (
                     self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 )
-                llm_response = await _llm_call_with_retry(
-                    self.llm.chat_collect,
+                llm_response = await self._chat_call_self_healing(
                     system=_round_system,
-                    messages=self._messages_with_volatile(self._chat_messages),
                     tools=_iter_tools,
                 )
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
@@ -4621,6 +4689,7 @@ class AgentLoop:
             current_origin.reset(origin_token)
 
     async def _chat_stream_inner(self, user_message: str):
+        from src.agent.llm import LLMContextOverflowError
         self.state = "working"
         total_tokens = 0
         tool_outputs: list[dict] = []
@@ -4634,6 +4703,17 @@ class AgentLoop:
 
         try:
             user_message, system = await self._prepare_chat_turn(user_message)
+
+            # Pre-flight wedge guard — see ``_chat_inner`` for rationale.
+            # Shrink an inherited over-limit context to the TRUE request size
+            # (messages + system + tools) before the first stream so it can't
+            # 400 "prompt is too long" and abort the turn before compaction.
+            if self.context_manager:
+                self._chat_messages = self.context_manager.prune_to_fit(
+                    self._chat_messages,
+                    system_prompt=system,
+                    tools=self.tools.get_tool_definitions(**self._tool_filter_kw) or None,
+                )
 
             if self._chat_total_rounds >= self.CHAT_MAX_TOTAL_ROUNDS:
                 if self._chat_auto_continues >= self._MAX_SESSION_CONTINUES:
@@ -4659,6 +4739,7 @@ class AgentLoop:
                 any_text_streamed = False
                 tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 _msgs = self._messages_with_volatile(self._chat_messages)
+                _overflowed = False
                 try:
                     async for event in self.llm.chat_stream(
                         system=system, messages=_msgs, tools=tools,
@@ -4671,16 +4752,62 @@ class AgentLoop:
                         elif etype == "done":
                             llm_response = event["response"]
                     used_streaming = True
+                except LLMContextOverflowError:
+                    # Context-overflow self-heal: emergency-prune and retry
+                    # rather than re-wedge. Only meaningful when nothing was
+                    # streamed yet (overflow 400s before the first token).
+                    _overflowed = True
+                    logger.warning(
+                        "LLM stream overflowed context window; emergency-pruning",
+                    )
                 except Exception as e:
                     logger.warning(f"LLM streaming failed ({e}), falling back to non-streaming")
 
                 streamed = llm_response is not None
                 if llm_response is None:
-                    if used_streaming:
+                    if _overflowed and self.context_manager:
+                        before = len(self._chat_messages)
+                        self._chat_messages = self.context_manager.prune_to_fit(
+                            self._chat_messages,
+                            system_prompt=system,
+                            tools=tools,
+                            ceiling_frac=0.75,
+                        )
+                        logger.warning(
+                            "emergency-pruned %d->%d messages after stream overflow",
+                            before, len(self._chat_messages),
+                        )
+                        _msgs = self._messages_with_volatile(self._chat_messages)
+                    elif used_streaming:
                         logger.warning("LLM stream ended without done event, falling back")
-                    llm_response = await _llm_call_with_retry(
-                        self.llm.chat, system=system, messages=_msgs, tools=tools,
-                    )
+                    # Non-streaming fallback with overflow self-heal: if it ALSO
+                    # overflows, prune harder and retry up to twice; re-raise at
+                    # the minimal kept set so the user sees a clear failure.
+                    for _heal_attempt in range(3):
+                        try:
+                            llm_response = await _llm_call_with_retry(
+                                self.llm.chat, system=system,
+                                messages=_msgs, tools=tools,
+                            )
+                            break
+                        except LLMContextOverflowError:
+                            if _heal_attempt >= 2 or not self.context_manager:
+                                raise
+                            before = len(self._chat_messages)
+                            self._chat_messages = self.context_manager.prune_to_fit(
+                                self._chat_messages,
+                                system_prompt=system,
+                                tools=tools,
+                                ceiling_frac=0.75,
+                            )
+                            if len(self._chat_messages) >= before:
+                                raise  # no progress — surface the failure
+                            _msgs = self._messages_with_volatile(self._chat_messages)
+                            logger.warning(
+                                "non-streaming fallback overflowed; pruned "
+                                "%d->%d and retrying (attempt %d/2)",
+                                before, len(self._chat_messages), _heal_attempt + 1,
+                            )
 
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
                 # a single deep-research call can run >5 min, and bumping

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3495,21 +3495,32 @@ class AgentLoop:
             except LLMContextOverflowError:
                 if attempt >= 2 or not self.context_manager:
                     raise
-                before = len(self._chat_messages)
+                before_msgs = len(self._chat_messages)
+                before_tokens = self.context_manager.estimate_request_tokens(
+                    self._chat_messages, system, tools,
+                )
                 self._chat_messages = self.context_manager.prune_to_fit(
                     self._chat_messages,
                     system_prompt=system,
                     tools=tools,
                     ceiling_frac=0.75,
                 )
+                after_tokens = self.context_manager.estimate_request_tokens(
+                    self._chat_messages, system, tools,
+                )
                 logger.warning(
                     "chat call overflowed context window; emergency-pruned "
-                    "%d->%d messages and retrying (attempt %d/2)",
-                    before, len(self._chat_messages), attempt + 1,
+                    "%d->%d messages (%d->%d est tokens), retrying (attempt %d/2)",
+                    before_msgs, len(self._chat_messages),
+                    before_tokens, after_tokens, attempt + 1,
                 )
-                if len(self._chat_messages) >= before:
-                    # Prune made no progress (already at the minimal kept set);
-                    # retrying would loop on the same 400. Surface the failure.
+                if after_tokens >= before_tokens:
+                    # No TOKEN progress (already at the minimal kept set);
+                    # retrying would 400 identically. Surface the failure.
+                    # Token-based, not message-count: dropping a 1-message group
+                    # while the role-alternation bridge adds 1 leaves the count
+                    # unchanged though tokens fell — a count check would bail
+                    # prematurely on text-heavy (no-tool) operator chats.
                     raise
 
     async def _compact_chat_context(self, system: str) -> None:
@@ -4793,20 +4804,27 @@ class AgentLoop:
                         except LLMContextOverflowError:
                             if _heal_attempt >= 2 or not self.context_manager:
                                 raise
-                            before = len(self._chat_messages)
+                            before_msgs = len(self._chat_messages)
+                            before_tokens = self.context_manager.estimate_request_tokens(
+                                self._chat_messages, system, tools,
+                            )
                             self._chat_messages = self.context_manager.prune_to_fit(
                                 self._chat_messages,
                                 system_prompt=system,
                                 tools=tools,
                                 ceiling_frac=0.75,
                             )
-                            if len(self._chat_messages) >= before:
-                                raise  # no progress — surface the failure
+                            after_tokens = self.context_manager.estimate_request_tokens(
+                                self._chat_messages, system, tools,
+                            )
+                            if after_tokens >= before_tokens:
+                                raise  # no token progress — surface the failure
                             _msgs = self._messages_with_volatile(self._chat_messages)
                             logger.warning(
                                 "non-streaming fallback overflowed; pruned "
-                                "%d->%d and retrying (attempt %d/2)",
-                                before, len(self._chat_messages), _heal_attempt + 1,
+                                "%d->%d messages (%d->%d est tokens), retrying (attempt %d/2)",
+                                before_msgs, len(self._chat_messages),
+                                before_tokens, after_tokens, _heal_attempt + 1,
                             )
 
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -30,7 +30,12 @@ import httpx
 from src.agent.attachments import convert_openai_image_blocks
 from src.host.oauth_providers import get_provider
 from src.host.transcript import sanitize_for_provider
-from src.shared.errors import LLMAuthError, LLMConfigError, LLMTransientError
+from src.shared.errors import (
+    LLMAuthError,
+    LLMConfigError,
+    LLMTransientError,
+    is_context_overflow,
+)
 from src.shared.models import KEYLESS_PROVIDERS, get_known_provider_names
 from src.shared.types import CRED_HANDLE_RE, APIProxyRequest, APIProxyResponse
 from src.shared.utils import friendly_streaming_error, setup_logging
@@ -1233,10 +1238,22 @@ class CredentialVault:
                 _masked = "Upstream service call failed."
                 if _status:
                     _masked = f"Upstream service call failed (HTTP {_status})."
+                # Tag context-length 400s ("prompt is too long" / "context
+                # length exceeded") on the TRUSTED side: the agent only sees the
+                # masked message above (raw provider text is withheld across the
+                # trust boundary, L15), so it cannot substring-match the overflow
+                # itself. error_type lets the agent's classifier raise
+                # LLMContextOverflowError and self-heal (prune + retry) instead
+                # of aborting the turn and re-wedging. The message stays masked —
+                # only the type leaks, no provider text. Note: OAuth errors are
+                # RuntimeErrors with no ``status_code``, so detect on str(e),
+                # not on the (possibly-None) status.
+                _overflow = is_context_overflow(str(e))
                 return APIProxyResponse(
                     success=False,
                     error=_masked,
                     status_code=_status,
+                    error_type="context_overflow" if _overflow else None,
                 )
 
         if lock is not None:

--- a/src/shared/errors.py
+++ b/src/shared/errors.py
@@ -96,3 +96,33 @@ class LLMTransientError(RuntimeError):
         # field positions the agent loop to extend that to typed transient
         # errors in a follow-up without changing the exception shape.
         self.retry_after = retry_after
+
+
+# Substrings (matched case-insensitively) that identify a context-length /
+# "prompt is too long" 400 across providers (Anthropic, OpenAI, OpenRouter
+# passthrough). Lives in shared/ because BOTH sides of the trust boundary need
+# it: the mesh proxy (which has the raw provider detail) tags
+# ``error_type="context_overflow"`` on the masked envelope, and the agent's LLM
+# classifier uses it as a backstop. One list keeps the two copies from drifting.
+CONTEXT_OVERFLOW_MARKERS = (
+    "prompt is too long",
+    "context length",
+    "context_length_exceeded",
+    "input length and max_tokens exceed",
+    "maximum context length",
+)
+
+
+def is_context_overflow(text: str) -> bool:
+    """True when an error message indicates the request exceeded the model's
+    context window (a context-length 400).
+
+    Used by the mesh proxy to tag ``error_type="context_overflow"`` (the proxy
+    masks the raw message across the trust boundary, so the agent cannot
+    substring-match it itself) and by ``LLMClient._raise_classified_error`` as a
+    backstop for any path that does forward the raw text. Routing to
+    ``LLMContextOverflowError`` lets the chat loop self-heal (prune + retry)
+    instead of aborting the turn and re-wedging.
+    """
+    t = (text or "").lower()
+    return any(marker in t for marker in CONTEXT_OVERFLOW_MARKERS)

--- a/src/shared/errors.py
+++ b/src/shared/errors.py
@@ -106,7 +106,7 @@ class LLMTransientError(RuntimeError):
 # classifier uses it as a backstop. One list keeps the two copies from drifting.
 CONTEXT_OVERFLOW_MARKERS = (
     "prompt is too long",
-    "context length",
+    "context length exceeded",
     "context_length_exceeded",
     "input length and max_tokens exceed",
     "maximum context length",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -385,6 +385,10 @@ class TestAutoContinueSession:
         cm.force_compact = AsyncMock(side_effect=RuntimeError("LLM down"))
         cm.maybe_compact = AsyncMock(side_effect=lambda s, m: (m, False))
         cm.context_warning = MagicMock(return_value=None)
+        # prune_to_fit is a no-op pass-through here (small convo, under ceiling);
+        # spec'd mocks must model it or the pre-flight guard reassigns
+        # _chat_messages to a MagicMock.
+        cm.prune_to_fit = MagicMock(side_effect=lambda messages, *a, **k: messages)
         loop.context_manager = cm
 
         loop._chat_total_rounds = loop.CHAT_MAX_TOTAL_ROUNDS

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1084,3 +1084,111 @@ class TestSummarizeCompactGroupAware:
             f"10-tool group split by compaction — missing tool ids: "
             f"{expected_ids - set(tool_ids_after)}"
         )
+
+
+def _tool_group_messages(num_groups: int, chars_each: int = 4000) -> list[dict]:
+    """Build a message list with ``num_groups`` tool-call groups.
+
+    Shape: an initial user message, then repeating
+    ``assistant(tool_calls) -> tool(result) -> assistant(text) -> user`` so the
+    grouping helper produces clearly-bounded groups that can be pruned at
+    boundaries without orphaning a tool result.
+    """
+    msgs: list[dict] = [{"role": "user", "content": "INITIAL " + "i" * chars_each}]
+    for g in range(num_groups):
+        msgs.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": f"c{g}", "function": {"name": "do", "arguments": "{}"}}],
+        })
+        msgs.append({"role": "tool", "tool_call_id": f"c{g}", "content": "R" + "r" * chars_each})
+        msgs.append({"role": "assistant", "content": "A" + "a" * chars_each})
+        msgs.append({"role": "user", "content": "U" + "u" * chars_each})
+    return msgs
+
+
+class TestEstimateRequestTokens:
+    def test_includes_system_and_tools(self):
+        cm = ContextManager(max_tokens=100_000, model="anthropic/claude")
+        msgs = _make_messages(4, chars_each=400)
+        msgs_only = cm.token_count(msgs)
+        with_sys = cm.estimate_request_tokens(msgs, system_prompt="S" * 4000)
+        tools = [{"type": "function", "function": {"name": "x", "description": "d" * 4000}}]
+        with_all = cm.estimate_request_tokens(msgs, system_prompt="S" * 4000, tools=tools)
+        assert with_sys > msgs_only, "system prompt must add to the estimate"
+        assert with_all > with_sys, "tool schema must add to the estimate"
+
+    def test_no_system_no_tools_equals_messages(self):
+        cm = ContextManager(max_tokens=100_000)
+        msgs = _make_messages(4, chars_each=400)
+        assert cm.estimate_request_tokens(msgs) == cm.token_count(msgs)
+
+
+class TestPruneToFit:
+    def test_reduces_over_limit_list_below_ceiling(self):
+        # Window small enough that several groups blow past 0.9 * max_tokens.
+        cm = ContextManager(max_tokens=8_000, model="anthropic/claude")
+        msgs = _tool_group_messages(8, chars_each=4000)
+        assert cm.estimate_request_tokens(msgs) > cm.max_tokens * 0.90
+        pruned = cm.prune_to_fit(msgs)
+        assert cm.estimate_request_tokens(pruned) <= cm.max_tokens * 0.90
+
+    def test_keeps_first_message(self):
+        cm = ContextManager(max_tokens=8_000, model="anthropic/claude")
+        msgs = _tool_group_messages(8, chars_each=4000)
+        pruned = cm.prune_to_fit(msgs)
+        assert pruned[0].get("content", "").startswith("INITIAL"), \
+            "first (initial-context) message must always be kept"
+
+    def test_preserves_role_alternation(self):
+        cm = ContextManager(max_tokens=8_000, model="anthropic/claude")
+        msgs = _tool_group_messages(8, chars_each=4000)
+        pruned = cm.prune_to_fit(msgs)
+        for a, b in zip(pruned, pruned[1:]):
+            ra, rb = a.get("role"), b.get("role")
+            assert not (ra == rb == "user"), "consecutive user messages"
+            assert not (ra == rb == "assistant"), "consecutive assistant messages"
+
+    def test_never_orphans_a_tool_group(self):
+        cm = ContextManager(max_tokens=8_000, model="anthropic/claude")
+        msgs = _tool_group_messages(8, chars_each=4000)
+        pruned = cm.prune_to_fit(msgs)
+        # Every tool message must be immediately preceded (within its group) by
+        # an assistant carrying tool_calls — i.e. no orphaned tool results.
+        groups = group_messages_by_tool_call(pruned)
+        for g in groups:
+            if any(m.get("role") == "tool" for m in g):
+                assert g[0].get("role") == "assistant" and g[0].get("tool_calls"), \
+                    "tool result orphaned from its parent assistant"
+
+    def test_noop_when_under_ceiling(self):
+        cm = ContextManager(max_tokens=1_000_000, model="anthropic/claude")
+        msgs = _make_messages(4, chars_each=400)
+        assert cm.prune_to_fit(msgs) is msgs
+
+    def test_aggressive_ceiling_prunes_more(self):
+        cm = ContextManager(max_tokens=8_000, model="anthropic/claude")
+        msgs = _tool_group_messages(8, chars_each=4000)
+        lenient = cm.prune_to_fit(msgs, ceiling_frac=0.90)
+        aggressive = cm.prune_to_fit(msgs, ceiling_frac=0.50)
+        assert len(aggressive) <= len(lenient)
+        assert cm.estimate_request_tokens(aggressive) <= cm.max_tokens * 0.50
+
+
+class TestSummarizeTailCap:
+    @pytest.mark.asyncio
+    async def test_tail_cap_drops_oversized_kept_groups(self):
+        # The retained recent tail (default keep_n up to 4 groups) is capped at
+        # ~0.5 * max_tokens. With huge groups, the tail must shed older kept
+        # groups so it stays under that cap.
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(content="SUMMARY", tokens_used=10))
+        cm = ContextManager(max_tokens=10_000, llm=llm, model="anthropic/claude")
+        # 6 standalone assistant/user groups, each ~big.
+        msgs = _tool_group_messages(6, chars_each=4000)
+        result = await cm._summarize_compact("system", msgs)
+        # Result = summary + retained tail; tail (excluding the summary msg)
+        # must be under 0.5 * max_tokens.
+        tail_tokens = estimate_tokens(result[1:], cm.model)
+        assert tail_tokens <= cm.max_tokens * 0.5 + 50, \
+            f"retained tail {tail_tokens} exceeds 0.5*max_tokens cap"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -261,6 +261,40 @@ async def test_handle_llm_no_failover_on_bad_request(monkeypatch):
     assert result.status_code == 400
 
 
+async def test_handle_llm_context_overflow_tagged(monkeypatch):
+    """A context-length 400 ("prompt is too long") is tagged
+    error_type='context_overflow' on the TRUSTED proxy side so the agent can
+    self-heal — while the raw provider text stays masked across the boundary.
+
+    This is the integration link the agent-side classifier depends on: the
+    agent only sees the masked message, so without this tag the substring
+    match never fires and the self-heal (prune + retry) is dead — the operator
+    re-wedges. See src/agent/llm.py:_raise_classified_error."""
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")
+    v = CredentialVault()
+
+    import litellm
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        raise litellm.BadRequestError(
+            message="prompt is too long: 1567410 tokens > 1000000 maximum",
+            model=model, llm_provider="anthropic",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        req = APIProxyRequest(
+            service="llm", action="chat",
+            params={"model": "anthropic/claude-haiku-4-5-20251001", "messages": []},
+        )
+        result = await v.execute_api_call(req)
+
+    assert not result.success
+    assert result.error_type == "context_overflow"
+    # Raw provider detail is still masked — only the TYPE crosses the boundary.
+    assert "prompt is too long" not in (result.error or "")
+    assert result.error == "Upstream service call failed (HTTP 400)."
+
+
 async def test_handle_llm_all_models_exhausted(monkeypatch):
     """All models fail → error returned."""
     monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.agent.llm import LLMClient, LLMRetryableError
+from src.agent.llm import LLMClient, LLMContextOverflowError, LLMRetryableError
 from src.shared.errors import LLMAuthError
 
 
@@ -157,6 +157,27 @@ async def test_unrelated_runtime_error_still_permanent():
         await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
     # Must NOT be the retryable subclass.
     assert not isinstance(exc_info.value, LLMRetryableError)
+    # ...nor the context-overflow subclass.
+    assert not isinstance(exc_info.value, LLMContextOverflowError)
+
+
+@pytest.mark.parametrize("msg", [
+    "prompt is too long: 1567410 tokens > 1000000 maximum",
+    "This model's maximum context length is 200000 tokens",
+    "context_length_exceeded",
+    "Your input length and max_tokens exceed the context window",
+    "context length exceeded the limit",
+])
+@pytest.mark.asyncio
+async def test_context_overflow_classified_distinctly(msg):
+    """Context-length 400s must raise the distinct LLMContextOverflowError so
+    the chat loop can self-heal (prune + retry) rather than aborting the turn
+    as a generic RuntimeError (the wedge bug)."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(return_value=_make_mesh_response(msg))
+    with pytest.raises(LLMContextOverflowError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -180,6 +180,39 @@ async def test_context_overflow_classified_distinctly(msg):
         await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
 
 
+@pytest.mark.asyncio
+async def test_context_overflow_via_proxy_error_type():
+    """REAL prod path: the mesh proxy MASKS the raw 400 text across the trust
+    boundary ("Upstream service call failed (HTTP 400).") and tags
+    error_type='context_overflow'. The masked message contains none of the
+    substring markers, so classifying on the TYPE is the only signal that
+    works in production — the substring backstop alone would miss it and the
+    self-heal would never fire (the wedge would persist)."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(return_value=_make_mesh_response(
+        "Upstream service call failed (HTTP 400).",
+        error_type="context_overflow",
+    ))
+    with pytest.raises(LLMContextOverflowError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_masked_generic_400_is_not_overflow():
+    """A generic masked 400 (no overflow type, no markers in the text) must NOT
+    be misclassified as overflow — it stays a plain RuntimeError so we don't
+    prune+retry on unrelated bad-request errors."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(return_value=_make_mesh_response(
+        "Upstream service call failed (HTTP 400).",
+    ))
+    with pytest.raises(RuntimeError) as exc_info:
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+    assert not isinstance(exc_info.value, LLMContextOverflowError)
+
+
 # --------------------------------------------------------------------------
 # _parse_tool_calls — truncated-args retryable carve-out
 #

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -5011,3 +5011,102 @@ def test_trim_context_preserves_multimodal_first_message() -> None:
         and "Previous Actions" in b.get("text", "")
         for b in trimmed[0]["content"]
     )
+
+
+# === Context-window wedge guard (defense in depth) ===
+
+
+@pytest.mark.asyncio
+async def test_restore_session_prunes_oversized_checkpoint():
+    """A fat checkpoint reloaded by _maybe_restore_session must be pruned under
+    the window so the agent can't re-wedge on the first call after restart."""
+    from src.agent.context import ContextManager
+
+    loop = _make_loop()
+    loop.context_manager = ContextManager(max_tokens=8_000, model="anthropic/claude")
+    loop._chat_messages = []
+
+    # Build a checkpoint far over the window: many big tool-call groups.
+    fat: list[dict] = [{"role": "user", "content": "INITIAL " + "i" * 4000}]
+    for g in range(10):
+        fat.append({
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": f"c{g}", "function": {"name": "do", "arguments": "{}"}}],
+        })
+        fat.append({"role": "tool", "tool_call_id": f"c{g}", "content": "r" * 4000})
+        fat.append({"role": "assistant", "content": "a" * 4000})
+        fat.append({"role": "user", "content": "u" * 4000})
+
+    before = loop.context_manager.estimate_request_tokens(fat)
+    assert before > loop.context_manager.max_tokens
+
+    loop.memory._run_db = AsyncMock(return_value={
+        "messages": fat,
+        "total_rounds": 3,
+        "auto_continues": 0,
+        "flush_triggered": False,
+    })
+
+    await loop._maybe_restore_session()
+
+    after = loop.context_manager.estimate_request_tokens(loop._chat_messages)
+    assert after <= loop.context_manager.max_tokens * 0.90
+    # First (initial) message preserved.
+    assert loop._chat_messages[0]["content"].startswith("INITIAL")
+
+
+@pytest.mark.asyncio
+async def test_chat_self_heals_on_context_overflow():
+    """A context-overflow on the first chat call triggers an emergency prune +
+    successful retry rather than aborting the turn."""
+    from src.agent.context import ContextManager
+    from src.agent.llm import LLMContextOverflowError
+
+    final = LLMResponse(content="recovered answer", tokens_used=20)
+
+    loop = _make_loop()
+    loop.context_manager = ContextManager(max_tokens=8_000, model="anthropic/claude")
+
+    # Oversized inherited context so prune_to_fit has groups to shed.
+    seed: list[dict] = [{"role": "user", "content": "INITIAL " + "i" * 4000}]
+    for g in range(10):
+        seed.append({
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": f"c{g}", "function": {"name": "do", "arguments": "{}"}}],
+        })
+        seed.append({"role": "tool", "tool_call_id": f"c{g}", "content": "r" * 4000})
+        seed.append({"role": "assistant", "content": "a" * 4000})
+        seed.append({"role": "user", "content": "u" * 4000})
+    loop._chat_messages = list(seed)
+
+    # First call overflows, second returns a normal response.
+    loop.llm.chat_collect = AsyncMock(
+        side_effect=[LLMContextOverflowError("prompt is too long: 9000 > 8000"), final]
+    )
+    loop.tools.get_tool_definitions = MagicMock(return_value=[])
+
+    resp = await loop._chat_call_self_healing(system="sys", tools=None)
+    assert resp is final
+    assert loop.llm.chat_collect.call_count == 2
+    # The context was pruned in the process.
+    assert len(loop._chat_messages) < len(seed)
+
+
+@pytest.mark.asyncio
+async def test_chat_self_heal_reraises_when_prune_cannot_help():
+    """If pruning makes no progress (already minimal), the overflow is
+    re-raised so the user sees a clear failure rather than an infinite loop."""
+    from src.agent.context import ContextManager
+    from src.agent.llm import LLMContextOverflowError
+
+    loop = _make_loop()
+    loop.context_manager = ContextManager(max_tokens=8_000, model="anthropic/claude")
+    # Single small message: nothing to prune.
+    loop._chat_messages = [{"role": "user", "content": "hi"}]
+    loop.llm.chat_collect = AsyncMock(
+        side_effect=LLMContextOverflowError("prompt is too long")
+    )
+    loop.tools.get_tool_definitions = MagicMock(return_value=[])
+
+    with pytest.raises(LLMContextOverflowError):
+        await loop._chat_call_self_healing(system="sys", tools=None)


### PR DESCRIPTION
## Incident this fixes

On kovarastudio (latest main), the **operator was fully wedged**: its chat context reached **~1,567,000 tokens** — over Anthropic's hard **1,000,000** limit for Opus 4.8 — so every call 400'd `prompt is too long`. A restart didn't help (the fat checkpoint reloaded verbatim). Operator already unwedged in prod via `/chat/reset`; this is the durable fix.

## Root cause (structural, not a single regression)

Compaction was blind to most of the request and only ran too late to help:
1. `ContextManager.usage()`/`should_compact()` counted **only `messages`** — not the system prompt, tool schemas, or the per-turn volatile suffix that `llm.py` actually sends.
2. The token estimate (`chars/3.5`) under-counts dense tool/JSON content.
3. Compaction is **reactive** (bottom of the round loop). The **first** call of a turn fired on the inherited context with **no pre-flight check** — if already over the limit it 400'd and aborted the turn *before* compaction ran.
4. `_maybe_restore_session` reloaded the checkpoint **verbatim** with no size guard → restart re-wedged.
5. The context-length 400 was a generic non-retryable error → turn aborted instead of recovering.
6. The 1M window amplifies all of it (0.70 trigger = 700K of messages alone; grouped-tool-search never activates at 1M so the full tool surface ships uncounted).

## The fix (defense in depth)

- **`estimate_request_tokens()`** — true request size = messages + system prompt + tool-schema estimate (conservative-high).
- **`prune_to_fit()`** — emergency, group-aware prune to a fraction of the window. Keeps the first group + most-recent group, prunes only at tool-call-group boundaries, and bridges role alternation (mirrors `_hard_prune`). Threshold-independent hard safety net.
- **Pre-flight guard** in `_chat_inner` / `_chat_stream_inner` — shrink an inherited over-limit context to the true request size *before* the first send.
- **Self-heal on overflow** — new `LLMContextOverflowError` (classified *before* the retryable checks); the chat call self-heals by pruning harder (`ceiling_frac=0.75`) and retrying up to 2×, re-raising at the minimal kept set so a genuine failure still surfaces.
- **Restore guard** — prune the restored checkpoint so a fat checkpoint can't reload into an un-sendable state.
- **Tail cap** in `_summarize_compact` — drop oldest *kept* groups until the retained tail is under ~0.5×window, so a few huge tool-result groups can't defeat compaction.
- Thresholds (0.60/0.70/0.80) are **unchanged** — this is a separate hard guard.

Folds in the held #1085 changes (the `claude-opus-4-8 → 1_000_000` fallback entry + the budget-resolution log line), so **#1085 should be closed as superseded** by this PR.

## Testing
`tests/test_context.py tests/test_loop.py tests/test_llm.py tests/test_models.py` and the full fast suite green: **7245 passed, 49 skipped** after the one mock-modeling fix (`prune_to_fit` stub on a spec'd `ContextManager` mock). New tests cover `estimate_request_tokens`, `prune_to_fit` (ceiling, keep-first, role-alternation, no orphaned tool group), the restore guard, overflow classification, and prune-and-retry self-heal.

## Review notes / risks
- **Hot-path change** (chat loop + context manager) — wants careful review before merge; **do not merge until reviewed + deployed carefully.**
- `origin/main` advanced to #1086 (operator-stream-keepalive, touches streaming) after this branch — **may need a rebase**; check mergeability.
- The self-heal relies on the size estimate; if the real request exceeds the estimate by >25% (the 0.75 margin) it surfaces a clear failure rather than looping — acceptable, but the estimate-calibration-from-actual-`input_tokens` follow-up (deferred) would tighten it.