### PR TITLE
fix: round-2 review — bound channel-push attempt time + cap pipeline roots

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1045,15 +1045,27 @@ class RuntimeContext:
 
     async def _channel_push_with_retry(
         self, origin: "MessageOrigin", message: str, agent_name: str,
-        *, attempts: int = 3, backoff_s: float = 3.0,
+        *, attempts: int = 3, backoff_s: float = 3.0, timeout_s: float = 30.0,
     ) -> None:
         """Deliver a chain-outcome push to a chat channel, retrying transient
         failures. Best-effort: the dashboard bell is the durable guarantee, so
-        after the attempts are exhausted we log and stop (no hot loop)."""
+        after the attempts are exhausted we log and stop (no hot loop).
+
+        Each attempt is bounded by ``timeout_s`` (mirrors the lane's
+        ``_NOTIFY_FORWARD_TIMEOUT``) so a wedged channel adapter can't hang the
+        loop forever — without it the retry count is meaningless and this
+        background task (held by a strong ref) would leak for the process life.
+        """
         for i in range(attempts):
             try:
-                if await self._handle_notify_origin(origin, message, agent_name):
+                ok = await asyncio.wait_for(
+                    self._handle_notify_origin(origin, message, agent_name),
+                    timeout=timeout_s,
+                )
+                if ok:
                     return
+            except asyncio.TimeoutError:
+                logger.debug("chain outcome channel push attempt timed out")
             except Exception as e:
                 logger.debug("chain outcome channel push attempt failed: %s", e)
             if i < attempts - 1:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -74,6 +74,9 @@ _HERE = Path(__file__).resolve().parent
 _TEMPLATES_DIR = _HERE / "templates"
 _STATIC_DIR = _HERE / "static"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Cap on in-flight chains the live pipeline card examines per request. Bounds
+# the per-task-event cost (each root runs a recursive workflow_snapshot).
+_MAX_PIPELINE_ROOTS = 40
 
 
 async def _fetch_browser_metrics_upstream(
@@ -7662,6 +7665,14 @@ def create_dashboard_router(
             roots = tasks_store.list_watchable_human_roots(
                 since=_t.time() - window_s,
             )
+            # Bound the per-root snapshot work: only the most-recent
+            # _MAX_PIPELINE_ROOTS are examined. This endpoint runs on every
+            # task lifecycle event (WS-debounced), and each root costs a
+            # recursive workflow_snapshot — without a cap a busy fleet could
+            # turn each event into O(many roots × CTE). In-flight chains are
+            # recent, so the newest N cover the realistic card.
+            roots.sort(key=lambda r: r.get("created_at") or 0, reverse=True)
+            roots = roots[:_MAX_PIPELINE_ROOTS]
             for root in roots:
                 snap = tasks_store.workflow_snapshot(root["id"])
                 if not snap:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5483,6 +5483,21 @@ class TestWorkplaceTabRoutes:
                  if p["root_task_id"] == root["id"])
         assert p["stalled"] is True
 
+    def test_workplace_pipelines_caps_root_count(self):
+        from src.dashboard.server import _MAX_PIPELINE_ROOTS
+        client = self._client_with_v2(True)
+        # More in-flight human roots than the cap (distinct assignees so the
+        # per-assignee pending cap can't interfere).
+        for i in range(_MAX_PIPELINE_ROOTS + 5):
+            r = self.tasks_store.create(
+                creator="operator", assignee=f"w{i}", title=f"p{i}",
+                origin={"kind": "human", "channel": "dashboard", "user": "u1"},
+            )
+            self.tasks_store.update_status(r["id"], "working", actor=f"w{i}")
+        resp = client.get("/dashboard/api/workplace/pipelines")
+        assert resp.status_code == 200
+        assert len(resp.json()["pipelines"]) <= _MAX_PIPELINE_ROOTS
+
     def test_workplace_pending_lists_open_nonces(self):
         # No need for v2 — pending list is independent of orchestration.
         client = self._client_with_v2(False)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2219,3 +2219,28 @@ class TestChannelPushRetry:
             stub, self._origin(), "msg", "agent", attempts=3, backoff_s=0,
         )
         assert stub.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_hung_send_times_out_and_gives_up(self):
+        # A wedged adapter (await never completes) must not hang the loop or
+        # leak the task — each attempt is bounded by timeout_s.
+        import asyncio as _a
+
+        from src.cli.runtime import RuntimeContext
+
+        class _Stub:
+            def __init__(self):
+                self.calls = 0
+            async def _handle_notify_origin(self, origin, message, agent_name):
+                self.calls += 1
+                await _a.sleep(3600)  # hang
+
+        stub = _Stub()
+        await _a.wait_for(
+            RuntimeContext._channel_push_with_retry(
+                stub, self._origin(), "msg", "agent",
+                attempts=3, backoff_s=0, timeout_s=0.01,
+            ),
+            timeout=5,  # the whole call must finish well under this
+        )
+        assert stub.calls == 3  # each attempt timed out → gave up


### PR DESCRIPTION
Independent Codex pass on the stall-watchdog (#1092) / pipeline-card (#1093) / channel-retry (#1094) work caught one must-fix and two worthwhile hardenings.

## Must-fix — unbounded "bounded retry"
`_channel_push_with_retry` bounded the attempt **count** but not the **time per attempt**. `_handle_notify_origin` awaits the channel send (cross-loop `wrap_future` / `send_to_user`) with **no timeout**, so a wedged adapter would hang the loop forever — never giving up, never releasing the strong-ref'd background task (a permanent leak, one per chain outcome). Each attempt is now wrapped in `asyncio.wait_for(timeout_s=30)` (mirrors the lane's `_NOTIFY_FORWARD_TIMEOUT`); a timeout counts as a failed attempt and the loop terminates. **Test added** (`test_hung_send_times_out_and_gives_up`) — it would previously hang forever.

## Hardening — bound the pipeline endpoint
`/api/workplace/pipelines` ran an unbounded `workflow_snapshot` per root on every (WS-debounced) task event. Cap the examined roots at `_MAX_PIPELINE_ROOTS=40` most-recent, so a busy fleet can't turn each event into O(many roots × recursive CTE) and stall the Work tab. In-flight chains are recent → the newest 40 cover the realistic card. **Test added** (`test_workplace_pipelines_caps_root_count`).

## Not changed (Codex agreed)
- The pipeline endpoint inherits the same dashboard auth + GET CSRF exemption as neighbouring routes (no new exposure).
- Stall ledger (`chain_stall_notices`) and delivery ledger (`chain_deliveries`) are separate — a chain can get a stall nudge AND a later terminal delivery; neither blocks the other.
- Terminal delivery still claims only after a successful bell write (no spam).

## Tests
517 broader tests green (runtime + dashboard). Ruff clean.