### PR TITLE
fix(credentials): make history prompt-caching hit across rounds + surface dead OAuth connections

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -50,10 +50,12 @@ _TOOL_TIMEOUT = int(os.environ.get("OPENLEGION_TOOL_TIMEOUT", "900"))  # seconds
 # C3 — cache-prefix stabilization (Phase 2 of the operator memory/context
 # overhaul). When ON, per-turn-volatile prompt fragments (context/round
 # warnings, operator playbooks, 5-min runtime context, the ``## Recent``
-# memory slice) are relocated OUT of the cached system block and appended
-# AFTER the mesh-side cache breakpoint (into the last message) so the stable
-# system prefix stays byte-identical turn-to-turn and #1073's prompt cache
-# actually hits. Volatile fragments are relocated below the cache breakpoint.
+# memory slice) are relocated OUT of the cached system block and folded into
+# the LAST message. The mesh-side rolling cache breakpoint is placed on the
+# SECOND-TO-LAST message (see credentials.py:_mark_anthropic_cache_breakpoints),
+# so the suffix-bearing final message sits AFTER every breakpoint: the stable
+# system prefix and the append-only history both stay byte-identical
+# round-to-round and #1073's prompt cache actually hits.
 _FLEET_ROSTER_TTL = 600  # seconds — cache TTL for fleet roster
 _GOALS_TTL = 300  # seconds — cache TTL for goals fetch
 _FALLBACK_MAX_TOKENS = 100_000  # context trim fallback when no context manager
@@ -4615,8 +4617,10 @@ class AgentLoop:
     def _append_volatile_to_messages(
         self, messages: list[dict], suffix: str,
     ) -> list[dict]:
-        """Append ``suffix`` after the cache breakpoint by folding it into a
-        COPY of the last message's content.
+        """Append ``suffix`` after the cache breakpoints by folding it into a
+        COPY of the last message's content. The mesh proxy places the rolling
+        history breakpoint on the SECOND-TO-LAST message precisely because
+        this final message mutates per request and never reappears verbatim.
 
         No-op (returns the same list) when there is nothing to relocate. When
         active, the persistent ``messages``/``_chat_messages`` list is never

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1088,6 +1088,38 @@ def create_dashboard_router(
                 )
                 _emit_notification_added(nid, "alert", title, body, agent_id, payload)
                 return
+
+            if event_type == "connection_refresh_failed":
+                # A third-party OAuth connection's refresh was hard-rejected
+                # by the provider (e.g. the user revoked access). Emitted at
+                # most once per failure episode by the mesh vault_resolve
+                # catch site — no extra dedup needed here.
+                conn_name = (data.get("connection") or "connection").strip()
+                provider = (data.get("provider") or "").strip()
+                provider_label = provider.capitalize() if provider else "OAuth"
+                title = (
+                    f"{provider_label} connection '{conn_name}' needs reconnecting"
+                )[:200]
+                err = (data.get("error") or "").strip()
+                body = (
+                    "Token refresh was rejected by the provider — open "
+                    "Settings → Integrations and reconnect."
+                    + (f" ({err})" if err else "")
+                )[:200]
+                payload = {
+                    "connection": data.get("connection"),
+                    "provider": data.get("provider"),
+                    "error": data.get("error"),
+                }
+                nid = notification_store.add(
+                    kind="credential",
+                    title=title,
+                    body=body,
+                    agent_id=agent_id,
+                    payload=payload,
+                )
+                _emit_notification_added(nid, "credential", title, body, agent_id, payload)
+                return
         except Exception as e:
             # Notifications are a polish surface — never let a write
             # failure break the broadcast path or starve other

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -58,6 +58,41 @@ _OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 _OPENAI_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback"
 
