### PR TITLE
feat(orchestration): stall watchdog — nudge the user when a chain is parked (Phase 3a)

### DIFF
--- a/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
+++ b/docs/plans/2026-06-10-operator-delegate-and-subscribe.md
@@ -151,9 +151,9 @@ Per-hop origin is deliberately **downgraded** for worker-originated calls (`_val
 **Acceptance:** user sees milestone pings as stages complete; fast chains don't flood the channel.
 
 ### Phase 3 — Polish: stall watchdog + live pipeline card
-- **Stall watchdog:** if a watched chain has no progress for N minutes, notify the user with a nudge and offer operator intervention (this is the legitimate, system-driven use of the `chain_breaks`/stale-task signal — via the new watcher, not the pull-only metrics path).
-- **Work-tab live pipeline card:** at-a-glance status of in-flight user-originated chains.
-**Acceptance:** a stuck chain pings the user within N minutes; the Work tab shows live pipeline state.
+- **Stall watchdog — DONE.** The `ChainWatcher` now nudges the user once when a chain is *parked*: non-terminal but with nothing `working` (stuck in `blocked`/`pending`/`accepted`) and no progress for `stall_after_s` (default 600s). This precisely covers the lane-watchdog blind spot — the lane watchdog only times out *actively-dispatched* (`working`) tasks into `failed`; a chain parked in a waiting state was the silent hole. Store: `chain_stall_state(root)` (last-progress ts iff parked) + `claim_chain_stall(root)` (separate `chain_stall_notices` ledger — a chain can get a stall nudge AND, later, a terminal delivery). Delivery: `_deliver_chain_outcome` `kind="stall"` → an `alert` bell ("⏳ Taking longer than expected … want me to check in?"). Advisory claim-then-deliver (the terminal delivery is the real guarantee). The "stall" promise was restored to the operator prompt + `await_task_event` description now that it's backed. `working`-but-slow chains are NOT nudged (they're progressing; a genuinely hung one is the lane watchdog's job).
+- **Work-tab live pipeline card — remaining.** At-a-glance status of in-flight user-originated chains (dashboard UI work).
+**Acceptance:** a parked chain pings the user within ~N minutes (✅ tested); the Work tab shows live pipeline state (pending).
 
 ---
 

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1116,7 +1116,8 @@ _AWAIT_TASK_EVENT_DEFAULT_TIMEOUT_S = 45
         "\n\nDO NOT use this to watch a multi-hop pipeline to completion. "
         "After handing user work to the team, acknowledge and RELEASE the "
         "turn — the system automatically delivers the final outcome (done or "
-        "failed) to the user. On 'timed_out', do NOT keep re-calling to "
+        "failed) to the user, plus a nudge if the chain gets stuck. On "
+        "'timed_out', do NOT keep re-calling to "
         "babysit; tell the user it's running and end your turn. For a "
         "one-shot read of chain state, use workflow_snapshot (non-blocking)."
     ),

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -964,12 +964,22 @@ class RuntimeContext:
         # the bell row or the channel message. (Display surfaces are
         # autoescaped; this is a size guard, not a safety one.)
         summary = (summary or "").strip()[:1500]
+        root_title = (root.get("title") or "your request").strip()[:80]
         if kind == "done":
             title = "✅ Task complete"
             body = summary or "Your request finished."
+            bell_kind = "delivered"
+        elif kind == "stall":
+            title = "⏳ Taking longer than expected"
+            body = (
+                f"No progress on '{root_title}' for a while — it may be stuck. "
+                "Want me to check in?"
+            )
+            bell_kind = "alert"
         else:
             title = "⚠️ Task failed"
             body = summary or "Your request hit a failure and stopped."
+            bell_kind = "delivered"
         payload = {
             "root_task_id": root_id,
             "outcome": kind,
@@ -981,7 +991,7 @@ class RuntimeContext:
             return False
         try:
             nid = self._notification_store.add(
-                kind="delivered", title=title, body=body,
+                kind=bell_kind, title=title, body=body,
                 agent_id=assignee or None, payload=payload,
             )
         except Exception as e:
@@ -994,7 +1004,7 @@ class RuntimeContext:
                 self.event_bus.emit(
                     "notification_added", agent=assignee or "",
                     data={
-                        "id": nid, "kind": "delivered", "title": title,
+                        "id": nid, "kind": bell_kind, "title": title,
                         "body": body, "agent_id": assignee, "payload": payload,
                     },
                 )

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -47,14 +47,21 @@ _DEFAULT_SWEEP_S = 10.0
 # Only chains created within this window are swept; abandoned, never-terminal
 # chains age out of the scan instead of being re-examined forever.
 _DEFAULT_WATCH_WINDOW_S = 7 * 24 * 3600.0
+# A chain parked in a waiting state (blocked / pending / accepted, nothing
+# working) with no progress for this long earns one stall nudge to the user.
+_DEFAULT_STALL_AFTER_S = 600.0
 
 
 class ChainWatcher:
     """Sweeps user chains and delivers one terminal outcome each.
 
     ``deliver(root: dict, kind: str, summary: str) -> bool`` must write the
-    durable user-facing surface and return truthy on success (the watcher
-    only claims the delivery when it does). It may be sync or async.
+    durable user-facing surface and return truthy on success. ``kind`` is one
+    of ``done`` / ``failed`` (terminal outcomes) or ``stall`` (a parked-chain
+    nudge). For terminal outcomes the watcher claims only on a truthy return
+    (deliver-then-claim, no silent loss); the stall nudge is advisory and uses
+    claim-then-deliver (at-most-once — the terminal delivery is the real
+    guarantee). It may be sync or async.
     """
 
     def __init__(
@@ -65,14 +72,18 @@ class ChainWatcher:
         settle_s: float = _DEFAULT_SETTLE_S,
         sweep_s: float = _DEFAULT_SWEEP_S,
         watch_window_s: float = _DEFAULT_WATCH_WINDOW_S,
+        stall_after_s: float = _DEFAULT_STALL_AFTER_S,
         clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
     ) -> None:
         self._tasks = tasks_store
         self._deliver = deliver
         self._settle_s = settle_s
         self._sweep_s = sweep_s
         self._watch_window_s = watch_window_s
-        self._clock = clock
+        self._stall_after_s = stall_after_s
+        self._clock = clock          # monotonic — for the terminal settle debounce
+        self._wall_clock = wall_clock  # wall-clock — for stall age vs stored updated_at
         # root_task_id -> monotonic timestamp first observed terminal.
         self._settling: dict[str, float] = {}
         self._running = False
@@ -113,6 +124,7 @@ class ChainWatcher:
             if verdict is None:
                 # Still active (or a new hop just appeared) — reset settle.
                 self._settling.pop(root_id, None)
+                await self._maybe_nudge_stall(root, root_id)
                 continue
 
             kind, summary = verdict
@@ -142,6 +154,26 @@ class ChainWatcher:
         # Bound memory: forget settle timers for roots no longer watchable.
         for stale in [r for r in self._settling if r not in live_ids]:
             self._settling.pop(stale, None)
+
+    async def _maybe_nudge_stall(self, root: dict, root_id: str) -> None:
+        """Nudge the user once if a non-terminal chain is parked + quiet.
+
+        ``chain_stall_state`` returns the last-progress timestamp only when the
+        chain is stuck in a waiting state (nothing ``working``); ``None`` means
+        it's progressing or terminal, so there's nothing to nudge about.
+        Claim-then-deliver (advisory, at-most-once).
+        """
+        try:
+            last_progress = self._tasks.chain_stall_state(root_id)
+        except Exception as e:
+            logger.warning("chain watcher: stall check failed for %s: %s", root_id, e)
+            return
+        if last_progress is None:
+            return
+        if self._wall_clock() - last_progress <= self._stall_after_s:
+            return
+        if self._tasks.claim_chain_stall(root_id):
+            await self._run_deliver(root, "stall", "")
 
     async def _run_deliver(self, root: dict, kind: str, summary: str) -> bool:
         try:

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -350,6 +350,11 @@ class Tasks:
                     terminal_kind TEXT NOT NULL,
                     delivered_at REAL NOT NULL
                 );
+
+                CREATE TABLE IF NOT EXISTS chain_stall_notices (
+                    root_task_id TEXT PRIMARY KEY,
+                    notified_at REAL NOT NULL
+                );
             """)
             # Resolve the active column name. ``team_id`` is canonical;
             # ``project_id`` is the pre-rename column kept readable so
@@ -544,6 +549,62 @@ class Tasks:
         done_leaves.sort(key=lambda r: r[4] or r[5] or 0.0)
         summary = (done_leaves[-1][2] or "").strip() if done_leaves else ""
         return "done", summary
+
+    def chain_stall_state(self, root_task_id: str) -> float | None:
+        """Last-progress timestamp iff the chain is a STALL candidate, else None.
+
+        A chain is a stall candidate when it is non-terminal but nothing is
+        actively progressing it — every task is terminal or *waiting*
+        (``pending`` / ``accepted`` / ``blocked``) and none is ``working``.
+        Returns the most recent ``updated_at`` across the chain (the last time
+        anything moved) so the caller can decide whether it has been quiet
+        long enough to nudge the user.
+
+        Returns ``None`` when the chain doesn't exist, is wholly terminal (the
+        :meth:`chain_terminal_verdict` path handles that), or has a ``working``
+        task — a ``working`` task is making progress, and a genuinely *hung*
+        one is the lane watchdog's job to time out into ``failed`` (which then
+        flows through the terminal path). This watcher only covers the
+        watchdog's blind spot: chains parked in a waiting state.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                "WITH RECURSIVE chain(id, depth) AS ("
+                "  SELECT id, 0 FROM tasks WHERE id = ?"
+                "  UNION ALL"
+                "  SELECT t.id, c.depth + 1 FROM tasks t "
+                "    JOIN chain c ON (t.parent_task_id = c.id "
+                "                  OR t.previous_task_id = c.id) "
+                "    WHERE c.depth < ?"
+                ") "
+                "SELECT t.status, t.updated_at "
+                "FROM tasks t "
+                "WHERE t.id IN (SELECT DISTINCT id FROM chain)",
+                (root_task_id, MAX_WORKFLOW_CHAIN_DEPTH),
+            ).fetchall()
+        if not rows:
+            return None
+        statuses = {r[0] for r in rows}
+        if all(s in TERMINAL_STATUSES for s in statuses):
+            return None  # wholly terminal — not a stall
+        if "working" in statuses:
+            return None  # something is actively progressing
+        return max((r[1] or 0.0) for r in rows)
+
+    def claim_chain_stall(self, root_task_id: str) -> bool:
+        """Atomically claim the one stall nudge for a chain (at-most-once).
+
+        Separate ledger from :meth:`claim_chain_delivery`: a chain can get a
+        stall nudge while parked AND, later, a terminal delivery when it
+        finally resolves. One nudge per chain (no re-nudging on a re-stall).
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO chain_stall_notices "
+                "(root_task_id, notified_at) VALUES (?, ?)",
+                (root_task_id, time.time()),
+            )
+            return cur.rowcount == 1
 
     def claim_chain_delivery(self, root_task_id: str, terminal_kind: str) -> bool:
         """Atomically claim the one terminal notification for a chain.

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -67,9 +67,9 @@ When the user wants work done:
 
 **Delegate and release.** After a hand_off, don't hold the turn open or chain \
 await_task_event to babysit a pipeline — the system watches every user chain \
-and auto-delivers the final result (or a failure) to the user when it \
-finishes. Re-engage only to summarize a finished result when asked, or to \
-unstick a real blocker.
+and auto-delivers the final result (or a failure) when it finishes, plus a \
+heads-up if it gets stuck. Re-engage only to summarize a finished result when \
+asked, or to unstick a real blocker.
 
 Don't do the work yourself. Don't over-explain the routing — just do it.
 

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -8,6 +8,8 @@ deliver-then-claim retry, cancelled handling, and human-origin gating).
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from src.host.chain_watcher import ChainWatcher
@@ -240,3 +242,111 @@ async def test_non_human_root_never_delivered():
     await w.sweep_once()
     await w.sweep_once()
     assert d.calls == []
+
+
+# ── Store: stall state + claim (Phase 3a) ────────────────────────
+
+
+def test_chain_stall_state_none_when_terminal():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done")
+    assert s.chain_stall_state(r["id"]) is None
+
+
+def test_chain_stall_state_none_when_working():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "working", actor="x")
+    # Actively progressing — not a stall, the lane watchdog owns hung working.
+    assert s.chain_stall_state(r["id"]) is None
+
+
+def test_chain_stall_state_ts_when_blocked():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "working", actor="x")
+    s.update_status(r["id"], "blocked", actor="x", blocker_note="need creds")
+    ts = s.chain_stall_state(r["id"])
+    assert ts is not None and ts > 0
+
+
+def test_chain_stall_state_ts_when_child_pending():
+    # root done, successor created but never dispatched — chain is parked.
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done")
+    s.create(creator="scout", assignee="writer", title="next",
+             parent_task_id=r["id"])  # pending, nothing working
+    assert s.chain_stall_state(r["id"]) is not None
+
+
+def test_claim_chain_stall_exactly_once():
+    s = _store()
+    assert s.claim_chain_stall("root-x") is True
+    assert s.claim_chain_stall("root-x") is False
+
+
+# ── Watcher: stall nudge (Phase 3a) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_watcher_nudges_parked_chain_once():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "working", actor="x")
+    s.update_status(r["id"], "blocked", actor="x", blocker_note="stuck")
+    d = _Deliver()
+    # wall_clock far ahead so the parked chain reads as long-quiet.
+    w = ChainWatcher(s, d, stall_after_s=600,
+                     wall_clock=lambda: time.time() + 10_000)
+    await w.sweep_once()
+    assert [c[1] for c in d.calls] == ["stall"]
+    await w.sweep_once()           # claimed → no second nudge
+    assert len(d.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_watcher_no_nudge_while_working():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "working", actor="x")
+    d = _Deliver()
+    w = ChainWatcher(s, d, stall_after_s=0,
+                     wall_clock=lambda: time.time() + 10_000)
+    await w.sweep_once()
+    assert d.calls == []           # working = progressing, never a stall
+
+
+@pytest.mark.asyncio
+async def test_watcher_no_nudge_before_threshold():
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "working", actor="x")
+    s.update_status(r["id"], "blocked", actor="x")
+    d = _Deliver()
+    # Parked, but only just — wall clock ≈ now, big threshold.
+    w = ChainWatcher(s, d, stall_after_s=10_000, wall_clock=time.time)
+    await w.sweep_once()
+    assert d.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stall_then_terminal_both_delivered():
+    """A parked chain gets a stall nudge; when it later completes it still
+    gets its terminal delivery (independent ledgers)."""
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "working", actor="x")
+    s.update_status(r["id"], "blocked", actor="x")
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=0, stall_after_s=600,
+                     wall_clock=lambda: time.time() + 10_000)
+    await w.sweep_once()           # stall nudge
+    assert [c[1] for c in d.calls] == ["stall"]
+    # Chain unsticks and finishes.
+    s.update_status(r["id"], "working", actor="x")
+    s.update_status(r["id"], "done", actor="x", result_summary="done now")
+    await w.sweep_once()           # settle armed
+    await w.sweep_once()           # terminal delivery
+    assert [c[1] for c in d.calls] == ["stall", "done"]


### PR DESCRIPTION
Closes the last "no silent death" gap found in the #1090/#1091 review.

## The gap
The chain watcher guarantees a terminal outcome for **done/failed**, but a chain **parked in a waiting state** (`blocked`/`pending`/`accepted`, nothing `working`) never reaches terminal → `chain_terminal_verdict` returns `None` forever → no auto-delivery. The lane watchdog doesn't cover it — it only times out *actively-dispatched* (`working`) tasks into `failed`. So a parked chain was a silent hole (only the operator's heartbeat surfaced it, best-effort).

## The fix — nudge once for a parked chain
- **`Tasks.chain_stall_state(root)`**: returns the chain's last-progress timestamp **iff** it's a stall candidate — non-terminal, **nothing `working`**, everything else terminal-or-waiting. Returns `None` for terminal chains (the verdict path owns them) and whenever a task is `working` (it's progressing; a *hung* working task is the lane watchdog's job → `failed` → terminal path).
- **`Tasks.claim_chain_stall(root)`**: a **separate** `chain_stall_notices` ledger, so a chain can get a stall nudge **and**, later, a terminal delivery. One nudge per chain.
- **`ChainWatcher`**: in the non-terminal sweep branch, if parked longer than `stall_after_s` (default 600s) → **claim-then-deliver** `kind="stall"`. Advisory (at-most-once); the terminal delivery stays the hard guarantee. Stall age uses a wall-clock vs the stored `updated_at`; the terminal settle still uses monotonic.
- **`_deliver_chain_outcome`** `kind="stall"` → an `alert` bell ("⏳ Taking longer than expected … want me to check in?") + best-effort channel push.

Restored the **"stall"** mention to `_OPERATOR_CORE` + the `await_task_event` description (removed in #1091 when unbacked — now backed).

## Why `working` is excluded
A `working` task is making progress, so nudging would false-positive on legitimately-slow work; and a genuinely *hung* `working` task is timed out into `failed` by the lane watchdog, which then flows through the terminal path. The stall watchdog covers exactly the watchdog's blind spot.

## Tests
10 new (`chain_stall_state` for terminal/working/blocked/pending-child; claim exactly-once; watcher nudges-once / no-nudge-while-working / no-nudge-before-threshold / stall-then-terminal-both-delivered). 23 chain-watcher + 282 broader tests green. Ruff clean.

Completes Phase 3a of `docs/plans/2026-06-10-operator-delegate-and-subscribe.md`. Remaining: Phase 2 milestone pings (deferred per D2) + Phase 3b Work-tab live pipeline card (UI) + the flagged channel-push hardening.