### PR TITLE
feat(operator): watch mode — narrate pipelines live + fix the playbook roll-forward gap

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -335,6 +335,21 @@ class WorkspaceManager:
                 f.write("\n" + _PLAYBOOK_V3_ADDENDUM + "\n")
             logger.info("Appended handoff-brief guidance to operator instructions (v3)")
 
+        # Migration v4 (watch mode): loop await_task_event + narrate when
+        # the user explicitly asks to watch a pipeline. Same append-only
+        # contract as v2/v3.
+        if (
+            instructions_file.exists()
+            and self._initial_instructions
+            and "<!-- playbook_v4_watch_mode -->" in self._initial_instructions
+            and "<!-- playbook_v4_watch_mode -->"
+            not in instructions_file.read_text(errors="replace")
+        ):
+            from src.shared.operator_playbooks import _PLAYBOOK_V4_ADDENDUM
+            with open(instructions_file, "a") as f:
+                f.write("\n" + _PLAYBOOK_V4_ADDENDUM + "\n")
+            logger.info("Appended watch-mode guidance to operator instructions (v4)")
+
         for filename, default_content in _SCAFFOLD_FILES.items():
             path = self.root / filename
             if not path.exists():

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -2013,6 +2013,63 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
                 "both layers fresh from the canonical template."
             )
 
+        # Refresh the operator's ``initial_instructions`` payload the same
+        # way. The workspace migrator appends a new playbook addendum to
+        # the live INSTRUCTIONS.md ONLY when the container's
+        # INITIAL_INSTRUCTIONS payload carries the new sentinel — and that
+        # payload comes verbatim from agents.yaml, which was written once
+        # at creation and never updated. Without this roll-forward,
+        # existing operators never receive any playbook addendum (live
+        # finding 2026-06-11: a production operator predating every
+        # sentinel had silently missed two playbook generations). Note
+        # this only refreshes the PAYLOAD — the workspace-side migrator
+        # still appends to the live INSTRUCTIONS.md, so the operator's
+        # self-evolved content is never rewritten.
+        from src.shared.types import PLAYBOOK_SENTINELS
+        existing_instructions = op_entry.get("initial_instructions") or ""
+        pb_latest = PLAYBOOK_SENTINELS[-1] if PLAYBOOK_SENTINELS else None
+        pb_new_has_latest = (
+            pb_latest is not None
+            and f"<!-- {pb_latest} -->" in _OPERATOR_CORE
+        )
+        pb_old_has_latest = (
+            pb_latest is not None
+            and f"<!-- {pb_latest} -->" in existing_instructions
+        )
+        pb_old_has_any = any(
+            f"<!-- {s} -->" in existing_instructions
+            for s in PLAYBOOK_SENTINELS
+        )
+        pb_existing_empty = not existing_instructions.strip()
+        if pb_new_has_latest and (
+            (not pb_old_has_latest and pb_old_has_any) or pb_existing_empty
+        ):
+            op_entry["initial_instructions"] = _OPERATOR_CORE
+            agents_cfg["agents"][_OPERATOR_AGENT_ID] = op_entry
+            AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+            with open(AGENTS_FILE, "w") as f:
+                yaml.dump(
+                    agents_cfg, f, default_flow_style=False, sort_keys=False,
+                )
+            logger.info(
+                "Refreshed operator instructions payload to versioned playbook%s",
+                " (was empty — bootstrapped)" if pb_existing_empty else "",
+            )
+        elif (
+            pb_new_has_latest
+            and not pb_old_has_latest
+            and not pb_old_has_any
+            and not pb_existing_empty
+        ):
+            logger.warning(
+                "operator instructions payload carries no known sentinel — "
+                "treating as user-customised and skipping refresh. To opt "
+                "in: clear the `initial_instructions:` field in agents.yaml "
+                "— startup rewrites it from the canonical playbook. The "
+                "live INSTRUCTIONS.md is never rewritten; new guidance is "
+                "appended to it."
+            )
+
         # Ensure permissions are correct even for existing operator
         # (handles upgrades where operator was created before permissions were set)
         perms = _load_permissions()

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -74,7 +74,8 @@ When the user wants work done:
 await_task_event to babysit a pipeline — the system watches every user chain \
 and auto-delivers the final result (or a failure) when it finishes, plus a \
 heads-up if it gets stuck. Re-engage only to summarize a finished result when \
-asked, or to unstick a real blocker.
+asked, or to unstick a real blocker. EXCEPTION: when the user explicitly asks \
+to watch — see "Watching a Pipeline".
 
 Don't do the work yourself. Don't over-explain the routing — just do it.
 
