### PR TITLE
fix: six post-review followups from the week's user-friendliness sweep

### DIFF
--- a/src/agent/builtins/git_tool.py
+++ b/src/agent/builtins/git_tool.py
@@ -25,6 +25,7 @@ import base64
 import hashlib
 import json
 import re
+from urllib.parse import quote
 
 from src.agent.builtins.file_tool import _safe_path
 from src.agent.builtins.http_tool import http_request
@@ -197,8 +198,11 @@ async def commit_file(
 
     b64 = base64.b64encode(raw).decode("ascii")
     headers = _gh_headers(credential)
-    base_url = f"{_GITHUB_API}/repos/{repo}/contents/{path}"
-    ref_q = f"?ref={branch}" if branch else ""
+    # URL-encode path/branch: a filename with a space (the primary CSV use
+    # case) or `?`/`#` would otherwise malform the URL / inject query params.
+    # `repo` is already validated to `owner/name` above, so left raw.
+    base_url = f"{_GITHUB_API}/repos/{repo}/contents/{quote(path, safe='/')}"
+    ref_q = f"?ref={quote(branch, safe='')}" if branch else ""
 
     # 1) Look up the existing file SHA (required by the API to UPDATE; absent
     #    means a fresh create). 404 = new file; other errors are fatal.

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -4009,8 +4009,16 @@ class AgentLoop:
                         _task_id,
                     )
                     self.state = "idle"
