### PR TITLE
feat(operator): opt-in per-stage milestone pings (Phase 2)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -981,6 +981,12 @@ class RuntimeContext:
                 "Want me to check in?"
             )
             bell_kind = "alert"
+        elif kind == "milestone":
+            # Opt-in per-stage progress ping. Bell-only (gated below) so it
+            # can't spam a chat channel; a gentle `info` note, not an alert.
+            title = "✅ Progress"
+            body = summary or f"A stage of '{root_title}' finished."
+            bell_kind = "info"
         else:
             title = "⚠️ Task failed"
             body = summary or "Your request hit a failure and stopped."
@@ -1021,8 +1027,9 @@ class RuntimeContext:
         #    limit) doesn't silently drop it. Runs as a background task so it
         #    never blocks the watcher sweep; the durable bell (above) remains
         #    the cross-restart guarantee, so a channel down past the retries
-        #    still leaves the user the bell.
-        if channel and channel != "dashboard" and user:
+        #    still leaves the user the bell. Milestones stay bell-only — a
+        #    per-stage play-by-play would spam a chat channel.
+        if kind != "milestone" and channel and channel != "dashboard" and user:
             try:
                 from src.shared.types import MessageOrigin
                 origin_obj = MessageOrigin(
@@ -1075,6 +1082,23 @@ class RuntimeContext:
             "(bell delivered as fallback)",
             origin.channel, origin.user, attempts,
         )
+
+    def _milestone_pings_enabled(self) -> bool:
+        """Read the opt-in milestone-pings toggle from config/settings.json.
+
+        Read on demand each sweep (mirrors how the host runtime reads
+        browser/captcha settings); default off, fail-safe to off on any error
+        so a malformed settings file can't start spamming pings.
+        """
+        try:
+            import json
+            from pathlib import Path
+            p = Path("config/settings.json")
+            if not p.exists():
+                return False
+            return bool(json.loads(p.read_text()).get("milestone_pings_enabled", False))
+        except Exception:
+            return False
 
     def _start_mesh_server(self) -> None:
         import uvicorn
@@ -1501,6 +1525,7 @@ class RuntimeContext:
             from src.host.chain_watcher import ChainWatcher
             self.chain_watcher = ChainWatcher(
                 self._tasks_store_ref, self._deliver_chain_outcome,
+                milestones_enabled=self._milestone_pings_enabled,
             )
 
             def run_chain_watcher():

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6125,6 +6125,28 @@ def create_dashboard_router(
             "delay": settings.get("browser_delay", 0.0),
         }
 