@@ -154,8 +155,25 @@ If nothing useful applies, omit the block entirely (the dashboard falls \
 back to free-text only). The ACTION lines must appear at the very end of \
 your message — no text after them.
 
+
+## Watching a Pipeline (watch mode)
+
+Only when the user EXPLICITLY asks to watch, follow, or test a \
+workflow live, stay on the turn and narrate instead of releasing: \
+after hand_off, loop await_task_event(task_id, timeout_s=90). Each \
+return, tell the user in ONE short line what changed (stage done -> \
+name it + who picked up next; unchanged -> "still working (Nm)" at \
+most every other timeout) — your text streams live. When a stage \
+completes, find the next task via workflow_snapshot(root_task_id) \
+and await that id. Stop and summarize when the chain is terminal \
+(one line per stage + where the deliverable landed), a stage fails \
+(inspect_task_run, then recover), or ~20 minutes pass (release — \
+the system auto-delivers the outcome). No explicit ask to watch -> \
+delegate and release.
+
 <!-- playbook_v2 -->
-<!-- playbook_v3_handoff_briefs -->"""
+<!-- playbook_v3_handoff_briefs -->
+<!-- playbook_v4_watch_mode -->"""
 
 # ── v3 addendum (appended to EXISTING operator INSTRUCTIONS.md) ──
 #
@@ -178,6 +196,29 @@ artifact, with concrete data per finding — not a bullet summary"). \
 A title-only handoff produces shallow work.
 
 <!-- playbook_v3_handoff_briefs -->"""
+
+# ── v4 addendum (appended to EXISTING operator INSTRUCTIONS.md) ──
+# Same append-only contract as v3; new operators get the identical
+# content inline in _OPERATOR_CORE above.
+
+_PLAYBOOK_V4_ADDENDUM = """\
+
+## Watching a Pipeline (v4 watch mode)
+
+Only when the user EXPLICITLY asks to watch, follow, or test a \
+workflow live, stay on the turn and narrate instead of releasing: \
+after hand_off, loop await_task_event(task_id, timeout_s=90). Each \
+return, tell the user in ONE short line what changed (stage done -> \
+name it + who picked up next; unchanged -> "still working (Nm)" at \
+most every other timeout) — your text streams live. When a stage \
+completes, find the next task via workflow_snapshot(root_task_id) \
+and await that id. Stop and summarize when the chain is terminal \
+(one line per stage + where the deliverable landed), a stage fails \
+(inspect_task_run, then recover), or ~20 minutes pass (release — \
+the system auto-delivers the outcome). No explicit ask to watch -> \
+delegate and release.
+
+<!-- playbook_v4_watch_mode -->"""
 
 # ── Boot greeting (seeded once on first operator creation) ────
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -105,6 +105,22 @@ HEARTBEAT_SENTINELS: tuple[str, ...] = (
     "heartbeat_v5_fleet_health",
 )
 
+# Same contract for the operator's INSTRUCTIONS playbook
+# (``operator_playbooks._OPERATOR_CORE``). The config-side migrator
+# refreshes the agents.yaml ``initial_instructions`` payload when the
+# canonical playbook gains a new sentinel (the workspace migrator then
+# APPENDS the matching addendum to the live INSTRUCTIONS.md — it never
+# rewrites the file, so the operator's self-evolved content survives).
+# Without the config-side refresh the container keeps receiving the
+# creation-time payload forever and no workspace addendum ever fires —
+# discovered live on a production box whose operator predated every
+# sentinel and had silently missed two playbook generations.
+PLAYBOOK_SENTINELS: tuple[str, ...] = (
+    "playbook_v2",
+    "playbook_v3_handoff_briefs",
+    "playbook_v4_watch_mode",
+)
+
 # === Inter-Component Messages ===
 
 

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -162,13 +162,16 @@ class TestEnsureOperatorModelSync(_TempConfigMixin):
         carries the sentinel) so the refresh branch is a no-op.
         """
         from src.cli.config import _OPERATOR_HEARTBEAT
+        from src.shared.operator_playbooks import _OPERATOR_CORE
 
         # Pre-create operator with matching model AND the canonical
-        # heartbeat template (sentinel present → no refresh).
+        # heartbeat + instructions templates (sentinels present → both
+        # refresh branches are no-ops, pinning the pure no-write path).
         agents_cfg = {"agents": {"operator": {
             "role": "Existing operator",
             "model": "openai/gpt-4o-mini",
             "heartbeat": _OPERATOR_HEARTBEAT,
+            "initial_instructions": _OPERATOR_CORE,
         }}}
         with open(self._agents_path, "w") as f:
             yaml.dump(agents_cfg, f)
