### PR TITLE
fix(dashboard): memory budget bar measures injected size, not raw file

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -37,11 +37,45 @@ const _IDENTITY_FILE_MAP = {
     { file: 'INTERFACE.md', label: 'Interface', cap: 4000, access: 'both', desc: 'Public collaboration contract — what this agent accepts, produces, and how other agents should interact with it. Teammates read this via get_agent_profile.' },
   ],
   memory: [
-    { file: 'MEMORY.md', label: 'Memory', cap: 16000, access: 'auto', desc: 'Facts and context the agent remembers across sessions. Auto-updated during conversations — you can also edit directly.' },
+    { file: 'MEMORY.md', label: 'Memory', cap: 16000, access: 'auto', desc: 'Facts and context the agent remembers across sessions. Auto-updated during conversations — you can also edit directly. Only the compiled head + newest log entries are injected into the prompt; older log entries stay on disk, recalled via memory search.' },
     { file: 'USER.md', label: 'Preferences', cap: 4000, access: 'both', desc: 'Your preferences, communication style, and project context. Helps the agent serve you better over time.' },
     { file: 'HEARTBEAT.md', label: 'Auto-checkup', cap: null, access: 'both', desc: 'Rules for what the agent does during periodic autonomous wakeups — what to check, what to work on, when to notify you.' },
   ],
 };
