### PR TITLE
fix(quality): dismantle the depth-compression pipeline (Workstream B)

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -32,6 +32,12 @@ logger = setup_logging("agent.builtins.coordination_tool")
 # only the artifact_ref, keeping the SQLite table small.
 _HANDOFF_TTL = 86_400  # 24 hours — safety net for unprocessed handoffs
 
+# Cap on the inline handoff ``brief``. The brief becomes the task
+# description AND is delivered inline in the recipient's wake message
+# (mesh-side enrichment), so it must stay bounded — long-form payloads
+# belong in ``data`` (blackboard) or artifacts.
+_MAX_BRIEF_CHARS = 6_000
+
 # Mirrors ``host/orchestration.TERMINAL_STATUSES`` — the set of statuses
 # that a task can no longer transition out of. Defined locally so the
 # coordination tool stays decoupled from host internals.
@@ -116,17 +122,22 @@ _RESERVED_ENVELOPE_KEYS: frozenset[str] = frozenset(
         "Keep the 'summary' SHORT — it becomes the task title in the "
         "recipient's inbox and on the dashboard. Aim for ≤80 characters, "
         "like a Git commit subject line. Examples: 'Draft Q3 launch brief' "
-        "or 'Review pricing change for SKU-123'. If you need to send a "
-        "full instruction or spec, put it in 'data' (JSON) — that's where "
-        "long context belongs. A long summary will still work (the system "
-        "auto-splits it into a short title + description) but a hand-"
-        "written short summary reads better.\n\n"
-        "If you have output data to share, pass it as 'data' (JSON string). "
-        "It will be written to the blackboard and the task will include a "
-        "pointer so the recipient can read it. For lightweight handoffs "
-        "where the summary is enough context, omit 'data'.\n\n"
+        "or 'Review pricing change for SKU-123'.\n\n"
+        "For any non-trivial handoff, ALWAYS pass 'brief'. The recipient "
+        "does NOT see your conversation — they start from only what you "
+        "send, so a one-line summary with no brief produces shallow work. "
+        "Write the brief as markdown covering: the objective, background "
+        "the recipient lacks (who asked and why, constraints, what you "
+        "already know), success criteria, and the expected deliverable "
+        "(form, depth, where to save it). The brief is delivered to the "
+        "recipient together with the task.\n\n"
+        "If you have structured output data to share, pass it as 'data' "
+        "(JSON string). It will be written to the blackboard and the task "
+        "will include a pointer so the recipient can read it. For "
+        "lightweight handoffs where the summary is enough context, omit "
+        "'data' and 'brief'.\n\n"
         "The target agent sees the task in their inbox (via check_inbox) "
-        "with your summary and a pointer to your output."
+        "with your summary, your brief, and a pointer to your output."
     ),
     parameters={
         "to": {
@@ -141,20 +152,31 @@ _RESERVED_ENVELOPE_KEYS: frozenset[str] = frozenset(
                 "Put long instructions in 'data', not here."
             ),
         },
+        "brief": {
+            "type": "string",
+            "description": (
+                "Full markdown brief for the recipient: objective, "
+                "background they lack, success criteria, expected "
+                "deliverable form and depth. Delivered with the task. "
+                "Strongly recommended for any non-trivial handoff "
+                "(max 6,000 chars)."
+            ),
+            "default": "",
+        },
         "data": {
             "type": "string",
             "description": (
-                "Optional JSON string of output data or a full instruction "
-                "for the recipient. Written to the blackboard so the "
-                "recipient can read the full details. This is where long "
-                "context belongs — keep 'summary' to a short title."
+                "Optional JSON string of structured output data for the "
+                "recipient. Written to the blackboard so the recipient "
+                "can read the full details. Use 'brief' for instructions "
+                "and context; use 'data' for payloads."
             ),
             "default": "",
         },
     },
 )
 async def hand_off(
-    to: str, summary: str, data: str = "", *, mesh_client=None,
+    to: str, summary: str, brief: str = "", data: str = "", *, mesh_client=None,
 ) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
@@ -164,14 +186,18 @@ async def hand_off(
         return {"error": f"Invalid agent ID: '{to}'"}
 
     summary = sanitize_for_prompt(summary)
-    # The handoff ``summary`` carries both the headline (becomes the
-    # task title) and the full instruction (becomes the description).
-    # Agents historically dumped multi-sentence instructions into
-    # ``summary`` — that produced wall-of-text titles in the dashboard.
-    # ``Tasks.create`` applies the same policy as a backstop, but we
-    # mirror it here so the title we surface in result envelopes, wake
-    # messages, and downstream logs is already short.
-    if len(summary) > LONG_TITLE_THRESHOLD:
+    brief = sanitize_for_prompt(brief)[:_MAX_BRIEF_CHARS] if brief.strip() else ""
+    # The handoff ``summary`` carries the headline (becomes the task
+    # title); the full instruction belongs in ``brief`` (becomes the
+    # description, and the mesh delivers it inline in the recipient's
+    # wake message). Agents historically dumped multi-sentence
+    # instructions into ``summary`` — that produced wall-of-text titles
+    # in the dashboard. ``Tasks.create`` applies the same policy as a
+    # backstop, but we mirror it here so the title we surface in result
+    # envelopes, wake messages, and downstream logs is already short.
+    if brief:
+        title, description = normalize_title_and_description(summary, brief)
+    elif len(summary) > LONG_TITLE_THRESHOLD:
         title, description = normalize_title_and_description(summary, None)
     else:
         title = summary

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -173,10 +173,21 @@ _RESERVED_ENVELOPE_KEYS: frozenset[str] = frozenset(
             ),
             "default": "",
         },
+        "thinking": {
+            "type": "string",
+            "description": (
+                "Optional reasoning depth for this task: 'high' for deep "
+                "analysis/research/audits, 'medium', 'low', or 'off'. "
+                "Omit to use the recipient's configured default. Use "
+                "'high' whenever the deliverable needs depth, not speed."
+            ),
+            "default": "",
+        },
     },
 )
 async def hand_off(
-    to: str, summary: str, brief: str = "", data: str = "", *, mesh_client=None,
+    to: str, summary: str, brief: str = "", data: str = "",
+    thinking: str = "", *, mesh_client=None,
 ) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