@@ -577,3 +580,86 @@ class TestEnsureOperatorUsesConfigModel(_TempConfigMixin):
         with open(self._agents_path) as f:
             agents_cfg = yaml.safe_load(f)
         assert agents_cfg["agents"]["operator"]["model"] == "anthropic/claude-3-haiku"
+
+
+class TestEnsureOperatorInstructionsRefresh(_TempConfigMixin):
+    """Config-side playbook roll-forward (PLAYBOOK_SENTINELS).
+
+    The workspace migrator appends a new playbook addendum only when the
+    container's INITIAL_INSTRUCTIONS payload carries the new sentinel —
+    and the payload comes verbatim from agents.yaml, written once at
+    creation. This refresh keeps the payload current (live finding
+    2026-06-11: a production operator predating every sentinel silently
+    missed two playbook generations)."""
+
+    def _seed_operator(self, instructions):
+        entry = {
+            "role": "Existing operator",
+            "model": "openai/gpt-4o-mini",
+        }
+        if instructions is not None:
+            entry["initial_instructions"] = instructions
+        with open(self._agents_path, "w") as f:
+            yaml.dump({"agents": {"operator": entry}}, f)
+
+    def _run(self):
+        with self._mock_config():
+            from src.cli.config import _ensure_operator_agent
+            _ensure_operator_agent(default_model="openai/gpt-4o-mini")
+        with open(self._agents_path) as f:
+            return yaml.safe_load(f)["agents"]["operator"]
+
+    def test_rolls_forward_payload_with_prior_sentinel(self):
+        self._seed_operator(
+            "old playbook text\n<!-- playbook_v2 -->\n"
+            "<!-- playbook_v3_handoff_briefs -->"
+        )
+        agent = self._run()
+        from src.shared.operator_playbooks import _OPERATOR_CORE
+        assert agent["initial_instructions"] == _OPERATOR_CORE
+        assert "<!-- playbook_v4_watch_mode -->" in agent["initial_instructions"]
+
+    def test_pre_sentinel_payload_treated_as_customised(self):
+        self._seed_operator("user-customised playbook, no sentinels")
+        agent = self._run()
+        assert agent["initial_instructions"] == (
+            "user-customised playbook, no sentinels"
+        )
+
+    def test_empty_payload_bootstrapped(self):
+        self._seed_operator("")
+        agent = self._run()
+        from src.shared.operator_playbooks import _OPERATOR_CORE
+        assert agent["initial_instructions"] == _OPERATOR_CORE
+
+    def test_current_payload_untouched(self):
+        custom = "current + user edit\n<!-- playbook_v4_watch_mode -->"
+        self._seed_operator(custom)
+        agent = self._run()
+        assert agent["initial_instructions"] == custom
+
+    def test_core_carries_latest_playbook_sentinel(self):
+        """Mirror of the heartbeat would-never-fire guard: the canonical
+        playbook must embed the LATEST sentinel or the roll-forward is
+        permanently inert."""
+        from src.shared.operator_playbooks import _OPERATOR_CORE
+        from src.shared.types import PLAYBOOK_SENTINELS
+        assert f"<!-- {PLAYBOOK_SENTINELS[-1]} -->" in _OPERATOR_CORE
+
+    def test_watch_mode_guidance_content(self):
+        """Watch mode pins: explicit-ask gating, the narrate loop, the
+        await timeout within the streaming-idle cap, and the
+        delegate-and-release carve-out."""
+        from src.agent.builtins.operator_tools import (
+            _AWAIT_TASK_EVENT_MAX_TIMEOUT_S,
+        )
+        from src.shared.operator_playbooks import (
+            _OPERATOR_CORE,
+            _PLAYBOOK_V4_ADDENDUM,
+        )
+        for text in (_OPERATOR_CORE, _PLAYBOOK_V4_ADDENDUM):
+            assert "EXPLICITLY" in text
+            assert "await_task_event" in text
+            assert "workflow_snapshot" in text
+            assert f"timeout_s={_AWAIT_TASK_EVENT_MAX_TIMEOUT_S}" in text
+            assert "delegate and release" in text

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -131,8 +131,10 @@ class TestPlaybookConstants:
         # 6000 → 6400 for the Phase-1d "delegate and release" routing rule
         # (hand off → stop; the chain watcher delivers the terminal outcome);
         # 6400 → 6800 for the handoff-brief rule (workers don't see the
