### PR TITLE
feat(dashboard): Work-tab live pipeline card (Phase 3b)

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -7640,6 +7640,56 @@ def create_dashboard_router(
             rows = []
         return {"enabled": True, "blockers": rows}
 
+    @api_router.get("/api/workplace/pipelines")
+    async def api_workplace_pipelines() -> dict:
+        """In-flight operator-rooted chains + stage progress (live pipeline card).
+
+        Reuses ``list_watchable_human_roots`` (human-origin chain roots not yet
+        terminally delivered, within the window) and ``workflow_snapshot`` per
+        root. Only chains with a non-terminal stage are returned (in-flight),
+        so completed chains drop off automatically. A chain is flagged
+        ``stalled`` when a stage is blocked or has been ``working`` a long time
+        — mirroring the stall watchdog's signal for the UI.
+        """
+        if tasks_store is None:
+            return {"enabled": False, "pipelines": []}
+        import time as _t
+        window_s = 24 * 3600   # show in-flight chains from the last day
+        slow_s = 300           # a working stage older than this reads as slow
+        _terminal = ("done", "failed", "cancelled")
+        pipelines: list[dict] = []
+        try:
+            roots = tasks_store.list_watchable_human_roots(
+                since=_t.time() - window_s,
+            )
+            for root in roots:
+                snap = tasks_store.workflow_snapshot(root["id"])
+                if not snap:
+                    continue
+                stages = snap.get("stages", [])
+                if not any(s.get("status") not in _terminal for s in stages):
+                    continue  # wholly terminal — not in-flight
+                stalled = any(
+                    s.get("status") == "blocked"
+                    or (s.get("status") == "working"
+                        and (s.get("age_in_state_seconds") or 0) > slow_s)
+                    for s in stages
+                )
+                pipelines.append({
+                    "root_task_id": root["id"],
+                    "title": root.get("title") or "",
+                    "assignee": root.get("assignee") or "",
+                    "created_at": root.get("created_at"),
+                    "stages": stages,
+                    "summary": snap.get("summary", {}),
+                    "stalled": stalled,
+                })
+        except Exception as e:
+            logger.warning("workplace pipelines listing failed: %s", e)
+            return {"enabled": True, "pipelines": []}
+        pipelines.sort(key=lambda p: p.get("created_at") or 0, reverse=True)
+        return {"enabled": True, "pipelines": pipelines}
+
     @api_router.get("/api/workplace/pending")
     async def api_workplace_pending() -> dict:
         """List open pending actions for inline + System>Operator review.

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -411,6 +411,11 @@ function dashboard() {
     // flow back into operator's next composition. List is ordered
     // newest-first by ``generated_at``.
     workplaceSummaries: [],
+    // In-flight operator-rooted pipelines (live card). Each entry:
+    // {root_task_id, title, assignee, created_at, stages[], summary{}, stalled}.
+    // Loaded from /api/workplace/pipelines, WS-debounce-refreshed on task
+    // status changes so the card tracks chains as they move.
+    workplacePipelines: [],
     // Per-summary inline feedback box state. Keyed by summary id;
     // value is the current draft feedback string. The user opens the
     // box by clicking the rework icon → enters reason → submits →
@@ -448,6 +453,7 @@ function dashboard() {
       help: false,
       summaries: false,
       goals: false,
+      pipelines: false,
     },
     workplaceErrors: {
       teams: '',
@@ -457,6 +463,7 @@ function dashboard() {
       help: '',
       summaries: '',
       goals: '',
+      pipelines: '',
     },
     // In-flight audit-log undo so we can disable the button per-row.
     auditReverting: {},
@@ -2624,6 +2631,7 @@ function dashboard() {
           this.loadWorkplaceHelpRequests(),
           this.loadWorkplaceSummaries(),
           this.loadWorkplaceGoals(),
+          this.loadWorkplacePipelines(),
         ]);
       } finally {
         this.workplaceLoading = false;
@@ -2643,8 +2651,50 @@ function dashboard() {
         help: this.loadWorkplaceHelpRequests,
         summaries: this.loadWorkplaceSummaries,
         goals: this.loadWorkplaceGoals,
+        pipelines: this.loadWorkplacePipelines,
       }[section];
       if (fn) fn.call(this);
+    },
+
+    // Live pipeline card — in-flight operator-rooted chains. Serial-guarded
+    // (mirrors loadWorkplaceSummaries) because it's WS-debounce-refreshed and
+    // can race the initial load / manual retry.
+    async loadWorkplacePipelines() {
+      const serial = (this._pipelinesFetchSerial || 0) + 1;
+      this._pipelinesFetchSerial = serial;
+      this.workplaceSectionLoading.pipelines = true;
+      this.workplaceErrors.pipelines = '';
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/pipelines`);
+        if (serial !== this._pipelinesFetchSerial) return;  // superseded
+        if (!resp.ok) {
+          this.workplaceErrors.pipelines = `Couldn't load pipelines (HTTP ${resp.status})`;
+          return;
+        }
+        const data = await resp.json();
+        if (serial !== this._pipelinesFetchSerial) return;  // superseded
+        this.workplacePipelines = data.pipelines || [];
+      } catch (e) {
+        if (serial !== this._pipelinesFetchSerial) return;  // superseded
+        this.workplaceErrors.pipelines = (e && e.message)
+          ? `Couldn't load pipelines: ${e.message}` : "Couldn't load pipelines";
+      } finally {
+        if (serial === this._pipelinesFetchSerial) {
+          this.workplaceSectionLoading.pipelines = false;
+        }
+      }
+    },
+
+    // Tailwind classes for a pipeline stage chip, by task status.
+    pipelineStageClass(status) {
+      switch (status) {
+        case 'done': return 'bg-emerald-900/30 border-emerald-700/40 text-emerald-300';
+        case 'working': return 'bg-blue-900/30 border-blue-700/40 text-blue-300';
+        case 'blocked': return 'bg-amber-900/30 border-amber-700/40 text-amber-300';
+        case 'failed': return 'bg-red-900/30 border-red-700/40 text-red-300';
+        case 'cancelled': return 'bg-gray-800/40 border-gray-700/40 text-gray-400';
+        default: return 'bg-gray-800/40 border-gray-700/40 text-gray-300'; // pending / accepted
+      }
     },
 
     async loadWorkplaceSummaries() {
@@ -3944,6 +3994,17 @@ function dashboard() {
     handleWorkplaceEvent(evt) {
       if (!evt || !evt.type) return;
       const data = evt.data || {};
+      // Live pipeline card — any task lifecycle change can move a chain
+      // through its stages, so debounce-refresh the in-flight pipelines.
+      if (evt.type === 'task_created' || evt.type === 'task_status_changed'
+          || evt.type === 'task_outcome') {
+        if (this._pipelinesDebounce) clearTimeout(this._pipelinesDebounce);
+        this._pipelinesDebounce = setTimeout(() => {
+          if (typeof this.loadWorkplacePipelines === 'function') {
+            this.loadWorkplacePipelines();
+          }
+        }, 300);
+      }
       if (evt.type === 'task_created') {
         // Add stub row so the Stuck Tasks panel + drill-in see it
         // immediately; background reload fills in the rest.

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4261,6 +4261,50 @@
           </div>
         </template>
 
+        <!-- Live pipeline card — in-flight operator-rooted chains and the
+             stages they're moving through. Ambient: only renders while work
+             is actually flowing (no empty state), refreshed live on task
+             status changes (WS-debounced). Sits above the daily summaries so
+             "what's happening now" reads before "what got delivered". -->
+        <template x-if="workplaceEnabled && workplacePipelines.length">
+          <div class="space-y-2 mb-4" data-testid="workplace-pipelines-view">
+            <div class="flex items-center gap-2 px-0.5">
+              <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">In flight</span>
+              <span class="text-[11px] text-gray-500"
+                    x-text="workplacePipelines.length + (workplacePipelines.length === 1 ? ' pipeline' : ' pipelines')"></span>
+            </div>
+            <template x-for="p in workplacePipelines" :key="p.root_task_id">
+              <div class="bg-gradient-to-b from-gray-800/55 to-gray-800/25 border rounded-xl p-3 pl-4 relative"
+                   :class="p.stalled ? 'border-amber-700/50' : 'border-gray-700/50'"
+                   data-testid="workplace-pipeline-card">
+                <span class="absolute left-0 top-3 bottom-3 w-1 rounded-full"
+                      :class="p.stalled ? 'bg-amber-500/70' : 'bg-emerald-500/60'" aria-hidden="true"></span>
+                <div class="flex items-center gap-2 mb-2">
+                  <span class="text-sm font-medium text-gray-100 truncate"
+                        x-text="p.title || 'Untitled pipeline'"></span>
+                  <template x-if="p.stalled">
+                    <span class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-300 flex-shrink-0">⏳ stalled</span>
+                  </template>
+                </div>
+                <!-- Stage chips: assignee + status, kickoff → downstream. -->
+                <div class="flex flex-wrap items-center gap-1.5">
+                  <template x-for="(st, i) in p.stages" :key="st.task_id">
+                    <div class="flex items-center gap-1.5">
+                      <span class="text-[11px] px-2 py-0.5 rounded-full border flex items-center gap-1"
+                            :class="pipelineStageClass(st.status)"
+                            :title="(st.title || '') + ' — ' + st.status + (st.blocker_note ? (': ' + st.blocker_note) : '')">
+                        <span class="truncate max-w-[7rem]" x-text="st.assignee || '?'"></span>
+                        <span class="opacity-70" x-text="st.status"></span>
+                      </span>
+                      <span x-show="i < p.stages.length - 1" class="text-gray-600 text-xs">→</span>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </template>
+          </div>
+        </template>
+
         <!-- Summary cards — primary content of the Work tab. One card
              per team renders the operator-composed daily summary:
              narrative (rendered markdown), recommendations bullet list,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5431,6 +5431,58 @@ class TestWorkplaceTabRoutes:
         rows = resp.json()["blockers"]
         assert any(r["id"] == rec["id"] for r in rows)
 
+    def test_workplace_pipelines_lists_in_flight_human_chain(self):
+        client = self._client_with_v2(True)
+        root = self.tasks_store.create(
+            creator="operator", assignee="scout", title="research trends",
+            origin={"kind": "human", "channel": "dashboard", "user": "u1"},
+        )
+        self.tasks_store.update_status(root["id"], "working", actor="scout")
+        resp = client.get("/dashboard/api/workplace/pipelines")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        p = next(p for p in data["pipelines"]
+                 if p["root_task_id"] == root["id"])
+        assert p["title"] == "research trends"
+        assert p["stages"] and p["summary"]["total"] >= 1
+        assert p["stalled"] is False  # working but not old
+
+    def test_workplace_pipelines_excludes_terminal_and_non_human(self):
+        client = self._client_with_v2(True)
+        # Completed human chain — excluded (not in-flight).
+        done = self.tasks_store.create(
+            creator="operator", assignee="scout", title="done one",
+            origin={"kind": "human", "channel": "dashboard", "user": "u1"},
+        )
+        self.tasks_store.update_status(done["id"], "working", actor="scout")
+        self.tasks_store.update_status(done["id"], "done", actor="scout")
+        # Worker-origin in-flight root — excluded (not human).
+        agent_root = self.tasks_store.create(
+            creator="a", assignee="b", title="internal",
+            origin={"kind": "agent", "channel": "", "user": "b"},
+        )
+        self.tasks_store.update_status(agent_root["id"], "working", actor="b")
+        resp = client.get("/dashboard/api/workplace/pipelines")
+        ids = [p["root_task_id"] for p in resp.json()["pipelines"]]
+        assert done["id"] not in ids
+        assert agent_root["id"] not in ids
+
+    def test_workplace_pipelines_flags_blocked_as_stalled(self):
+        client = self._client_with_v2(True)
+        root = self.tasks_store.create(
+            creator="operator", assignee="scout", title="stuck pipeline",
+            origin={"kind": "human", "channel": "dashboard", "user": "u1"},
+        )
+        self.tasks_store.update_status(root["id"], "working", actor="scout")
+        self.tasks_store.update_status(
+            root["id"], "blocked", actor="scout", blocker_note="needs creds",
+        )
+        resp = client.get("/dashboard/api/workplace/pipelines")
+        p = next(p for p in resp.json()["pipelines"]
+                 if p["root_task_id"] == root["id"])
+        assert p["stalled"] is True
+
     def test_workplace_pending_lists_open_nonces(self):
         # No need for v2 — pending list is independent of orchestration.
         client = self._client_with_v2(False)


### PR DESCRIPTION
Ambient visibility of in-flight operator-rooted chains on the Work tab — the non-noisy counterpart to the terminal/stall pushes. The user sees work moving through the team (trend-scout → writer → editor) at a glance, **without** the per-stage ping noise that D2 deferred.

## Backend — `GET /api/workplace/pipelines`
- Reuses `list_watchable_human_roots` (human-origin chain roots, 24h window, not yet terminally delivered) + `workflow_snapshot` per root. **No new Tasks method.**
- Returns only **in-flight** chains (a stage still non-terminal); completed chains drop off automatically. Each entry carries ordered `stages`, the status `summary`, and a `stalled` flag (a `blocked` stage, or a `working` stage older than 5 min) mirroring the stall watchdog's signal.
- GET → no CSRF; same `{enabled, pipelines}` envelope as the other workplace routes; failures degrade to an empty list.

## Frontend (Alpine SPA)
- `loadWorkplacePipelines()` with the same monotonic serial guard as the summaries loader (it's WS-debounce-refreshed); wired into `loadWorkplace()` + the retry helper.
- `handleWorkplaceEvent` debounces a reload on `task_created`/`task_status_changed`/`task_outcome` so the card tracks chains **live**.
- Renders **above** the daily summaries ("what's happening now" before "what got delivered"): one card per pipeline with stage chips (assignee + status, kickoff → downstream) + an amber `stalled` accent. **Hidden entirely when nothing's in flight** (ambient, no empty state). New `pipelineStageClass()` for per-status chip colours.

Tab id `workplace` unchanged (Constraint #5).

## Tests
3 new endpoint tests (in-flight listing, terminal/non-human exclusion, stalled flag). Full dashboard suite **377 green**; Jinja template parses; `node --check` app.js clean. Ruff clean. (Frontend rendering verified via tests + parse; visual confirmation is browser-side.)

Phase 3b of `docs/plans/2026-06-10-operator-delegate-and-subscribe.md`.