### PR TITLE
fix(tests): close the runtime .env read-leak and the credentials reload landmine

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,24 +102,61 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
-@pytest.fixture(autouse=True)
-def _isolate_default_env_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Redirect the credential vault's default .env writes to a temp file.
+# Credential-bearing env prefixes (see src/host/credentials.py). Snapshotted
+# and restored around every test by ``_isolate_credential_env`` below.
+_CREDENTIAL_ENV_PREFIXES = (
+    "OPENLEGION_SYSTEM_", "OPENLEGION_CRED_", "OPENLEGION_CONN_",
+)
 
-    Tests must never touch the developer's real .env — it holds real
+
+@pytest.fixture(autouse=True)
+def _isolate_credential_env(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate every test from the developer's real .env — reads AND writes.
+
+    Tests must never touch the real PROJECT_ROOT/.env — it holds real
     credentials (OAuth tokens, wallet seed), and a crash mid-test
-    corrupts it. ``_persist_to_env`` / ``_remove_from_env`` default to
-    PROJECT_ROOT/.env when called without an explicit ``env_file``, so
-    any test exercising the vault's persistence paths with the default
-    would rewrite the real file. Patching ``_default_env_file`` sends
-    those writes to a per-test temp file instead; tests that pass an
-    explicit ``env_file`` are unaffected.
+    corrupts it. Three seams:
+
+    1. ``_default_env_file`` — ``_persist_to_env`` / ``_remove_from_env``
+       default to PROJECT_ROOT/.env when called without an explicit
+       ``env_file``; redirect to a per-test temp file. Tests that pass an
+       explicit ``env_file`` are unaffected.
+    2. ``ENV_FILE`` — the CLI group callback (``src/cli/main.py``) calls
+       ``load_dotenv(cli_config.ENV_FILE)`` on EVERY CliRunner invocation
+       that reaches a subcommand, loading the developer's real .env into
+       ``os.environ`` mid-run and flipping later credential/template tests
+       (the LITELLM_MODE guard above only covers litellm's import-time
+       load). ``cli/config.py`` also WRITES through ``str(ENV_FILE)``.
+       Patched on BOTH modules that bind it — ``src.cli.config`` and
+       ``src.cli.runtime`` (``from``-import copies the binding).
+    3. Belt-and-braces: snapshot the credential-prefixed ``os.environ``
+       keys before the test and restore after, so any pollution path not
+       covered above (e.g. ``_persist_to_env`` setting ``os.environ``)
+       stays confined to the test that caused it. Ambient pre-session
+       values (a developer's deliberate exports) are preserved.
     """
+    from src.cli import config as cli_config
+    from src.cli import runtime as cli_runtime
     from src.host import credentials as cred_mod
 
     monkeypatch.setattr(
         cred_mod, "_default_env_file", lambda: str(tmp_path / "test.env")
     )
+    fake_env_file = tmp_path / "cli.env"
+    monkeypatch.setattr(cli_config, "ENV_FILE", fake_env_file)
+    monkeypatch.setattr(cli_runtime, "ENV_FILE", fake_env_file)
+
+    saved = {
+        k: v for k, v in os.environ.items()
+        if k.startswith(_CREDENTIAL_ENV_PREFIXES)
+    }
+    yield
+    for key in [
+        k for k in os.environ if k.startswith(_CREDENTIAL_ENV_PREFIXES)
+    ]:
+        if key not in saved:
+            os.environ.pop(key, None)
+    os.environ.update(saved)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4783,26 +4783,36 @@ class TestCredentialKindAndModelCompat:
         assert v.get_credential_kind("anthropic") == "api_key"
 
     def test_oauth_allowed_models_env_override(self, monkeypatch):
-        """OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI overrides the default subset."""
-        # The env override is read at module import time, so we have to
-        # reload the module to pick it up.
-        import importlib
+        """OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI overrides the default subset.
 
-        import src.host.credentials as creds_mod
+        Exercises ``_parse_env_models`` (the module-import-time parser)
+        directly rather than ``importlib.reload``-ing the module — an
+        in-place reload re-mints every class in the module's (shared) dict,
+        breaking ``pytest.raises``/``except`` class-identity for any other
+        test file that captured a binding at collection time.
+        """
+        from src.host.credentials import (
+            OAUTH_ALLOWED_MODELS_OPENAI,
+            _parse_env_models,
+        )
         monkeypatch.setenv(
             "OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI",
             "openai/custom-model-one,openai/custom-model-two",
         )
-        importlib.reload(creds_mod)
-        try:
-            assert "openai/custom-model-one" in creds_mod.OAUTH_ALLOWED_MODELS_OPENAI
-            assert "openai/custom-model-two" in creds_mod.OAUTH_ALLOWED_MODELS_OPENAI
-            # Default model dropped after override.
-            assert "openai/gpt-5.3-codex" not in creds_mod.OAUTH_ALLOWED_MODELS_OPENAI
-        finally:
-            # Reset to defaults so other tests aren't polluted.
-            monkeypatch.delenv("OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI", raising=False)
-            importlib.reload(creds_mod)
+        parsed = _parse_env_models(
+            "OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI",
+            OAUTH_ALLOWED_MODELS_OPENAI,
+        )
+        assert "openai/custom-model-one" in parsed
+        assert "openai/custom-model-two" in parsed
+        # Default model dropped after override.
+        assert "openai/gpt-5.3-codex" not in parsed
+        # Unset env falls back to the passed default set.
+        monkeypatch.delenv("OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI")
+        assert _parse_env_models(
+            "OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI",
+            OAUTH_ALLOWED_MODELS_OPENAI,
+        ) == OAUTH_ALLOWED_MODELS_OPENAI
 
     def test_anthropic_oauth_family_accepts_any_claude_by_default(self, monkeypatch):
         """By default (no override env), Anthropic OAuth accepts ANY model
@@ -4878,39 +4888,43 @@ class TestCredentialKindAndModelCompat:
     def test_anthropic_oauth_override_enforces_exact_match(self, monkeypatch):
         """When the operator sets OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC,
         it becomes an opt-in EXACT restriction — family matching is disabled
-        and only the listed models pass."""
-        import importlib
+        and only the listed models pass.
 
+        The env var is parsed at module import time into
+        ``_ANTHROPIC_OAUTH_ALLOWLIST_IS_OPERATOR_SET`` + the
+        ``_OAUTH_ALLOWED_MODELS`` entry; patch those parsed globals directly
+        instead of ``importlib.reload``-ing the module — an in-place reload
+        re-mints every class in the module's (shared) dict, so exception
+        classes raised afterwards no longer match the bindings other test
+        files captured at collection time (``pytest.raises`` in
+        test_oauth_integrations.py broke exactly this way).
+        ``test_parse_env_models_override`` covers the env-string parsing.
+        """
         import src.host.credentials as creds_mod
-        monkeypatch.setenv(
-            "OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC",
-            "anthropic/claude-opus-4-7",
+        monkeypatch.setattr(
+            creds_mod, "_ANTHROPIC_OAUTH_ALLOWLIST_IS_OPERATOR_SET", True,
         )
-        importlib.reload(creds_mod)
-        try:
-            # Recreate the vault from the reloaded module so it picks up
-            # the operator-set flag + parsed override set.
-            self._purge_env(monkeypatch)
-            monkeypatch.setenv(
-                "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
-                "sk-ant-oat01-" + "x" * 80,
-            )
-            v = creds_mod.CredentialVault()
-            assert v.get_credential_kind("anthropic") == "oauth"
-            # Exact-listed model passes.
-            ok, reason = v.is_model_compatible("anthropic/claude-opus-4-7")
-            assert ok is True, reason
-            # A different (family-matching) version is now REJECTED because
-            # the operator opted into an exact subset.
-            ok2, reason2 = v.is_model_compatible("anthropic/claude-opus-4-8")
-            assert ok2 is False
-            assert reason2 is not None
-            assert "OAuth-allowed models" in reason2
-        finally:
-            monkeypatch.delenv(
-                "OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC", raising=False
-            )
-            importlib.reload(creds_mod)
+        monkeypatch.setitem(
+            creds_mod._OAUTH_ALLOWED_MODELS,
+            "anthropic",
+            frozenset({"anthropic/claude-opus-4-7"}),
+        )
+        self._purge_env(monkeypatch)
+        monkeypatch.setenv(
+            "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+            "sk-ant-oat01-" + "x" * 80,
+        )
+        v = creds_mod.CredentialVault()
+        assert v.get_credential_kind("anthropic") == "oauth"
+        # Exact-listed model passes.
+        ok, reason = v.is_model_compatible("anthropic/claude-opus-4-7")
+        assert ok is True, reason
+        # A different (family-matching) version is now REJECTED because
+        # the operator opted into an exact subset.
+        ok2, reason2 = v.is_model_compatible("anthropic/claude-opus-4-8")
+        assert ok2 is False
+        assert reason2 is not None
+        assert "OAuth-allowed models" in reason2
 
     def test_openai_oauth_unchanged_still_exact(self, monkeypatch):
         """The OpenAI OAuth subset is genuinely restricted (codex) and stays


### PR DESCRIPTION
Two order-dependent failure sources that only show on a machine with a
real .env (never CI, which has none) and only in the combined tree —
PR #1102 and #1103 each branched from the same base, so neither CI run
covered their interaction:

1. Runtime read-leak #1103 missed: every CliRunner invocation that
   reaches a subcommand runs the cli group callback, which calls
   load_dotenv(cli_config.ENV_FILE) and loads the developer's real .env
   into os.environ mid-run — flipping 31 credential/template tests that
   run after test_cli_commands.py. The LITELLM_MODE guard only covers
   litellm's import-time load. The conftest fixture now also patches
   ENV_FILE on both modules that bind it (src.cli.config and the
   from-import copy in src.cli.runtime — which also closes the WRITE
   path through cli/config.py's _persist_to_env(env_file=str(ENV_FILE)))
   and snapshots/restores OPENLEGION_{SYSTEM,CRED,CONN}_* env keys
   around every test so any uncovered pollution stays confined to the
   test that caused it.

2. Class-identity landmine: two OAuth-allowlist tests reloaded
   src.host.credentials in place to re-evaluate import-time env parsing.
   importlib.reload reuses the module dict, so even pre-reload vault
   instances raise the re-minted exception classes while other test
   files still hold collection-time bindings — pytest.raises
   (ConnectionRefreshError) in test_oauth_integrations.py failed
   order-dependently (pass alone, fail in the full sweep). Rewritten to
   exercise _parse_env_models directly and monkeypatch the parsed
   globals (_ANTHROPIC_OAUTH_ALLOWLIST_IS_OPERATOR_SET, the
   _OAUTH_ALLOWED_MODELS entry); no module reloads remain in the file.

Full sweep with an adversarial fake .env in the repo root:
7360 passed, 0 failed (was 31 failed on merged main with a real .env).
