### PR TITLE
feat(operator): post-completion verification wake + playbook v5

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -350,6 +350,21 @@ class WorkspaceManager:
                 f.write("\n" + _PLAYBOOK_V4_ADDENDUM + "\n")
             logger.info("Appended watch-mode guidance to operator instructions (v4)")
 
+        # Migration v5 (verification wake): the system wakes the operator
+        # once per completed chain to verify side effects; promise nothing
+        # beyond that. Same append-only contract as v2-v4.
+        if (
+            instructions_file.exists()
+            and self._initial_instructions
+            and "<!-- playbook_v5_verification_wake -->" in self._initial_instructions
+            and "<!-- playbook_v5_verification_wake -->"
+            not in instructions_file.read_text(errors="replace")
+        ):
+            from src.shared.operator_playbooks import _PLAYBOOK_V5_ADDENDUM
+            with open(instructions_file, "a") as f:
+                f.write("\n" + _PLAYBOOK_V5_ADDENDUM + "\n")
+            logger.info("Appended verification-wake guidance to operator instructions (v5)")
+
         for filename, default_content in _SCAFFOLD_FILES.items():
             path = self.root / filename
             if not path.exists():

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -163,6 +164,11 @@ class RuntimeContext:
         self.trace_store = None
         self.agent_urls: dict[str, str] = {}
         self._dispatch_loop = None
+        # Post-completion verification wakes (success path) — sliding
+        # window so a burst of completing chains can't turn the operator
+        # interrupt-driven. Suppressed chains are still rated on the
+        # next heartbeat.
+        self._verify_wake_times: deque = deque()
         self._server = None
         self._active_channels: list = []
         self._start_time: float | None = None
@@ -1036,6 +1042,19 @@ class RuntimeContext:
             except Exception as e:
                 logger.debug("notification_added emit failed: %s", e)
 
+        # 1b. Post-completion verification wake (success path only). The
+        #     user already has the result (bell above); the operator gets
+        #     ONE wake per completed chain to verify side effects are
+        #     REAL (artifacts/files/PRs, not just 'done' statuses), rate
+        #     the stages, and speak up only if something is wrong.
+        #     failed/blocked chains are excluded — the mesh recovery wake
+        #     already fires per failed task. Best-effort: a wake failure
+        #     never flips this delivery to False (the bell is the
+        #     guarantee), and the rate cap keeps a completion burst from
+        #     monopolizing the operator's lane.
+        if kind == "done":
+            self._maybe_wake_operator_verification(root, root_id, root_title)
+
         # 2. Push to a paired chat channel for non-dashboard originators, with
         #    bounded retry so a transient channel failure (network blip, rate
         #    limit) doesn't silently drop it. Runs as a background task so it
@@ -1095,6 +1114,75 @@ class RuntimeContext:
             "(bell delivered as fallback)",
             origin.channel, origin.user, attempts,
         )
