### PR TITLE
fix(chain-watcher): close 4 review findings — truncation, cancel semantics, sweep isolation

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -4765,6 +4765,7 @@ function dashboard() {
           storage: ['fetchStorage', 'fetchDatabaseDetails'],
           uploads: ['fetchUploads'],
           skills: ['loadSkillsCatalog'],
+          milestone_pings: ['fetchMilestonePings'],
         };
         for (const fn of (_configLoaders[evt.data?.scope] || [])) {
           if (typeof this[fn] === 'function') this[fn]();

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -136,42 +136,58 @@ class ChainWatcher:
                 continue
             live_ids.add(root_id)
 
-            verdict = self._tasks.chain_terminal_verdict(root_id)
-            if verdict is None:
-                # Still active (or a new hop just appeared) — reset settle.
-                self._settling.pop(root_id, None)
-                await self._maybe_nudge_stall(root, root_id)
-                if milestones_on:
-                    await self._maybe_ping_milestones(root, root_id)
-                continue
-
-            kind, summary = verdict
-            if kind == "cancelled":
-                # Manual cancellation is not a surprise to surface. Claim it
-                # so the chain stops being re-scanned, but deliver nothing.
-                self._tasks.claim_chain_delivery(root_id, "cancelled")
-                self._settling.pop(root_id, None)
-                continue
-
-            first = self._settling.get(root_id)
-            now_mono = self._clock()
-            if first is None:
-                self._settling[root_id] = now_mono
-                continue
-            if now_mono - first < self._settle_s:
-                continue
-
-            # Settled and still terminal — deliver, then claim on success.
-            delivered = await self._run_deliver(root, kind, summary)
-            if delivered:
-                self._tasks.claim_chain_delivery(root_id, kind)
-                self._settling.pop(root_id, None)
-            # If delivery failed, leave the settle timestamp in place so the
-            # next sweep retries immediately (no silent loss).
+            # Per-root isolation: a failure deriving the verdict or claiming a
+            # delivery for ONE root must not abort the rest of the sweep (the
+            # stall/milestone helpers already self-isolate; this guards the
+            # terminal path the same way). A poison root self-heals next sweep.
+            try:
+                await self._process_root(root, root_id, milestones_on)
+            except Exception as e:
+                logger.warning(
+                    "chain watcher: processing root %s failed: %s", root_id, e,
+                )
 
         # Bound memory: forget settle timers for roots no longer watchable.
         for stale in [r for r in self._settling if r not in live_ids]:
             self._settling.pop(stale, None)
+
+    async def _process_root(
+        self, root: dict, root_id: str, milestones_on: bool,
+    ) -> None:
+        """Deliver/settle/nudge a single watchable root. Raises on store
+        errors so :meth:`sweep_once` can isolate one bad root from the rest."""
+        verdict = self._tasks.chain_terminal_verdict(root_id)
+        if verdict is None:
+            # Still active (or a new hop just appeared) — reset settle.
+            self._settling.pop(root_id, None)
+            await self._maybe_nudge_stall(root, root_id)
+            if milestones_on:
+                await self._maybe_ping_milestones(root, root_id)
+            return
+
+        kind, summary = verdict
+        if kind == "cancelled":
+            # Manual cancellation is not a surprise to surface. Claim it
+            # so the chain stops being re-scanned, but deliver nothing.
+            self._tasks.claim_chain_delivery(root_id, "cancelled")
+            self._settling.pop(root_id, None)
+            return
+
+        first = self._settling.get(root_id)
+        now_mono = self._clock()
+        if first is None:
+            self._settling[root_id] = now_mono
+            return
+        if now_mono - first < self._settle_s:
+            return
+
+        # Settled and still terminal — deliver, then claim on success.
+        delivered = await self._run_deliver(root, kind, summary)
+        if delivered:
+            self._tasks.claim_chain_delivery(root_id, kind)
+            self._settling.pop(root_id, None)
+        # If delivery failed, leave the settle timestamp in place so the
+        # next sweep retries immediately (no silent loss).
 
     async def _maybe_nudge_stall(self, root: dict, root_id: str) -> None:
         """Nudge the user once if a non-terminal chain is parked + quiet.

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -522,6 +522,14 @@ class Tasks:
         ``summary`` is a best-effort human string: the failed task's
         blocker_note, or the most-recently-completed done leaf's
         result_summary.
+
+        Cancellation is judged by the ROOT task (the user's request itself):
+        a chain whose root completed but had a *cancelled* downstream branch
+        resolves to ``done`` (don't swallow real completion); only a chain
+        whose root was cancelled is treated as a silent manual cancellation
+        (don't claim "complete" just because a sub-stage finished before the
+        user cancelled). This keeps the "every user pipeline ends in a
+        user-facing outcome" guarantee without false "complete" pings.
         """
         with self._conn() as conn:
             rows = conn.execute(
@@ -534,12 +542,32 @@ class Tasks:
                 "    WHERE c.depth < ?"
                 ") "
                 "SELECT t.id, t.status, t.result_summary, t.blocker_note, "
-                "  t.completed_at, t.updated_at "
+                "  t.completed_at, t.updated_at, "
+                "  (SELECT COUNT(*) FROM tasks x "
+                "     WHERE (x.parent_task_id IN (SELECT id FROM chain) "
+                "         OR x.previous_task_id IN (SELECT id FROM chain)) "
+                "       AND x.id NOT IN (SELECT id FROM chain)) "
                 "FROM tasks t "
                 "WHERE t.id IN (SELECT DISTINCT id FROM chain)",
                 (root_task_id, MAX_WORKFLOW_CHAIN_DEPTH),
             ).fetchall()
         if not rows:
+            return None
+        # Truncation guard: count any task that is a child (by parent_task_id
+        # or previous_task_id) of a chain node yet falls OUTSIDE the recursion
+        # — i.e. the depth cap cut off real descendants we cannot see. When
+        # that happens we can't prove the WHOLE chain is terminal, so treat it
+        # as still-active (return None) rather than risk a false "done"/"failed"
+        # delivery while a deep branch is still running. A chain that naturally
+        # ENDS at the cap has no such children (count 0) and still delivers —
+        # only genuine truncation is suppressed. Practically unreachable below
+        # the creation guard's default ceiling (25 << 200).
+        if (rows[0][6] or 0) > 0:
+            logger.warning(
+                "chain_terminal_verdict: chain %s has descendants beyond depth "
+                "cap %d — treating as active (cannot prove terminal)",
+                root_task_id, MAX_WORKFLOW_CHAIN_DEPTH,
+            )
             return None
         if any(r[1] not in TERMINAL_STATUSES for r in rows):
             return None
@@ -548,11 +576,23 @@ class Tasks:
             failed = [r for r in rows if r[1] == "failed"]
             failed.sort(key=lambda r: r[4] or r[5] or 0.0)
             return "failed", (failed[-1][3] or "").strip()
-        if "cancelled" in statuses:
+        # No failure: the chain is wholly done/cancelled. Judge by the ROOT.
+        # The chain is proven terminal above, so the root is itself done or
+        # cancelled — gate the silent path on the root, not on "any cancelled".
+        root_status = next(
+            (r[1] for r in rows if r[0] == root_task_id), None
+        )
+        if root_status == "cancelled":
+            # The user's request task itself was cancelled — a manual action,
+            # not a surprise to surface. Don't claim "complete" even if a
+            # sub-stage finished first. The watcher claims it silently.
             return "cancelled", ""
+        # The root completed — deliver the done outcome (a cancelled downstream
+        # branch must not swallow real completion). The root itself is a done
+        # row, so done_leaves is non-empty here.
         done_leaves = [r for r in rows if r[1] == "done"]
         done_leaves.sort(key=lambda r: r[4] or r[5] or 0.0)
-        summary = (done_leaves[-1][2] or "").strip() if done_leaves else ""
+        summary = (done_leaves[-1][2] or "").strip()
         return "done", summary
 
     def chain_stall_state(self, root_task_id: str) -> float | None:
@@ -582,12 +622,21 @@ class Tasks:
                 "                  OR t.previous_task_id = c.id) "
                 "    WHERE c.depth < ?"
                 ") "
-                "SELECT t.status, t.updated_at "
+                "SELECT t.status, t.updated_at, "
+                "  (SELECT COUNT(*) FROM tasks x "
+                "     WHERE (x.parent_task_id IN (SELECT id FROM chain) "
+                "         OR x.previous_task_id IN (SELECT id FROM chain)) "
+                "       AND x.id NOT IN (SELECT id FROM chain)) "
                 "FROM tasks t "
                 "WHERE t.id IN (SELECT DISTINCT id FROM chain)",
                 (root_task_id, MAX_WORKFLOW_CHAIN_DEPTH),
             ).fetchall()
         if not rows:
