### PR TITLE
fix(tests): isolate the suite from the developer's real .env

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -208,6 +208,17 @@ def _extract_content(raw_content) -> tuple[str, str | None]:
     return "".join(text_parts), "".join(thinking_parts) if thinking_parts else None
 
 
+def _default_env_file() -> str:
+    """Default .env path (PROJECT_ROOT/.env) used when callers pass no env_file.
+
+    Module-level indirection (rather than inlining the path in
+    ``_persist_to_env`` / ``_remove_from_env``) so the test suite can
+    monkeypatch a single seam and redirect default-path writes away from
+    the developer's real .env.
+    """
+    return str(Path(__file__).resolve().parent.parent.parent / ".env")
+
+
 def _persist_to_env(env_key: str, value: str, env_file: str = "") -> None:
     """Persist an environment variable to .env and os.environ.
 
@@ -224,7 +235,7 @@ def _persist_to_env(env_key: str, value: str, env_file: str = "") -> None:
         raise ValueError(f"Invalid env key name: {env_key}")
 
     if not env_file:
-        env_file = str(Path(__file__).resolve().parent.parent.parent / ".env")
+        env_file = _default_env_file()
 
     # Quote to prevent python-dotenv from mangling values.
     # Single quotes: no interpolation, no escape processing — safest.
@@ -277,7 +288,7 @@ def _persist_to_env(env_key: str, value: str, env_file: str = "") -> None:
 def _remove_from_env(env_key: str, env_file: str = "") -> None:
     """Remove an environment variable from .env and os.environ."""
     if not env_file:
-        env_file = str(Path(__file__).resolve().parent.parent.parent / ".env")
+        env_file = _default_env_file()
 
     env_path = Path(env_file)
     if env_path.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,22 @@ import pytest
 # whole session. The test session unconditionally needs the bypass.
 os.environ["OPENLEGION_SKIP_TRUST_TIER_BOOT_GATE"] = "1"
 
+# Keep litellm from autoloading the repo .env during collection.
+# ``import litellm`` (pulled in transitively when test modules import)
+# calls ``load_dotenv()`` unless ``LITELLM_MODE=PRODUCTION``. On a dev
+# machine with a real .env (OAuth creds, wallet seed) that leaks the
+# developer's real credentials into ``os.environ`` before any test
+# runs — ``CredentialVault._load_credentials()`` then picks them up,
+# making local runs diverge from CI (which has no .env) and letting
+# real OAuth-only creds flip vault-behavior tests (e.g. the BYOK
+# provider-validation gate).
+#
+# ``setdefault`` (not hard assignment) — a runner that deliberately
+# wants litellm's dev-mode dotenv loading can still override. The e2e
+# files call ``load_dotenv()`` themselves at module level, so explicit
+# e2e runs with real keys keep working.
+os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
+
 # Time-returning helpers consumed by ``src.browser.service`` via
 # ``from src.browser.timing import X``. ``scroll_increment`` and
 # ``scroll_ramp`` are intentionally excluded — they return pixel counts
@@ -83,6 +99,26 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "real_timing: opt out of the autouse fast-timing fixture and use "
         "the real human-pacing delays from src.browser.timing.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_env_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect the credential vault's default .env writes to a temp file.
+
+    Tests must never touch the developer's real .env — it holds real
+    credentials (OAuth tokens, wallet seed), and a crash mid-test
+    corrupts it. ``_persist_to_env`` / ``_remove_from_env`` default to
+    PROJECT_ROOT/.env when called without an explicit ``env_file``, so
+    any test exercising the vault's persistence paths with the default
+    would rewrite the real file. Patching ``_default_env_file`` sends
+    those writes to a per-test temp file instead; tests that pass an
+    explicit ``env_file`` are unaffected.
+    """
+    from src.host import credentials as cred_mod
+
+    monkeypatch.setattr(
+        cred_mod, "_default_env_file", lambda: str(tmp_path / "test.env")
     )
 
 


### PR DESCRIPTION
Two leaks made local test runs diverge from CI and put the developer's real credentials file at risk:

**Read leak** — `import litellm` (pulled in transitively during collection) calls `load_dotenv()` unless `LITELLM_MODE=PRODUCTION`. On a dev machine with a real `.env` (OAuth creds, wallet seed), those load into `os.environ`, `CredentialVault` picks them up, and 28 tests fail locally that pass in CI (21 in test_credentials.py from ambient OAuth state, 7 in test_templates.py from the BYOK provider-validation gate tripping on OAuth-only creds). Fix: conftest sets `LITELLM_MODE=PRODUCTION` via `setdefault` before collection. The e2e files call `load_dotenv()` themselves at module level, so explicit e2e runs with real keys still work.

**Write leak** — `_persist_to_env` / `_remove_from_env` default to PROJECT_ROOT/.env, so tests exercising the real vault (e.g. test_integration.py's `add_credential`) rewrote the developer's actual `.env` on every sweep (observed via mtime). Fix: the default path is extracted into `_default_env_file()` and an autouse fixture redirects it to a per-test temp file. Tests passing an explicit `env_file` are unaffected.

Verification: full sweep before fix `28 failed, 7310 passed`; after fix `7338 passed, 28 skipped` with no `.env` created in the repo root and the real `.env` mtime unchanged.