+
+// MEMORY.md head/log split markers + injection caps. Source of truth:
+// src/agent/workspace.py (MEMORY_COMPILED_BEGIN/END, _MAX_MEMORY,
+// _MEMORY_RECENT_LOG_CHARS, _MEMORY_FILE_MAX). The on-disk file is a
+// compiled head + append-only log bounded at 64,000 chars, but only the
+// head (capped at 16000 - 5000 - 32 = 10968) plus the newest 5,000 log
+// chars are ever injected into the prompt — so the budget bar must
+// measure the injected slice, not the raw file.
+const _MEMORY_COMPILED_BEGIN = '<!-- compiled:begin -->';
+const _MEMORY_COMPILED_END = '<!-- compiled:end -->';
+const _MEMORY_HEAD_CAP = 10968;
+const _MEMORY_RECENT_LOG_CHARS = 5000;
+
+// Approximate the prompt-injected size of raw MEMORY.md content,
+// mirroring WorkspaceManager._split_memory + get_memory_injection:
+// strip the "# Long-Term Memory" title, head = between markers, log =
+// after the end marker; a marker-less file is ALL head with an empty log.
+function _memoryInjectedLength(raw) {
+  let body = raw.trim();
+  if (body.startsWith('# Long-Term Memory')) {
+    body = body.slice('# Long-Term Memory'.length).trimStart();
+  }
+  let head = raw.trim();
+  let log = '';
+  if (body.startsWith(_MEMORY_COMPILED_BEGIN)) {
+    const inner = body.slice(_MEMORY_COMPILED_BEGIN.length);
+    const end = inner.indexOf(_MEMORY_COMPILED_END);
+    if (end !== -1) {
+      head = inner.slice(0, end).trim();
+      log = inner.slice(end + _MEMORY_COMPILED_END.length).trim();
+    }
+  }
+  return Math.min(head.length, _MEMORY_HEAD_CAP) + Math.min(log.length, _MEMORY_RECENT_LOG_CHARS);
+}
 
 function dashboard() {
   return {
@@ -1143,8 +1177,11 @@ function dashboard() {
 
     fileBudgetPct(file, cap) {
       if (!cap) return 0;
-      const text = (this.identityEditing && this.identityEditingFile === file) ? this.identityEditBuffer : (this.identityContent[file] || '');
-      return Math.min(100, (text.length / cap) * 100);
+      // MEMORY.md's cap applies to the injected slice (head + recent log),
+      // not the raw file — the on-disk log is bounded separately at 64K, so
+      // raw length pegs the bar at 100% by design once the log grows.
+      const len = file === 'MEMORY.md' ? this.memoryInjectedCharCount() : this.fileCharCount(file);
+      return Math.min(100, (len / cap) * 100);
     },
 
     fileBudgetColor(file, cap) {
@@ -1157,6 +1194,11 @@ function dashboard() {
     fileCharCount(file) {
       const text = (this.identityEditing && this.identityEditingFile === file) ? this.identityEditBuffer : (this.identityContent[file] || '');
       return text.length;
+    },
+
+    memoryInjectedCharCount() {
+      const text = (this.identityEditing && this.identityEditingFile === 'MEMORY.md') ? this.identityEditBuffer : (this.identityContent['MEMORY.md'] || '');
+      return _memoryInjectedLength(text);
     },
 
     get filteredTraces() {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -54,6 +54,7 @@ const _MEMORY_COMPILED_BEGIN = '<!-- compiled:begin -->';
 const _MEMORY_COMPILED_END = '<!-- compiled:end -->';
 const _MEMORY_HEAD_CAP = 10968;
 const _MEMORY_RECENT_LOG_CHARS = 5000;
+const _MEMORY_MAX_INJECT = 16000; // _MAX_MEMORY — the per-file bootstrap cap
 
 // Approximate the prompt-injected size of raw MEMORY.md content,
 // mirroring WorkspaceManager._split_memory + get_memory_injection:
@@ -74,6 +75,12 @@ function _memoryInjectedLength(raw) {
       log = inner.slice(end + _MEMORY_COMPILED_END.length).trim();
     }
   }
+  // With no log to inject, the engine skips the head/recent split entirely
+  // (get_memory_injection returns the head un-capped when there is no recent
+  // slice) and only the per-file bootstrap cap bounds it — exactly the legacy
+  // marker-less-file case, where the 10968 cap would understate a saturated,
+  // clipping injection as ~69%.
+  if (!log) return Math.min(head.length, _MEMORY_MAX_INJECT);
   return Math.min(head.length, _MEMORY_HEAD_CAP) + Math.min(log.length, _MEMORY_RECENT_LOG_CHARS);
 }
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2786,7 +2786,10 @@
                         <!-- Budget bar (for files with cap) -->
                         <div x-show="section.cap && !(identityEditing && identityEditingFile === section.file)" class="mb-2">
                           <div class="flex justify-between items-center text-[11px] text-gray-400 mb-1">
-                            <span x-text="fileCharCount(section.file).toLocaleString() + ' / ' + section.cap.toLocaleString() + ' chars'"></span>
+                            <!-- MEMORY.md: the cap applies to the prompt-injected slice, not the raw file (see _memoryInjectedLength in app.js) -->
+                            <span x-text="section.file === 'MEMORY.md'
+                              ? 'Injected into prompt: ' + memoryInjectedCharCount().toLocaleString() + ' / ' + section.cap.toLocaleString() + ' chars · On-disk: ' + fileCharCount(section.file).toLocaleString() + ' (log auto-trimmed at 64,000)'
+                              : fileCharCount(section.file).toLocaleString() + ' / ' + section.cap.toLocaleString() + ' chars'"></span>
                             <span x-text="Math.round(fileBudgetPct(section.file, section.cap)) + '%'"></span>
                           </div>
                           <div class="w-full bg-gray-800 rounded-full h-1">


### PR DESCRIPTION
## Bug (real user report)

The agent-detail Memory tab's char-budget bar for MEMORY.md computed `raw_file_length / 16000`. But MEMORY.md on disk is a compiled head + an append-only log bounded at **64,000** chars (`_MEMORY_FILE_MAX`, `src/agent/workspace.py`). Only a derived slice is ever injected into the prompt (`get_memory_injection`):

- head, clipped to **10,968** chars (`_MAX_MEMORY` 16000 − `_MEMORY_RECENT_LOG_CHARS` 5000 − 32)
- plus the newest **5,000** chars of the log

So once the log grows past ~16K, the bar reads 100% / red **permanently** — correct engine behavior, misleading UI: users think memory is "over the limit" when it is healthy by design.

### Before
- Bar: `min(100, raw_len / 16000)` → pegged red at 100% for any well-used agent
- Count line: `34,812 / 16,000 chars`

### After
- Bar: `min(100, injected_len / 16000)` where `injected_len = min(head, 10968) + min(log, 5000)`, computed by splitting on the literal `<!-- compiled:begin/end -->` markers exactly like `WorkspaceManager._split_memory` (title stripped, marker-less file = all head + empty log)
- Count line: `Injected into prompt: 12,400 / 16,000 chars · On-disk: 34,812 (log auto-trimmed at 64,000)`
- `_IDENTITY_FILE_MAP` desc for MEMORY.md now explains the head/recent-log injection split

## Scope

Dashboard only — `app.js` + `index.html`. No engine changes; `src/agent/workspace.py` stays the source of truth for markers/constants (the new JS helper comments point there). All other files keep raw-length math.

## Verification

- Helper checked against `_split_memory` edge cases via node: compiled file with big log, marker-less legacy file, oversized head, empty file, begin-without-end marker — all match expected engine semantics; full `app.js` still parses.
- `python -m pytest tests/test_dashboard*.py -q` → **516 passed, 4 skipped** (no server-side code touched).