+            return None
+        # Truncation guard (mirrors chain_terminal_verdict): if real descendants
+        # were cut off by the depth cap, a deep ``working`` node would be
+        # invisible — so don't emit a (possibly wrong) stall nudge.
+        if (rows[0][2] or 0) > 0:
             return None
         statuses = {r[0] for r in rows}
         if all(s in TERMINAL_STATUSES for s in statuses):

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -132,6 +132,82 @@ def test_verdict_cancelled():
     assert s.chain_terminal_verdict(r["id"]) == ("cancelled", "")
 
 
+def test_verdict_partial_cancel_delivers_done():
+    """A chain that substantively completed but has one cancelled branch must
+    resolve to 'done' (not a silent 'cancelled') — every user pipeline ends in
+    a user-facing outcome."""
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="main work done")
+    branch = s.create(creator="scout", assignee="helper", title="optional",
+                      parent_task_id=r["id"])
+    s.update_status(branch["id"], "cancelled", actor="x")
+    assert s.chain_terminal_verdict(r["id"]) == ("done", "main work done")
+
+
+def test_verdict_all_cancelled_stays_silent():
+    """A chain whose root was cancelled is a genuine manual cancellation →
+    ('cancelled', ''), even with downstream cancelled branches."""
+    s = _store()
+    r = _human_root(s)
+    s.update_status(r["id"], "cancelled", actor="x")
+    branch = s.create(creator="scout", assignee="helper", title="optional",
+                      parent_task_id=r["id"])
+    s.update_status(branch["id"], "cancelled", actor="x")
+    assert s.chain_terminal_verdict(r["id"]) == ("cancelled", "")
+
+
+def test_verdict_root_cancelled_after_partial_progress_stays_silent():
+    """Cancellation is judged by the ROOT, not "any done task": if the user
+    cancels their request after a sub-stage already finished, we must NOT claim
+    "✅ complete" — the root was cancelled, so stay silent."""
+    s = _store()
+    r = _human_root(s)
+    child = s.create(creator="scout", assignee="helper", title="sub-stage",
+                     parent_task_id=r["id"])
+    _finish(s, child["id"], "done", result_summary="a stage finished")
+    s.update_status(r["id"], "cancelled", actor="x")  # user cancels the request
+    assert s.chain_terminal_verdict(r["id"]) == ("cancelled", "")
+
+
+def test_verdict_depth_cap_not_false_terminal(monkeypatch):
+    """A chain deeper than the recursion cap must NOT be declared terminal
+    while a node beyond the cap is still non-terminal — otherwise the watcher
+    delivers a false 'done' while a deep branch is still running."""
+    monkeypatch.setattr("src.host.orchestration.MAX_WORKFLOW_CHAIN_DEPTH", 3)
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="root")
+    prev = r["id"]
+    for i in range(1, 4):  # depths 1..3 — all done, all visible to the CTE
+        rec = s.create(creator="scout", assignee="w", title=f"s{i}",
+                       parent_task_id=prev)
+        _finish(s, rec["id"], "done")
+        prev = rec["id"]
+    # depth 4 — still working, beyond the cap, so invisible to the CTE.
+    deep = s.create(creator="scout", assignee="w", title="deep",
+                    parent_task_id=prev)
+    s.update_status(deep["id"], "working", actor="x")
+    assert s.chain_terminal_verdict(r["id"]) is None
+
+
+def test_verdict_chain_ending_exactly_at_cap_still_delivers(monkeypatch):
+    """A chain that NATURALLY ends at the depth cap (no descendants beyond it)
+    is NOT truncated — it must still deliver, not be silenced forever. Guards
+    against a depth-heuristic that can't tell a cap-deep leaf from truncation."""
+    monkeypatch.setattr("src.host.orchestration.MAX_WORKFLOW_CHAIN_DEPTH", 3)
+    s = _store()
+    r = _human_root(s)
+    _finish(s, r["id"], "done", result_summary="root")
+    prev = r["id"]
+    for i in range(1, 4):  # depths 1..3 — the deepest (3) is a genuine leaf
+        rec = s.create(creator="scout", assignee="w", title=f"s{i}",
+                       parent_task_id=prev)
+        _finish(s, rec["id"], "done", result_summary=f"leaf{i}")
+        prev = rec["id"]
+    assert s.chain_terminal_verdict(r["id"]) == ("done", "leaf3")
+
+
 # ── Watcher: a recording deliver double ──────────────────────────
 
 