+    @api_router.get("/api/milestone-pings")
+    async def api_get_milestone_pings() -> dict:
+        """Return the opt-in milestone-pings toggle (per-stage progress pings).
+
+        Off by default — the chain watcher reads this same key from
+        config/settings.json and only pings per stage when it's on.
+        """
+        settings = _load_settings()
+        return {"enabled": bool(settings.get("milestone_pings_enabled", False))}
+
+    @api_router.post("/api/milestone-pings")
+    async def api_set_milestone_pings(request: Request) -> dict:
+        """Persist the milestone-pings toggle (default off)."""
+        body = await request.json()
+        enabled = bool(body.get("enabled", False))
+        with _settings_lock:
+            settings = _load_settings()
+            settings["milestone_pings_enabled"] = enabled
+            _save_settings(settings)
+        _emit_config_changed("milestone_pings")
+        return {"enabled": enabled}
+
     @api_router.get("/api/dashboard/platform-success")
     async def api_get_platform_success() -> dict:
         """Per-platform fleet success rollup over the last 24h.

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -281,6 +281,9 @@ function dashboard() {
     // System settings
     systemSettings: null,
     systemSettingsLoading: false,
+    // Opt-in: per-stage milestone pings (default off). Toggle in Settings.
+    milestonePings: false,
+    milestonePingsSaving: false,
     _systemSettingsDebounce: null,
     _restartingAll: false,
     _defaultModelSearch: '',
@@ -2504,6 +2507,7 @@ function dashboard() {
         if (this.systemTab === 'settings') {
           this.fetchBrowserSettings();
           this.fetchSystemSettings();
+          this.fetchMilestonePings();
         }
         if (this.systemTab === 'browser') {
           this.fetchBrowserSettings();
@@ -7809,6 +7813,34 @@ function dashboard() {
         }
       } catch (e) { console.warn('fetchBrowserSettings failed:', e); }
       this.browserSettingsLoading = false;
+    },
+
+    async fetchMilestonePings() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/milestone-pings`);
+        if (resp.ok) this.milestonePings = !!(await resp.json()).enabled;
+      } catch (e) { console.warn('fetchMilestonePings failed:', e); }
+    },
+
+    async saveMilestonePings(enabled) {
+      // Optimistic; revert on failure. CSRF header is auto-injected globally.
+      const prev = this.milestonePings;
+      this.milestonePings = !!enabled;
+      this.milestonePingsSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/milestone-pings`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: !!enabled }),
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        this.milestonePings = !!(await resp.json()).enabled;
+      } catch (e) {
+        console.warn('saveMilestonePings failed:', e);
+        this.milestonePings = prev;  // revert
+      } finally {
+        this.milestonePingsSaving = false;
+      }
     },
 
     saveBrowserSpeed(value) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -7504,6 +7504,32 @@
         <!-- ═══ SETTINGS SUB-TAB ═══ -->
         <div x-show="systemTab === 'settings'" class="space-y-4">
 
+          <!-- ── Notifications ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
+              <h3 class="text-base font-medium text-gray-200">Notifications</h3>
+            </div>
+            <div class="flex items-center justify-between gap-4">
+              <div class="flex-1">
+                <div class="text-sm text-gray-200">Pipeline milestone pings</div>
+                <div class="text-xs text-gray-400 mt-0.5 max-w-prose">
+                  Get a notification each time a stage of your work finishes — the
+                  play-by-play. Off by default: you always get the final result
+                  (and a heads-up if it gets stuck), and you can watch live
+                  progress on the Work tab without this.
+                </div>
+              </div>
+              <label class="flex-shrink-0 inline-flex items-center cursor-pointer"
+                :class="milestonePingsSaving && 'opacity-60 cursor-not-allowed'">
+                <input type="checkbox" class="sr-only peer"
+                  :checked="milestonePings" :disabled="milestonePingsSaving"
+                  @change="saveMilestonePings($event.target.checked)">
+                <div class="relative w-9 h-5 bg-gray-700 rounded-full peer-checked:bg-indigo-600 transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4"></div>
+              </label>
+            </div>
+          </div>
+
           <!-- ── 1. LLM ── -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
             <div class="flex items-center gap-2 mb-4">

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -50,6 +50,10 @@ _DEFAULT_WATCH_WINDOW_S = 7 * 24 * 3600.0
 # A chain parked in a waiting state (blocked / pending / accepted, nothing
 # working) with no progress for this long earns one stall nudge to the user.
 _DEFAULT_STALL_AFTER_S = 600.0
+# Opt-in milestone pings fire only for stages that completed within this
+# window — so toggling the feature on mid-pipeline doesn't retro-ping every
+# already-done stage, and a sweep only ever pings a just-finished one.
+_MILESTONE_RECENT_S = 120.0
 
 
 class ChainWatcher:
@@ -73,6 +77,7 @@ class ChainWatcher:
         sweep_s: float = _DEFAULT_SWEEP_S,
         watch_window_s: float = _DEFAULT_WATCH_WINDOW_S,
         stall_after_s: float = _DEFAULT_STALL_AFTER_S,
+        milestones_enabled: Callable[[], bool] = lambda: False,
         clock: Callable[[], float] = time.monotonic,
         wall_clock: Callable[[], float] = time.time,
     ) -> None:
@@ -82,6 +87,9 @@ class ChainWatcher:
         self._sweep_s = sweep_s
         self._watch_window_s = watch_window_s
         self._stall_after_s = stall_after_s
+        # Read each sweep — an opt-in toggle (default off); only when on do we
+        # do the extra per-stage snapshot + milestone pings.
+        self._milestones_enabled = milestones_enabled
         self._clock = clock          # monotonic — for the terminal settle debounce
         self._wall_clock = wall_clock  # wall-clock — for stall age vs stored updated_at
         # root_task_id -> monotonic timestamp first observed terminal.
@@ -125,6 +133,7 @@ class ChainWatcher:
                 # Still active (or a new hop just appeared) — reset settle.
                 self._settling.pop(root_id, None)
                 await self._maybe_nudge_stall(root, root_id)
+                await self._maybe_ping_milestones(root, root_id)
                 continue
 
             kind, summary = verdict
@@ -174,6 +183,45 @@ class ChainWatcher:
             return
         if self._tasks.claim_chain_stall(root_id):
             await self._run_deliver(root, "stall", "")
+
+    async def _maybe_ping_milestones(self, root: dict, root_id: str) -> None:
+        """Opt-in: ping the user once per *recently-completed* stage of an
+        in-flight chain (play-by-play progress). Gated by the live toggle —
+        off by default, so the extra per-stage snapshot only runs when on.
+        Claim-then-deliver (advisory, at-most-once per stage)."""
+        try:
+            if not self._milestones_enabled():
+                return
+        except Exception:
+            return
+        try:
+            snap = self._tasks.workflow_snapshot(root_id)
+        except Exception as e:
+            logger.warning(
+                "chain watcher: milestone snapshot failed for %s: %s",
+                root_id, e,
+            )
+            return
+        if not snap:
+            return
+        for st in snap.get("stages", []):
+            if st.get("status") != "done":
+                continue
+            # Only just-finished stages — flipping the toggle on mid-pipeline
+            # must not retro-ping every already-done stage.
+            if (st.get("age_in_state_seconds") or 0) > _MILESTONE_RECENT_S:
+                continue
+            tid = st.get("task_id")
+            if not tid:
+                continue
+            if self._tasks.claim_milestone_ping(tid):
+                assignee = st.get("assignee") or "an agent"
+                stage_title = (st.get("title") or "").strip()
+                msg = (
+                    f"{assignee} finished: {stage_title}"
+                    if stage_title else f"{assignee} finished a stage"
+                )
+                await self._run_deliver(root, "milestone", msg)
 
     async def _run_deliver(self, root: dict, kind: str, summary: str) -> bool:
         try:

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -355,6 +355,11 @@ class Tasks:
                     root_task_id TEXT PRIMARY KEY,
                     notified_at REAL NOT NULL
                 );
+
+                CREATE TABLE IF NOT EXISTS milestone_pings (
+                    task_id TEXT PRIMARY KEY,
+                    pinged_at REAL NOT NULL
+                );
             """)
             # Resolve the active column name. ``team_id`` is canonical;
             # ``project_id`` is the pre-rename column kept readable so
