### PR TITLE
fix(chat): stream-chat turns lost origin/trace context — chains went unwatched

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -7,6 +7,7 @@ Max 20 iterations per task. Proper LLM tool-calling message roles.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import re
@@ -4877,6 +4878,19 @@ class AgentLoop:
             return
 
         from src.shared.trace import current_origin, current_trace_id
+        # NOTE: when this generator is driven by the server's
+        # task-per-__anext__ pump (``/chat/stream`` in agent/server.py),
+        # each resume runs in a fresh context COPY, so these sets do NOT
+        # persist across steps — tools like hand_off saw
+        # ``current_origin = None`` and every dashboard-stream chat
+        # created NULL-origin chain roots, silently disabling chain
+        # delivery / stall nudges / recovery wakes. The server now seeds
+        # the same vars in the pump's own context (inherited by every
+        # per-step copy); the sets here still cover single-task consumers
+        # (tests, direct iteration). The reset is suppressed because the
+        # token may have been minted in a different context copy than the
+        # one running this ``finally`` — that exact ValueError fired at
+        # the end of every streamed turn in production and was the tell.
         current_trace_id.set(trace_id)
         origin_token = current_origin.set(origin)
         try:
@@ -4888,7 +4902,8 @@ class AgentLoop:
                 finally:
                     await self._checkpoint_chat_session()
         finally:
-            current_origin.reset(origin_token)
+            with contextlib.suppress(ValueError):
+                current_origin.reset(origin_token)
 
     async def _chat_stream_inner(self, user_message: str):
         from src.agent.llm import LLMContextOverflowError

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -395,6 +395,21 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         _trace_id = request.headers.get("x-trace-id")
         _origin = _origin_from_mesh_request(request)
         async def event_generator():
+            # Seed the trace/origin contextvars HERE, in the pump's own
+            # task context. Each ``__anext__`` below is wrapped in its own
+            # task, and a task runs in a COPY of the creating context —
+            # so sets made INSIDE the generator (loop.chat_stream) live
+            # and die with one step's copy and are invisible to the next.
+            # In production that meant every tool call in a streamed chat
+            # saw ``current_origin = None``: dashboard-initiated chains
+            # stored NULL origins and the entire delegate-and-subscribe
+            # surface (chain completion delivery, stall nudges, failure
+            # recovery wakes) silently never fired, and ``llm.py`` sent
+            # no x-trace-id (no per-call traces). Seeding in THIS context
+            # makes every per-step task copy inherit the values.
+            from src.shared.trace import current_origin, current_trace_id
+            _tid_token = current_trace_id.set(_trace_id)
+            _origin_token = current_origin.set(_origin)
             stream = loop.chat_stream(
                 sanitize_for_prompt(msg.message), trace_id=_trace_id,
                 origin=_origin,
@@ -423,6 +438,11 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
                     next_event.cancel()
                     with contextlib.suppress(asyncio.CancelledError, Exception):
                         await next_event
+                # Tokens were minted in THIS context, so the resets are
+                # safe (unlike the in-generator reset, which lands in a
+                # per-step context copy and is suppressed there).
+                current_origin.reset(_origin_token)
+                current_trace_id.reset(_tid_token)
         return StreamingResponse(event_generator(), media_type="text/event-stream")
 
     @app.post("/chat/reset")

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -1008,3 +1008,87 @@ class TestLearningsFeedbackEndpoint:
                 headers={"x-mesh-internal": "1"},
             )
         assert r.status_code == 400
+
+
+class TestChatStreamContextSeeding:
+    """The /chat/stream pump wraps every ``__anext__`` in its own task,
+    and tasks run in context COPIES — sets made inside the generator
+    don't survive to the next step. The route must seed
+    ``current_origin`` / ``current_trace_id`` in the pump's own context
+    so every per-step copy (where tools execute) inherits them.
+    Regression for the production NULL-origin chain roots that disabled
+    chain delivery, stall nudges, and recovery wakes for every
+    dashboard-stream chat."""
+
+    @pytest.mark.asyncio
+    async def test_tools_see_origin_and_trace_across_stream_steps(self):
+        from httpx import ASGITransport, AsyncClient
+
+        app, loop = _make_app()
+        captured: list[tuple] = []
+
+        async def fake_chat_stream(message, *, trace_id=None, origin=None):
+            from src.shared.trace import current_origin, current_trace_id
+            # Each yield forces the pump to resume us in a NEW task
+            # (fresh context copy) — capture what a tool running in the
+            # SECOND step would see.
+            yield {"type": "text_delta", "content": "step1"}
+            captured.append(
+                (current_origin.get(), current_trace_id.get()),
+            )
+            yield {"type": "text_delta", "content": "step2"}
+
+        loop.chat_stream = fake_chat_stream
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as client:
+            async with client.stream(
+                "POST", "/chat/stream",
+                json={"message": "hi"},
+                headers={
+                    "x-mesh-internal": "1",
+                    "x-trace-id": "tr_streamtest1",
+                    "X-Origin": (
+                        '{"kind": "human", "channel": "dashboard",'
+                        ' "user": "admin"}'
+                    ),
+                },
+            ) as resp:
+                assert resp.status_code == 200
+                async for _ in resp.aiter_lines():
+                    pass
+
+        assert captured, "stream never reached the second step"
+        origin, trace_id = captured[0]
+        assert origin is not None, (
+            "current_origin was lost between stream steps — tools in "
+            "streamed chats create NULL-origin chain roots again"
+        )
+        assert origin.kind == "human"
+        assert origin.channel == "dashboard"
+        assert trace_id == "tr_streamtest1"
+
+    @pytest.mark.asyncio
+    async def test_stream_completes_without_context_token_error(self):
+        """The end-of-turn reset must not raise 'Token was created in a
+        different Context' (fired on every streamed turn before the
+        fix)."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, loop = _make_app()
+
+        async def fake_chat_stream(message, *, trace_id=None, origin=None):
+            yield {"type": "text_delta", "content": "ok"}
+
+        loop.chat_stream = fake_chat_stream
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as client:
+            async with client.stream(
+                "POST", "/chat/stream", json={"message": "hi"},
+                headers={"x-mesh-internal": "1"},
+            ) as resp:
+                lines = [ln async for ln in resp.aiter_lines() if ln]
+        assert any("ok" in ln for ln in lines)


### PR DESCRIPTION
The /chat/stream pump wraps every generator __anext__ in its own task
(deliberately, so a keepalive timeout never cancels the pending step),
but a task runs in a COPY of the creating context — so the
current_origin / current_trace_id sets made INSIDE loop.chat_stream
lived and died with the first step's copy. Every tool call in a
streamed chat saw current_origin = None.

Production impact (verified on cake): every chain started from a real
dashboard chat stored NULL-origin roots, so list_watchable_human_roots
never matched them — no chain-completion delivery, no stall nudge, no
failure recovery wake. The user-visible symptom: the operator promises
'you'll get notified' and nothing ever arrives. The tell was a
'Token was created in a different Context' ValueError at the end of
every streamed turn (set in step-1's copy, reset in step-N's copy).
Trace ids were lost the same way, so streamed turns also recorded no
per-call llm traces.

Fix: seed the contextvars in the pump's own task context (event
generator) — every per-step task copy inherits them — and reset them
there, where the tokens are valid. The in-generator set stays for
single-task consumers (tests, direct iteration) with its cross-context
reset suppressed.

Regression test drives the real route through the real pump and
asserts a second-step tool sees the seeded origin + trace id; verified
to FAIL against the unfixed route.
