### PR TITLE
fix(memory): consolidate oversized/legacy MEMORY.md heads, not just log growth

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -15,6 +15,7 @@ import time
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
+from src.agent.workspace import _MEMORY_HEAD_BUDGET
 from src.shared.models import get_context_window
 from src.shared.utils import sanitize_for_prompt, setup_logging
 
@@ -618,8 +619,9 @@ class ContextManager:
     async def _maybe_consolidate_memory(self) -> None:
         """Re-derive the compiled MEMORY.md head from the append-only log +
         high-salience facts. Time-gated (>=6h) and material-gated (>=1.5k log
-        chars) so it adds at most one LLM call per cycle. Best-effort: never
-        raises into the caller (compaction or the maintenance pass).
+        chars, OR a head exceeding its injection budget) so it adds at most
+        one LLM call per cycle. Best-effort: never raises into the caller
+        (compaction or the maintenance pass).
         """
         ws, llm = self.workspace, self.llm
         if not ws or not llm:
@@ -629,9 +631,13 @@ class ContextManager:
         if not ws.consolidation_due(_CONSOLIDATION_MIN_INTERVAL_S):
             return
         log = ws.load_memory_log()
-        if len(log) < _CONSOLIDATION_MIN_LOG_CHARS:
-            return
         head = ws.load_compiled_memory()
+        # An oversized head is either a legacy marker-less MEMORY.md (split as
+        # all-head, empty log) or an LLM-overshot compile; both must be
+        # re-compiled even with no new log material — otherwise they inject
+        # clipped + stale at the head budget forever.
+        if len(log) < _CONSOLIDATION_MIN_LOG_CHARS and len(head) <= _MEMORY_HEAD_BUDGET:
+            return
         salient = ""
         if self.memory:
             try:

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -104,6 +104,12 @@ MEMORY_COMPILED_END = "<!-- compiled:end -->"
 _MEMORY_FILE_MAX = 64_000
 # Newest slice of the log injected alongside the compiled head.
 _MEMORY_RECENT_LOG_CHARS = 5_000
+# The compiled head's injection budget: room left for the head once the
+# recent-log slice (plus the "## Recent" header overhead) is reserved under
+# the per-file bootstrap cap. Also the consolidation trigger threshold for
+# oversized/legacy heads (see context.py:_maybe_consolidate_memory) — a head
+# beyond this budget injects clipped every turn until it is re-compiled.
+_MEMORY_HEAD_BUDGET = max(0, _MAX_MEMORY - _MEMORY_RECENT_LOG_CHARS - 32)
 
 
 # Public mapping for external consumers (tool response, dashboard).
@@ -578,9 +584,8 @@ class WorkspaceManager:
             return head
         # Reserve room for the recent slice so a large head can't crowd it out
         # under the per-file cap applied by get_bootstrap_content.
-        head_cap = max(0, _MAX_MEMORY - _MEMORY_RECENT_LOG_CHARS - 32)
-        if len(head) > head_cap:
-            head = head[:head_cap]
+        if len(head) > _MEMORY_HEAD_BUDGET:
+            head = head[:_MEMORY_HEAD_BUDGET]
         return f"{head}\n\n## Recent\n\n{recent}".strip()
 
     def load_daily_logs(self, days: int = 2) -> str:

--- a/tests/test_compiled_memory.py
+++ b/tests/test_compiled_memory.py
@@ -20,6 +20,7 @@ from src.agent.context import (
 )
 from src.agent.workspace import (
     _MEMORY_FILE_MAX,
+    _MEMORY_HEAD_BUDGET,
     MEMORY_COMPILED_BEGIN,
     MEMORY_COMPILED_END,
     WorkspaceManager,
@@ -353,6 +354,78 @@ class TestConsolidateMemory:
             )
             await cm._maybe_decay_salience()
             mem.decay_all.assert_not_awaited()
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_oversized_head_consolidates_without_log_material(self):
+        """An oversized head (legacy marker-less file split as all-head, or an
+        LLM-overshot compile) must consolidate even with an EMPTY log —
+        otherwise it injects clipped + stale at the head budget forever."""
+        ws = self._make_workspace(
+            due=True, log="", head="H" * (_MEMORY_HEAD_BUDGET + 1)
+        )
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="RECOMPILED HEAD", tokens_used=10)
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+        await cm._maybe_consolidate_memory()
+
+        llm.chat.assert_awaited_once()
+        ws.write_compiled_memory.assert_called_once()
+        ws.mark_consolidated.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_markerless_file_consolidates_via_maintenance(self):
+        """Prod regression: a legacy MEMORY.md with no compiled markers splits
+        as ALL head + empty log, so the log-only material gate never fired and
+        the stale blob injected clipped every turn. run_maintenance() must
+        re-compile it: LLM called, file gains markers, sentinel stamped."""
+        d = tempfile.mkdtemp()
+        try:
+            body = "# Long-Term Memory\n\n" + (
+                "stale legacy fact line\n" * ((_MEMORY_HEAD_BUDGET // 23) + 50)
+            )
+            (Path(d) / "MEMORY.md").write_text(body)
+            ws = WorkspaceManager(workspace_dir=d)
+            assert len(ws.load_compiled_memory()) > _MEMORY_HEAD_BUDGET
+            assert ws.load_memory_log() == ""
+
+            llm = MagicMock()
+            llm.chat = AsyncMock(
+                return_value=LLMResponse(content="COMPILED LEGACY", tokens_used=10)
+            )
+            cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+            await cm.run_maintenance()
+
+            llm.chat.assert_awaited_once()
+            raw = (Path(d) / "MEMORY.md").read_text()
+            assert MEMORY_COMPILED_BEGIN in raw
+            assert MEMORY_COMPILED_END in raw
+            assert "COMPILED LEGACY" in ws.load_compiled_memory()
+            # Sentinel stamped → not due again within the window.
+            assert ws.consolidation_due(10_000) is False
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_small_legacy_markerless_file_still_skips(self):
+        """A legacy marker-less file UNDER the head budget with no new log
+        material injects fine as-is — the gate must still skip (no LLM call)."""
+        d = tempfile.mkdtemp()
+        try:
+            (Path(d) / "MEMORY.md").write_text(
+                "# Long-Term Memory\n\nsmall legacy body\n"
+            )
+            ws = WorkspaceManager(workspace_dir=d)
+            llm = MagicMock()
+            llm.chat = AsyncMock()
+            cm = ContextManager(max_tokens=1000, llm=llm, workspace=ws, memory=None)
+            await cm._maybe_consolidate_memory()
+
+            llm.chat.assert_not_called()
+            assert ws.consolidation_due(10_000) is True  # no sentinel stamped
         finally:
             shutil.rmtree(d, ignore_errors=True)
 


### PR DESCRIPTION
## Problem

A legacy MEMORY.md with no `<!-- compiled:begin -->` markers never consolidates. Verified in prod: 5 agents with 4–19K marker-less files stuck un-consolidated — the whole stale blob is injected as head every turn and silently clipped at the injection head budget (10,968 chars).

## Root cause

- `src/agent/workspace.py:471` — `_split_memory` deliberately treats a marker-less file as ALL head + empty log (content preservation for legacy/hand-edited files).
- `src/agent/context.py:632` — `_maybe_consolidate_memory` gated only on `len(log) >= _CONSOLIDATION_MIN_LOG_CHARS` (1,500). With an empty log, the gate never fires, so the legacy head is never re-compiled.
- `src/agent/workspace.py:581` — `get_memory_injection` then clips the oversized head at an inline-computed budget every turn: clipped + stale forever.

## Fix

- **workspace.py**: hoist the inline head-budget computation into a module-level `_MEMORY_HEAD_BUDGET = max(0, _MAX_MEMORY - _MEMORY_RECENT_LOG_CHARS - 32)` next to the other memory constants; `get_memory_injection` now uses it. It doubles as the consolidation trigger threshold.
- **context.py**: load `head` before the material gate and skip only when BOTH `len(log) < _CONSOLIDATION_MIN_LOG_CHARS` AND `len(head) <= _MEMORY_HEAD_BUDGET`. An oversized head is either a legacy marker-less file (split as all-head, empty log) or an LLM-overshot compile; both re-compile even with no new log material.

Unchanged on purpose: the time gate (`consolidation_due`), the failure backoff, and the prompt (it already includes `head[:_SUMMARIZATION_INPUT_LIMIT]`, so an oversized head feeds the compile correctly).

## Tests (tests/test_compiled_memory.py)

- `test_oversized_head_consolidates_without_log_material` — mock-workspace gate check: empty log + head over budget → LLM called, head rewritten, sentinel stamped.
- `test_legacy_markerless_file_consolidates_via_maintenance` — real tmp workspace with a >10,968-char marker-less MEMORY.md, empty log → `run_maintenance()` consolidates: LLM called once, file gains compiled markers, sentinel stamped.
- `test_small_legacy_markerless_file_still_skips` — marker-less file under the budget, empty log → no LLM call, no sentinel.
- Existing log-driven path already covered by `test_consolidates_when_due_and_log_long_enough`.

`pytest tests/test_compiled_memory.py tests/test_context.py tests/test_workspace.py -x -q` → 222 passed; `tests/test_loop.py tests/test_memory_v2_dated_facts.py` → 216 passed; `ruff check` clean.