+# ── OAuth connection refresh failure caching ─────────────────
+# When a third-party OAuth provider HARD-rejects a refresh (4xx, e.g.
+# ``invalid_grant`` after the user revokes access), re-hitting the token
+# endpoint on every agent resolve is pure waste — the grant is dead until
+# the operator reconnects. Cache the failure for this many seconds and
+# re-raise it immediately. Transient errors (network, 5xx) are NOT cached;
+# retrying those is correct.
+_CONNECTION_REFRESH_FAILURE_TTL = 60.0
+
+
+class ConnectionRefreshError(RuntimeError):
+    """Hard (4xx) OAuth connection-refresh failure.
+
+    Raised by :meth:`CredentialVault.ensure_connection_token` when the
+    provider rejects the refresh outright. Carries structure so the mesh
+    catch site (``/mesh/vault/resolve``) can emit a
+    ``connection_refresh_failed`` DashboardEvent without re-parsing the
+    message. ``first_failure`` is True only on the first hard failure of an
+    episode — it resets when a refresh succeeds or the connection is
+    removed/re-stored — so the operator is notified exactly once per episode.
+    Subclasses RuntimeError so existing "refresh failed" handling is
+    unaffected.
+    """
+
+    def __init__(
+        self, message: str, *, connection: str, provider: str,
+        provider_error: str, first_failure: bool,
+    ) -> None:
+        super().__init__(message)
+        self.connection = connection
+        self.provider = provider
+        self.provider_error = provider_error
+        self.first_failure = first_failure
+
+
 # ── Anthropic prompt caching (OAuth path) ────────────────────
 _PROMPT_CACHE_ENABLED = os.environ.get(
     "OPENLEGION_PROMPT_CACHING", "1"
@@ -565,6 +600,14 @@ class CredentialVault:
         self.connections: dict[str, dict] = {}
         self._connection_locks: dict[str, asyncio.Lock] = {}
         self._connection_locks_guard = asyncio.Lock()
+        # Hard refresh-failure cache: ``name`` → {ts (monotonic), provider,
+        # error, message}. Within ``_CONNECTION_REFRESH_FAILURE_TTL`` of
+        # ``ts`` the cached ``ConnectionRefreshError`` is re-raised without
+        # touching the provider. The entry outlives the TTL on purpose — its
+        # PRESENCE marks an ongoing failure episode (notify-once dedup);
+        # only a successful refresh, removal, or re-store clears it.
+        # Mutated only under the per-name connection lock.
+        self._connection_refresh_failures: dict[str, dict] = {}
         # ``_auth_failure_recorder`` (Fix 4 in seam follow-up): optional
         # callback ``(agent_id, provider, model, http_status) -> None``
         # invoked when an LLM call raises ``LLMAuthError`` during
@@ -796,6 +839,7 @@ class CredentialVault:
         if cred_key in self.connections:
             self.connections.pop(cred_key, None)
             self._connection_locks.pop(cred_key, None)
+            self._connection_refresh_failures.pop(cred_key, None)
             _remove_from_env(f"{CONNECTION_PREFIX}{name.upper()}")
             logger.info("Connection removed: %s", cred_key)
             return True
@@ -947,6 +991,9 @@ class CredentialVault:
         if not data.get("access_token"):
             raise ValueError("connection requires access_token")
         self.connections[name] = data
+        # A (re)connect supersedes any cached refresh failure — fresh tokens,
+        # fresh episode.
+        self._connection_refresh_failures.pop(name, None)
         _persist_to_env(f"{CONNECTION_PREFIX}{name.upper()}", json.dumps(data))
         logger.info("Connection stored: %s (%s)", name, data.get("provider", ""))
         return f"$CRED{{{name}}}"
@@ -959,6 +1006,28 @@ class CredentialVault:
                 self._connection_locks[name] = lock
             return lock
 
+    def _raise_if_refresh_recently_failed(self, name: str) -> None:
+        """Re-raise a cached hard refresh failure if it is still fresh.
+
+        Called under the per-name connection lock. Entries older than
+        ``_CONNECTION_REFRESH_FAILURE_TTL`` fall through so the provider is
+        re-tried (the operator may have restored access on the provider
+        side); the entry itself is kept so the failure episode — and its
+        notify-once dedup — survives until a refresh actually succeeds.
+        """
+        cached = self._connection_refresh_failures.get(name)
+        if cached is None:
+            return
+        if time.monotonic() - cached["ts"] >= _CONNECTION_REFRESH_FAILURE_TTL:
+            return
+        raise ConnectionRefreshError(
+            cached["message"],
+            connection=name,
+            provider=cached["provider"],
+            provider_error=cached["error"],
+            first_failure=False,
+        )
+
     async def ensure_connection_token(self, name: str) -> str:
         """Return a valid access token for a connection, refreshing if needed.
 
@@ -967,6 +1036,12 @@ class CredentialVault:
         token (offline access not granted, or a long-lived token), returns the
         current token — a 401 then surfaces naturally to the agent rather than
         failing the resolve.
+
+        Hard provider rejections (4xx) raise :class:`ConnectionRefreshError`
+        and are cached for ``_CONNECTION_REFRESH_FAILURE_TTL`` seconds so a
+        dead grant doesn't get hammered on every agent resolve. Transient
+        errors (network, 5xx) keep raising plain ``RuntimeError`` and are
+        never cached.
         """
         name = name.lower()
         conn = self.connections.get(name)
@@ -984,6 +1059,7 @@ class CredentialVault:
             now = int(time.time())
             if conn.get("expires_at", 0) > now + 300:
                 return conn["access_token"]
+            self._raise_if_refresh_recently_failed(name)
             refresh_token = conn.get("refresh_token", "")
             if not refresh_token:
                 return conn["access_token"]
@@ -1012,14 +1088,41 @@ class CredentialVault:
                     f"{provider.key} token refresh request failed: {exc}",
                 ) from exc
             if not resp.is_success:
