### PR TITLE
fix(milestone-pings): review fixes — input validation + read toggle once per sweep

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6138,8 +6138,16 @@ def create_dashboard_router(
     @api_router.post("/api/milestone-pings")
     async def api_set_milestone_pings(request: Request) -> dict:
         """Persist the milestone-pings toggle (default off)."""
-        body = await request.json()
-        enabled = bool(body.get("enabled", False))
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(400, "body must be valid JSON")
+        if not isinstance(body, dict):
+            raise HTTPException(400, "body must be a JSON object")
+        enabled = body.get("enabled")
+        # Require a real bool — a string like "false" must not enable it.
+        if not isinstance(enabled, bool):
+            raise HTTPException(400, "enabled must be a boolean")
         with _settings_lock:
             settings = _load_settings()
             settings["milestone_pings_enabled"] = enabled

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -121,6 +121,14 @@ class ChainWatcher:
             logger.warning("chain watcher: listing roots failed: %s", e)
             return
 
+        # Read the opt-in milestone toggle ONCE per sweep, not per chain —
+        # otherwise the default-off common case re-reads + parses
+        # config/settings.json for every in-flight chain on every sweep.
+        try:
+            milestones_on = bool(self._milestones_enabled())
+        except Exception:
+            milestones_on = False
+
         live_ids: set[str] = set()
         for root in roots:
             root_id = root.get("id")
@@ -133,7 +141,8 @@ class ChainWatcher:
                 # Still active (or a new hop just appeared) — reset settle.
                 self._settling.pop(root_id, None)
                 await self._maybe_nudge_stall(root, root_id)
-                await self._maybe_ping_milestones(root, root_id)
+                if milestones_on:
+                    await self._maybe_ping_milestones(root, root_id)
                 continue
 
             kind, summary = verdict
@@ -185,15 +194,17 @@ class ChainWatcher:
             await self._run_deliver(root, "stall", "")
 
     async def _maybe_ping_milestones(self, root: dict, root_id: str) -> None:
-        """Opt-in: ping the user once per *recently-completed* stage of an
-        in-flight chain (play-by-play progress). Gated by the live toggle —
-        off by default, so the extra per-stage snapshot only runs when on.
-        Claim-then-deliver (advisory, at-most-once per stage)."""
-        try:
-            if not self._milestones_enabled():
-                return
-        except Exception:
-            return
+        """Ping the user once per *recently-completed* stage of an in-flight
+        chain (play-by-play progress). Only called when the opt-in toggle is on
+        (checked once per sweep by the caller), so the extra per-stage snapshot
+        runs only then. Claim-then-deliver (advisory, at-most-once per stage).
+
+        Contract: milestones fire only while the chain is non-terminal, so the
+        FINAL stage is never a milestone (it's the terminal delivery), and a
+        chain that completes *between* sweeps (e.g. two fast stages inside one
+        ~10s window) surfaces only as the terminal outcome — intermediate pings
+        for such a chain may be skipped. Acceptable for an advisory feature; the
+        guaranteed result/failure/stall delivery is unaffected."""
         try:
             snap = self._tasks.workflow_snapshot(root_id)
         except Exception as e:

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -1283,7 +1283,7 @@ class Tasks:
                           "total": N},
             }
 