+                    # Non-empty closer: this message persists in durable chat
+                    # history, and the Anthropic Messages API rejects empty
+                    # content on non-final assistant messages — an empty
+                    # string here 400s the NEXT turn. Chat-bubble suppression
+                    # is handled separately via ``silent_reply`` below.
                     self._chat_messages.append(
-                        {"role": "assistant", "content": ""}
+                        {
+                            "role": "assistant",
+                            "content": "Task closed via terminal coordination tool.",
+                        }
                     )
                     self._log_chat_turn(
                         user_message, "", tool_outputs, turn_id=turn_id,

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -990,7 +990,9 @@ class RuntimeContext:
         else:
             title = "⚠️ Task failed"
             body = summary or "Your request hit a failure and stopped."
-            bell_kind = "delivered"
+            # Failure rings the warning bell, not the success/delivery one —
+            # same kind the stall branch and degradation notifications use.
+            bell_kind = "alert"
         payload = {
             "root_task_id": root_id,
             "outcome": kind,

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6468,6 +6468,7 @@ def create_dashboard_router(
         from src.cli.runtime import (
             _EMBEDDING_PROVIDER_LADDER,
             _embedding_providers_with_keys,
+            _resolve_embedding,
         )
 
         body = await request.json()
@@ -6509,6 +6510,18 @@ def create_dashboard_router(
         config_path.parent.mkdir(parents=True, exist_ok=True)
         with open(config_path, "w") as f:
             yaml.dump(mesh_cfg, f, default_flow_style=False, sort_keys=False)
+
+        # Agent containers read embedding config from runtime.extra_env at
+        # container start (cli/runtime.py populates EMBEDDING_MODEL/DIM only
+        # at engine boot). Without refreshing it here, "save + restart
+        # agents" restarts containers with the OLD embedding env while the
+        # UI reports the new model active.
+        if runtime is not None:
+            eff_model, eff_dim = _resolve_embedding(
+                stored, _embedding_providers_with_keys(),
+            )
+            runtime.extra_env["EMBEDDING_MODEL"] = eff_model
+            runtime.extra_env["EMBEDDING_DIM"] = str(eff_dim)
 
         _emit_config_changed("system_settings")
         return {"value": value, "embedding_model": stored}

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -4726,9 +4726,14 @@ function dashboard() {
         }
         // Brief (TEAM.md) edited elsewhere — live-reload the content for the
         // active team unless the user is mid-edit (don't clobber their buffer).
+        // Two producers: the dashboard's own TEAM.md save emits
+        // field 'project_md' (dashboard/server.py), while the operator
+        // agent's update_team_context mesh endpoint emits field 'context'
+        // (host/server.py).
         const d = evt.data || {};
         const changedTeam = d.team_name || d.name || d.team_id || d.project_id;
-        if (d.field === 'project_md' && changedTeam === this.activeTeam &&
+        if ((d.field === 'project_md' || d.field === 'context') &&
+            changedTeam === this.activeTeam &&
             !this.teamEditing && typeof this.fetchTeamContent === 'function') {
           this.fetchTeamContent();
         }

--- a/src/shared/errors.py
+++ b/src/shared/errors.py
@@ -124,5 +124,7 @@ def is_context_overflow(text: str) -> bool:
     ``LLMContextOverflowError`` lets the chat loop self-heal (prune + retry)
     instead of aborting the turn and re-wedging.
     """
-    t = (text or "").lower()
+    # Strip backticks first: Anthropic also emits "input length and
+    # `max_tokens` exceed context limit...", which would defeat the marker.
+    t = (text or "").lower().replace("`", "")
     return any(marker in t for marker in CONTEXT_OVERFLOW_MARKERS)

--- a/tests/test_embedding_model_endpoint.py
+++ b/tests/test_embedding_model_endpoint.py
@@ -51,6 +51,10 @@ class TestEmbeddingModelEndpoint:
         runtime_mock.browser_vnc_url = None
         runtime_mock.browser_service_url = None
         runtime_mock.browser_auth_token = ""
+        # Real dict so the POST handler's extra_env refresh is observable
+        # (containers read EMBEDDING_MODEL/DIM from extra_env at start).
+        runtime_mock.extra_env = {}
+        self.runtime_mock = runtime_mock
         health_monitor = HealthMonitor(
             runtime=runtime_mock,
             transport=MagicMock(),
@@ -69,6 +73,7 @@ class TestEmbeddingModelEndpoint:
         )
         router = create_dashboard_router(
             **self.components, mesh_port=8420, telemetry=self.telemetry,
+            runtime=runtime_mock,
         )
         app = FastAPI()
         app.include_router(router)
@@ -154,6 +159,35 @@ class TestEmbeddingModelEndpoint:
             headers=_CSRF,
         )
         assert resp.status_code == 400
+
+    def test_provider_post_refreshes_runtime_extra_env(
+        self, mesh_yaml, monkeypatch,
+    ):
+        # Agent containers read EMBEDDING_MODEL/DIM from runtime.extra_env at
+        # container start — extra_env is otherwise populated only at engine
+        # boot. Without the write-time refresh, "save + restart agents" would
+        # restart containers with the OLD embedding env.
+        monkeypatch.setenv("OPENLEGION_SYSTEM_VOYAGE_API_KEY", "vk-test")
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "voyage"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 200, resp.text
+        assert self.runtime_mock.extra_env["EMBEDDING_MODEL"] == "voyage/voyage-3.5"
+        assert self.runtime_mock.extra_env["EMBEDDING_DIM"] == "1024"
+
+    def test_none_post_refreshes_runtime_extra_env(self, mesh_yaml, monkeypatch):
+        # "none" must propagate too — keyword-only memory on next restart.
+        for p in ("OPENAI", "VOYAGE", "GEMINI", "COHERE"):
+            monkeypatch.delenv(f"OPENLEGION_SYSTEM_{p}_API_KEY", raising=False)
+        resp = self.client.post(
+            "/dashboard/api/embedding-model",
+            json={"value": "none"},
+            headers=_CSRF,
+        )
+        assert resp.status_code == 200, resp.text
+        assert self.runtime_mock.extra_env["EMBEDDING_MODEL"] == "none"
 
     def test_provider_without_key_rejected(self, mesh_yaml, monkeypatch):
         # A provider with no configured API key is rejected — persisting it

--- a/tests/test_git_tool.py
+++ b/tests/test_git_tool.py
@@ -25,8 +25,10 @@ class FakeGitHub:
         self.put_status_override = put_status_override
         self.corrupt_sha = corrupt_sha
         self.get_truncated = get_truncated
+        self.urls: list[tuple[str, str]] = []
 
     async def __call__(self, url, method="GET", headers=None, body="", timeout=30, *, mesh_client=None):
+        self.urls.append((method, url))
         if method == "GET":
             if self.stored is None:
                 return {"status_code": 404, "body": json.dumps({"message": "Not Found"})}
@@ -119,6 +121,32 @@ async def test_source_path_reads_file_in_code(monkeypatch, tmp_path):
     out = await git_tool.commit_file(repo="o/r", path="data/leads.csv", message="m", source_path="leads.csv")
     assert out["verified"] is True
     assert base64.b64decode(fake.put_body["content"]) == payload.encode()
+
+
+@pytest.mark.asyncio
+async def test_path_and_branch_url_encoded(monkeypatch):
+    # A filename with a space (the tool's primary CSV use case) or `?`/`#`
+    # must be percent-encoded in the contents-API URL — raw interpolation
+    # malforms the URL / injects query params. The PUT body stays raw
+    # (JSON-encoded). `/` in the path must survive as a separator.
+    fake = FakeGitHub(existing=None)
+    monkeypatch.setattr(git_tool, "http_request", fake)
+    out = await git_tool.commit_file(
+        repo="o/r", path="data/q2 leads #1.csv", message="add",
+        content="a,b\n", branch="feat/spaced branch?",
+    )
+    assert out["committed"] is True and out["verified"] is True
+    get_url = next(u for m, u in fake.urls if m == "GET")
+    put_url = next(u for m, u in fake.urls if m == "PUT")
+    assert get_url == (
+        "https://api.github.com/repos/o/r/contents/data/q2%20leads%20%231.csv"
+        "?ref=feat%2Fspaced%20branch%3F"
+    )
+    assert put_url == (
+        "https://api.github.com/repos/o/r/contents/data/q2%20leads%20%231.csv"
+    )
+    # Branch in the PUT body stays raw — it's a JSON field, not a URL part.
+    assert fake.put_body["branch"] == "feat/spaced branch?"
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -166,6 +166,9 @@ async def test_unrelated_runtime_error_still_permanent():
     "This model's maximum context length is 200000 tokens",
     "context_length_exceeded",
     "Your input length and max_tokens exceed the context window",
+    # Anthropic's backticked variant — the backticks around max_tokens must
+    # not defeat the marker match (is_context_overflow strips them).
+    "input length and `max_tokens` exceed context limit: 215000 + 32000 > 204798",
     "context length exceeded the limit",
 ])
 @pytest.mark.asyncio

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4569,6 +4569,17 @@ async def test_complete_task_on_exact_cap_round_closes_done_not_blocked():
     # Early return fired after exactly ONE LLM round — the extra tool-calling
     # responses were never consumed.
     assert loop.llm.chat.await_count == 1
+    # The closing assistant message persisted to durable history must be
+    # NON-empty: the Anthropic Messages API rejects empty content on
+    # non-final assistant messages, so an empty closer 400s the NEXT turn
+    # (chat-bubble suppression is handled via ``silent_reply``, not here).
+    # Assistant messages WITH tool_calls may legitimately be empty.
+    for msg in loop._chat_messages:
+        if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+            assert str(msg.get("content", "")).strip(), (
+                f"empty persisted assistant message would 400 the next "
+                f"Anthropic turn: {msg!r}"
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2157,6 +2157,53 @@ class TestDispatchErrorSurfacing:
         assert fetched["status"] == "working"
 
 
+# ── Chain-outcome bell kinds ──────────────────────────────────
+
+
+class TestDeliverChainOutcomeBellKind:
+    """The dashboard-bell `kind` chosen per chain outcome. Bound to a stub
+    `self` (same pattern as TestChannelPushRetry); a dashboard origin keeps
+    the channel-push branch out of play, so only the bell write runs."""
+
+    def _deliver(self, kind):
+        from src.cli.runtime import RuntimeContext
+
+        class _Store:
+            def __init__(self):
+                self.adds = []
+            def add(self, **kw):
+                self.adds.append(kw)
+                return "n1"
+
+        class _Stub:
+            _notification_store = _Store()
+            event_bus = None
+
+        stub = _Stub()
+        root = {
+            "id": "t-root", "assignee": "worker", "title": "do thing",
+            "origin": {"kind": "human", "channel": "dashboard", "user": "u1"},
+        }
+        ok = RuntimeContext._deliver_chain_outcome(stub, root, kind, "summary")
+        assert ok is True
+        assert len(stub._notification_store.adds) == 1
+        return stub._notification_store.adds[0]
+
+    def test_failed_chain_rings_alert_not_delivered(self):
+        # A failure must NOT ride the success/delivery bell kind — `alert`
+        # is what the stall branch and degradation notifications use.
+        add = self._deliver("failed")
+        assert add["kind"] == "alert"
+
+    def test_done_chain_rings_delivered(self):
+        add = self._deliver("done")
+        assert add["kind"] == "delivered"
+
+    def test_stall_chain_rings_alert(self):
+        add = self._deliver("stall")
+        assert add["kind"] == "alert"
+
+
 # ── Chain-outcome channel push retry ──────────────────────────
 
 


### PR DESCRIPTION
Six verified fixes from a principal-engineer review of the week's shipped PRs. Each is minimal and idiomatic to the surrounding code; regression tests added where a natural home exists.

- **Empty assistant message 400s the next Anthropic OAuth turn** (`src/agent/loop.py`, follows #1090): the terminal-completion early return appended `{"role": "assistant", "content": ""}` to durable chat history; the Anthropic Messages API rejects empty content on non-final assistant messages, so the NEXT turn 400'd through the OAuth fast-path. Now persists a short non-empty closer ("Task closed via terminal coordination tool.") — chat-bubble suppression stays on `silent_reply`, unchanged.
- **Embedding selector never reached agent containers** (`src/dashboard/server.py`, follows #1063): `api_set_embedding_model` wrote `llm.embedding_model` to mesh.yaml, but containers read `EMBEDDING_MODEL`/`EMBEDDING_DIM` from `runtime.extra_env`, populated only at engine boot — so "save + restart agents" restarted with the OLD embedding env while the UI reported the new model active. The endpoint now refreshes `extra_env` at config-write time, mirroring `cli/runtime.py`.
- **Brief live-reload missed the operator edit path** (`src/dashboard/static/js/app.js`, follows #1070): the `team_updated` handler matched only `field === 'project_md'` (the dashboard's own TEAM.md save), but the operator's `update_team_context` mesh endpoint emits `field: 'context'` — the most common "edited elsewhere" producer — leaving the Brief tab stale. Now matches both.
- **Chain failure bell rode the success kind** (`src/cli/runtime.py`, follows #1094): `_deliver_chain_outcome`'s failed branch set `bell_kind = "delivered"` (the success/delivery icon). Now `"alert"`, matching the stall branch and the dashboard's degradation notifications.
- **`is_context_overflow` missed Anthropic's backticked variant** (`src/shared/errors.py`, follows #1087): Anthropic also emits ``input length and `max_tokens` exceed context limit...`` — the backticks defeated the marker, so the proxy never tagged `error_type="context_overflow"` and the agent's prune-and-retry self-heal never fired. Backticks are now stripped before matching; markers unchanged.
- **`commit_file` didn't URL-encode path/branch** (`src/agent/builtins/git_tool.py`, follows #1057): raw interpolation into the GitHub contents-API URL meant a filename with a space (the tool's primary CSV use case) or `?`/`#` produced a malformed URL / query injection. Now `quote(path, safe="/")` + `quote(branch, safe="")`, matching the mesh `read_peer_file` convention; `repo` stays raw (already validated), PUT body JSON fields stay raw (correct).

**Tests**: regression assertions added in `tests/test_loop.py` (non-empty persisted closer), `tests/test_embedding_model_endpoint.py` (extra_env refreshed after POST), `tests/test_runtime.py` (failed chain → `alert` bell), `tests/test_llm.py` (backticked overflow variant), `tests/test_git_tool.py` (space/`#` path + branch encoding). The app.js fix has no JS test infra. Touched test files all pass locally (`193 passed`, `204 passed`); `ruff check` clean. The 21 `tests/test_credentials.py` failures seen locally reproduce identically on clean HEAD (environmental, unrelated).