-                raise RuntimeError(
+                msg = (
                     f"{provider.key} token refresh failed "
                     f"(HTTP {resp.status_code}): {resp.text[:200]}"
                 )
+                if 400 <= resp.status_code < 500:
+                    # Hard provider rejection (e.g. ``invalid_grant`` after
+                    # the user revokes access): the grant is dead until the
+                    # operator reconnects. Cache the failure so resolves
+                    # within the TTL re-raise immediately instead of
+                    # hammering the token endpoint. ``first_failure`` is True
+                    # only when this starts a new episode — the mesh catch
+                    # site uses it to notify the operator exactly once.
+                    first = name not in self._connection_refresh_failures
+                    self._connection_refresh_failures[name] = {
+                        "ts": time.monotonic(),
+                        "provider": provider.key,
+                        "error": resp.text[:200],
+                        "message": msg,
+                    }
+                    raise ConnectionRefreshError(
+                        msg,
+                        connection=name,
+                        provider=provider.key,
+                        provider_error=resp.text[:200],
+                        first_failure=first,
+                    )
+                # Transient (5xx) — retrying is correct; do NOT cache.
+                raise RuntimeError(msg)
             payload = resp.json()
             new_access = payload.get("access_token", "")
             if not new_access:
                 raise RuntimeError(f"{provider.key} refresh returned no access_token")
+            # Successful refresh ends any failure episode — the next hard
+            # failure (if ever) starts a new one and re-notifies.
+            self._connection_refresh_failures.pop(name, None)
             expires_in = int(payload.get("expires_in", 3600))
             updated = dict(conn)
             updated["access_token"] = new_access

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -64,18 +64,51 @@ _PROMPT_CACHE_ENABLED = os.environ.get(
 ).strip().lower() not in ("0", "false", "no", "off", "")
 
 
+def _tag_anthropic_message_block(msg: dict, cc: dict) -> bool:
+    """Tag *msg*'s last content block with ``cache_control`` if cacheable.
+
+    String content is converted to a single tagged text block. List content is
+    tagged only when its last block is a cacheable type — Anthropic rejects
+    cache_control on e.g. ``thinking`` blocks; normal agent history ends in
+    text/tool_use/tool_result, but guard defensively so a stray block can
+    never make the proxy emit a rejected request. Returns True iff a
+    breakpoint landed.
+    """
+    content = msg.get("content")
+    if isinstance(content, str) and content:
+        msg["content"] = [{"type": "text", "text": content, "cache_control": cc}]
+        return True
+    if isinstance(content, list) and content and isinstance(content[-1], dict):
+        if content[-1].get("type") in ("text", "tool_use", "tool_result"):
+            content[-1]["cache_control"] = cc
+            return True
+    return False
+
+
 def _mark_anthropic_cache_breakpoints(body: dict) -> None:
     """Tag the stable Anthropic request prefix with ephemeral prompt-cache
-    breakpoints so repeated within-turn re-sends are billed as cache reads
-    (~0.10x) instead of full input.
+    breakpoints so repeated re-sends are billed as cache reads (~0.10x)
+    instead of full input.
 
     Anthropic caches the request prefix up to and including each block marked
     with ``cache_control``. We mark, at most, three breakpoints (limit is 4):
       (a) the LAST tool definition  -> caches the whole tools array,
       (b) the LAST system content block -> caches tools + system,
-      (c) the LAST message's last content block -> caches the append-only
-          message history within a turn (rolling breakpoint).
-    Mutates ``body`` in place. Safe no-op on missing/empty fields; idempotent.
+      (c) the SECOND-TO-LAST message's last cacheable content block -> the
+          rolling history breakpoint. NOT the last message: the agent loop
+          folds a per-request volatile suffix (recent-memory slice, playbooks,
+          runtime context — see ``loop.py:_append_volatile_to_messages``) into
+          the final message of every request, so round N's last message never
+          reappears verbatim in round N+1 (where the history copy is resent
+          CLEAN). Tagging it would make every next round diverge from the
+          cached span right at that message and re-bill the whole history.
+          The second-to-last message is pure append-only history, resent
+          byte-identical next round, so the cache read covers nearly all of
+          it. We walk backward from ``messages[-2]`` to the nearest message
+          with a cacheable last block; single-message bodies get no message
+          breakpoint (nothing stable worth caching).
+    Mutates ``body`` in place. Safe no-op on missing/empty fields; idempotent
+    (a re-run walks to the already-tagged block and re-tags the same dict).
     """
     if not _PROMPT_CACHE_ENABLED:
         return
@@ -87,19 +120,11 @@ def _mark_anthropic_cache_breakpoints(body: dict) -> None:
     if isinstance(system, list) and system and isinstance(system[-1], dict):
         system[-1]["cache_control"] = cc
     messages = body.get("messages")
-    if isinstance(messages, list) and messages and isinstance(messages[-1], dict):
-        content = messages[-1].get("content")
-        if isinstance(content, str) and content:
-            messages[-1]["content"] = [
-                {"type": "text", "text": content, "cache_control": cc}
-            ]
-        elif isinstance(content, list) and content and isinstance(content[-1], dict):
-            # Only tag a cacheable block type. Anthropic rejects cache_control
-            # on e.g. ``thinking`` blocks; normal agent history ends in
-            # text/tool_use/tool_result, but guard defensively so a stray
-            # block can never make the proxy emit a rejected request.
-            if content[-1].get("type") in ("text", "tool_use", "tool_result"):
-                content[-1]["cache_control"] = cc
+    if isinstance(messages, list) and len(messages) >= 2:
+        for i in range(len(messages) - 2, -1, -1):
+            msg = messages[i]
+            if isinstance(msg, dict) and _tag_anthropic_message_block(msg, cc):
+                break
 
 
 def _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs: dict) -> None:
@@ -109,8 +134,22 @@ def _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs: dict) -> None:
     cache_control through to the Anthropic Messages API for native anthropic
     models. NO-OP unless the final model is native ``anthropic/...`` — the
     OpenAI-compatible rewrite (custom api_base / credit-proxy) drops
