### PR TITLE
fix(traces): synthesize a trace id for lane dispatches — unblind inspect_task_run

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -776,10 +776,25 @@ class RuntimeContext:
             task_id: str | None = None,
             **_kwargs,
         ) -> str:
-            from src.shared.trace import current_trace_id, origin_header
+            from src.shared.trace import (
+                current_trace_id,
+                new_trace_id,
+                origin_header,
+            )
 
-            tid = current_trace_id.get()
-            if tid and self.trace_store:
+            # Synthesize a trace id when the dispatch context has none.
+            # Lane-dispatched turns (hand_off wakes, recovery wakes) run
+            # in the lane worker's bare context, so ``current_trace_id``
+            # is unset — the x-trace-id header was never sent, the
+            # recipient's LLM calls carried no trace id, and the mesh
+            # proxy (whose trace writes are gated on ``req_trace_id``)
+            # recorded NO llm rows for exactly the handoff runs that
+            # ``inspect_task_run`` exists to diagnose: its execution
+            # summary read 0 calls / 0 tokens in production. (Caught
+            # live on cake; unit tests seed trace rows manually and
+            # could not surface this.)
+            tid = current_trace_id.get() or new_trace_id()
+            if self.trace_store:
                 self.trace_store.record(
                     trace_id=tid, source="dispatch", agent=agent_name,
                     event_type="chat", detail=message[:200],
@@ -787,9 +802,7 @@ class RuntimeContext:
                 )
             import time as _time
             t0 = _time.time()
-            extra_headers: dict[str, str] = {}
-            if tid:
-                extra_headers["x-trace-id"] = tid
+            extra_headers: dict[str, str] = {"x-trace-id": tid}
             extra_headers.update(origin_header(origin))
             # Bug 2/3 fix: when the wake carried an originating task_id,
             # forward it so the agent's /chat handler can auto-close that

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1909,6 +1909,48 @@ class TestDispatchTimeoutAlignment:
         _args, kwargs = transport.request.call_args
         assert kwargs["timeout"] == 1860  # 1800 (override) + 60
 
+    @pytest.mark.asyncio
+    async def test_dispatch_synthesizes_trace_id_when_context_has_none(
+        self, monkeypatch,
+    ):
+        """Lane-dispatched turns run in the lane worker's bare context, so
+        ``current_trace_id`` is unset. Without a synthesized id the
+        x-trace-id header was never sent, the recipient's LLM calls
+        carried no trace id, and the mesh proxy recorded NO llm rows for
+        handoff runs — ``inspect_task_run`` read 0 calls / 0 tokens in
+        production (caught live on cake)."""
+        from src.shared.trace import current_trace_id
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {"response": "done"}
+        assert current_trace_id.get() is None
+
+        result = await dispatch_fn("agent-x", "handoff work")
+
+        assert result == "done"
+        _args, kwargs = transport.request.call_args
+        tid = kwargs["headers"]["x-trace-id"]
+        assert tid.startswith("tr_") and len(tid) > 6
+
+    @pytest.mark.asyncio
+    async def test_dispatch_propagates_ambient_trace_id_unchanged(
+        self, monkeypatch,
+    ):
+        """An ambient trace id (channel/user-originated dispatch) must keep
+        propagating verbatim — synthesis only fills the gap."""
+        from src.shared.trace import current_trace_id
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {"response": "done"}
+        token = current_trace_id.set("tr_ambient123")
+        try:
+            await dispatch_fn("agent-x", "channel work")
+        finally:
+            current_trace_id.reset(token)
+
+        _args, kwargs = transport.request.call_args
+        assert kwargs["headers"]["x-trace-id"] == "tr_ambient123"
+
 
 # ── RC-2: dispatch-error surfacing + redaction ─────────────────────────────
 #


### PR DESCRIPTION
Lane-dispatched turns (hand_off wakes, recovery wakes) run in the lane
worker's bare context where current_trace_id is unset, so _direct_dispatch
sent no x-trace-id header, the recipient's LLM calls carried no trace id,
and the mesh proxy — whose trace writes are gated on req_trace_id —
recorded zero llm rows for exactly the handoff runs inspect_task_run
(PR #1104) exists to diagnose. In production its execution summary read
0 calls / 0 tokens / no models on every handoff run.

Caught by live verification on cake: a brief+thinking=high test task
executed correctly (marker file, artifact, thinking applied) but
inspect_task_run aggregated nothing; the box's traces.db had never held
a single llm_call row. Unit tests seed trace rows manually, so only a
live run could surface this.

Fix: synthesize a fresh trace id at the dispatch boundary when the
context has none; ambient trace ids (channel/user-originated) still
propagate verbatim. Dispatch trace rows now also record for synthesized
ids, which is desirable — they were equally blind before.