-        # conversation — carry the user's ask + deliverable depth in `brief`).
-        assert len(_OPERATOR_CORE) < 6800
+        # conversation — carry the user's ask + deliverable depth in `brief`);
+        # 6800 → 7800 for watch mode (loop await_task_event + narrate when
+        # the user explicitly asks to watch a pipeline live).
+        assert len(_OPERATOR_CORE) < 7800
         assert len(_OPERATOR_CORE) > 1000
 
     def test_playbooks_have_numbered_steps(self):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1383,3 +1383,54 @@ class TestHeartbeatVersionedRefresh:
         )
         assert "New revision" in content
         assert "Older revision text" not in content
+
+
+class TestPlaybookV4WatchModeMigration:
+    """v4 watch-mode addendum — append-only migration to a live
+    INSTRUCTIONS.md, gated on the sentinel arriving in the container's
+    INITIAL_INSTRUCTIONS payload (see PLAYBOOK_SENTINELS in shared types)."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _seed_pre_v4_instructions(self):
+        (Path(self._tmpdir) / "INSTRUCTIONS.md").write_text(
+            "# My evolved instructions\n\nOperator-curated content.\n"
+            "<!-- playbook_v2 -->\n<!-- playbook_v3_handoff_briefs -->\n"
+        )
+
+    def test_appends_addendum_when_payload_carries_sentinel(self):
+        from src.shared.operator_playbooks import _OPERATOR_CORE
+        self._seed_pre_v4_instructions()
+        WorkspaceManager(
+            workspace_dir=self._tmpdir, initial_instructions=_OPERATOR_CORE,
+        )
+        text = (Path(self._tmpdir) / "INSTRUCTIONS.md").read_text()
+        # Evolved content preserved (append-only), addendum landed once.
+        assert "Operator-curated content." in text
+        assert "Watching a Pipeline" in text
+        assert text.count("<!-- playbook_v4_watch_mode -->") == 1
+
+    def test_migration_is_idempotent(self):
+        from src.shared.operator_playbooks import _OPERATOR_CORE
+        self._seed_pre_v4_instructions()
+        WorkspaceManager(
+            workspace_dir=self._tmpdir, initial_instructions=_OPERATOR_CORE,
+        )
+        WorkspaceManager(
+            workspace_dir=self._tmpdir, initial_instructions=_OPERATOR_CORE,
+        )
+        text = (Path(self._tmpdir) / "INSTRUCTIONS.md").read_text()
+        assert text.count("<!-- playbook_v4_watch_mode -->") == 1
+
+    def test_skips_when_payload_lacks_sentinel(self):
+        self._seed_pre_v4_instructions()
+        WorkspaceManager(
+            workspace_dir=self._tmpdir,
+            initial_instructions="stale payload without sentinels",
+        )
+        text = (Path(self._tmpdir) / "INSTRUCTIONS.md").read_text()
+        assert "playbook_v4_watch_mode" not in text


### PR DESCRIPTION
Two changes, one discovery.

Watch mode (playbook v4): when the user EXPLICITLY asks to watch a
workflow ('watch it', 'test end to end and show me'), the operator now
stays on the turn and narrates instead of delegate-and-release: loop
await_task_event(task_id, timeout_s=90) — each return emits a one-line
progress update (text streams live to the dashboard), follow the chain
to the next stage via workflow_snapshot, stop on chain-terminal /
stage-failure / ~20 minutes. The 90s await cadence is deliberate: the
cap is pinned under the 120s streaming-idle window, and each round is
prompt-cache-cheap. Delegate-and-release stays the default; watch mode
is the explicit-ask exception, stated in both texts.

Playbook roll-forward gap (the discovery): agents.yaml's operator
initial_instructions was written once at creation and NEVER refreshed —
but the workspace migrator only appends a new playbook addendum when
the container's INITIAL_INSTRUCTIONS payload carries the new sentinel.
Net effect: no existing operator ever received any playbook addendum;
a production operator was found running a payload predating every
sentinel, two guidance generations behind (which is why it sat on one
bare await with no brief when asked to watch a pipeline). Fix mirrors
the heartbeat sentinel refresh: PLAYBOOK_SENTINELS in shared types, a
config-side roll-forward of the yaml payload (sentinel-guarded so
user-customised payloads are skipped, empty payloads bootstrap), and
the workspace-side v4 addendum append. The live INSTRUCTIONS.md is
never rewritten — addenda only — so operator self-evolution survives.

Tests: workspace v4 migration (append/idempotent/skip), config
roll-forward (prior-sentinel/pre-sentinel/empty/current), would-never-
fire sentinel guard, watch-mode content pins incl. timeout-under-
streaming-idle; no-write test now seeds both canonical templates.
