### PR TITLE
feat(orchestration): durable chain watcher — guaranteed terminal outcome for user pipelines (Phase 1 net)

### DIFF
--- a/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
+++ b/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
@@ -131,6 +131,9 @@ Per-hop origin is deliberately **downgraded** for worker-originated calls (`_val
 ### Phase 1 — The guarantee: delegate-and-release + durable terminal outcome
 **Goal:** every user-initiated pipeline ALWAYS produces a final user-facing message (done/failed/stalled), exactly once; the operator stops block-watching.
 
+> **Status: 1a–1c IMPLEMENTED (the guarantee net). 1d (operator behavior) deferred to its own PR — net before trapeze.**
+> The net ships as: a `chain_deliveries` exactly-once ledger + `Tasks.{list_watchable_human_roots, chain_terminal_verdict, claim_chain_delivery}` (`src/host/orchestration.py`); a periodic, restart-safe `ChainWatcher` with settle/debounce against the in-flight-handoff race (`src/host/chain_watcher.py`); and runtime wiring that delivers a guaranteed terminal outcome to the dashboard bell (durable, deliver-then-claim) plus a best-effort paired-channel push — targeting **only** the root's first-party human origin (`src/cli/runtime.py`). The operator still block-watches for now; the net is purely additive so it cannot regress current behavior. 1d removes block-watching once this is proven on cake.
+
 - **1a (gate — design + schema, tests first):**
   - Decide the root-origin trust model per §4 security constraint: `chain_watch` row carries the trusted root origin set at chain creation; delivery never trusts per-hop origin and never re-opens the back-edge skip.
   - Define **"chain terminal"** for fan-out: no non-terminal task remains under `root_task_id` (not merely "a `done` leaf with no child" — that's `chain_breaks`'s weaker per-leaf notion).

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -191,6 +191,8 @@ class RuntimeContext:
     def shutdown(self) -> None:
         """Tear down all components in reverse order."""
         click.echo("  Stopping OpenLegion...", nl=False)
+        if self.chain_watcher:
+            self.chain_watcher.stop()
         if self.channel_manager:
             self.channel_manager.stop_all()
         if self.health_monitor:
@@ -400,6 +402,11 @@ class RuntimeContext:
             self._notification_store = NotificationStore()
         except Exception as e:
             logger.warning("Failed to instantiate NotificationStore: %s", e)
+
+        # Chain watcher (delegate-and-subscribe terminal delivery). Wired in
+        # _start_background once the mesh app's tasks_store is available.
+        self.chain_watcher = None
+        self._tasks_store_ref = None
 
         self.health_monitor = HealthMonitor(
             runtime=self.runtime, transport=self.transport, router=self.router,
@@ -935,6 +942,77 @@ class RuntimeContext:
                 "send_to_user(%s, %s) failed: %s", channel_type, user, e,
             )
 
+    def _deliver_chain_outcome(self, root: dict, kind: str, summary: str) -> bool:
+        """Deliver one terminal outcome for a user chain to its originator.
+
+        The durable dashboard bell is the guarantee surface — the watcher
+        only claims the delivery when this returns True, so a failed write
+        is retried rather than silently lost. A paired chat channel
+        (telegram/discord/slack/whatsapp) additionally gets a best-effort
+        push so a non-dashboard originator hears back in their own channel.
+        Targeting uses ONLY the root's first-party human origin.
+        """
+        origin = root.get("origin") or {}
+        channel = origin.get("channel") or "dashboard"
+        user = origin.get("user") or ""
+        root_id = root.get("id") or ""
+        assignee = root.get("assignee") or ""
+        if kind == "done":
+            title = "✅ Task complete"
+            body = summary or "Your request finished."
+        else:
+            title = "⚠️ Task failed"
+            body = summary or "Your request hit a failure and stopped."
+        payload = {
+            "root_task_id": root_id,
+            "outcome": kind,
+            "origin_channel": channel,
+        }
+
+        # 1. Durable surface — the dashboard bell. This IS the guarantee.
+        if self._notification_store is None:
+            return False
+        try:
+            nid = self._notification_store.add(
+                kind="delivered", title=title, body=body,
+                agent_id=assignee or None, payload=payload,
+            )
+        except Exception as e:
+            logger.warning(
+                "chain outcome bell write failed for %s: %s", root_id, e,
+            )
+            return False
+        if self.event_bus is not None:
+            try:
+                self.event_bus.emit(
+                    "notification_added", agent=assignee or "",
+                    data={
+                        "id": nid, "kind": "delivered", "title": title,
+                        "body": body, "agent_id": assignee, "payload": payload,
+                    },
+                )
+            except Exception as e:
+                logger.debug("notification_added emit failed: %s", e)
+
+        # 2. Best-effort — push to a paired chat channel for non-dashboard
+        #    originators. Never blocks or fails the durable delivery.
+        if channel and channel != "dashboard" and user:
+            try:
+                from src.shared.types import MessageOrigin
+                origin_obj = MessageOrigin(
+                    kind="human", channel=channel, user=user,
+                )
+                asyncio.create_task(
+                    self._handle_notify_origin(
+                        origin_obj, f"{title}\n{body}", assignee,
+                    )
+                )
+            except Exception as e:
+                logger.debug(
+                    "chain outcome channel push schedule failed: %s", e,
+                )
+        return True
+
     def _start_mesh_server(self) -> None:
         import uvicorn
 
@@ -991,6 +1069,10 @@ class RuntimeContext:
         _tasks_store_ref = getattr(app, "tasks_store", None)
         if _tasks_store_ref is not None and self.lane_manager is not None:
             self.lane_manager.set_tasks_store(_tasks_store_ref)
+        # Hold the same store instance for the chain watcher (started in
+        # _start_background) so terminal-chain delivery reads/writes the
+        # very tasks DB the mesh transitions tasks in.
+        self._tasks_store_ref = _tasks_store_ref
         # Wire the mesh's back-edge writer into the lane watchdog so a
         # lane-timeout failure produces a ``task_failed`` inbox event for
         # the originator AND triggers the wake-on-event chain. Without
@@ -1348,6 +1430,22 @@ class RuntimeContext:
 
         health_thread = threading.Thread(target=run_health, daemon=True)
         health_thread.start()
+
+        # Start chain watcher — delivers a guaranteed terminal outcome for
+        # user-originated task chains so the operator can hand off and
+        # release instead of block-watching a multi-hop pipeline.
+        if self._tasks_store_ref is not None and self._notification_store is not None:
+            from src.host.chain_watcher import ChainWatcher
+            self.chain_watcher = ChainWatcher(
+                self._tasks_store_ref, self._deliver_chain_outcome,
+            )
+
+            def run_chain_watcher():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                loop.run_until_complete(self.chain_watcher.start())
+
+            threading.Thread(target=run_chain_watcher, daemon=True).start()
 
     def _init_channel_manager(self) -> None:
         """Create the ChannelManager with callbacks (but don't start channels yet)."""

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -1,0 +1,157 @@
+"""Chain watcher — delegate-and-subscribe terminal delivery.
+
+The operator hands user work off to a team and *releases* its turn instead
+of block-watching a multi-hop pipeline (which dies at the browser's 120s
+idle abort and strands the operator). This watcher makes "watching" a
+durable, system-side behavior: it periodically sweeps user-originated task
+chains and pushes exactly ONE terminal outcome (done / failed) to the human
+who started the chain.
+
+Design (see docs/plans/2026-06-10-operator-delegate-and-subscribe.md):
+
+- **Periodic sweep, not an event listener.** A sweep re-derives everything
+  from the durable tasks table on each pass, so it is inherently
+  restart-safe and free of cross-thread event-affinity concerns. The
+  ``chain_deliveries`` table is the exactly-once ledger.
+- **Settle/debounce.** A root reaching ``done`` a beat before its successor
+  task row exists reads as "whole chain terminal" momentarily. We require a
+  chain to stay terminal for ``settle_s`` before delivering, so an in-flight
+  hand-off resets the timer instead of triggering a premature "done".
+- **Deliver-then-claim.** The durable surface (the dashboard bell) is
+  written first; only on success is the delivery claimed. A chain is thus
+  never silently lost (it retries until the durable write succeeds); the
+  worst case is a rare duplicate if the process dies between write and
+  claim, which is strictly preferable to silence.
+- **Security.** Targeting comes from the chain ROOT's first-party human
+  origin only (the store filters ``origin_kind='human'`` roots); mid-chain
+  worker origins — which ``_validated_origin`` downgrades and the L9 binding
+  treats as forgeable — are never used. No origin-trust boundary is touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Callable
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("host.chain_watcher")
+
+# A chain must look terminal continuously for this long before we deliver —
+# covers the in-flight hand-off window (root `done` before the next hop's
+# row exists).
+_DEFAULT_SETTLE_S = 30.0
+# How often to sweep watchable chains.
+_DEFAULT_SWEEP_S = 10.0
+# Only chains created within this window are swept; abandoned, never-terminal
+# chains age out of the scan instead of being re-examined forever.
+_DEFAULT_WATCH_WINDOW_S = 7 * 24 * 3600.0
+
+
+class ChainWatcher:
+    """Sweeps user chains and delivers one terminal outcome each.
+
+    ``deliver(root: dict, kind: str, summary: str) -> bool`` must write the
+    durable user-facing surface and return truthy on success (the watcher
+    only claims the delivery when it does). It may be sync or async.
+    """
+
+    def __init__(
+        self,
+        tasks_store: Any,
+        deliver: Callable[[dict, str, str], Any],
+        *,
+        settle_s: float = _DEFAULT_SETTLE_S,
+        sweep_s: float = _DEFAULT_SWEEP_S,
+        watch_window_s: float = _DEFAULT_WATCH_WINDOW_S,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._tasks = tasks_store
+        self._deliver = deliver
+        self._settle_s = settle_s
+        self._sweep_s = sweep_s
+        self._watch_window_s = watch_window_s
+        self._clock = clock
+        # root_task_id -> monotonic timestamp first observed terminal.
+        self._settling: dict[str, float] = {}
+        self._running = False
+
+    def stop(self) -> None:
+        self._running = False
+
+    async def start(self) -> None:
+        self._running = True
+        logger.info(
+            "chain watcher started (settle=%ss sweep=%ss window=%ss)",
+            self._settle_s, self._sweep_s, self._watch_window_s,
+        )
+        while self._running:
+            try:
+                await self.sweep_once()
+            except Exception as e:
+                logger.warning("chain watcher sweep failed: %s", e)
+            await asyncio.sleep(self._sweep_s)
+
+    async def sweep_once(self) -> None:
+        """One pass: deliver terminal outcomes for settled human chains."""
+        since = time.time() - self._watch_window_s
+        try:
+            roots = self._tasks.list_watchable_human_roots(since=since)
+        except Exception as e:
+            logger.warning("chain watcher: listing roots failed: %s", e)
+            return
+
+        live_ids: set[str] = set()
+        for root in roots:
+            root_id = root.get("id")
+            if not root_id:
+                continue
+            live_ids.add(root_id)
+
+            verdict = self._tasks.chain_terminal_verdict(root_id)
+            if verdict is None:
+                # Still active (or a new hop just appeared) — reset settle.
+                self._settling.pop(root_id, None)
+                continue
+
+            kind, summary = verdict
+            if kind == "cancelled":
+                # Manual cancellation is not a surprise to surface. Claim it
+                # so the chain stops being re-scanned, but deliver nothing.
+                self._tasks.claim_chain_delivery(root_id, "cancelled")
+                self._settling.pop(root_id, None)
+                continue
+
+            first = self._settling.get(root_id)
+            now_mono = self._clock()
+            if first is None:
+                self._settling[root_id] = now_mono
+                continue
+            if now_mono - first < self._settle_s:
+                continue
+
+            # Settled and still terminal — deliver, then claim on success.
+            delivered = await self._run_deliver(root, kind, summary)
+            if delivered:
+                self._tasks.claim_chain_delivery(root_id, kind)
+                self._settling.pop(root_id, None)
+            # If delivery failed, leave the settle timestamp in place so the
+            # next sweep retries immediately (no silent loss).
+
+        # Bound memory: forget settle timers for roots no longer watchable.
+        for stale in [r for r in self._settling if r not in live_ids]:
+            self._settling.pop(stale, None)
+
+    async def _run_deliver(self, root: dict, kind: str, summary: str) -> bool:
+        try:
+            result = self._deliver(root, kind, summary)
+            if asyncio.iscoroutine(result):
+                result = await result
+            return bool(result)
+        except Exception as e:
+            logger.warning(
+                "chain watcher delivery raised for root %s: %s",
+                root.get("id"), e,
+            )
+            return False

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -344,6 +344,12 @@ class Tasks:
                 );
                 CREATE INDEX IF NOT EXISTS idx_task_events_task
                     ON task_events (task_id, created_at);
+
+                CREATE TABLE IF NOT EXISTS chain_deliveries (
+                    root_task_id TEXT PRIMARY KEY,
+                    terminal_kind TEXT NOT NULL,
+                    delivered_at REAL NOT NULL
+                );
             """)
             # Resolve the active column name. ``team_id`` is canonical;
             # ``project_id`` is the pre-rename column kept readable so
@@ -446,6 +452,100 @@ class Tasks:
         )
 
     # ── Helpers ─────────────────────────────────────────────────
+
+    # ── Chain-watch support (delegate-and-subscribe) ─────────────
+    #
+    # A "chain" is the parent_task_id-linked tree rooted at the FIRST
+    # task of a user request (``parent_task_id IS NULL``). The operator's
+    # initial hand_off creates that root as a trusted caller, so its
+    # ``origin_kind == "human"`` is first-party; every later hop is
+    # created by an untrusted worker whose ``kind="human"`` claim is
+    # downgraded to ``agent`` by ``_validated_origin`` at the mesh edge.
+    # The chain watcher therefore delivers ONLY to the root's stored
+    # human origin (never a mid-chain, possibly-forged origin), which
+    # keeps the existing origin-trust boundary fully intact.
+
+    def list_watchable_human_roots(self, *, since: float) -> list[dict]:
+        """Root tasks of user-originated chains awaiting a terminal push.
+
+        A row qualifies when it is a chain root (``parent_task_id IS
+        NULL``), carries a first-party human origin, was created within
+        the watch window (``created_at >= since``), and has not already
+        had a terminal notification claimed in ``chain_deliveries``.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM tasks "
+                "WHERE parent_task_id IS NULL "
+                "  AND origin_kind = 'human' "
+                "  AND created_at >= ? "
+                "  AND id NOT IN (SELECT root_task_id FROM chain_deliveries) "
+                "ORDER BY created_at ASC",
+                (since,),
+            ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def chain_terminal_verdict(self, root_task_id: str) -> tuple[str, str] | None:
+        """Return ``(terminal_kind, summary)`` iff the WHOLE chain is terminal.
+
+        Walks the same ``parent_task_id``/``previous_task_id`` recursion
+        as :meth:`workflow_snapshot`. Returns ``None`` while ANY task in
+        the chain is non-terminal (including a still-being-created next
+        hop, which is why the watcher additionally debounces). When every
+        task is terminal, ``terminal_kind`` is ``failed`` if any task
+        failed, else ``cancelled`` if any was cancelled, else ``done``.
+        ``summary`` is a best-effort human string: the failed task's
+        blocker_note, or the most-recently-completed done leaf's
+        result_summary.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                "WITH RECURSIVE chain(id, depth) AS ("
+                "  SELECT id, 0 FROM tasks WHERE id = ?"
+                "  UNION ALL"
+                "  SELECT t.id, c.depth + 1 FROM tasks t "
+                "    JOIN chain c ON (t.parent_task_id = c.id "
+                "                  OR t.previous_task_id = c.id) "
+                "    WHERE c.depth < ?"
+                ") "
+                "SELECT t.id, t.status, t.result_summary, t.blocker_note, "
+                "  t.completed_at, t.updated_at "
+                "FROM tasks t "
+                "WHERE t.id IN (SELECT DISTINCT id FROM chain)",
+                (root_task_id, MAX_WORKFLOW_CHAIN_DEPTH),
+            ).fetchall()
+        if not rows:
+            return None
+        if any(r[1] not in TERMINAL_STATUSES for r in rows):
+            return None
+        statuses = {r[1] for r in rows}
+        if "failed" in statuses:
+            failed = [r for r in rows if r[1] == "failed"]
+            failed.sort(key=lambda r: r[4] or r[5] or 0.0)
+            return "failed", (failed[-1][3] or "").strip()
+        if "cancelled" in statuses:
+            return "cancelled", ""
+        done_leaves = [r for r in rows if r[1] == "done"]
+        done_leaves.sort(key=lambda r: r[4] or r[5] or 0.0)
+        summary = (done_leaves[-1][2] or "").strip() if done_leaves else ""
+        return "done", summary
+
+    def claim_chain_delivery(self, root_task_id: str, terminal_kind: str) -> bool:
+        """Atomically claim the one terminal notification for a chain.
+
+        Returns ``True`` for the first caller and ``False`` forever after
+        (``INSERT OR IGNORE`` on the ``root_task_id`` primary key). This
+        is the exactly-once guard: it is safe against repeated terminal
+        transitions, a restart replay, and the startup re-scan all racing
+        to deliver the same chain.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO chain_deliveries "
+                "(root_task_id, terminal_kind, delivered_at) VALUES (?, ?, ?)",
+                (root_task_id, terminal_kind, time.time()),
+            )
+            return cur.rowcount == 1
 
     @staticmethod
     def _row_to_dict(row: tuple) -> dict:

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -1,0 +1,228 @@
+"""Tests for the chain watcher (delegate-and-subscribe terminal delivery).
+
+Covers the Tasks store helpers (chain_deliveries dedup, human-root listing,
+whole-chain terminal verdict) and the ChainWatcher sweep semantics
+(settle/debounce against the in-flight hand-off race, exactly-once delivery,
+deliver-then-claim retry, cancelled handling, and human-origin gating).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.host.chain_watcher import ChainWatcher
+from src.host.orchestration import Tasks
+
+HUMAN = {"kind": "human", "channel": "dashboard", "user": "u1"}
+
+
+def _store() -> Tasks:
+    return Tasks(db_path=":memory:")
+
+
+def _human_root(store: Tasks, *, assignee: str = "scout") -> dict:
+    return store.create(
+        creator="operator", assignee=assignee, title="do research",
+        origin=HUMAN,
+    )
+
+
+def _finish(store: Tasks, task_id: str, status: str = "done", **kw) -> None:
+    store.update_status(task_id, "working", actor="x")
+    store.update_status(task_id, status, actor="x", **kw)
+
+
+# ── Store: chain_deliveries dedup ────────────────────────────────
+
+
+def test_claim_chain_delivery_is_exactly_once():
+    s = _store()
+    assert s.claim_chain_delivery("root-1", "done") is True
+    assert s.claim_chain_delivery("root-1", "done") is False
+    assert s.claim_chain_delivery("root-1", "failed") is False
+
+
+# ── Store: list_watchable_human_roots ────────────────────────────
+
+
+def test_list_watchable_only_human_roots():
+    s = _store()
+    human = _human_root(s)
+    # Non-human root (worker-origin / no origin) — excluded.
+    s.create(creator="a", assignee="b", title="internal")
+    # A child hop of the human root — not a root, excluded.
+    s.create(creator="scout", assignee="writer", title="next",
+             parent_task_id=human["id"])
+    roots = s.list_watchable_human_roots(since=0.0)
+    assert [r["id"] for r in roots] == [human["id"]]
+
+
+def test_list_watchable_excludes_claimed_and_old():
+    s = _store()
+    r = _human_root(s)
+    # since in the future → outside window → excluded.
+    assert s.list_watchable_human_roots(since=r["created_at"] + 1000) == []
+    # claimed → excluded.
+    s.claim_chain_delivery(r["id"], "done")
+    assert s.list_watchable_human_roots(since=0.0) == []
+
+
+# ── Store: chain_terminal_verdict ────────────────────────────────
+
+
+def test_verdict_none_while_active():
+    s = _store()
+    r = _human_root(s)
+    assert s.chain_terminal_verdict(r["id"]) is None  # pending
+    s.update_status(r["id"], "working", actor="x")
+    assert s.chain_terminal_verdict(r["id"]) is None  # working
+
+
+def test_verdict_done_single_task():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="found 5 trends")
+    assert s.chain_terminal_verdict(r["id"]) == ("done", "found 5 trends")
+
+
+def test_verdict_multi_hop_all_done():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="stage1")
+    child = s.create(creator="scout", assignee="writer", title="draft",
+                     parent_task_id=r["id"])
+    # Chain not terminal until the child finishes.
+    assert s.chain_terminal_verdict(r["id"]) is None
+    _finish(s, child["id"], "done", result_summary="final draft")
+    kind, summary = s.chain_terminal_verdict(r["id"])
+    assert kind == "done"
+    assert summary == "final draft"  # most-recent done leaf
+
+
+def test_verdict_failed_takes_precedence():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="ok")
+    child = s.create(creator="scout", assignee="writer", title="draft",
+                     parent_task_id=r["id"])
+    _finish(s, child["id"], "failed", blocker_note="model rejected")
+    assert s.chain_terminal_verdict(r["id"]) == ("failed", "model rejected")
+
+
+def test_verdict_cancelled():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "cancelled", actor="x")
+    assert s.chain_terminal_verdict(r["id"]) == ("cancelled", "")
+
+
+# ── Watcher: a recording deliver double ──────────────────────────
+
+
+class _Deliver:
+    def __init__(self, returns=True):
+        self.calls: list[tuple] = []
+        self._returns = returns
+
+    def __call__(self, root, kind, summary):
+        self.calls.append((root["id"], kind, summary))
+        if callable(self._returns):
+            return self._returns(len(self.calls))
+        return self._returns
+
+
+@pytest.mark.asyncio
+async def test_settle_debounce_then_deliver_once():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="r")
+    clk = [1000.0]
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=10, clock=lambda: clk[0])
+
+    await w.sweep_once()           # first observe terminal → start settle
+    assert d.calls == []
+    clk[0] += 5
+    await w.sweep_once()           # within settle → still nothing
+    assert d.calls == []
+    clk[0] += 6                    # 11s > 10s settle
+    await w.sweep_once()           # settled → deliver
+    assert [c[1] for c in d.calls] == ["done"]
+    await w.sweep_once()           # claimed → never again
+    assert len(d.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_in_flight_handoff_resets_settle():
+    """A successor hop appearing before settle must cancel a premature done."""
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="stage1")
+    clk = [0.0]
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=10, clock=lambda: clk[0])
+
+    await w.sweep_once()           # root looks terminal → settle armed
+    clk[0] += 5
+    # Hand-off lands: a non-terminal child appears.
+    child = s.create(creator="scout", assignee="writer", title="draft",
+                     parent_task_id=r["id"])
+    s.update_status(child["id"], "working", actor="x")
+    await w.sweep_once()           # chain no longer terminal → no deliver
+    clk[0] += 20
+    await w.sweep_once()           # still working → no deliver
+    assert d.calls == []
+    # Child finishes — chain terminal again, settle re-arms from scratch.
+    s.update_status(child["id"], "done", actor="x", result_summary="final")
+    await w.sweep_once()           # re-arm
+    assert d.calls == []
+    clk[0] += 11
+    await w.sweep_once()           # settled → deliver exactly once
+    assert [c[1] for c in d.calls] == ["done"]
+    assert d.calls[0][2] == "final"
+
+
+@pytest.mark.asyncio
+async def test_failed_delivery_is_retried_not_lost():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="r")
+    clk = [0.0]
+    # Fail the first delivery, succeed the second.
+    d = _Deliver(returns=lambda n: n >= 2)
+    w = ChainWatcher(s, d, settle_s=0, clock=lambda: clk[0])
+
+    await w.sweep_once()           # arm settle (settle_s=0 still needs 2 passes)
+    await w.sweep_once()           # settled → deliver #1 returns False
+    await w.sweep_once()           # retry → deliver #2 returns True → claim
+    assert len(d.calls) == 2
+    await w.sweep_once()           # claimed → no more
+    assert len(d.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_chain_claimed_not_delivered():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "cancelled", actor="x")
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=0)
+
+    await w.sweep_once()
+    assert d.calls == []
+    # Claimed, so it drops out of the watch set.
+    assert s.list_watchable_human_roots(since=0.0) == []
+
+
+@pytest.mark.asyncio
+async def test_non_human_root_never_delivered():
+    s = _store()
+    # Worker-origin root (the kind a downgraded mid-chain create would yield).
+    r = s.create(creator="a", assignee="b", title="internal",
+                 origin={"kind": "agent", "channel": "", "user": "b"})
+    _finish(s, r["id"], "done", result_summary="x")
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=0)
+    await w.sweep_once()
+    await w.sweep_once()
+    assert d.calls == []


### PR DESCRIPTION
## What

**Phase 1 (steps 1a–1c)** of delegate-and-subscribe: make "watching a pipeline" a durable, system-side behaviour so the operator can hand off and **release** a turn instead of block-watching a multi-hop chain. The operator behaviour change (1d) is deliberately a **separate later PR** — *net before trapeze*: this PR is purely additive and cannot regress current behaviour. Builds on #1086 (Phase 0 keepalive).

## Security (no boundary touched)

Deliver **only to the chain root's first-party human origin**:
- The operator's initial `hand_off` is a *trusted* caller, so the root task keeps `origin_kind="human"`.
- Every later **worker** hop has its `kind="human"` claim **downgraded to `agent`** by `_validated_origin` (dashboard isn't a paired channel), and the L9 back-edge binding treats mid-chain `origin_user` as forgeable.
- The watcher walks up to the root (`parent_task_id IS NULL`), reads **that** origin, and never trusts a mid-chain one. It does **not** modify `_validated_origin` or the back-edge `origin_user != creator` skip.

## How it works

- **Chain** = the `parent_task_id`-linked tree rooted at the first task of a user request. `hand_off` sets `parent_task_id` to the handing-off task (coordination_tool.py), so walking up reaches the root.
- **Periodic sweep, not an event listener** → re-derives state from the durable table each pass ⇒ inherently restart-safe, no cross-thread event affinity.
- **Settle/debounce** absorbs the in-flight-handoff race (a root reaching `done` a beat before its successor row exists would otherwise read as "whole chain terminal").
- **Deliver-then-claim**: the durable dashboard bell is written first; the delivery is claimed (exactly-once) only on success ⇒ a chain is never silently lost (a rare duplicate on crash-between is preferred to silence).

## Changes

- `src/host/orchestration.py` — `chain_deliveries` ledger + `list_watchable_human_roots(since)`, `chain_terminal_verdict(root)` (recursive CTE; `None` while any task non-terminal, else `(done|failed|cancelled, summary)`), `claim_chain_delivery(root, kind)` (atomic `INSERT OR IGNORE`).
- `src/host/chain_watcher.py` (new) — `ChainWatcher`: periodic sweep, settle/debounce, deliver-then-claim, memory-bounded.
- `src/cli/runtime.py` — start the watcher on a daemon-thread loop (mirrors cron/health), stop on shutdown; deliver to the dashboard bell + best-effort paired-channel push via `_handle_notify_origin`.

## Tests
- `tests/test_chain_watcher.py` — **13 new**: store dedup/listing/verdict (single + multi-hop + failed-precedence + cancelled) and watcher debounce, exactly-once, deliver-then-claim retry, cancelled-claimed-not-delivered, human-origin gating.
- Regression: `test_orchestration*` **219 passed**. Ruff clean.

## Deferred (next PRs)
- **1d** — operator playbook change (acknowledge-and-release; stop chaining `await_task_event`). Ships after this net is proven on cake.
- **Phase 2/3** — per-stage milestone pings (terminal-only for v1 per D2), stall watchdog, Work-tab live pipeline card.

## Verify on cake (post-merge)
Multi-hop pipeline where a stage takes >120s ⇒ the user receives exactly one terminal outcome on the dashboard bell, surviving a mesh restart mid-pipeline.