@@ -603,6 +608,21 @@ class Tasks:
                 "INSERT OR IGNORE INTO chain_stall_notices "
                 "(root_task_id, notified_at) VALUES (?, ?)",
                 (root_task_id, time.time()),
+            )
+            return cur.rowcount == 1
+
+    def claim_milestone_ping(self, task_id: str) -> bool:
+        """Atomically claim the one milestone ping for a completed stage.
+
+        One ping per stage (task), ever. Separate ledger so milestone pings
+        (opt-in, per-stage progress) don't interact with terminal / stall
+        delivery. Durable → survives restarts (no re-ping of old stages).
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO milestone_pings (task_id, pinged_at) "
+                "VALUES (?, ?)",
+                (task_id, time.time()),
             )
             return cur.rowcount == 1
 

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -350,3 +350,60 @@ async def test_stall_then_terminal_both_delivered():
     await w.sweep_once()           # settle armed
     await w.sweep_once()           # terminal delivery
     assert [c[1] for c in d.calls] == ["stall", "done"]
+
+
+# ── Milestone pings (Phase 2, opt-in) ────────────────────────────
+
+
+def test_claim_milestone_ping_exactly_once():
+    s = _store()
+    assert s.claim_milestone_ping("t1") is True
+    assert s.claim_milestone_ping("t1") is False
+
+
+@pytest.mark.asyncio
+async def test_milestone_ping_when_enabled():
+    s = _store()
+    r = _human_root(s)                       # root assigned to "scout"
+    _finish(s, r["id"], "done", result_summary="stage1")
+    child = s.create(creator="scout", assignee="writer", title="draft",
+                     parent_task_id=r["id"])
+    s.update_status(child["id"], "working", actor="writer")  # chain in-flight
+    d = _Deliver()
+    w = ChainWatcher(s, d, milestones_enabled=lambda: True)
+    await w.sweep_once()
+    # The recently-done root stage is pinged; the working child is not.
+    assert [c[1] for c in d.calls] == ["milestone"]
+    await w.sweep_once()                     # deduped — one ping per stage
+    assert [c[1] for c in d.calls] == ["milestone"]
+
+
+@pytest.mark.asyncio
+async def test_no_milestone_when_disabled():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done")
+    child = s.create(creator="scout", assignee="writer", title="draft",
+                     parent_task_id=r["id"])
+    s.update_status(child["id"], "working", actor="writer")
+    d = _Deliver()
+    w = ChainWatcher(s, d, milestones_enabled=lambda: False)  # default off
+    await w.sweep_once()
+    assert d.calls == []
+
+
+@pytest.mark.asyncio
+async def test_milestone_skips_old_completions():
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done")
+    child = s.create(creator="scout", assignee="writer", title="d",
+                     parent_task_id=r["id"])
+    s.update_status(child["id"], "working", actor="writer")
+    # Backdate the root's completion well outside the recent window.
+    with s._conn() as conn:
+        conn.execute("UPDATE tasks SET updated_at=1.0 WHERE id=?", (r["id"],))
+    d = _Deliver()
+    w = ChainWatcher(s, d, milestones_enabled=lambda: True)
+    await w.sweep_once()
+    assert d.calls == []  # toggling on mid-pipeline doesn't retro-ping

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5498,6 +5498,27 @@ class TestWorkplaceTabRoutes:
         assert resp.status_code == 200
         assert len(resp.json()["pipelines"]) <= _MAX_PIPELINE_ROOTS
 
+    def test_milestone_pings_toggle_roundtrip(self, tmp_path, monkeypatch):
+        # The settings helpers read a RELATIVE config/settings.json at request
+        # time. Build the client at repo-root cwd (so its construction reads
+        # real config), then chdir into a tmp dir so the toggle read/write
+        # lands in an isolated config/settings.json — never the repo's.
+        client = self._client_with_v2(True)
+        (tmp_path / "config").mkdir()
+        monkeypatch.chdir(tmp_path)
+        # Default off.
+        r = client.get("/dashboard/api/milestone-pings")
+        assert r.status_code == 200 and r.json()["enabled"] is False
+        # Turn on → persisted.
+        r = client.post("/dashboard/api/milestone-pings", json={"enabled": True})
+        assert r.status_code == 200 and r.json()["enabled"] is True
+        assert client.get(
+            "/dashboard/api/milestone-pings").json()["enabled"] is True
+        # Turn back off.
+        r = client.post(
+            "/dashboard/api/milestone-pings", json={"enabled": False})
+        assert r.json()["enabled"] is False
+
     def test_workplace_pending_lists_open_nonces(self):
         # No need for v2 — pending list is independent of orchestration.
         client = self._client_with_v2(False)


### PR DESCRIPTION
The play-by-play progress notification you asked about — **off by default** so it doesn't re-introduce the bell noise D2 deliberately removed. Default users keep the quiet experience (terminal outcome + stall nudge + the live Work-tab card); those who want a ping per stage flip a toggle.

## How it works
- **Setting:** `config/settings.json` key `milestone_pings_enabled` (default `false`), via `GET`/`POST /api/milestone-pings` (mirrors the browser-settings pair). The chain watcher reads it on demand each sweep (fail-safe to off).
- **Watcher:** when on, in the in-flight (non-terminal) sweep branch it pings each **recently-completed** stage once. "Recently" (`_MILESTONE_RECENT_S=120s`) means flipping the toggle on mid-pipeline doesn't retro-ping every already-done stage. Durable per-stage dedup via a new `milestone_pings(task_id)` ledger → restart-safe, exactly-once per stage. The final stage isn't double-counted (that's the terminal delivery, not a milestone).
- **Delivery:** `kind="milestone"` → an `info` bell ("✅ Progress — scout finished: research"). **Bell-only** — a per-stage play-by-play to a chat channel would spam it; terminal/stall still reach channels.
- **UI:** a toggle in **Settings → Notifications** with copy explaining it's optional.

## Why opt-in (respects D2)
Per-stage *push* pings are exactly what D2 deferred (bell noise). Default-off keeps the quiet default; the live Work-tab card already gives ambient progress for free. So this adds the play-by-play only for users who explicitly want it.

## Tests
`claim_milestone_ping` exactly-once; watcher pings-when-enabled / silent-when-disabled / skips-old-completions / dedups; endpoint toggle round-trip (chdir-isolated — the repo's `config/settings.json` is never touched, verified). 46 watcher+workplace tests green; Jinja parses; `node --check` clean. Ruff clean.

Completes Phase 2 of `docs/plans/2026-06-10-operator-delegate-and-subscribe.md`.