@@ -244,6 +320,31 @@ async def test_non_human_root_never_delivered():
     assert d.calls == []
 
 
+@pytest.mark.asyncio
+async def test_poison_root_does_not_abort_sweep():
+    """A store error deriving the verdict for ONE root must not starve the
+    others — the terminal path is isolated per-root like stall/milestone."""
+    s = _store()
+    bad = _human_root(s, assignee="bad")    # created first → swept first
+    good = _human_root(s, assignee="good")
+    _finish(s, bad["id"], "done", result_summary="bad")
+    _finish(s, good["id"], "done", result_summary="good")
+    # The bad root's verdict raises every sweep; the good one is fine.
+    real_verdict = s.chain_terminal_verdict
+
+    def flaky(root_id):
+        if root_id == bad["id"]:
+            raise RuntimeError("boom")
+        return real_verdict(root_id)
+
+    s.chain_terminal_verdict = flaky
+    d = _Deliver()
+    w = ChainWatcher(s, d, settle_s=0)
+    await w.sweep_once()   # arm settle for good (bad raises, isolated)
+    await w.sweep_once()   # settled → good delivered despite bad raising
+    assert [c[0] for c in d.calls] == [good["id"]]
+
+
 # ── Store: stall state + claim (Phase 3a) ────────────────────────
 
 