+
+
+    # Verification-wake rate cap: at most N wakes per sliding window.
+    # Mirrors the mesh-side recovery-wake storm guard (same numbers) —
+    # one operator turn per completed chain is the point, but a backlog
+    # of chains completing together must not queue an interrupt storm.
+    _VERIFY_WAKE_MAX = 5
+    _VERIFY_WAKE_WINDOW_S = 600.0
+
+    def _maybe_wake_operator_verification(
+        self, root: dict, root_id: str, root_title: str,
+    ) -> None:
+        """Wake the operator once to verify a COMPLETED user chain.
+
+        Fire-and-forget onto the dispatch loop (this runs on the chain
+        watcher's own loop — never block its sweep on a busy operator
+        lane). ``auto_notify=False``: the user already got the terminal
+        delivery; if verification finds a problem the operator decides
+        to speak via notify_user. ``task_id`` is deliberately NOT
+        threaded — a verification turn must never auto-close anything.
+        """
+        if self.lane_manager is None or self._dispatch_loop is None:
+            return
+        now = time.time()
+        while (
+            self._verify_wake_times
+            and now - self._verify_wake_times[0] > self._VERIFY_WAKE_WINDOW_S
+        ):
+            self._verify_wake_times.popleft()
+        if len(self._verify_wake_times) >= self._VERIFY_WAKE_MAX:
+            logger.warning(
+                "verification wake for chain %s suppressed: cap (%d/%ds) "
+                "reached — the heartbeat rating step covers it",
+                root_id, self._VERIFY_WAKE_MAX,
+                int(self._VERIFY_WAKE_WINDOW_S),
+            )
+            return
+        self._verify_wake_times.append(now)
+        from src.shared.utils import sanitize_for_prompt
+        msg = (
+            f"User chain {root_id} ('{sanitize_for_prompt(root_title)}') "
+            "completed and the user was ALREADY notified of the result — "
+            "do NOT re-announce it. Verify it now: confirm the promised "
+            "side effects really exist (artifacts, files, merged PRs — "
+            "check externally visible effects with your tools, not just "
+            f"task statuses), use workflow_snapshot('{root_id}') and "
+            "inspect_task_run on any stage that looks shallow, then "
+            "rate_delivery the done stages. Message the user ONLY if "
+            "verification fails or adds something material."
+        )
+        origin_dict = root.get("origin") or {}
+        try:
+            from src.shared.types import MessageOrigin
+            wake_origin = MessageOrigin(
+                kind="human",
+                channel=str(origin_dict.get("channel") or ""),
+                user=str(origin_dict.get("user") or ""),
+            )
+            asyncio.run_coroutine_threadsafe(
+                self.lane_manager.enqueue(
+                    "operator", msg, mode="followup",
+                    origin=wake_origin, auto_notify=False,
+                ),
+                self._dispatch_loop,
+            )
+        except Exception as e:
+            logger.warning(
+                "verification wake for chain %s failed: %s", root_id, e,
+            )
 
     def _start_mesh_server(self) -> None:
         import uvicorn

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -171,9 +171,16 @@ and await that id. Stop and summarize when the chain is terminal \
 the system auto-delivers the outcome). No explicit ask to watch -> \
 delegate and release.
 
+After a chain completes, the system wakes you ONCE to verify it: \
+confirm the side effects are real (artifacts, files, merged PRs — not \
+just task statuses) and rate the stages. Never promise the user any \
+other follow-up — promise only what the system delivers: the result \
+notification and this post-completion verification.
+
 <!-- playbook_v2 -->
 <!-- playbook_v3_handoff_briefs -->
-<!-- playbook_v4_watch_mode -->"""
+<!-- playbook_v4_watch_mode -->
+<!-- playbook_v5_verification_wake -->"""
 
 # ── v3 addendum (appended to EXISTING operator INSTRUCTIONS.md) ──
 #