-        ``age_in_state_seconds`` is ``int(now - max(updated_at, created_at))``
+        ``age_in_state_seconds`` is ``int(now - (updated_at or created_at))``
         — the wall-clock age since the last status mutation (or
         creation, for never-transitioned rows).
         """

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -407,3 +407,40 @@ async def test_milestone_skips_old_completions():
     w = ChainWatcher(s, d, milestones_enabled=lambda: True)
     await w.sweep_once()
     assert d.calls == []  # toggling on mid-pipeline doesn't retro-ping
+
+
+@pytest.mark.asyncio
+async def test_milestone_at_most_once_even_if_delivery_fails():
+    # claim-then-deliver: a failing bell write does NOT cause a re-ping next
+    # sweep (advisory at-most-once, deliberately NOT at-least-once).
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done")
+    child = s.create(creator="scout", assignee="writer", title="d",
+                     parent_task_id=r["id"])
+    s.update_status(child["id"], "working", actor="writer")
+    d = _Deliver(returns=False)              # delivery always "fails"
+    w = ChainWatcher(s, d, milestones_enabled=lambda: True)
+    await w.sweep_once()
+    assert len(d.calls) == 1                 # delivered once (failed)
+    await w.sweep_once()
+    assert len(d.calls) == 1                 # claimed → not retried despite failure
+
+
+@pytest.mark.asyncio
+async def test_milestone_skipped_when_chain_already_terminal():
+    # Fast-chain contract: a chain wholly terminal at sweep time yields the
+    # terminal delivery only — intermediate stages get no milestone.
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done")
+    child = s.create(creator="scout", assignee="writer", title="d",
+                     parent_task_id=r["id"])
+    _finish(s, child["id"], "done")          # both done before any sweep
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=0, milestones_enabled=lambda: True)
+    await w.sweep_once()                      # arm terminal settle
+    await w.sweep_once()                      # terminal delivery
+    kinds = [c[1] for c in d.calls]
+    assert "milestone" not in kinds
+    assert kinds.count("done") == 1

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5498,6 +5498,20 @@ class TestWorkplaceTabRoutes:
         assert resp.status_code == 200
         assert len(resp.json()["pipelines"]) <= _MAX_PIPELINE_ROOTS
 
+    def test_milestone_pings_rejects_non_bool(self):
+        # A string "false" must NOT enable it; missing/non-object body → 400.
+        # All these 400 before any settings write, so no chdir isolation needed.
+        client = self._client_with_v2(True)
+        assert client.post(
+            "/dashboard/api/milestone-pings", json={"enabled": "false"}
+        ).status_code == 400
+        assert client.post(
+            "/dashboard/api/milestone-pings", json={}
+        ).status_code == 400
+        assert client.post(
+            "/dashboard/api/milestone-pings", json=[]
+        ).status_code == 400
+
     def test_milestone_pings_toggle_roundtrip(self, tmp_path, monkeypatch):
         # The settings helpers read a RELATIVE config/settings.json at request
         # time. Build the client at repo-root cwd (so its construction reads


### PR DESCRIPTION
Principal-engineer + independent Codex pass on #1096.

## Must-fix (Codex)
`POST /api/milestone-pings` did `bool(body.get("enabled"))` — so `{"enabled": "false"}` (a string) **enabled** the feature, and a non-object body 500'd. Now requires a real `bool` and rejects missing / non-bool / non-object bodies with **HTTP 400** (matches the neighbouring settings routes). Test added (`test_milestone_pings_rejects_non_bool`).

## Fix — toggle read once per sweep
The watcher read the opt-in toggle (`config/settings.json`) **once per chain** inside `_maybe_ping_milestones`, so the **default-off common case** re-read + parsed the file for every in-flight chain on every 10s sweep. Now read **once per `sweep_once()`** and gate the per-chain call on the result.

## Contract (Codex must-fix #1 — downgraded, deliberately)
Codex flagged that a chain completing **between sweeps** (two fast stages within one ~10s window) can miss intermediate milestones — the watcher sees it already-terminal and delivers only the terminal outcome. Rather than scan milestones in the **critical terminal-delivery path** (complexity on the guarantee path for a rare race on an *advisory, opt-in* feature), I **documented the contract** and pinned it with a test (`test_milestone_skipped_when_chain_already_terminal`). The guaranteed result/failure/stall delivery is unaffected.

## Also
- Fixed the stale `workflow_snapshot` docstring (said `max(updated_at, created_at)`; code is `updated_at or created_at`).
- Added an **at-most-once** test (a failing milestone delivery is not re-pinged — advisory, claim-then-deliver).

## Flagged, not changed
The milestone bell's `agent_id` is the root assignee while the message names the stage assignee (cosmetic; a future deep-link could add `stage_task_id` to the payload).

## Tests
29 chain-watcher + 6 milestone/pipeline dashboard + 166 orchestration green; `config/settings.json` untouched (verified). Ruff clean.