@@ -187,6 +198,14 @@ async def hand_off(
 
     summary = sanitize_for_prompt(summary)
     brief = sanitize_for_prompt(brief)[:_MAX_BRIEF_CHARS] if brief.strip() else ""
+    thinking = (thinking or "").strip().lower()
+    if thinking and thinking not in ("off", "low", "medium", "high"):
+        return {
+            "error": (
+                f"Invalid thinking level {thinking!r} — use "
+                "'off', 'low', 'medium', or 'high' (or omit it)."
+            ),
+        }
     # The handoff ``summary`` carries the headline (becomes the task
     # title); the full instruction belongs in ``brief`` (becomes the
     # description, and the mesh delivers it inline in the recipient's
@@ -344,6 +363,7 @@ async def hand_off(
             parent_task_id=parent_task_id,
             artifact_refs=[artifact_ref] if artifact_ref else None,
             origin=origin,
+            thinking=thinking or None,
         )
     except Exception as e:
         # Bug H: operator hit a live case where seo-strategist called

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -197,6 +197,9 @@ async def hand_off(
         return {"error": f"Invalid agent ID: '{to}'"}
 
     summary = sanitize_for_prompt(summary)
+    # ``or ""`` — models emit explicit ``brief: null``, which arrives
+    # here as None (same defense the ``thinking`` line below uses).
+    brief = brief or ""
     brief = sanitize_for_prompt(brief)[:_MAX_BRIEF_CHARS] if brief.strip() else ""
     thinking = (thinking or "").strip().lower()
     if thinking and thinking not in ("off", "low", "medium", "high"):

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1085,6 +1085,54 @@ async def workflow_snapshot(
     return result
 
 
+@tool(
+    name="inspect_task_run",
+    operator_only=True,
+    description=(
+        "Diagnose HOW a task actually executed — use this when a "
+        "deliverable came out shallow, wrong, or late and you need to "
+        "know why before fixing anything. Returns the task record "
+        "(thinking level, blocker note, outcome/feedback), the status-"
+        "transition timeline, and an execution summary from traces: "
+        "LLM call count, total tokens, models used, and error events "
+        "during the run. Read it for the common failure shapes: very "
+        "few LLM calls + low tokens on a deep task = the worker "
+        "finished too early (re-dispatch with a fuller brief and "
+        "thinking='high'); trace errors = tooling/infra trouble; "
+        "thinking=null on analysis work = depth was never requested. "
+        "Trace numbers are window-scoped to the assignee, so "
+        "concurrent activity in the window is included."
+    ),
+    parameters={
+        "task_id": {
+            "type": "string",
+            "description": "Task id to diagnose",
+        },
+    },
+)
+async def inspect_task_run(
+    task_id: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Operator-only per-task execution diagnostics via mesh endpoint."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    try:
+        result = await mesh_client.get_task_run(task_id)
+    except Exception as e:
+        return {
+            "error": f"Failed to read task run: {e}",
+            "task_id": task_id,
+        }
+    if result is None:
+        return {"error": "not_found", "task_id": task_id}
+    return result
+
+
 # Each task-status poll is wrapped in
 # ``asyncio.wait_for(..., _AWAIT_TASK_EVENT_POLL_BUDGET_S)`` so a stuck HTTP
 # retry chain (``_get_with_retry`` worst-case ≈ 90s with 3×30s attempts)

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -746,7 +746,7 @@ class ContextManager:
             return self._hard_prune(messages)
         if len(chunks) > _SUMMARIZATION_MAX_CHUNKS:
             # Pathological volume: keep the first chunk (original ask / early
-            # framing) plus the newest chunks, and say so in the summary.
+            # framing) plus the newest chunks; the omission is logged only.
             omitted = len(chunks) - _SUMMARIZATION_MAX_CHUNKS
             logger.warning(
                 f"Compaction input spans {len(chunks)} chunks; "

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -31,7 +31,10 @@ _WARNING_THRESHOLD = 0.80  # warn agent to wrap up or save facts
 
 _encoding_cache: dict[str, object | None] = {}
 
-_SUMMARIZATION_INPUT_LIMIT = 20_000  # max chars fed to the summarization LLM call
+_SUMMARIZATION_INPUT_LIMIT = 20_000  # max chars per summarization LLM call (chunk size)
+_SUMMARIZATION_MAX_CHUNKS = 8        # cap on summarization calls per compaction
+_SUMMARY_FOLD_THRESHOLD = 12_000     # combined partial summaries above this get folded once
+_TOOL_RESULT_SUMMARY_CHARS = 2_000   # per tool-result slice fed to the compaction summarizer
 
 _CONSOLIDATION_MIN_INTERVAL_S = 6 * 3600   # at most every 6 hours
 _CONSOLIDATION_MIN_LOG_CHARS = 1_500       # skip if little new material accrued
@@ -722,43 +725,70 @@ class ContextManager:
         older_groups = groups[: len(groups) - len(recent_groups)]
 
         older_messages = [m for g in older_groups for m in g]
-        conversation_text = self._messages_to_text(older_messages)
 
-        summary_prompt = (
+        # Chunked summarization: the legacy shape fed only the FIRST 20k chars
+        # of the older history (and 200 chars per tool result) to a single
+        # summarization call and silently discarded the rest — on research
+        # tasks that orphaned most gathered data right before synthesis.
+        # Instead, pack the older history into ≤20k chunks at message
+        # boundaries, summarize each, and stitch the partials.
+        base_instruction = (
             "Summarize this conversation concisely, preserving key context "
             "the assistant needs to continue helpfully. Include: what was discussed, "
-            "what actions were taken, what's pending, and any user preferences revealed.\n\n"
-            f"Conversation:\n{conversation_text[:_SUMMARIZATION_INPUT_LIMIT]}"
+            "what actions were taken, what's pending, and any user preferences revealed. "
+            "Preserve concrete data points the assistant gathered (names, numbers, "
+            "metrics, URLs, findings) — they cannot be recovered after compaction."
         )
+        chunks = self._chunk_message_texts(
+            older_messages, _SUMMARIZATION_INPUT_LIMIT, _TOOL_RESULT_SUMMARY_CHARS,
+        )
+        if not chunks:
+            return self._hard_prune(messages)
+        if len(chunks) > _SUMMARIZATION_MAX_CHUNKS:
+            # Pathological volume: keep the first chunk (original ask / early
+            # framing) plus the newest chunks, and say so in the summary.
+            omitted = len(chunks) - _SUMMARIZATION_MAX_CHUNKS
+            logger.warning(
+                f"Compaction input spans {len(chunks)} chunks; "
+                f"omitting {omitted} middle chunk(s)"
+            )
+            chunks = [chunks[0]] + chunks[-(_SUMMARIZATION_MAX_CHUNKS - 1):]
 
-        last_err = None
-        summary = None
-        for attempt in range(self._SUMMARIZE_RETRIES + 1):
-            try:
-                response = await self.llm.chat(
-                    system="You produce concise conversation summaries.",
-                    messages=[{"role": "user", "content": summary_prompt}],
-                    max_tokens=1024,
-                    temperature=0.3,
+        if len(chunks) == 1:
+            summary = await self._summarize_text(
+                f"{base_instruction}\n\nConversation:\n{chunks[0]}"
+            )
+            if summary is None:
+                logger.warning("Summarization unavailable, falling back to hard prune")
+                return self._hard_prune(messages)
+        else:
+            partials: list[str] = []
+            for i, chunk in enumerate(chunks):
+                part = await self._summarize_text(
+                    f"{base_instruction}\n\n"
+                    f"This is part {i + 1} of {len(chunks)} of the conversation "
+                    f"(chronological order).\n\nConversation:\n{chunk}"
                 )
-                summary = response.content.strip()
-                if not summary:
-                    logger.warning("Summarization returned empty response, falling back to hard prune")
+                if part is None:
+                    logger.warning("Chunk summarization unavailable, falling back to hard prune")
                     return self._hard_prune(messages)
-                break
-            except Exception as e:
-                last_err = e
-                if attempt < self._SUMMARIZE_RETRIES:
-                    wait = self._SUMMARIZE_BACKOFF * (2 ** attempt)
-                    logger.warning(
-                        f"Summarization failed (attempt {attempt + 1}/{self._SUMMARIZE_RETRIES + 1}), "
-                        f"retrying in {wait}s: {e}"
-                    )
-                    await asyncio.sleep(wait)
-                else:
-                    logger.warning(f"Summarization failed after {self._SUMMARIZE_RETRIES + 1} attempts, "
-                                   f"falling back to hard prune: {last_err}")
-                    return self._hard_prune(messages)
+                partials.append(part)
+            summary = "\n\n".join(
+                f"### Part {i + 1} of {len(partials)}\n{p}"
+                for i, p in enumerate(partials)
+            )
+            if len(summary) > _SUMMARY_FOLD_THRESHOLD:
+                folded = await self._summarize_text(
+                    "Merge these sequential summaries of one conversation into a "
+                    "single coherent summary. Preserve concrete data points "
+                    "(names, numbers, metrics, URLs, findings), decisions, and "
+                    "pending work.\n\n" + summary,
+                    max_tokens=2048,
+                )
+                # Fold failure is non-fatal: the unfolded partials are valid,
+                # just longer.
+                if folded:
+                    summary = folded
 
         # M2: sanitize the LLM-produced summary before re-injecting it into the
         # context window, for Unicode-hygiene uniformity with the memory /
@@ -865,8 +895,15 @@ class ContextManager:
         return pruned
 
     @staticmethod
-    def _messages_to_text(messages: list[dict]) -> str:
-        """Convert messages to readable text for summarization."""
+    def _messages_to_text(messages: list[dict], tool_chars: int = 200) -> str:
+        """Convert messages to readable text for summarization.
+
+        ``tool_chars`` bounds each tool-result slice. The default keeps the
+        fact-extraction path cheap; the compaction summarizer passes a much
+        larger bound because tool results are where gathered data (research
+        findings, fetched pages, query output) lives — over-truncating them
+        here is unrecoverable data loss for the post-compaction conversation.
+        """
         parts: list[str] = []
         for msg in messages:
             role = msg.get("role", "unknown")
@@ -879,10 +916,68 @@ class ContextManager:
                     if isinstance(b, dict) and b.get("type") == "text"
                 )
             if role == "tool":
-                content = content[:200]
+                content = content[:tool_chars]
             if content:
                 parts.append(f"[{role}]: {content}")
         return "\n\n".join(parts)
+
+    @classmethod
+    def _chunk_message_texts(
+        cls, messages: list[dict], chunk_size: int, tool_chars: int,
+    ) -> list[str]:
+        """Render messages to text and pack them into ≤``chunk_size`` chunks.
+
+        Chunk boundaries fall between messages so no message is split across
+        summarization calls (a single oversized message is truncated to fit).
+        """
+        chunks: list[str] = []
+        current: list[str] = []
+        current_len = 0
+        for msg in messages:
+            piece = cls._messages_to_text([msg], tool_chars=tool_chars)
+            if not piece:
+                continue
+            if len(piece) > chunk_size:
+                piece = piece[:chunk_size]
+            if current and current_len + len(piece) + 2 > chunk_size:
+                chunks.append("\n\n".join(current))
+                current = []
+                current_len = 0
+            current.append(piece)
+            current_len += len(piece) + 2
+        if current:
+            chunks.append("\n\n".join(current))
+        return chunks
+
+    async def _summarize_text(self, prompt: str, max_tokens: int = 1024) -> str | None:
+        """One summarization LLM call with retry/backoff.
+
+        Returns the stripped summary, or None on persistent failure or an
+        empty response (callers decide the fallback).
+        """
+        last_err: Exception | None = None
+        for attempt in range(self._SUMMARIZE_RETRIES + 1):
+            try:
+                response = await self.llm.chat(
+                    system="You produce concise conversation summaries.",
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=max_tokens,
+                    temperature=0.3,
+                )
+                return response.content.strip() or None
+            except Exception as e:
+                last_err = e
+                if attempt < self._SUMMARIZE_RETRIES:
+                    wait = self._SUMMARIZE_BACKOFF * (2 ** attempt)
+                    logger.warning(
+                        f"Summarization failed (attempt {attempt + 1}/{self._SUMMARIZE_RETRIES + 1}), "
+                        f"retrying in {wait}s: {e}"
+                    )
+                    await asyncio.sleep(wait)
+        logger.warning(
+            f"Summarization failed after {self._SUMMARIZE_RETRIES + 1} attempts: {last_err}"
+        )
+        return None
 
 
 def _now_str() -> str:

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -66,6 +66,12 @@ class LLMClient:
         self.default_model = default_model
         self.embedding_model = embedding_model
         self.thinking = thinking
+        # B4 — per-task reasoning override. Set by the agent loop for the
+        # duration of a single handoff turn when the task record carries
+        # an explicit thinking level; None falls back to ``self.thinking``.
+        # Turn execution is serialized (chat lock / busy guard) so a plain
+        # attribute is safe here.
+        self.thinking_override: str | None = None
         # Default output-token cap for chat()/chat_stream() when the caller
         # doesn't pass max_tokens explicitly. Configurable per-agent via the
         # LLM_MAX_TOKENS env var (see __main__.py) and hot-reloadable via the
@@ -122,7 +128,8 @@ class LLMClient:
 
     def _get_thinking_params(self, model: str | None = None) -> dict:
         """Build provider-specific thinking/reasoning parameters."""
-        if self.thinking == "off":
+        level = self.thinking_override or self.thinking
+        if level == "off":
             return {}
         m = model or self.default_model
         if m.startswith("openrouter/"):
@@ -130,7 +137,7 @@ class LLMClient:
         if m.startswith("openlegion/"):
             m = m[len("openlegion/"):]
         if m.startswith("anthropic/"):
-            budget = self._THINKING_BUDGETS.get(self.thinking, 10_000)
+            budget = self._THINKING_BUDGETS.get(level, 10_000)
             # Anthropic requires max_tokens > budget_tokens; ensure enough room
             # for both thinking and output text. Honour the configured output
             # cap so the per-agent max_output_tokens lever is meaningful for
@@ -145,7 +152,7 @@ class LLMClient:
                 "max_tokens": max(self.max_output_tokens, budget + 4096),
             }
         if m.startswith("openai/o") or m.startswith("o1") or m.startswith("o3") or m.startswith("o4"):
-            return {"reasoning_effort": self.thinking}
+            return {"reasoning_effort": level}
         return {}
 
     def _apply_thinking_params(self, params: dict, model: str | None, kwargs: dict) -> None:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2867,6 +2867,10 @@ class AgentLoop:
                 # it handles any auto-transition, not just terminal ones.
                 if task_id:
                     await self._auto_close_task(task_id, "working")
+                    # B4: honour a per-task reasoning depth carried on the
+                    # task record (hand_off thinking="high"). Cleared in
+                    # the outer finally so it never outlives this turn.
+                    await self._apply_task_thinking(task_id)
                 try:
                     try:
                         result = await self._chat_inner(user_message)
@@ -3126,6 +3130,24 @@ class AgentLoop:
         finally:
             current_origin.reset(origin_token)
             current_task_id.reset(task_id_token)
+            self.llm.thinking_override = None
+
+    async def _apply_task_thinking(self, task_id: str) -> None:
+        """B4: read the task's ``thinking`` column and pin it as the LLM
+        reasoning level for this turn. Best-effort — a lookup failure or
+        an absent/invalid level just keeps the agent's configured default.
+        """
+        try:
+            record = await self.mesh_client.get_task(task_id)
+        except Exception as e:
+            logger.debug("task thinking lookup failed for %s: %s", task_id, e)
+            return
+        level = (record or {}).get("thinking")
+        if level and level in self.llm.VALID_THINKING_LEVELS:
+            self.llm.thinking_override = level
+            logger.info(
+                "Applying per-task thinking=%s for task %s", level, task_id,
+            )
 
     async def _auto_close_task(
         self, task_id: str, status: str, *,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1892,6 +1892,12 @@ class AgentLoop:
                 "- Use notify_user for the user; blackboard for other agents only.\n"
             )
         rules += (
+            "- Long-form deliverables (reports, audits, plans, research): "
+            "append findings to a working-notes file via write_file AS YOU "
+            "WORK (notes survive context compaction), then save the FULL "
+            "document with save_artifact. Reference the artifact in your "
+            "final JSON and notify_user — never shrink the deliverable "
+            "itself into a summary.\n"
             f"- You have max {self.MAX_ITERATIONS} iterations.\n"
             f"- Use update_workspace to evolve your SOUL.md, INSTRUCTIONS.md, "
             f"USER.md, and HEARTBEAT.md over time.\n"
@@ -4516,6 +4522,12 @@ class AgentLoop:
             "there is genuinely nothing to do). A plain-text reply with no "
             "tool call and no {\"result\": {...}} envelope auto-closes the "
             "task as failed (no_outbound_effects).\n"
+            "- Long-form deliverables (reports, audits, plans, research): "
+            "append findings to a working-notes file via write_file AS YOU "
+            "WORK (notes survive context compaction), then save the FULL "
+            "document with save_artifact. Reference the artifact in your "
+            "final answer — never shrink the deliverable itself into a "
+            "summary.\n"
             "- Before answering from memory, run memory_search first.\n"
             "- Use update_workspace to save lasting knowledge and user preferences.\n"
         )

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -203,6 +203,10 @@ _HEARTBEAT_TOOLS = frozenset({
     # for drill-ins; without it the prompted procedure is denied by
     # this allowlist (caught by Codex pre-merge review of PR 972).
     "inspect_agents",
+    # B5 — read-only per-task execution diagnostics. Lets the heartbeat's
+    # rate-stale-deliverables step look at HOW a task ran (tokens, LLM
+    # calls, thinking, trace errors) before grading it.
+    "inspect_task_run",
 })
 
 # Tool calls whose ONLY purpose is to read state — they don't produce

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1349,6 +1349,7 @@ class MeshClient:
         dependencies: list[str] | None = None,
         artifact_refs: list[str] | None = None,
         origin: "MessageOrigin | None" = None,
+        thinking: str | None = None,
     ) -> dict:
         """Create a durable task. Returns the new task record.
 
@@ -1356,6 +1357,8 @@ class MeshClient:
         receiving agent's lane worker can attribute task completion back
         to the originating channel/user. Without this, ``hand_off`` v2
         loses the origin a sibling ``wake_agent`` call still carries.
+        ``thinking`` (B4) pins a per-task reasoning depth
+        (off/low/medium/high) for the assignee while executing this task.
         """
         client = await self._get_client()
         body: dict = {
@@ -1373,6 +1376,8 @@ class MeshClient:
             body["dependencies"] = dependencies
         if artifact_refs is not None:
             body["artifact_refs"] = artifact_refs
+        if thinking is not None:
+            body["thinking"] = thinking
         headers = self._trace_headers()
         if origin is not None:
             headers.update(origin_header(origin))

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1411,6 +1411,16 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def get_task_run(self, task_id: str) -> dict | None:
+        """Operator-tier per-task execution diagnostics. ``None`` on 404."""
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/tasks/{task_id}/run",
+        )
+        if response.status_code == 404:
+            return None
+        _raise_with_body(response)
+        return response.json()
+
     async def read_user_notifications(
         self, hours: float = 24, limit: int = 50,
     ) -> dict:

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -1225,6 +1225,13 @@ exchanges when the window fills, but first flushes important facts to
 MEMORY.md (write-then-compact). To reduce cost: be concise, avoid
 unnecessary tool calls, and save important facts to memory early.
 
+**Deep work pattern** — On research-heavy or long-form tasks, raw tool
+results (fetched pages, query output, data pulls) are summarized away
+when the window compacts. Append findings to a working-notes file
+(write_file) as you gather them, then write the final deliverable from
+your notes and save it with save_artifact. Notes and artifacts live on
+disk — they survive compaction; conversation history does not.
+
 **Tool calls** — Each tool round costs a full LLM call (system prompt +
 entire history re-sent). Batching multiple actions in one response is
 cheaper than one action per turn. The system detects repeated identical
@@ -1334,6 +1341,13 @@ turn. Longer history = more tokens = higher cost. The system trims old
 exchanges when the window fills, but first flushes important facts to
 MEMORY.md (write-then-compact). To reduce cost: be concise, avoid
 unnecessary tool calls, and save important facts to memory early.
+
+**Deep work pattern** — On research-heavy or long-form tasks, raw tool
+results (fetched pages, query output, data pulls) are summarized away
+when the window compacts. Append findings to a working-notes file
+(write_file) as you gather them, then write the final deliverable from
+your notes and save it with save_artifact. Notes and artifacts live on
+disk — they survive compaction; conversation history does not.
 
 **Tool calls** — Each tool round costs a full LLM call (system prompt +
 entire history re-sent). Batching multiple actions in one response is

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -320,6 +320,21 @@ class WorkspaceManager:
                 f.write("\n<!-- playbook_v2 -->\n")
             logger.info("Marked operator instructions as playbook-aware (v2)")
 
+        # Migration v3 (handoff briefs): existing operator instructions
+        # predate the `brief` guidance. Same append-only contract as v2 —
+        # the addendum block carries its own sentinel so this runs once.
+        if (
+            instructions_file.exists()
+            and self._initial_instructions
+            and "<!-- playbook_v3_handoff_briefs -->" in self._initial_instructions
+            and "<!-- playbook_v3_handoff_briefs -->"
+            not in instructions_file.read_text(errors="replace")
+        ):
+            from src.shared.operator_playbooks import _PLAYBOOK_V3_ADDENDUM
+            with open(instructions_file, "a") as f:
+                f.write("\n" + _PLAYBOOK_V3_ADDENDUM + "\n")
+            logger.info("Appended handoff-brief guidance to operator instructions (v3)")
+
         for filename, default_content in _SCAFFOLD_FILES.items():
             path = self.root / filename
             if not path.exists():

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1718,6 +1718,10 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # blocking primitive (see _HEARTBEAT_TOOLS in src/agent/loop.py for
     # the heartbeat surface; both tools self-reject for non-operators).
     "workflow_snapshot", "await_task_event",
+    # Per-task execution diagnostics (B5) — answers "why did this come
+    # out shallow/wrong": thinking level, token/LLM-call counts, trace
+    # errors, status timeline. Pairs with rate_delivery on rework.
+    "inspect_task_run",
     # Configuration edits — edit_agent applies every field immediately
     # and emits an undo receipt (5min for soft fields, 30min for hard).
     # undo_change lets the operator self-revert within the TTL.
@@ -1807,6 +1811,9 @@ _OPERATOR_HEARTBEAT_TOOLS: list[str] = [
     # heartbeat procedure but missing from this allowlist; added so
     # the runtime gate stops denying the prompted call.
     "inspect_agents",
+    # B5 — read-only per-task run diagnostics (tokens, LLM calls,
+    # thinking, trace errors) so rating decisions can be informed.
+    "inspect_task_run",
 ]
 
 _OPERATOR_SOUL = """\

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11274,6 +11274,7 @@ function dashboard() {
         compose_work_summary: 'composing a work summary',
         workflow_snapshot: 'mapping the workflow',
         await_task_event: 'waiting on a task',
+        inspect_task_run: 'diagnosing a task run',
         skills_list: 'browsing its skills',
         skill_view: 'reading a skill',
         install_skill: 'installing a skill',

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -398,6 +398,9 @@ class Tasks:
                 ("feedback_text", "TEXT"),
                 ("previous_task_id", "TEXT"),
                 ("result_summary", "TEXT"),
+                # B4 — per-task reasoning depth ("off"/"low"/"medium"/
+                # "high", NULL = use the assignee's configured default).
+                ("thinking", "TEXT"),
             )
             for col_name, col_type in outcome_columns:
                 if col_name not in existing:
@@ -726,6 +729,7 @@ class Tasks:
             "previous_task_id": row[21],
             "outcome_set_at": row[22],
             "result_summary": row[23],
+            "thinking": row[24],
         }
 
     # ``{team_col}`` is filled in at query time from ``self._team_col``
@@ -738,7 +742,7 @@ class Tasks:
         "blocker_note, origin_kind, origin_channel, origin_user, "
         "created_at, updated_at, completed_at, retention_until, "
         "outcome, feedback_text, previous_task_id, outcome_set_at, "
-        "result_summary"
+        "result_summary, thinking"
     )
 
     @property
@@ -811,6 +815,7 @@ class Tasks:
         artifact_refs: list[str] | None = None,
         origin: dict | None = None,
         task_id: str | None = None,
+        thinking: str | None = None,
     ) -> dict:
         """Insert a task. Returns the public record dict.
 
@@ -819,7 +824,16 @@ class Tasks:
         same shape :class:`MessageOrigin` produces; passing the typed
         Pydantic model is the caller's responsibility (use
         ``model_dump()`` or unpack as needed).
+        ``thinking`` (B4) pins a per-task reasoning depth for the
+        assignee's LLM calls while executing this task; NULL means the
+        assignee's configured default applies.
         """
+        if thinking is not None and thinking not in (
+            "off", "low", "medium", "high",
+        ):
+            raise ValueError(
+                f"thinking must be off/low/medium/high, got {thinking!r}"
+            )
         # Strip leading/trailing whitespace before any further checks so
         # a whitespace-only title (audit edge case: 200 spaces) is
         # rejected the same way as an empty string. Without this the
@@ -878,16 +892,16 @@ class Tasks:
                 f"creator, assignee, status, priority, dependencies_json, "
                 f"artifact_refs_json, blocker_note, origin_kind, "
                 f"origin_channel, origin_user, created_at, updated_at, "
-                f"completed_at, retention_until) "
+                f"completed_at, retention_until, thinking) "
                 f"VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, NULL, "
-                f"?, ?, ?, ?, ?, NULL, NULL)",
+                f"?, ?, ?, ?, ?, NULL, NULL, ?)",
                 (
                     tid, project_id, parent_task_id, title, description,
                     creator, assignee, priority,
                     json.dumps(dependencies) if dependencies else None,
                     json.dumps(artifact_refs) if artifact_refs else None,
                     kind, channel, user,
-                    now, now,
+                    now, now, thinking,
                 ),
             )
             self._emit_event(

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5723,6 +5723,93 @@ def create_mesh_app(
             )
         return snapshot
 
+    @app.get("/mesh/tasks/{task_id}/run")
+    async def get_task_run(task_id: str, request: Request) -> dict:
+        """Operator diagnostics for a single task run (B5).
+
+        Answers "why did this come out the way it did": the task record
+        (thinking level, blocker note, outcome), the durable
+        ``task_events`` timeline, and an execution summary aggregated
+        from the trace store — LLM call count, total tokens, models
+        used, and any error-status trace events for the assignee within
+        the task's lifetime window. The trace slice is time-window
+        scoped (traces are keyed by trace_id, not task_id), so
+        concurrent activity by the same agent in the window is included
+        — treat the numbers as the agent's activity DURING the task,
+        not a strict per-task ledger. Operator-only.
+        """
+        caller = _extract_verified_agent_id(request)
+        if not (
+            _caller_is_operator(caller, request)
+            or _is_internal_caller(request)
+        ):
+            raise HTTPException(403, "task run inspection is operator-only")
+        record = tasks_store.get(task_id)
+        if record is None:
+            raise HTTPException(404, f"Task '{task_id}' not found")
+        events = tasks_store.list_events(task_id)
+
+        started = record.get("created_at")
+        ended = record.get("completed_at") or time.time()
+        llm_calls = 0
+        tokens_used = 0
+        models: set[str] = set()
+        trace_errors: list[dict] = []
+        if trace_store is not None and record.get("assignee") and started:
+            try:
+                rows = trace_store.query(
+                    agent=record["assignee"],
+                    since=started - 5,
+                    until=ended + 5,
+                    limit=1000,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("task run trace query failed: %s", e)
+                rows = []
+            for ev in rows:
+                meta = ev.get("meta") or {}
+                if ev.get("event_type") in ("llm_call", "llm_stream"):
+                    llm_calls += 1
+                    t = meta.get("tokens_used")
+                    if isinstance(t, (int, float)):
+                        tokens_used += int(t)
+                    m = meta.get("model")
+                    if m:
+                        models.add(str(m))
+                if ev.get("status") == "error" or ev.get("error"):
+                    trace_errors.append({
+                        "event_type": ev.get("event_type", ""),
+                        "error": (ev.get("error") or "")[:200],
+                        "timestamp": ev.get("timestamp"),
+                    })
+
+        duration_s = (
+            round(ended - started, 1) if started else None
+        )
+        return {
+            "task": {
+                k: record.get(k)
+                for k in (
+                    "id", "title", "status", "assignee", "creator",
+                    "thinking", "blocker_note", "outcome", "feedback_text",
+                    "result_summary", "created_at", "completed_at",
+                    "parent_task_id", "previous_task_id",
+                )
+            },
+            "execution": {
+                "duration_seconds": duration_s,
+                "llm_calls": llm_calls,
+                "tokens_used": tokens_used,
+                "models": sorted(models),
+                "trace_errors": trace_errors[:10],
+                "trace_window_note": (
+                    "aggregated from the assignee's trace events during "
+                    "the task window — includes any concurrent activity"
+                ),
+            },
+            "events": events[:50],
+        }
+
     @app.get("/mesh/user-notifications")
     async def get_user_notifications(
         request: Request, hours: float = 24, limit: int = 50,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1640,9 +1640,17 @@ def create_mesh_app(
                     )
                 _refs = _task_record.get("artifact_refs") or []
                 if _refs:
+                    # Refs are creator-supplied strings off the task row —
+                    # same trust level as the description above, so they
+                    # get the same sanitize pass before riding the
+                    # recipient's prompt (str() guards a non-string item
+                    # from turning the wake into a join TypeError).
                     wake_msg += (
                         "\n\nData payload on the blackboard — fetch with "
-                        "read_blackboard: " + ", ".join(_refs[:5])
+                        "read_blackboard: "
+                        + sanitize_for_prompt(
+                            ", ".join(str(r)[:200] for r in _refs[:5])
+                        )
                     )
 
         if lane_manager is not None and dispatch_loop is not None:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1622,6 +1622,28 @@ def create_mesh_app(
                     target,
                 )
                 task_id = None
+            else:
+                # Brief delivery: the wake message travels as a URL query
+                # param and is historically a one-liner ("New task from X:
+                # {summary[:200]}"), so the recipient's chat turn used to
+                # start from a title-sized stub — the full task description
+                # (the handoff brief) never reached the worker unless it
+                # thought to call check_inbox. Enrich the lane message with
+                # the bound task's description + artifact pointers here,
+                # where the record is already in hand from the M3 lookup.
+                _desc = (_task_record.get("description") or "").strip()
+                _title = (_task_record.get("title") or "").strip()
+                if _desc and _desc != _title and _desc[:200] not in wake_msg:
+                    wake_msg += (
+                        "\n\n## Task Brief\n"
+                        + sanitize_for_prompt(_desc[:6_000])
+                    )
+                _refs = _task_record.get("artifact_refs") or []
+                if _refs:
+                    wake_msg += (
+                        "\n\nData payload on the blackboard — fetch with "
+                        "read_blackboard: " + ", ".join(_refs[:5])
+                    )
 
         if lane_manager is not None and dispatch_loop is not None:
             try:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5776,7 +5776,16 @@ def create_mesh_app(
                 rows = []
             for ev in rows:
                 meta = ev.get("meta") or {}
-                if ev.get("event_type") in ("llm_call", "llm_stream"):
+                # Count ``llm_call`` rows only. The streaming proxy path
+                # records TWO rows per call — ``llm_stream`` at stream
+                # start and ``llm_call`` (with tokens) at completion —
+                # and the agent loop streams everything, so counting
+                # both kinds doubled ``llm_calls`` and masked exactly
+                # the "very few calls = shallow run" signal this
+                # endpoint exists to surface. A stream aborted before
+                # completion has no ``llm_call`` row and is not counted;
+                # its failure still shows up under ``trace_errors``.
+                if ev.get("event_type") == "llm_call":
                     llm_calls += 1
                     t = meta.get("tokens_used")
                     if isinstance(t, (int, float)):

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5511,6 +5511,12 @@ def create_mesh_app(
         priority = int(body.get("priority", 0) or 0)
         dependencies = body.get("dependencies") or None
         artifact_refs = body.get("artifact_refs") or None
+        # B4 — optional per-task reasoning depth for the assignee.
+        thinking = body.get("thinking") or None
+        if thinking is not None and thinking not in ("off", "low", "medium", "high"):
+            raise HTTPException(
+                400, f"thinking must be off/low/medium/high, got {thinking!r}",
+            )
         if not title:
             raise HTTPException(400, "title is required")
         if not assignee or not _AGENT_ID_RE.match(assignee):
@@ -5567,6 +5573,7 @@ def create_mesh_app(
                 dependencies=dependencies if isinstance(dependencies, list) else None,
                 artifact_refs=artifact_refs if isinstance(artifact_refs, list) else None,
                 origin=origin_dict,
+                thinking=thinking,
             )
         except TaskLimitExceeded as e:
             # H5 — per-assignee backlog cap or runaway/cyclic parent

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -60,9 +60,14 @@ plan as a bullet list with agent names bolded, then "Go ahead?"
 
 When the user wants work done:
 1. Identify the right agent from inspect_agents()
-2. hand_off() with a SHORT summary (≤80 chars — it's the task title). \
-   Long instructions go in `data`. Good: "Draft Q3 launch brief". \
-   Bad: "TEST RUN — execute now, do NOT wait for the 08:00 cron...".
+2. hand_off() with a SHORT summary (≤80 chars — the task title. Good: \
+   "Draft Q3 launch brief". Bad: "TEST RUN — execute now, do NOT wait \
+   for the 08:00 cron...") AND a full `brief`: the worker does NOT see \
+   this conversation, so carry the user's actual ask — objective in \
+   their own terms, business context the worker lacks, success \
+   criteria, and deliverable form/depth (e.g. "full written audit as \
+   an artifact, concrete data per finding — not a bullet summary"). \
+   A title-only handoff produces shallow work.
 3. Tell the user who's on it, then stop.
 
 **Delegate and release.** After a hand_off, don't hold the turn open or chain \
@@ -149,7 +154,30 @@ If nothing useful applies, omit the block entirely (the dashboard falls \
 back to free-text only). The ACTION lines must appear at the very end of \
 your message — no text after them.
 
-<!-- playbook_v2 -->"""
+<!-- playbook_v2 -->
+<!-- playbook_v3_handoff_briefs -->"""
+
+# ── v3 addendum (appended to EXISTING operator INSTRUCTIONS.md) ──
+#
+# The scaffold migration only ever APPENDS to a live INSTRUCTIONS.md
+# (rewriting would clobber user customizations), so guidance changes
+# that must reach already-deployed operators ship as a versioned
+# addendum block. New operators get the same content inline in
+# _OPERATOR_CORE above.
+
+_PLAYBOOK_V3_ADDENDUM = """\
+
+## Handoff Briefs (v3)
+
+Workers do NOT see your conversation with the user — they start from \
+only what you send. For any non-trivial hand_off, pass a full `brief` \
+alongside the short summary: the objective in the user's own terms, \
+business context the worker lacks, success criteria, and the expected \
+deliverable form and depth (e.g. "a thorough written audit saved as an \
+artifact, with concrete data per finding — not a bullet summary"). \
+A title-only handoff produces shallow work.
+
+<!-- playbook_v3_handoff_briefs -->"""
 
 # ── Boot greeting (seeded once on first operator creation) ────
 

--- a/src/templates/deep-research.yaml
+++ b/src/templates/deep-research.yaml
@@ -45,6 +45,10 @@ agents:
          active list to disambiguate.
 
       ## Source quality criteria
+      - Append raw findings (URLs, quotes, data points) to a working-notes
+        file via write_file AS YOU RESEARCH — long sessions compact the
+        conversation history and raw findings are lost; files on disk
+        survive. Hand off from your notes, not from memory.
       - Prefer primary sources over summaries
       - Note publication date — flag anything older than 2 years
       - Include both mainstream and niche perspectives

--- a/src/templates/research.yaml
+++ b/src/templates/research.yaml
@@ -70,6 +70,10 @@ agents:
       9. Call update_status() when starting and finishing work
 
       ## Research principles
+      - Append raw findings (URLs, quotes, data points) to a working-notes
+        file via write_file AS YOU RESEARCH — on long tasks the conversation
+        history gets compacted and raw findings are lost; files on disk
+        survive. Write the final report from your notes, not from memory.
       - Cast a wide net first, then go deep on the best sources
       - Try at least 3 different search queries before concluding nothing exists
       - Prefer primary sources over secondhand summaries

--- a/src/templates/starter.yaml
+++ b/src/templates/starter.yaml
@@ -53,6 +53,10 @@ agents:
       - When a task involves multiple steps, execute them sequentially
       - If a command fails, read the error carefully and try a different approach
       - Save important facts to memory so you remember them across sessions
+      - On research-heavy or long-form tasks, append findings to a
+        working-notes file (write_file) as you go — long sessions compact
+        the conversation history; files survive. Save the full deliverable
+        with save_artifact, never just a summary of it.
       - When working autonomously (heartbeat, cron), use notify_user to report results
 
       ## Using tools proactively

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1192,3 +1192,109 @@ class TestSummarizeTailCap:
         tail_tokens = estimate_tokens(result[1:], cm.model)
         assert tail_tokens <= cm.max_tokens * 0.5 + 50, \
             f"retained tail {tail_tokens} exceeds 0.5*max_tokens cap"
+
+
+class TestChunkedSummarization:
+    """B1: compaction summarizes ALL older history in chunks instead of
+    truncating to the first 20k chars (and 200 chars per tool result)."""
+
+    @staticmethod
+    def _recording_llm(fold_content: str = "FOLDED", part_content: str = "part summary"):
+        llm = MagicMock()
+        prompts: list[str] = []
+
+        async def chat(system, messages, max_tokens=None, temperature=None, **kw):
+            prompt = messages[0]["content"]
+            prompts.append(prompt)
+            if prompt.startswith("Merge these sequential summaries"):
+                return LLMResponse(content=fold_content, tokens_used=10)
+            return LLMResponse(content=part_content, tokens_used=10)
+
+        llm.chat = AsyncMock(side_effect=chat)
+        return llm, prompts
+
+    @pytest.mark.asyncio
+    async def test_content_beyond_20k_reaches_summarizer(self):
+        llm, prompts = self._recording_llm()
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+        msgs = []
+        for i in range(30):
+            role = "user" if i % 2 == 0 else "assistant"
+            msgs.append({"role": role, "content": f"MARKER_{i} " + "x" * 2000})
+
+        result = await cm._summarize_compact("system", msgs)
+
+        joined = "\n".join(prompts)
+        # Multiple chunk calls were made...
+        assert len(prompts) >= 2
+        # ...and content past the legacy 20k truncation point survived.
+        assert "MARKER_20" in joined
+        assert "MARKER_25" in joined
+        # The stitched summary carries part headers.
+        summary_msg = result[0]["content"]
+        assert "Part 1 of" in summary_msg
+
+    @pytest.mark.asyncio
+    async def test_tool_results_not_over_truncated(self):
+        llm, prompts = self._recording_llm()
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+        msgs = [
+            {"role": "user", "content": "do deep research"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "t1", "function": {"name": "web_search", "arguments": "{}"}}],
+            },
+            # Marker sits past the legacy 200-char tool-result cut.
+            {"role": "tool", "tool_call_id": "t1", "content": "x" * 1000 + " TOOLMARKER " + "y" * 200},
+        ]
+        # Trailing small groups so the tool group lands in "older".
+        for i in range(8):
+            role = "user" if i % 2 == 0 else "assistant"
+            msgs.append({"role": role, "content": f"tail {i}"})
+
+        await cm._summarize_compact("system", msgs)
+
+        assert "TOOLMARKER" in "\n".join(prompts)
+
+    @pytest.mark.asyncio
+    async def test_long_partials_get_folded_once(self):
+        llm, prompts = self._recording_llm(part_content="p" * 5000)
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+        msgs = []
+        for i in range(30):
+            role = "user" if i % 2 == 0 else "assistant"
+            msgs.append({"role": role, "content": f"m{i} " + "x" * 2000})
+
+        result = await cm._summarize_compact("system", msgs)
+
+        fold_calls = [p for p in prompts if p.startswith("Merge these sequential summaries")]
+        assert len(fold_calls) == 1
+        assert "FOLDED" in result[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_single_chunk_keeps_single_call(self):
+        llm, prompts = self._recording_llm()
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+        msgs = _make_messages(10, chars_each=200)
+
+        result = await cm._summarize_compact("system", msgs)
+
+        assert len(prompts) == 1
+        assert "part summary" in result[0]["content"]
+
+    def test_chunk_message_texts_boundaries(self):
+        msgs = [{"role": "user", "content": f"msg{i} " + "z" * 40} for i in range(10)]
+        chunks = ContextManager._chunk_message_texts(msgs, chunk_size=120, tool_chars=200)
+        assert len(chunks) > 1
+        assert all(len(c) <= 120 for c in chunks)
+        # Every message's marker survives across the chunk set.
+        joined = "".join(chunks)
+        for i in range(10):
+            assert f"msg{i}" in joined
+
+    def test_chunk_message_texts_truncates_oversized_message(self):
+        msgs = [{"role": "user", "content": "B" * 500}]
+        chunks = ContextManager._chunk_message_texts(msgs, chunk_size=100, tool_chars=200)
+        assert len(chunks) == 1
+        assert len(chunks[0]) <= 100

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1700,3 +1700,48 @@ class TestHandOffBrief:
         kwargs = mc.create_task.call_args.kwargs
         assert kwargs["title"] == "quick ping"
         assert kwargs["description"] == "quick ping"
+
+
+class TestHandOffThinking:
+    """B4: hand_off can pin a per-task reasoning depth for the recipient."""
+
+    @pytest.mark.asyncio
+    async def test_thinking_passes_through_to_create_task(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"analyst": {}}
+
+        result = await hand_off(
+            to="analyst", summary="deep audit", thinking="high",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert mc.create_task.call_args.kwargs["thinking"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_omitted_thinking_sends_none(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {}}
+
+        await hand_off(to="analyst", summary="quick ping", mesh_client=mc)
+
+        assert mc.create_task.call_args.kwargs["thinking"] is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_thinking_rejected_before_any_write(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {}}
+
+        result = await hand_off(
+            to="analyst", summary="x", thinking="ultra", mesh_client=mc,
+        )
+
+        assert "error" in result
+        mc.create_task.assert_not_called()
+        mc.write_blackboard.assert_not_called()

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1618,3 +1618,85 @@ class TestHandOffParentTaskIdPropagation:
 
         kwargs = mc.create_task.call_args.kwargs
         assert kwargs.get("parent_task_id") is None
+
+
+class TestHandOffBrief:
+    """B2: the `brief` param becomes the task description so the recipient
+    starts with full context instead of a title-sized stub."""
+
+    @pytest.mark.asyncio
+    async def test_brief_becomes_description(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        brief = (
+            "## Objective\nDeep SEO audit of example.com\n\n"
+            "## Context\nUser cares about long-tail keyword gaps.\n\n"
+            "## Deliverable\nFull written audit saved as an artifact."
+        )
+
+        result = await hand_off(
+            to="analyst",
+            summary="Deep SEO audit of example.com",
+            brief=brief,
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        kwargs = mc.create_task.call_args.kwargs
+        assert kwargs["title"] == "Deep SEO audit of example.com"
+        assert kwargs["description"] == brief
+
+    @pytest.mark.asyncio
+    async def test_brief_truncated_at_cap(self):
+        from src.agent.builtins.coordination_tool import (
+            _MAX_BRIEF_CHARS,
+            hand_off,
+        )
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"analyst": {}}
+
+        await hand_off(
+            to="analyst",
+            summary="big brief",
+            brief="b" * (_MAX_BRIEF_CHARS + 5_000),
+            mesh_client=mc,
+        )
+
+        kwargs = mc.create_task.call_args.kwargs
+        assert len(kwargs["description"]) <= _MAX_BRIEF_CHARS
+
+    @pytest.mark.asyncio
+    async def test_long_summary_with_brief_keeps_caller_split(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"analyst": {}}
+        long_summary = "Audit the SEO of example.com and " + "x" * 150
+
+        await hand_off(
+            to="analyst",
+            summary=long_summary,
+            brief="the real instructions",
+            mesh_client=mc,
+        )
+
+        kwargs = mc.create_task.call_args.kwargs
+        # Caller provided both — title hard-capped, brief preserved verbatim.
+        assert len(kwargs["title"]) <= 200
+        assert kwargs["description"] == "the real instructions"
+
+    @pytest.mark.asyncio
+    async def test_no_brief_preserves_legacy_shape(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {}}
+
+        await hand_off(to="analyst", summary="quick ping", mesh_client=mc)
+
+        kwargs = mc.create_task.call_args.kwargs
+        assert kwargs["title"] == "quick ping"
+        assert kwargs["description"] == "quick ping"

--- a/tests/test_handoff_integration.py
+++ b/tests/test_handoff_integration.py
@@ -69,7 +69,8 @@ async def test_hand_off_creates_task_visible_to_recipient_inbox(monkeypatch):
     async def fake_create_task(*, assignee, title, description=None,
                                project=None, parent_task_id=None,
                                priority=0, dependencies=None,
-                               artifact_refs=None, origin=None):
+                               artifact_refs=None, origin=None,
+                               thinking=None):
         return store.create(
             creator=mc.agent_id,
             assignee=assignee,
@@ -81,6 +82,7 @@ async def test_hand_off_creates_task_visible_to_recipient_inbox(monkeypatch):
             dependencies=dependencies,
             artifact_refs=artifact_refs,
             origin=None,
+            thinking=thinking,
         )
     mc.create_task = AsyncMock(side_effect=fake_create_task)
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -452,3 +452,29 @@ def test_thinking_max_tokens_honours_raised_cap():
     assert params["max_tokens"] == 64000
     # The thinking budget itself is unchanged — only the total ceiling grows.
     assert params["thinking"]["budget_tokens"] == 10_000
+
+
+def test_thinking_override_takes_precedence_and_clears():
+    """B4: a per-task override beats the configured default for the
+    duration it is set, and removing it restores the default."""
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1",
+        default_model="anthropic/claude-sonnet-4-6", thinking="off",
+    )
+    assert llm._get_thinking_params() == {}
+
+    llm.thinking_override = "high"
+    params = llm._get_thinking_params()
+    assert params["thinking"]["budget_tokens"] == 25_000
+
+    llm.thinking_override = None
+    assert llm._get_thinking_params() == {}
+
+
+def test_thinking_override_on_openai_reasoning_models():
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1",
+        default_model="openai/o3-mini", thinking="low",
+    )
+    llm.thinking_override = "high"
+    assert llm._get_thinking_params() == {"reasoning_effort": "high"}

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -5110,3 +5110,33 @@ async def test_chat_self_heal_reraises_when_prune_cannot_help():
 
     with pytest.raises(LLMContextOverflowError):
         await loop._chat_call_self_healing(system="sys", tools=None)
+
+
+@pytest.mark.asyncio
+async def test_apply_task_thinking_sets_validates_and_survives_errors():
+    """B4: the loop pins the task's thinking level as the LLM override,
+    ignores invalid levels, and treats lookup failures as best-effort."""
+    loop = _make_loop()
+    loop.llm.VALID_THINKING_LEVELS = {"off", "low", "medium", "high"}
+    loop.llm.thinking_override = None
+
+    loop.mesh_client.get_task = AsyncMock(
+        return_value={"id": "t1", "thinking": "high"},
+    )
+    await loop._apply_task_thinking("t1")
+    assert loop.llm.thinking_override == "high"
+
+    loop.llm.thinking_override = None
+    loop.mesh_client.get_task = AsyncMock(
+        return_value={"id": "t2", "thinking": "bogus"},
+    )
+    await loop._apply_task_thinking("t2")
+    assert loop.llm.thinking_override is None
+
+    loop.mesh_client.get_task = AsyncMock(side_effect=RuntimeError("down"))
+    await loop._apply_task_thinking("t3")
+    assert loop.llm.thinking_override is None
+
+    loop.mesh_client.get_task = AsyncMock(return_value=None)
+    await loop._apply_task_thinking("t4")
+    assert loop.llm.thinking_override is None

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -306,7 +306,9 @@ class TestOperatorConstants:
         #    the heartbeat procedure already called it but the allowlist
         #    denied the call. (Note: main had previously dropped
         #    save_observations, so v3 baseline was 9 not 10.)
-        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 10
+        #  * v5 (B5 task-run diagnostics): +inspect_task_run — read-only
+        #    per-task execution summary so rating decisions are informed.
+        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 11
         # The operator-tier heartbeat tools must also be on the main
         # operator allowlist — they're the tools operator can use from
         # both /chat and heartbeat. Two heartbeat entries are

--- a/tests/test_operator_heartbeat.py
+++ b/tests/test_operator_heartbeat.py
@@ -104,14 +104,18 @@ def test_heartbeat_tools_constant():
       the heartbeat procedure already called it for roster summary
       and drill-ins but the allowlist denied the call — a pre-existing
       contract mismatch Codex flagged during PR 972 review.
+    * v5 (B5 task-run diagnostics): + ``inspect_task_run``. Read-only
+      per-task execution summary (tokens, LLM calls, thinking, trace
+      errors) so the rate-stale-deliverables step can look at HOW a
+      task ran before grading it.
     """
     assert _HEARTBEAT_TOOLS == frozenset({
         "list_agents", "get_agent_profile", "get_system_status",
         "notify_user",
         "check_inbox", "workflow_snapshot", "await_task_event",
         "rate_delivery", "manage_goals",
-        "inspect_agents",
+        "inspect_agents", "inspect_task_run",
     })
     # v3 main was 9 tools (no save_observations — removed pre-merge);
-    # v4 this branch added inspect_agents = 10.
-    assert len(_HEARTBEAT_TOOLS) == 10
+    # v4 added inspect_agents = 10; v5 added inspect_task_run = 11.
+    assert len(_HEARTBEAT_TOOLS) == 11

--- a/tests/test_operator_inspect_task_run.py
+++ b/tests/test_operator_inspect_task_run.py
@@ -1,0 +1,69 @@
+"""Tests for the operator ``inspect_task_run`` tool (B5).
+
+Operator-only diagnostic over ``GET /mesh/tasks/{id}/run`` — surfaces how
+a task actually executed (thinking level, LLM calls, tokens, trace
+errors, status timeline) so the operator can diagnose shallow or failed
+deliverables before re-dispatching or rating.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_operator_env(monkeypatch):
+    """inspect_task_run requires ALLOWED_TOOLS to be set (defence-in-depth)."""
+    monkeypatch.setenv("ALLOWED_TOOLS", "inspect_task_run")
+
+
+@pytest.mark.asyncio
+async def test_inspect_task_run_returns_payload():
+    from src.agent.builtins.operator_tools import inspect_task_run
+
+    payload = {
+        "task": {"id": "task_1", "thinking": "high", "status": "done"},
+        "execution": {"llm_calls": 4, "tokens_used": 9000, "models": ["m"]},
+        "events": [{"event_kind": "created"}],
+    }
+    mc = MagicMock()
+    mc.get_task_run = AsyncMock(return_value=payload)
+
+    result = await inspect_task_run("task_1", mesh_client=mc)
+    assert result == payload
+    mc.get_task_run.assert_awaited_once_with("task_1")
+
+
+@pytest.mark.asyncio
+async def test_inspect_task_run_not_found():
+    from src.agent.builtins.operator_tools import inspect_task_run
+
+    mc = MagicMock()
+    mc.get_task_run = AsyncMock(return_value=None)
+
+    result = await inspect_task_run("task_missing", mesh_client=mc)
+    assert result["error"] == "not_found"
+    assert result["task_id"] == "task_missing"
+
+
+@pytest.mark.asyncio
+async def test_inspect_task_run_transport_error_envelope():
+    from src.agent.builtins.operator_tools import inspect_task_run
+
+    mc = MagicMock()
+    mc.get_task_run = AsyncMock(side_effect=RuntimeError("mesh down"))
+
+    result = await inspect_task_run("task_1", mesh_client=mc)
+    assert "error" in result
+    assert "mesh down" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_inspect_task_run_rejects_non_operator(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "")
+    from src.agent.builtins.operator_tools import inspect_task_run
+
+    result = await inspect_task_run("task_1", mesh_client=MagicMock())
+    assert "error" in result
+    assert "operator" in result["error"]

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -129,8 +129,10 @@ class TestPlaybookConstants:
         # Bumped 5200 → 6000 to accommodate the autonomous-by-default
         # frame copy (immediate-apply edits, ratings-as-feedback guidance);
         # 6000 → 6400 for the Phase-1d "delegate and release" routing rule
-        # (hand off → stop; the chain watcher delivers the terminal outcome).
-        assert len(_OPERATOR_CORE) < 6400
+        # (hand off → stop; the chain watcher delivers the terminal outcome);
+        # 6400 → 6800 for the handoff-brief rule (workers don't see the
+        # conversation — carry the user's ask + deliverable depth in `brief`).
+        assert len(_OPERATOR_CORE) < 6800
         assert len(_OPERATOR_CORE) > 1000
 
     def test_playbooks_have_numbered_steps(self):

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -2509,3 +2509,29 @@ def test_unknown_parent_allowed(tmp_path):
         parent_task_id="task_doesnotexist",
     )
     assert rec["parent_task_id"] == "task_doesnotexist"
+
+
+# ── B4: per-task thinking ─────────────────────────────────────────
+
+
+class TestTaskThinking:
+    def test_create_with_thinking_persists(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = store.create(
+            creator="operator", assignee="analyst",
+            title="deep audit", thinking="high",
+        )
+        assert rec["thinking"] == "high"
+        assert store.get(rec["id"])["thinking"] == "high"
+
+    def test_create_default_thinking_is_null(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = store.create(creator="op", assignee="a", title="quick")
+        assert rec["thinking"] is None
+
+    def test_create_invalid_thinking_rejected(self, tmp_path):
+        store = _make_store(tmp_path)
+        with pytest.raises(ValueError, match="thinking"):
+            store.create(
+                creator="op", assignee="a", title="t", thinking="ultra",
+            )

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1364,6 +1364,24 @@ async def test_task_run_aggregates_traces_in_window(tmp_path, monkeypatch):
             status="error", error="rate limited",
             meta={"model": "anthropic/claude-x", "tokens_used": 300},
         )
+        # Streamed call: the proxy records an ``llm_stream`` row at
+        # stream start AND an ``llm_call`` row (tokens, streaming=True)
+        # at completion. Only the completion row may count — counting
+        # both kinds doubled llm_calls for streamed traffic.
+        traces.record(
+            trace_id="tr3", source="mesh.api_proxy", agent="analyst",
+            event_type="llm_stream", detail="llm/chat",
+            meta={"model": "anthropic/claude-x"},
+        )
+        traces.record(
+            trace_id="tr3", source="mesh.api_proxy", agent="analyst",
+            event_type="llm_call", detail="llm/chat", duration_ms=700,
+            status="ok",
+            meta={
+                "model": "anthropic/claude-x", "tokens_used": 500,
+                "streaming": True,
+            },
+        )
         # Different agent in the same window — must NOT count.
         traces.record(
             trace_id="tr2", source="mesh.api_proxy", agent="scout",
@@ -1377,8 +1395,8 @@ async def test_task_run_aggregates_traces_in_window(tmp_path, monkeypatch):
             )
         assert r.status_code == 200
         execution = r.json()["execution"]
-        assert execution["llm_calls"] == 2
-        assert execution["tokens_used"] == 1500
+        assert execution["llm_calls"] == 3
+        assert execution["tokens_used"] == 2000
         assert execution["models"] == ["anthropic/claude-x"]
         assert len(execution["trace_errors"]) == 1
         assert "rate limited" in execution["trace_errors"][0]["error"]

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1274,3 +1274,116 @@ async def test_create_task_rate_limit_allows_normal_volume(v2_app):
                 headers={"X-Agent-ID": "scout"},
             )
             assert r.status_code == 200, r.text
+
+
+# ── B5: GET /mesh/tasks/{task_id}/run ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_task_run_is_operator_only(v2_app):
+    app, _, _ = v2_app
+    rec = app.tasks_store.create(
+        creator="operator", assignee="analyst", title="deep work",
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get(
+            f"/mesh/tasks/{rec['id']}/run", headers={"X-Agent-ID": "scout"},
+        )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_task_run_unknown_id_404(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get(
+            "/mesh/tasks/task_doesnotexist/run",
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_task_run_returns_record_events_and_execution(v2_app):
+    app, _, _ = v2_app
+    rec = app.tasks_store.create(
+        creator="operator", assignee="analyst", title="deep audit",
+        description="full brief", thinking="high",
+    )
+    app.tasks_store.update_status(rec["id"], "working", actor="analyst")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get(
+            f"/mesh/tasks/{rec['id']}/run", headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["task"]["id"] == rec["id"]
+    assert body["task"]["thinking"] == "high"
+    assert body["task"]["status"] == "working"
+    # No trace store wired in this fixture — execution summary is zeroed
+    # but present and well-formed.
+    assert body["execution"]["llm_calls"] == 0
+    assert body["execution"]["tokens_used"] == 0
+    # Timeline includes the created + status-change events.
+    kinds = [e["event_kind"] for e in body["events"]]
+    assert "created" in kinds
+
+
+@pytest.mark.asyncio
+async def test_task_run_aggregates_traces_in_window(tmp_path, monkeypatch):
+    """LLM-call traces for the assignee inside the task window roll up
+    into llm_calls / tokens_used / models."""
+    from src.host.traces import TraceStore
+
+    server_module = _reload_server(
+        monkeypatch, tasks_db=str(tmp_path / "tasks.db"),
+    )
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    permissions = PermissionMatrix()
+    router = MessageRouter(permissions, {"analyst": "http://analyst:8400"})
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=PubSub(),
+        router=router,
+        permissions=permissions,
+        trace_store=traces,
+    )
+    try:
+        rec = app.tasks_store.create(
+            creator="operator", assignee="analyst", title="deep audit",
+        )
+        traces.record(
+            trace_id="tr1", source="mesh.api_proxy", agent="analyst",
+            event_type="llm_call", detail="llm/chat", duration_ms=900,
+            status="ok", meta={"model": "anthropic/claude-x", "tokens_used": 1200},
+        )
+        traces.record(
+            trace_id="tr1", source="mesh.api_proxy", agent="analyst",
+            event_type="llm_call", detail="llm/chat", duration_ms=400,
+            status="error", error="rate limited",
+            meta={"model": "anthropic/claude-x", "tokens_used": 300},
+        )
+        # Different agent in the same window — must NOT count.
+        traces.record(
+            trace_id="tr2", source="mesh.api_proxy", agent="scout",
+            event_type="llm_call", detail="llm/chat",
+            meta={"model": "other", "tokens_used": 999},
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get(
+                f"/mesh/tasks/{rec['id']}/run",
+                headers={"X-Agent-ID": "operator"},
+            )
+        assert r.status_code == 200
+        execution = r.json()["execution"]
+        assert execution["llm_calls"] == 2
+        assert execution["tokens_used"] == 1500
+        assert execution["models"] == ["anthropic/claude-x"]
+        assert len(execution["trace_errors"]) == 1
+        assert "rate limited" in execution["trace_errors"][0]["error"]
+    finally:
+        blackboard.close()
+        traces.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)

--- a/tests/test_wake_task_binding.py
+++ b/tests/test_wake_task_binding.py
@@ -182,3 +182,108 @@ async def test_unknown_task_id_dropped(wake_app):
 
     assert len(lane.calls) == 1
     assert lane.calls[0]["kwargs"].get("task_id") is None
+
+
+@pytest.mark.asyncio
+async def test_wake_message_carries_task_brief(wake_app):
+    """B2: when the wake is bound to a task (M3 check passed), the lane
+    message is enriched with the task description so the recipient's chat
+    turn starts from the full brief, not the title-sized wake stub."""
+    app, lane, tasks_store = wake_app
+    brief = (
+        "## Objective\nDeep SEO audit of example.com\n"
+        "## Deliverable\nFull written audit saved as an artifact."
+    )
+    rec = tasks_store.create(
+        creator="scout", assignee="writer",
+        title="Deep SEO audit", description=brief,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "New task from scout: Deep SEO audit"},
+            headers={"X-Agent-ID": "scout", "x-task-id": rec["id"]},
+        )
+    assert resp.status_code == 200
+    _settle()
+
+    assert len(lane.calls) == 1
+    lane_msg = lane.calls[0]["args"][1]
+    assert "## Task Brief" in lane_msg
+    assert "Deep SEO audit of example.com" in lane_msg
+    assert "saved as an artifact" in lane_msg
+
+
+@pytest.mark.asyncio
+async def test_wake_message_skips_brief_when_description_is_title(wake_app):
+    """Legacy handoffs (description == title) gain no redundant brief block."""
+    app, lane, tasks_store = wake_app
+    rec = tasks_store.create(
+        creator="scout", assignee="writer",
+        title="quick ping", description="quick ping",
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "New task from scout: quick ping"},
+            headers={"X-Agent-ID": "scout", "x-task-id": rec["id"]},
+        )
+    _settle()
+
+    lane_msg = lane.calls[0]["args"][1]
+    assert "## Task Brief" not in lane_msg
+
+
+@pytest.mark.asyncio
+async def test_wake_message_lists_artifact_refs(wake_app):
+    """Data-payload pointers ride the wake so the recipient knows to fetch."""
+    app, lane, tasks_store = wake_app
+    rec = tasks_store.create(
+        creator="scout", assignee="writer", title="stage work",
+        artifact_refs=["output/scout/ho_123"],
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "New task from scout: stage work"},
+            headers={"X-Agent-ID": "scout", "x-task-id": rec["id"]},
+        )
+    _settle()
+
+    lane_msg = lane.calls[0]["args"][1]
+    assert "read_blackboard" in lane_msg
+    assert "output/scout/ho_123" in lane_msg
+
+
+@pytest.mark.asyncio
+async def test_dropped_task_id_means_no_brief_enrichment(wake_app):
+    """A mismatched task_id is dropped by the M3 gate — the brief of an
+    UNRELATED task must not leak into the wake message either."""
+    app, lane, tasks_store = wake_app
+    rec = tasks_store.create(
+        creator="scout", assignee="analyst",  # NOT the wake target
+        title="other work", description="secret brief for analyst",
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "nudge"},
+            headers={"X-Agent-ID": "scout", "x-task-id": rec["id"]},
+        )
+    _settle()
+
+    lane_msg = lane.calls[0]["args"][1]
+    assert "secret brief" not in lane_msg
+    assert lane.calls[0]["kwargs"].get("task_id") is None


### PR DESCRIPTION
## Context

A user ran a deep SEO/GSC audit through the operator and got a shallow, "fluffy" report — the same task run in Claude natively produced far deeper analysis. A full audit of the operator→worker execution path found five converging mechanisms that systematically convert deep work into shallow summaries. None is a bug in isolation; together they form a depth-compression pipeline. This PR dismantles it.

## Changes

**B1 — Chunked compaction summarization** (`src/agent/context.py`)
At 70% context fill, compaction fed only the FIRST 20,000 chars of older history to a single summarization call (`conversation_text[:LIMIT]`) and truncated every tool result to 200 chars first — on research tasks this silently discarded most gathered data right before synthesis. Now older history is packed into ≤20k-char chunks at message boundaries (tool results kept to 2,000 chars), each chunk summarized with an explicit "preserve concrete data points" instruction, partials stitched, and a single fold pass when combined partials exceed 12k chars. Chunk failure falls back to hard prune (legacy semantics).

**B2 — Rich handoff briefs delivered inline** (`coordination_tool.py`, `host/server.py`, `operator_playbooks.py`, `workspace.py`)
A handed-off worker's chat turn started from `"New task from X: {summary[:200]}"` — the operator's conversation with the user never reached the worker, and the `hand_off` docstring actively discouraged context. Now: `hand_off` gains a `brief` param (objective/background/success criteria/deliverable depth, 6k cap) that becomes the task description; the mesh wake handler enriches the lane message with the bound task's description + artifact pointers (reusing the record already fetched for the M3 binding check), so briefs reach workers inline on ALL handoffs without URL-length risk. Operator playbook updated + appended to existing operators via a `playbook_v3` append-only sentinel migration.

**B3 — Artifact-first deliverable contract** (`loop.py`, `workspace.py`, templates)
No instruction existed to write full reports anywhere durable; the structured-final contract + "be concise" rules pushed agents to compress deliverables into a summary envelope. New operating rule in task + chat prompts: append findings to a working-notes file via `write_file` while working (disk survives compaction), save the FULL document with `save_artifact`, reference the artifact in the final answer. Mirrored in the SYSTEM.md preamble and starter/research/deep-research templates.

**B4 — Per-task thinking override** (`orchestration.py`, `host/server.py`, `mesh_client.py`, `coordination_tool.py`, `llm.py`, `loop.py`)
Reasoning depth was locked per-agent at init; a deep-analysis handoff ran at whatever the recipient's template chose. Tasks gain a nullable `thinking` column (idempotent ALTER migration); `hand_off(thinking="high")` threads through create_task → task record → the worker's chat turn, where the loop pins `llm.thinking_override` for that turn only (cleared in `finally`). Validated at every layer.

**B5 — `inspect_task_run` operator diagnostics** (`operator_tools.py`, `host/server.py`, `mesh_client.py`, `cli/config.py`)
The operator had no way to answer "why did this come out shallow" — traces existed but weren't exposed. New operator-only `GET /mesh/tasks/{id}/run` + `inspect_task_run` tool: task record (thinking, blocker note, outcome/feedback), `task_events` timeline, and an execution summary aggregated from the assignee's trace events in the task window (LLM calls, tokens, models, errors; documented as window-scoped). Heartbeat-allowed (read-only, pin tests bumped to v5) so rating decisions can be informed.

## Testing

- New unit coverage per item: chunked summarizer preserves content beyond 20k chars and >200-char tool results; brief lands inline in the lane message (incl. the M3-dropped-task_id negative case); per-task thinking persists, validates, and reaches `_get_thinking_params`; `inspect_task_run` endpoint auth/404/trace aggregation.
- Full fast suite: 7,318 passed. The only failures are two pre-existing `TestFileToolErrorHandling` permission tests that cannot fail correctly when run as root (this container); they pass in CI's unprivileged runner and touch no code changed here.

## Follow-up (separate PR)

Workstream A — closing the feedback loop: rework/rejected ratings written into the rated agent's learnings, operator wake on failed/blocked human-origin chains, feedback/blocker context in rework+retry briefs, fleet-health digest in the operator's runtime context, heartbeat consistency fixes.

https://claude.ai/code/session_0172GtagPvEa9upWRExCiyy9

---
_Generated by [Claude Code](https://claude.ai/code/session_0172GtagPvEa9upWRExCiyy9)_