@@ -219,6 +226,21 @@ the system auto-delivers the outcome). No explicit ask to watch -> \
 delegate and release.
 
 <!-- playbook_v4_watch_mode -->"""
+
+# ── v5 addendum (appended to EXISTING operator INSTRUCTIONS.md) ──
+# Same append-only contract as v3/v4.
+
+_PLAYBOOK_V5_ADDENDUM = """\
+
+## Post-Completion Verification (v5)
+
+After a chain completes, the system wakes you ONCE to verify it: \
+confirm the side effects are real (artifacts, files, merged PRs — not \
+just task statuses) and rate the stages. Never promise the user any \
+other follow-up — promise only what the system delivers: the result \
+notification and this post-completion verification.
+
+<!-- playbook_v5_verification_wake -->"""
 
 # ── Boot greeting (seeded once on first operator creation) ────
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -119,6 +119,7 @@ PLAYBOOK_SENTINELS: tuple[str, ...] = (
     "playbook_v2",
     "playbook_v3_handoff_briefs",
     "playbook_v4_watch_mode",
+    "playbook_v5_verification_wake",
 )
 
 # === Inter-Component Messages ===

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -633,7 +633,13 @@ class TestEnsureOperatorInstructionsRefresh(_TempConfigMixin):
         assert agent["initial_instructions"] == _OPERATOR_CORE
 
     def test_current_payload_untouched(self):
-        custom = "current + user edit\n<!-- playbook_v4_watch_mode -->"
+        # Pin against the LATEST sentinel so this test means "payload is
+        # already current" forever — a hardcoded older sentinel silently
+        # turns into the roll-forward case when a new version ships.
+        from src.shared.types import PLAYBOOK_SENTINELS
+        custom = (
+            f"current + user edit\n<!-- {PLAYBOOK_SENTINELS[-1]} -->"
+        )
         self._seed_operator(custom)
         agent = self._run()
         assert agent["initial_instructions"] == custom

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -133,8 +133,10 @@ class TestPlaybookConstants:
         # 6400 → 6800 for the handoff-brief rule (workers don't see the
         # conversation — carry the user's ask + deliverable depth in `brief`);
         # 6800 → 7800 for watch mode (loop await_task_event + narrate when
-        # the user explicitly asks to watch a pipeline live).
-        assert len(_OPERATOR_CORE) < 7800
+        # the user explicitly asks to watch a pipeline live);
+        # 7800 → 8400 for the post-completion verification-wake contract
+        # (system wakes you once per completed chain; promise nothing else).
+        assert len(_OPERATOR_CORE) < 8400
         assert len(_OPERATOR_CORE) > 1000
 
     def test_playbooks_have_numbered_steps(self):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2226,6 +2226,11 @@ class TestDeliverChainOutcomeBellKind:
         class _Stub:
             _notification_store = _Store()
             event_bus = None
+            lane_manager = None
+            _dispatch_loop = None
+            _maybe_wake_operator_verification = (
+                RuntimeContext._maybe_wake_operator_verification
+            )
 
         stub = _Stub()
         root = {
@@ -2339,3 +2344,130 @@ class TestChannelPushRetry:
             timeout=5,  # the whole call must finish well under this
         )
         assert stub.calls == 3  # each attempt timed out → gave up
+
+
+# ── Post-completion verification wake (success path) ───────────────────────
+
+
+class TestVerificationWake:
+    """A completed user chain wakes the operator ONCE for side-effect
+    verification; failed/stall outcomes do not (the mesh recovery wake
+    covers failures). Fire-and-forget onto the dispatch loop; rate-capped."""
+
+    def _ctx_stub(self):
+        import asyncio as _asyncio
+        import threading
+        from collections import deque as _deque
+
+        from src.cli.runtime import RuntimeContext
+
+        class _Store:
+            def add(self, **kw):
+                return "n1"
+
+        class _Lane:
+            def __init__(self):
+                self.calls = []
+
+            async def enqueue(self, agent, message, **kw):
+                self.calls.append((agent, message, kw))
+                return "ok"
+
+        loop = _asyncio.new_event_loop()
+        t = threading.Thread(target=loop.run_forever, daemon=True)
+        t.start()
+
+        class _Stub:
+            _notification_store = _Store()
+            event_bus = None
+            lane_manager = _Lane()
+            _dispatch_loop = loop
+            _verify_wake_times = _deque()
+            _VERIFY_WAKE_MAX = RuntimeContext._VERIFY_WAKE_MAX
+            _VERIFY_WAKE_WINDOW_S = RuntimeContext._VERIFY_WAKE_WINDOW_S
+            _maybe_wake_operator_verification = (
+                RuntimeContext._maybe_wake_operator_verification
+            )
+
+        return RuntimeContext, _Stub(), loop
+
+    def _root(self):
+        return {
+            "id": "t-root", "assignee": "worker", "title": "ship the thing",
+            "origin": {"kind": "human", "channel": "dashboard", "user": "u1"},
+        }
+
+    def _drain(self, loop, until=None):
+        # run_coroutine_threadsafe queues task CREATION as one callback and
+        # the task's first step as a later one — a single round-trip lands
+        # between them. Poll briefly so the enqueue body has actually run.
+        import time as _t
+        import concurrent.futures
+        for _ in range(100):
+            done = concurrent.futures.Future()
+            loop.call_soon_threadsafe(lambda: done.set_result(True))
+            done.result(timeout=5)
+            if until is None or until():
+                if until is not None:
+                    return
+            if until is None:
+                return
+            _t.sleep(0.02)
+
+    def test_done_chain_wakes_operator_for_verification(self):
+        RuntimeContext, stub, loop = self._ctx_stub()
+        try:
+            ok = RuntimeContext._deliver_chain_outcome(
+                stub, self._root(), "done", "summary",
+            )
+            assert ok is True
+            self._drain(loop, until=lambda: stub.lane_manager.calls)
+            assert len(stub.lane_manager.calls) == 1
+            agent, message, kw = stub.lane_manager.calls[0]
+            assert agent == "operator"
+            assert "t-root" in message
+            assert "rate_delivery" in message
+            assert "ALREADY notified" in message
+            assert kw["auto_notify"] is False
+            assert kw["origin"].kind == "human"
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+
+    def test_failed_and_stall_do_not_wake(self):
+        RuntimeContext, stub, loop = self._ctx_stub()
+        try:
+            for kind in ("failed", "stall"):
+                RuntimeContext._deliver_chain_outcome(
+                    stub, self._root(), kind, "summary",
+                )
+            self._drain(loop)
+            assert stub.lane_manager.calls == []
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+
+    def test_wake_rate_cap_suppresses_burst(self):
+        import time as _time
+
+        RuntimeContext, stub, loop = self._ctx_stub()
+        try:
+            now = _time.time()
+            for _ in range(stub._VERIFY_WAKE_MAX):
+                stub._verify_wake_times.append(now)
+            RuntimeContext._deliver_chain_outcome(
+                stub, self._root(), "done", "summary",
+            )
+            self._drain(loop)
+            assert stub.lane_manager.calls == []
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+
+    def test_wake_failure_does_not_flip_delivery(self):
+        RuntimeContext, stub, loop = self._ctx_stub()
+        try:
+            stub._dispatch_loop = None  # wake guard path
+            ok = RuntimeContext._deliver_chain_outcome(
+                stub, self._root(), "done", "summary",
+            )
+            assert ok is True  # bell already written — delivery stands
+        finally:
+            loop.call_soon_threadsafe(loop.stop)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1434,3 +1434,31 @@ class TestPlaybookV4WatchModeMigration:
         )
         text = (Path(self._tmpdir) / "INSTRUCTIONS.md").read_text()
         assert "playbook_v4_watch_mode" not in text
+
+
+class TestPlaybookV5VerificationWakeMigration:
+    """v5 addendum — same append-only contract as v2-v4."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_appends_v5_once_and_idempotent(self):
+        from src.shared.operator_playbooks import _OPERATOR_CORE
+        (Path(self._tmpdir) / "INSTRUCTIONS.md").write_text(
+            "# Mine\n<!-- playbook_v2 -->\n"
+            "<!-- playbook_v3_handoff_briefs -->\n"
+            "<!-- playbook_v4_watch_mode -->\n"
+        )
+        WorkspaceManager(
+            workspace_dir=self._tmpdir, initial_instructions=_OPERATOR_CORE,
+        )
+        WorkspaceManager(
+            workspace_dir=self._tmpdir, initial_instructions=_OPERATOR_CORE,
+        )
+        text = (Path(self._tmpdir) / "INSTRUCTIONS.md").read_text()
+        assert text.count("<!-- playbook_v5_verification_wake -->") == 1
+        assert "Post-Completion Verification" in text
+        assert "# Mine" in text