@@ -279,6 +380,26 @@ def test_chain_stall_state_ts_when_child_pending():
     s.create(creator="scout", assignee="writer", title="next",
              parent_task_id=r["id"])  # pending, nothing working
     assert s.chain_stall_state(r["id"]) is not None
+
+
+def test_chain_stall_state_depth_cap_returns_none(monkeypatch):
+    """A truncated chain isn't assessed for stall: the visible prefix reads as
+    parked (all pending) but a deep ``working`` node beyond the cap is making
+    progress invisibly — the guard suppresses a wrong nudge."""
+    monkeypatch.setattr("src.host.orchestration.MAX_WORKFLOW_CHAIN_DEPTH", 3)
+    s = _store()
+    r = _human_root(s)  # pending
+    prev = r["id"]
+    for i in range(1, 4):  # depths 1..3 — pending, visible to the CTE
+        rec = s.create(creator="scout", assignee="w", title=f"s{i}",
+                       parent_task_id=prev)
+        prev = rec["id"]
+    # depth 4 — working, beyond the cap, so invisible. Without the guard the
+    # visible prefix would read as a stall candidate and return a timestamp.
+    deep = s.create(creator="scout", assignee="w", title="deep",
+                    parent_task_id=prev)
+    s.update_status(deep["id"], "working", actor="x")
+    assert s.chain_stall_state(r["id"]) is None
 
 
 def test_claim_chain_stall_exactly_once():


