### PR TITLE
fix(dashboard): cap the Work-tab in-flight pipeline list height

### DIFF
--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4276,6 +4276,11 @@
               <span class="text-[11px] text-gray-500"
                     x-text="workplacePipelines.length + (workplacePipelines.length === 1 ? ' pipeline' : ' pipelines')"></span>
             </div>
+            <!-- Cap the in-flight list height so a busy fleet's pipelines
+                 scroll internally instead of pushing the daily summaries far
+                 down the page. With few cards the height collapses under the
+                 cap and no scrollbar shows. -->
+            <div class="space-y-2 max-h-96 overflow-y-auto custom-scrollbar pr-0.5">
             <!-- Pipeline card. Collapsed: title + status badge + a condensed
                  stage-dot flow and the current stage. Click the header to
                  expand the full per-stage detail (assignee, age, title,
@@ -4358,6 +4363,7 @@
                 </div>
               </div>
             </template>
+            </div>
           </div>
         </template>
 


### PR DESCRIPTION
When many pipelines are in flight, the ambient **In flight** strip grew unbounded and pushed the daily summaries (the Work tab's primary content) far down the page.

Wrap the pipeline card list in a `max-h-96 overflow-y-auto custom-scrollbar` container so it scrolls internally instead. The **In flight** header stays fixed above the scroll area; with few cards the height collapses under the cap and no scrollbar shows.

Template-only (one wrapper div). Verified visually with a headless-Chrome harness (9 pipelines → section caps at ~384px, cards 6–9 scroll internally, summaries sit right beneath). `custom-scrollbar` is the existing dashboard scroll style (dashboard.css:667). Jinja parse ✓; `test_dashboard.py` + `test_dashboard_ui.py` → 573 passed, no markup-dependent test affected.