-    cache_control, so we must not tag there. Mutates ``llm_kwargs`` in place;
-    safe no-op on missing/empty fields; idempotent.
+    cache_control, so we must not tag there.
+
+    Rolling history breakpoint: the SECOND-TO-LAST qualifying message, not the
+    last. The agent loop folds a per-request volatile suffix into the final
+    message of every request (see ``loop.py:_append_volatile_to_messages``),
+    so the last message never reappears verbatim next round and tagging it
+    would defeat the history cache. We walk backward from ``messages[-2]``,
+    skipping ``system`` (tagged separately at the front — re-tagging the same
+    dict would be harmless but pointless) and ``tool`` roles (uncertain
+    whether litellm passes cache_control through on tool-role content;
+    tagging the nearest user/assistant text message still caches everything
+    before it).
+
+    Mutates ``llm_kwargs`` in place; safe no-op on missing/empty fields;
+    idempotent (a re-run walks to the already-tagged block and re-tags the
+    same dict).
     """
     if not _PROMPT_CACHE_ENABLED:
         return
@@ -125,24 +164,32 @@ def _mark_anthropic_cache_breakpoints_openai_fmt(llm_kwargs: dict) -> None:
     if not isinstance(messages, list) or not messages:
         return
 
-    def _tag_block(msg: dict) -> None:
+    def _tag_block(msg: dict) -> bool:
         c = msg.get("content")
         if isinstance(c, str) and c:
             msg["content"] = [{"type": "text", "text": c, "cache_control": cc}]
-        elif isinstance(c, list) and c and isinstance(c[-1], dict):
+            return True
+        if isinstance(c, list) and c and isinstance(c[-1], dict):
             if c[-1].get("type") == "text":
                 c[-1]["cache_control"] = cc
+                return True
+        return False
 
     # (a) system message (first one) — caches system + tools prefix
     for m in messages:
         if isinstance(m, dict) and m.get("role") == "system":
             _tag_block(m)
             break
-    # (b) last message (rolling breakpoint over append-only history),
-    #     unless it IS the system message already tagged above
-    last = messages[-1]
-    if isinstance(last, dict) and last.get("role") != "system":
-        _tag_block(last)
+    # (b) rolling history breakpoint: nearest qualifying message at or before
+    #     the second-to-last (the final message carries the volatile suffix —
+    #     see docstring). Skip system (already tagged) and tool roles.
+    if len(messages) >= 2:
+        for i in range(len(messages) - 2, -1, -1):
+            m = messages[i]
+            if not isinstance(m, dict) or m.get("role") in ("system", "tool"):
+                continue
+            if _tag_block(m):
+                break
 
 
 # ── Same-model transient retry (prod 503 incident) ───────────

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -28,7 +28,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import StreamingResponse
 
 from src.host.change_history import ChangeHistory
-from src.host.credentials import is_system_credential
+from src.host.credentials import ConnectionRefreshError, is_system_credential
 from src.host.help_requests import HelpRequests
 from src.host.orchestration import (
     MAX_FEEDBACK_CHARS,
@@ -41,7 +41,7 @@ from src.host.orchestration import (
 )
 from src.host.pending_actions import PendingActions
 from src.shared.paths import resolve_under_root
-from src.shared.redaction import redact_url
+from src.shared.redaction import redact_text_with_urls, redact_url
 from src.shared.types import (
     AGENT_ID_RE_PATTERN,
     HARD_EDIT_FIELDS,
@@ -2271,6 +2271,21 @@ def create_mesh_app(
         # credentials fall through to the in-memory lookup.
         try:
             value = await credential_vault.resolve_credential_async(name)
+        except ConnectionRefreshError as exc:
+            # Hard provider rejection (e.g. invalid_grant after the user
+            # revokes access). The vault caches the failure (no provider
+            # re-hit for the TTL); here we surface it to the operator —
+            # once per failure episode (``first_failure``) — via the same
+            # event→notification pipeline as ``credit_exhausted``. The
+            # provider error text is untrusted; redact before emitting.
+            logger.warning("Credential resolve failed for %s: %s", name, exc)
+            if event_bus is not None and exc.first_failure:
+                event_bus.emit("connection_refresh_failed", agent=agent_id, data={
+                    "connection": exc.connection,
+                    "provider": exc.provider,
+                    "error": redact_text_with_urls(str(exc.provider_error))[:200],
+                })
+            raise HTTPException(502, f"Credential resolve failed: {name}") from exc
         except Exception as exc:  # noqa: BLE001 — surface refresh failures as 502
             logger.warning("Credential resolve failed for %s: %s", name, exc)
             raise HTTPException(502, f"Credential resolve failed: {name}") from exc

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -763,6 +763,12 @@ class DashboardEvent(BaseModel):
         "credential_request",
         "credential_request_cancelled",
         "credential_stored",
+        # OAuth connection refresh hard-failed (e.g. ``invalid_grant`` after
+        # the user revoked access at the provider). Emitted once per failure
+        # episode from the mesh ``/mesh/vault/resolve`` catch site; the
+        # notifications producer maps it to a ``credential`` bell entry so
+        # the operator knows to reconnect via Settings → Integrations.
+        "connection_refresh_failed",
         "browser_login_request",
         "browser_login_completed",
         "browser_login_cancelled",

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,6 @@
 """Unit tests for credential vault."""
 
+import copy
 import json
 from unittest.mock import MagicMock, patch
 
@@ -5672,10 +5673,11 @@ class TestMarkAnthropicCacheBreakpoints:
             ],
             "messages": [
                 {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "working\n\nvolatile suffix"},
             ],
         }
 
-    def test_marks_last_tool_system_and_string_message(self):
+    def test_marks_last_tool_system_and_second_to_last_message(self):
         body = self._full_body()
         _mark_anthropic_cache_breakpoints(body)
 
@@ -5685,13 +5687,15 @@ class TestMarkAnthropicCacheBreakpoints:
         # (b) last system block only
         assert "cache_control" not in body["system"][0]
         assert body["system"][1]["cache_control"] == _EPHEMERAL
-        # (c) string content converted to a list block with cache_control
-        content = body["messages"][0]["content"]
-        assert content == [
+        # (c) SECOND-TO-LAST message: string content converted to a list
+        # block with cache_control. The (volatile-bearing) last message
+        # stays untouched so it sits after the breakpoint.
+        assert body["messages"][0]["content"] == [
             {"type": "text", "text": "hello", "cache_control": _EPHEMERAL}
         ]
+        assert body["messages"][1]["content"] == "working\n\nvolatile suffix"
 
-    def test_last_message_list_content_marks_last_block(self):
+    def test_second_to_last_list_content_marks_last_block(self):
         body = {
             "messages": [
                 {
@@ -5701,20 +5705,36 @@ class TestMarkAnthropicCacheBreakpoints:
                         {"type": "tool_result", "tool_use_id": "2", "content": "y"},
                     ],
                 },
+                {"role": "assistant", "content": "final + volatile"},
             ],
         }
         _mark_anthropic_cache_breakpoints(body)
         blocks = body["messages"][0]["content"]
         assert "cache_control" not in blocks[0]
         assert blocks[1]["cache_control"] == _EPHEMERAL
+        assert body["messages"][1]["content"] == "final + volatile"
 
-    def test_last_message_non_cacheable_block_not_tagged(self):
-        # A non-cacheable trailing block (e.g. ``thinking``) must NOT be
-        # tagged — Anthropic rejects cache_control there. The system/tools
-        # breakpoints still apply; only the message breakpoint is skipped.
+    def test_single_message_body_gets_no_message_breakpoint(self):
+        # With one message there is no stable history worth caching — the
+        # final message carries the per-request volatile suffix and never
+        # reappears verbatim, so tagging it would never produce a cache hit.
+        body = {
+            "system": [{"type": "text", "text": "s"}],
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        _mark_anthropic_cache_breakpoints(body)
+        assert body["messages"][0]["content"] == "hello"
+        assert body["system"][0]["cache_control"] == _EPHEMERAL
+
+    def test_non_cacheable_block_walks_back_to_earlier_message(self):
+        # A non-cacheable trailing block (e.g. ``thinking``) on the
+        # second-to-last message must NOT be tagged — Anthropic rejects
+        # cache_control there. The walk continues backward to the nearest
+        # message with a cacheable last block.
         body = {
             "system": [{"type": "text", "text": "s"}],
             "messages": [
+                {"role": "user", "content": "early"},
                 {
                     "role": "assistant",
                     "content": [
@@ -5722,13 +5742,78 @@ class TestMarkAnthropicCacheBreakpoints:
                         {"type": "thinking", "thinking": "..."},
                     ],
                 },
+                {"role": "user", "content": "final + volatile"},
             ],
         }
         _mark_anthropic_cache_breakpoints(body)
-        blocks = body["messages"][0]["content"]
+        blocks = body["messages"][1]["content"]
         assert "cache_control" not in blocks[0]
         assert "cache_control" not in blocks[1]
+        assert body["messages"][0]["content"] == [
+            {"type": "text", "text": "early", "cache_control": _EPHEMERAL}
+        ]
+        assert body["messages"][2]["content"] == "final + volatile"
         assert body["system"][0]["cache_control"] == _EPHEMERAL
+
+    def test_no_cacheable_message_before_last_tags_nothing(self):
+        body = {
+            "messages": [
+                {"role": "assistant", "content": [{"type": "thinking", "thinking": "..."}]},
+                {"role": "user", "content": "final"},
+            ],
+        }
+        _mark_anthropic_cache_breakpoints(body)
+        assert "cache_control" not in body["messages"][0]["content"][0]
+        assert body["messages"][1]["content"] == "final"
+
+    def test_breakpoint_targets_message_resent_verbatim_next_round(self):
+        # Regression for the volatile-suffix divergence: the agent loop folds
+        # a per-request volatile suffix into the LAST message only
+        # (loop.py:_append_volatile_to_messages), so round N's last message
+        # never reappears verbatim in round N+1 — the history copy is resent
+        # CLEAN. The rolling breakpoint must therefore land on a message that
+        # IS resent byte-identical, i.e. the second-to-last.
+        history = [
+            {"role": "user", "content": "do the task"},
+            {"role": "assistant", "content": [{"type": "text", "text": "step 1 done"}]},
+            {"role": "user", "content": "continue"},
+        ]
+        # Round N: last message carries that round's volatile suffix.
+        round_n = copy.deepcopy(history)
+        round_n[-1] = {
+            "role": "user",
+            "content": "continue\n\n[Live context]\nvolatile-round-N",
+        }
+        body_n = {"messages": copy.deepcopy(round_n)}
+        _mark_anthropic_cache_breakpoints(body_n)
+
+        # Tag landed on the second-to-last (pure history) message — the
+        # suffix-bearing last message is untouched.
+        tagged_idx = 1
+        assert (
+            body_n["messages"][tagged_idx]["content"][-1]["cache_control"]
+            == _EPHEMERAL
+        )
+        assert body_n["messages"][-1] == round_n[-1]
+
+        # Round N+1: history resent CLEAN, two new messages appended, the new
+        # last message carries round N+1's suffix.
+        round_n1 = copy.deepcopy(history) + [
+            {"role": "assistant", "content": "step 2 done"},
+            {
+                "role": "user",
+                "content": "wrap up\n\n[Live context]\nvolatile-round-N+1",
+            },
+        ]
+        # Core assertion: the message the round-N breakpoint landed on
+        # reappears byte-identical in round N+1, so the cached span up to the
+        # breakpoint matches and the history is billed as a cache READ.
+        assert json.dumps(history[tagged_idx], sort_keys=True) == json.dumps(
+            round_n1[tagged_idx], sort_keys=True
+        )
+        # Whereas the old last-message target (suffix-bearing) does NOT
+        # reappear in round N+1 — it is resent clean there.
+        assert round_n[-1] != round_n1[2]
 
     def test_empty_or_missing_fields_no_error_no_spurious_keys(self):
         # Completely empty.
@@ -5783,10 +5868,19 @@ class TestMarkAnthropicCacheBreakpointsOpenAiFmt:
             "messages": [
                 {"role": "system", "content": "agent system prompt"},
                 {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "working"},
+                {"role": "user", "content": "final + volatile suffix"},
             ],
         }
 
-    def test_native_anthropic_tags_system_last_tool_and_last_message(self):
+    def _assert_untagged(self, kw):
+        assert "cache_control" not in kw["tools"][1]
+        assert kw["messages"][0]["content"] == "agent system prompt"
+        assert kw["messages"][1]["content"] == "hello"
+        assert kw["messages"][2]["content"] == "working"
+        assert kw["messages"][3]["content"] == "final + volatile suffix"
+
+    def test_native_anthropic_tags_system_last_tool_and_second_to_last(self):
         kw = self._kwargs()
         _mark_anthropic_cache_breakpoints_openai_fmt(kw)
 
@@ -5801,34 +5895,78 @@ class TestMarkAnthropicCacheBreakpointsOpenAiFmt:
                 "cache_control": _EPHEMERAL,
             }
         ]
-        # last (user) message string content → list block with cache_control
-        assert kw["messages"][1]["content"] == [
-            {"type": "text", "text": "hello", "cache_control": _EPHEMERAL}
+        # SECOND-TO-LAST message tagged — the final (volatile-bearing)
+        # message stays untouched so it sits after the rolling breakpoint.
+        assert kw["messages"][1]["content"] == "hello"
+        assert kw["messages"][2]["content"] == [
+            {"type": "text", "text": "working", "cache_control": _EPHEMERAL}
         ]
+        assert kw["messages"][3]["content"] == "final + volatile suffix"
+
+    def test_walk_skips_tool_and_system_roles(self):
+        kw = {
+            "model": "anthropic/claude-x",
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "assistant", "content": "calling tool"},
+                {"role": "tool", "content": "tool result", "tool_call_id": "1"},
+                {"role": "user", "content": "final + volatile"},
+            ],
+        }
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        # tool-role message (index 2, the second-to-last) skipped — litellm's
+        # cache_control passthrough on tool-role content is uncertain. The
+        # walk lands on the nearest assistant message instead.
+        assert kw["messages"][2]["content"] == "tool result"
+        assert kw["messages"][1]["content"] == [
+            {"type": "text", "text": "calling tool", "cache_control": _EPHEMERAL}
+        ]
+        assert kw["messages"][3]["content"] == "final + volatile"
+
+    def test_system_only_prefix_gets_no_rolling_breakpoint(self):
+        # [system, user] — the walk from index len-2 hits the system message
+        # (already tagged at the front) and skips it; no second tag lands.
+        kw = {
+            "model": "anthropic/claude-x",
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hello + volatile"},
+            ],
+        }
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        assert kw["messages"][0]["content"] == [
+            {"type": "text", "text": "sys", "cache_control": _EPHEMERAL}
+        ]
+        assert kw["messages"][1]["content"] == "hello + volatile"
+
+    def test_idempotent(self):
+        kw = self._kwargs()
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        first = json.dumps(kw, sort_keys=True)
+        _mark_anthropic_cache_breakpoints_openai_fmt(kw)
+        second = json.dumps(kw, sort_keys=True)
+        assert first == second
+        # Exactly one cache_control per breakpoint slot (tools, system,
+        # rolling message) — no accumulation across re-runs.
+        assert second.count('"cache_control"') == 3
 
     def test_rewritten_openai_model_tags_nothing(self):
         # api_base / credit-proxy rewrite turns the model into ``openai/...``,
         # which silently drops cache_control — the guard must skip.
         kw = self._kwargs(model="openai/claude-x")
         _mark_anthropic_cache_breakpoints_openai_fmt(kw)
-        assert "cache_control" not in kw["tools"][1]
-        assert kw["messages"][0]["content"] == "agent system prompt"
-        assert kw["messages"][1]["content"] == "hello"
+        self._assert_untagged(kw)
 
     def test_non_anthropic_model_tags_nothing(self):
         kw = self._kwargs(model="gemini/gemini-2.5-pro")
         _mark_anthropic_cache_breakpoints_openai_fmt(kw)
-        assert "cache_control" not in kw["tools"][1]
-        assert kw["messages"][0]["content"] == "agent system prompt"
-        assert kw["messages"][1]["content"] == "hello"
+        self._assert_untagged(kw)
 
     def test_disabled_flag_tags_nothing(self, monkeypatch):
         monkeypatch.setattr(_cred_mod, "_PROMPT_CACHE_ENABLED", False)
         kw = self._kwargs()
         _mark_anthropic_cache_breakpoints_openai_fmt(kw)
-        assert "cache_control" not in kw["tools"][1]
-        assert kw["messages"][0]["content"] == "agent system prompt"
-        assert kw["messages"][1]["content"] == "hello"
+        self._assert_untagged(kw)
 
     def test_single_system_message_not_double_tagged(self):
         # When the only message IS the system message, tag it once (via the

--- a/tests/test_dashboard_notifications.py
+++ b/tests/test_dashboard_notifications.py
@@ -472,6 +472,24 @@ class TestNotificationsProducerWiring:
         assert "writer" in rows[0]["title"]
         assert "out of credit" in rows[0]["title"]
 
+    def test_connection_refresh_failed_creates_credential_notification(self):
+        # Dead OAuth grant (e.g. invalid_grant after the user revoked
+        # access). The mesh emits this once per failure episode; the
+        # producer maps it to an actionable ``credential`` bell entry.
+        self.bus.emit("connection_refresh_failed", agent="researcher", data={
+            "connection": "google_drive",
+            "provider": "google",
+            "error": "HTTP 400: invalid_grant",
+        })
+        rows = self.store.list_recent()
+        assert len(rows) == 1
+        assert rows[0]["kind"] == "credential"
+        assert "google_drive" in rows[0]["title"]
+        assert "needs reconnecting" in rows[0]["title"]
+        assert "Settings" in rows[0]["body"]
+        assert rows[0]["payload"]["connection"] == "google_drive"
+        assert rows[0]["payload"]["provider"] == "google"
+
     def test_unrelated_event_does_not_create_notification(self):
         # Sanity check — events outside the frozen mapping table never
         # create rows. Without this we'd be tempted to grow the mapping

--- a/tests/test_oauth_integrations.py
+++ b/tests/test_oauth_integrations.py
@@ -15,7 +15,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import src.host.credentials as cred_mod
-from src.host.credentials import CONNECTION_PREFIX, CredentialVault
+from src.host.credentials import (
+    CONNECTION_PREFIX,
+    ConnectionRefreshError,
+    CredentialVault,
+)
 from src.host.oauth_providers import GOOGLE, generate_pkce, get_provider
 from src.host.oauth_state import OAuthStateStore
 
@@ -332,6 +336,195 @@ async def test_exchange_account_fetch_failure_is_nonfatal(captured_env):
     )
     assert conn["access_token"] == "at"
     assert conn["account"] == ""  # best-effort, swallowed
+
+
+# ── Hard refresh-failure caching + operator surfacing ────────────────────
+
+def _expired_google_conn(v: CredentialVault) -> None:
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    v.connections["g"] = {
+        "provider": "google", "access_token": "old",
+        "refresh_token": "rt", "expires_at": int(time.time()) - 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_hard_4xx_refresh_cached_within_ttl(captured_env):
+    post = AsyncMock(return_value=_fake_response(status=400, text="invalid_grant"))
+    v = _vault_with_fake_http(post=post)
+    _expired_google_conn(v)
+
+    with pytest.raises(ConnectionRefreshError) as first:
+        await v.resolve_credential_async("g")
+    assert first.value.first_failure is True
+    assert first.value.connection == "g"
+    assert first.value.provider == "google"
+    assert post.await_count == 1
+
+    # Second resolve within the TTL: same error re-raised from the cache —
+    # the provider's token endpoint is NOT re-hit, and it's the same episode.
+    with pytest.raises(ConnectionRefreshError) as second:
+        await v.resolve_credential_async("g")
+    assert str(second.value) == str(first.value)
+    assert second.value.first_failure is False
+    assert post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_transient_5xx_refresh_not_cached(captured_env):
+    post = AsyncMock(return_value=_fake_response(status=503, text="upstream down"))
+    v = _vault_with_fake_http(post=post)
+    _expired_google_conn(v)
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError) as exc:
+            await v.resolve_credential_async("g")
+        assert not isinstance(exc.value, ConnectionRefreshError)
+    # Retried both times — transient provider blips must not be cached.
+    assert post.await_count == 2
+    assert "g" not in v._connection_refresh_failures
+
+
+@pytest.mark.asyncio
+async def test_network_error_refresh_not_cached(captured_env):
+    import httpx
+    post = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    v = _vault_with_fake_http(post=post)
+    _expired_google_conn(v)
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError) as exc:
+            await v.resolve_credential_async("g")
+        assert not isinstance(exc.value, ConnectionRefreshError)
+    assert post.await_count == 2
+    assert "g" not in v._connection_refresh_failures
+
+
+@pytest.mark.asyncio
+async def test_refresh_success_after_ttl_clears_failure_state(captured_env):
+    post = AsyncMock(side_effect=[
+        _fake_response(status=400, text="invalid_grant"),
+        _fake_response(payload={"access_token": "new-at", "expires_in": 3600}),
+        _fake_response(status=400, text="invalid_grant again"),
+    ])
+    v = _vault_with_fake_http(post=post)
+    _expired_google_conn(v)
+
+    with pytest.raises(ConnectionRefreshError):
+        await v.resolve_credential_async("g")
+    # Age the cached failure past the TTL so the provider is re-tried
+    # (the operator may have restored access on the provider side).
+    v._connection_refresh_failures["g"]["ts"] -= (
+        cred_mod._CONNECTION_REFRESH_FAILURE_TTL + 1
+    )
+    assert await v.resolve_credential_async("g") == "new-at"
+    assert "g" not in v._connection_refresh_failures  # episode over
+
+    # A later hard failure starts a NEW episode → notifies again.
+    v.connections["g"]["expires_at"] = int(time.time()) - 10
+    with pytest.raises(ConnectionRefreshError) as exc:
+        await v.resolve_credential_async("g")
+    assert exc.value.first_failure is True
+
+
+@pytest.mark.asyncio
+async def test_refailure_after_ttl_stays_in_same_episode(captured_env):
+    post = AsyncMock(return_value=_fake_response(status=400, text="invalid_grant"))
+    v = _vault_with_fake_http(post=post)
+    _expired_google_conn(v)
+
+    with pytest.raises(ConnectionRefreshError) as e1:
+        await v.resolve_credential_async("g")
+    assert e1.value.first_failure is True
+    v._connection_refresh_failures["g"]["ts"] -= (
+        cred_mod._CONNECTION_REFRESH_FAILURE_TTL + 1
+    )
+    with pytest.raises(ConnectionRefreshError) as e2:
+        await v.resolve_credential_async("g")
+    assert post.await_count == 2            # provider re-tried after the TTL
+    assert e2.value.first_failure is False  # still the same episode — no re-notify
+
+
+def test_reconnect_clears_failure_episode(captured_env):
+    v = CredentialVault()
+    v._connection_refresh_failures["g"] = {
+        "ts": 0.0, "provider": "google", "error": "x", "message": "m",
+    }
+    v.store_connection("g", {
+        "provider": "google", "access_token": "at", "refresh_token": "rt",
+        "expires_at": 9999999999, "scopes": [], "account": "a@b.com",
+    })
+    assert "g" not in v._connection_refresh_failures
+
+
+def test_remove_connection_clears_failure_episode(captured_env, monkeypatch):
+    monkeypatch.setenv(f"{CONNECTION_PREFIX}G", json.dumps({
+        "provider": "google", "access_token": "at",
+    }))
+    v = CredentialVault()
+    v._connection_refresh_failures["g"] = {
+        "ts": 0.0, "provider": "google", "error": "x", "message": "m",
+    }
+    assert v.remove_credential("g") is True
+    assert "g" not in v._connection_refresh_failures
+
+
+def test_vault_resolve_hard_failure_502_and_single_operator_event(
+    captured_env, tmp_path,
+):
+    """Mesh-endpoint flow: a dead OAuth grant keeps returning 502 to agents
+    (unchanged contract) but (a) the provider is hit only once within the
+    failure-cache TTL and (b) the operator gets exactly ONE redacted
+    ``connection_refresh_failed`` event per episode."""
+    from fastapi.testclient import TestClient
+
+    from src.dashboard.events import EventBus
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.shared.types import AgentPermissions
+
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "trusted": AgentPermissions(
+            agent_id="trusted", can_message=["mesh"],
+            allowed_credentials=["*"],
+        ),
+    }
+    post = AsyncMock(return_value=_fake_response(
+        status=400, text="invalid_grant token=sk-secretsecret1234567890123456",
+    ))
+    vault = _vault_with_fake_http(post=post)
+    _expired_google_conn(vault)
+
+    bus = EventBus()
+    events: list[dict] = []
+
+    def _capture(evt: dict) -> None:
+        if evt.get("type") == "connection_refresh_failed":
+            events.append(evt)
+
+    bus.add_listener(_capture)
+    app = create_mesh_app(
+        Blackboard(db_path=str(tmp_path / "bb.db")), PubSub(),
+        MessageRouter(permissions=perms, agent_registry={}), perms,
+        credential_vault=vault, event_bus=bus,
+    )
+    client = TestClient(app)
+
+    r1 = client.post("/mesh/vault/resolve", json={"agent_id": "trusted", "name": "g"})
+    r2 = client.post("/mesh/vault/resolve", json={"agent_id": "trusted", "name": "g"})
+    assert r1.status_code == 502
+    assert r2.status_code == 502
+    assert post.await_count == 1  # second resolve served from the failure cache
+    assert len(events) == 1       # operator notified once per episode
+    data = events[0]["data"]
+    assert data["connection"] == "g"
+    assert data["provider"] == "google"
+    # Provider error text is untrusted — token shapes must be redacted.
+    assert "sk-secret" not in json.dumps(data)
+    assert "invalid_grant" in data["error"]
 
 
 # ── End-to-end: the agent's http_request resolver path ───────────────────


### PR DESCRIPTION
## Commit 1 — move the rolling message cache breakpoint off the volatile last message

The agent loop folds a per-request volatile suffix (recent-memory slice, playbooks, runtime ctx — `loop.py:_append_volatile_to_messages`) into the **last** message of every request. Round N's last message therefore never reappears verbatim in round N+1 (history is resent clean), so the rolling breakpoint tagged on `messages[-1]` diverged from every cached span at that message — the whole message history (the dominant token mass in long operator sessions) was re-billed at full input price every round. Tools + system breakpoints still hit; only the messages breakpoint was defeated.

Fix: tag the **second-to-last** message instead, walking backward from `messages[-2]` to the nearest message with a cacheable last block, leaving the suffix-bearing final message after the breakpoint. Round N+1's prefix through round N's tagged message then matches byte-for-byte and the cache read covers nearly all history.

- Anthropic-native (`_mark_anthropic_cache_breakpoints`): single-message bodies get no message breakpoint; non-cacheable trailing blocks (`thinking`) walk further back.
- OpenAI-fmt (`_mark_anthropic_cache_breakpoints_openai_fmt`): same walk, additionally skipping `system` (tagged separately at the front) and `tool` roles (litellm cache_control passthrough on tool-role content is uncertain).
- Idempotent: re-runs find the already-tagged block and re-tag the same dict.
- `loop.py` comments updated to describe the new arrangement.

Tests: volatile-divergence regression (round-N tagged message is byte-identical to its round-N+1 occurrence), single-message skip, role-skip walk, idempotency (exactly one cache_control per slot).

## Commit 2 — cache hard OAuth refresh failures + surface them to the operator

On a hard provider rejection of a connection refresh (e.g. `400 invalid_grant` after the user revokes access), every agent resolve re-hit the provider's token endpoint and the operator was never told — agents just kept failing with 502s.

- **Failure cache**: hard 4xx raises `ConnectionRefreshError` (RuntimeError subclass — `/mesh/vault/resolve` still returns 502, unchanged contract) and is cached for 60s; resolves within the TTL re-raise immediately without hitting the provider. Transient network errors / 5xx are never cached. Entry presence marks the failure *episode* (notify-once dedup); cleared on successful refresh, disconnect, or reconnect. Mutation stays under the existing per-name connection lock.
- **Operator signal**: new `connection_refresh_failed` `DashboardEvent` literal, emitted at the mesh `vault_resolve` catch site once per episode (provider error redacted via `redact_text_with_urls`), mapped by `_notifications_producer` to a `kind=credential` bell entry: *"Google connection 'X' needs reconnecting — open Settings → Integrations"*.

Tests: cached 4xx (provider hit once, same error re-raised), 5xx/network not cached, success-after-TTL clears episode, re-failure after TTL stays in-episode (no re-notify), reconnect/disconnect clear state, mesh-endpoint flow (502 both times, one provider hit, exactly one redacted event), producer mapping.

## Test results (all with `LITELLM_MODE=PRODUCTION`)

- `tests/test_credentials.py` — 308 passed (302 on base before change)
- `tests/test_oauth_integrations.py` + `tests/test_oauth_integrations_endpoints.py` + `tests/test_dashboard_notifications.py` — 88 passed
- `tests/test_integration.py` — passed (439 total with test_credentials.py)
- `tests/test_types.py` + `tests/test_events.py` — 85 passed
- ruff clean on all changed files