### PR DESCRIPTION
Follow-up to **delegate-and-subscribe** (PRs #1086–#1097) closing findings from the final principal-engineer review (3 independent passes + a Codex second pass on this diff).

## Changes

### 1. Truncation guard — `chain_terminal_verdict` + `chain_stall_state` (correctness, HIGH)
The recursive chain CTE caps at `MAX_WORKFLOW_CHAIN_DEPTH` (200). Tasks beyond the cap were invisible, so a chain all-terminal *within* the cap but with a non-terminal node *past* it could be **falsely declared done/failed and delivered while a deep branch was still running**. Reachable via the (uncapped) `previous_task_id` rework lineage or a disabled creation cap.

Now the query counts any child (`parent_task_id` **or** `previous_task_id`) of a chain node that falls *outside* the recursion; if `> 0` the chain is genuinely truncated → return `None` (treat as active) instead of risking a false terminal. A chain that **naturally ends** at the cap has no such children and still delivers — only real truncation is suppressed.

> Codex's independent pass caught that my first attempt (`MAX(depth) >= cap`) mis-fired on a cap-deep *leaf* and would silence a legit completed chain forever. Switched to the exact child-count detector.

### 2. ⚠️ BEHAVIOR CHANGE — cancelled semantics judged by the ROOT task (MED)
Previously **any** cancelled task in a chain made the whole chain silent, so a chain whose root completed but had a cancelled downstream branch delivered **nothing** — breaking the "every user pipeline ends in a user-facing outcome" guarantee.

- root **cancelled** → silent (the user cancelled their request; don't claim "✅ complete" even if a sub-stage finished first)
- root **done** with a cancelled branch → deliver **done**
- `failed` still takes precedence

This is the one deliberate product-behavior change in the PR.

### 3. Per-root sweep isolation — `chain_watcher.sweep_once` (robustness, MED)
Extracted the per-root terminal logic into `_process_root` wrapped in `try/except`, so a store error deriving the verdict / claiming a delivery for **one** poison root can't abort the rest of the sweep (the stall/milestone helpers already self-isolate; this brings the terminal path in line). `CancelledError` still propagates (it's `BaseException`, not `Exception`). Behavior otherwise identical — the `live_ids` stale-timer cleanup stays in `sweep_once`.

### 4. Cross-tab config sync — `app.js` (LOW)
Add `milestone_pings: ['fetchMilestonePings']` to `_configLoaders` so flipping the Settings toggle live-syncs other open tabs.

## Tests
7 new tests in `tests/test_chain_watcher.py`:
- truncation: real-truncation (deep node beyond cap) **and** natural-cap-leaf-still-delivers (the Codex false-positive)
- root-cancel boundary: partial-cancel→done, all-cancelled→silent, and **cancel-after-partial-progress→silent** (the differentiator vs. an "any done" rule)
- stall truncation guard
- poison-root sweep isolation

Each new test fails against the pre-fix code. Suites green: chain_watcher **36**, orchestration **166**, runtime/transport/operator_tools **244**. `ruff` + `node --check` clean.

## Reviewed-and-deferred (not in this PR)
- **MED** — stall clock resets on any non-progress `updated_at` write (needs a `status_changed_at` source / `task_events` join; flagged for a separate change).
- **LOW** — `await_task_event` `CancelledError` branch builds an unused `out` envelope (dead code, different subsystem); milestone bell `agent_id` = root vs stage assignee (cosmetic, needs a deliver() signature change); `_milestone_pings_enabled` reads `config/settings.json` from CWD.