### PR TITLE
fix(chain-watcher): post-merge review fixes (column projection, task ref, summary cap, scope docs)

### DIFF
--- a/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
+++ b/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
@@ -171,6 +171,7 @@ Per-hop origin is deliberately **downgraded** for worker-originated calls (`_val
 - **Q2.** Progress cadence/throttle policy for Phase 2 (debounce window; templated copy).
 - **Q3.** Concurrency: multiple simultaneous pipelines per user/channel — threading/attribution so the user can tell them apart (`root_task_id` in the row + a human-readable chain label).
 - **Q4.** Backwards-compat: chains created without a captured root origin — fall back to a dashboard bell entry keyed by the originating session, and lean on the watcher's boot re-scan to close orphans.
+- **Q5 (DECISION — surfaced in the #1088 post-merge review).** The watcher covers **operator-rooted** chains only. A *direct* user→worker→sub-agent chat produces a root created by an untrusted worker, whose `kind="human"` origin is correctly downgraded to `agent` by `_validated_origin` — so it is not watched (delivering on it would trust a forgeable origin). Per CLAUDE.md Constraint #1 ("users talk to agents directly") this topology is common. Covering it **safely** needs a trusted server-side chain registration at the dashboard `/chat` entry (the mesh knows the inbound chat was human there) rather than loosening the downgrade. **Open question for the user: is operator-rooted coverage sufficient for v1, or do we want the trusted-registration follow-up (Phase 1.5)?** Until then, direct-worker chains keep today's behavior (no terminal push) — purely a non-regression gap.
 
 ---
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -407,6 +407,9 @@ class RuntimeContext:
         # _start_background once the mesh app's tasks_store is available.
         self.chain_watcher = None
         self._tasks_store_ref = None
+        # Strong refs for best-effort channel pushes so the event loop
+        # doesn't GC an in-flight asyncio.Task before it sends.
+        self._pending_chain_pushes: set = set()
 
         self.health_monitor = HealthMonitor(
             runtime=self.runtime, transport=self.transport, router=self.router,
@@ -957,6 +960,10 @@ class RuntimeContext:
         user = origin.get("user") or ""
         root_id = root.get("id") or ""
         assignee = root.get("assignee") or ""
+        # Raw worker output — bound it so a large result_summary can't bloat
+        # the bell row or the channel message. (Display surfaces are
+        # autoescaped; this is a size guard, not a safety one.)
+        summary = (summary or "").strip()[:1500]
         if kind == "done":
             title = "✅ Task complete"
             body = summary or "Your request finished."
@@ -1002,11 +1009,15 @@ class RuntimeContext:
                 origin_obj = MessageOrigin(
                     kind="human", channel=channel, user=user,
                 )
-                asyncio.create_task(
+                push = asyncio.create_task(
                     self._handle_notify_origin(
                         origin_obj, f"{title}\n{body}", assignee,
                     )
                 )
+                # Retain a strong ref until the push completes (asyncio only
+                # holds a weak ref; without this the task can be GC'd mid-send).
+                self._pending_chain_pushes.add(push)
+                push.add_done_callback(self._pending_chain_pushes.discard)
             except Exception as e:
                 logger.debug(
                     "chain outcome channel push schedule failed: %s", e,

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -472,10 +472,25 @@ class Tasks:
         NULL``), carries a first-party human origin, was created within
         the watch window (``created_at >= since``), and has not already
         had a terminal notification claimed in ``chain_deliveries``.
+
+        **Coverage is intentionally limited to OPERATOR-rooted chains.**
+        ``origin_kind = 'human'`` is only first-party when a *trusted*
+        caller created the root: the operator's initial hand_off keeps
+        ``kind="human"``, but a non-operator worker's hand_off has its
+        claim downgraded to ``agent`` by ``_validated_origin`` (``dashboard``
+        is not a paired channel). A *direct* user→worker→sub-agent chat
+        therefore produces an ``agent``-origin root that is (correctly) NOT
+        watched — delivering on it would mean trusting a forgeable origin.
+        Covering that topology safely needs a trusted server-side chain
+        registration at the dashboard ``/chat`` entry (follow-up).
+
+        Projects ``_SELECT_COLS`` (never ``SELECT *``) so ``_row_to_dict``'s
+        positional mapping stays correct on DBs with differing ALTER-column
+        histories.
         """
         with self._conn() as conn:
             rows = conn.execute(
-                "SELECT * FROM tasks "
+                f"SELECT {self._SELECT_COLS} FROM tasks "
                 "WHERE parent_task_id IS NULL "
                 "  AND origin_kind = 'human' "
                 "  AND created_at >= ? "

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -57,6 +57,20 @@ def test_list_watchable_only_human_roots():
     assert [r["id"] for r in roots] == [human["id"]]
 
 
+def test_list_watchable_maps_columns_correctly():
+    """The projected row must map back to the right fields (guards against a
+    SELECT * positional drift vs _row_to_dict / _SELECT_COLS)."""
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="the deliverable")
+    [row] = s.list_watchable_human_roots(since=0.0)
+    assert row["id"] == r["id"]
+    assert row["origin"] == HUMAN
+    assert row["assignee"] == "scout"
+    assert row["result_summary"] == "the deliverable"
+    assert row["status"] == "done"
+
+
 def test_list_watchable_excludes_claimed_and_old():
     s = _store()
     r = _human_root(s)


### PR DESCRIPTION
Follow-up to #1088 from a final principal-engineer + independent Codex review of the merged diff.

## Fixes
- **`list_watchable_human_roots`: `SELECT *` → `SELECT {self._SELECT_COLS}`.** The store maps rows positionally via `_row_to_dict`; `SELECT *` returns physical table order, which only *coincidentally* matches `_SELECT_COLS` on a fresh DB. On a prod DB with a different `ALTER`-column history the `origin`/`result_summary` fields could silently mis-map. Now uses the same explicit projection every other reader uses. **New test** asserts the round-trip mapping.
- **Strong ref for the best-effort channel-push task.** `asyncio` only keeps a weak ref to a bare `create_task`, so an in-flight Telegram/Discord send could be GC'd mid-flight. Retained in a set with a done-callback (mirrors `lanes.py`). The durable bell is unaffected (written first).
- **Cap raw `result_summary` at 1500 chars** before the bell row / channel message (size guard; display surfaces are autoescaped, so this is not a safety fix).

## Flagged (not silently worked around) — scope decision
The watcher covers **operator-rooted** chains only. A *direct* user→worker→sub-agent chat produces a root created by an untrusted worker whose `kind="human"` origin is correctly **downgraded to `agent`** by `_validated_origin` (dashboard isn't a paired channel) → not watched. Delivering on it would trust a forgeable origin, so this is **deliberate**. Covering that topology safely needs a trusted server-side chain registration at the dashboard `/chat` entry — written up as **Q5 / Phase 1.5** in the plan for your decision. It's a **non-regression** gap (those chats get no terminal push today either).

## Not changed (reviewed, deferred)
- `chain_terminal_verdict` CTE has no outer row limit — correct (need all rows to judge terminal); fan-out cost is a scale-only concern, depth-capped at 200.
- `SandboxTransport` doesn't stream, so the #1086 keepalive doesn't cover microVM mode — pre-existing (sandbox was never streaming); cake/clients run Docker/`HttpTransport`.

## Tests
14 chain-watcher (1 new mapping guard) + 166 orchestration green. Ruff clean.