### PR DESCRIPTION
When a user chain completes, the operator now gets ONE lane wake to
verify the outcome is real — externally visible side effects (merged
PRs, files, artifacts), not just 'done' statuses — and to rate the
stages, speaking to the user only if verification finds a problem.
This makes the operator's standing 'I'll verify when results come
back' promise true: previously it woke on failure/blocked only (the
mesh recovery wake) and on success nothing ever brought it back.

Design: the wake rides the existing chain-terminal delivery in
RuntimeContext._deliver_chain_outcome — after the user's bell write
succeeds, kind == 'done' fires a fire-and-forget enqueue onto the
dispatch loop (the watcher's sweep never blocks on a busy operator
lane), auto_notify=False (the user already has the result), no task_id
(a verification turn must not auto-close anything), and a sliding-
window rate cap (5/10min, mirroring the mesh recovery-wake storm
guard) so a completion burst can't make the operator interrupt-driven
— suppressed chains are still rated by the heartbeat. failed/blocked
chains are excluded: the per-task recovery wake already covers them.

Playbook v5 (inline + addendum, same roll-forward machinery as v4):
tells the operator the system wakes it once per completed chain and to
never promise the user any other follow-up — promise only what the
system delivers. The over-promise shape ('I'll check back') had no
wake path before this.

Tests: wake fired on done with correct target/flags/origin, not fired
on failed/stall, rate-cap suppression, wake failure never flips the
delivery result; workspace v5 migration; current-payload test now pins
the LATEST sentinel dynamically (hardcoding v4 silently became the
roll-forward case when v5 shipped).
