### PR TITLE
feat(dashboard): operator Advanced settings — open the full agent panel from the guided page

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10214,10 +10214,14 @@ function dashboard() {
 
     // ── Agent drill-down ──────────────────────────────────
 
-    drillDown(agentId) {
+    drillDown(agentId, { advanced = false } = {}) {
       // Operator is a system agent — route to its dedicated settings page instead of the generic agent detail panel.
       // Centralizes operator routing for all callers (card clicks, URL routes, search results).
-      if (agentId === 'operator') {
+      // ``advanced: true`` is the deliberate escape hatch (the "Advanced settings" button on the
+      // Operator settings page): skip the reroute and open the full agent detail panel — tools,
+      // skills, memory, files, activity — which already self-defends for the operator (warning
+      // banner, SOUL/INSTRUCTIONS confirm gate, hidden Restart/Delete menu items).
+      if (agentId === 'operator' && !advanced) {
         // Suppress switchTab's URL push so the back button returns to the source page, not the intermediate /system/<previous-tab>.
         // Save/restore _skipPush so we don't clobber the outer invariant (e.g. _applyRoute holds _skipPush=true).
         const prevSkip = this._skipPush;

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -6946,6 +6946,16 @@
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
                 Restart
               </button>
+              <!-- Escape hatch to the generic agent detail panel — the guided page above is
+                   intentionally minimal, but the full panel is the only place to inspect the
+                   operator's tools, skills, memory, files, activity, logs and spend. drillDown
+                   normally reroutes operator back here; ``advanced: true`` bypasses that. -->
+              <button @click="drillDown('operator', { advanced: true })"
+                title="Full agent panel: tools, skills, memory, files, activity"
+                class="text-xs px-3 py-1.5 rounded bg-gray-800 border border-gray-700 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors flex items-center gap-1.5">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"/></svg>
+                Advanced settings
+              </button>
             </div>
           </div>
 


### PR DESCRIPTION
## Why

`drillDown()` reroutes ALL navigation to the operator agent away from the generic agent-detail panel and onto the dedicated guided Operator settings page (`systemTab === 'operator'`). That guided page is intentionally minimal — model, heartbeat, capability toggles, audit log — which left an observability gap: users had **no way** to see the operator's tools, skills, memory, identity files, activity, logs, files, or spend.

The generic panel already fully supports the operator and self-defends:
- warning banner ("System agent — these files literally change how your Operator behaves") with a link back to the guided page
- confirm gate on operator `SOUL.md` / `INSTRUCTIONS.md` saves
- Restart/Delete menu items hidden via `x-show="selectedAgent !== 'operator'"`
- server-side delete protection

## What

- `drillDown(agentId, { advanced = false } = {})` — when `advanced` is true, skip the operator reroute and fall through to the normal panel-opening path. All existing call sites (card clicks, URL routes, command-palette search, chat header, WS-driven opens) pass a single argument, so **the default reroute stays unchanged**.
- An "Advanced settings" button on the Operator settings page, next to Chat / Restart and matching their secondary styling, with a `title` hint ("Full agent panel: tools, skills, memory, files, activity") that calls `drillDown('operator', { advanced: true })`.

## Deliberately not done

- URL routes are untouched: `/teams/operator` deep-links still funnel to the guided page via the default reroute. The advanced view has no deep-link of its own — it pushes `/teams/operator` like any detail view, and a reload lands you safely back on the guided page.
- No defensive gate on the generic panel was weakened or removed. Operator-specific early-returns in the panel's fetch helpers (browser session, cookie import) degrade gracefully as before.

## Testing

`python -m pytest tests/test_dashboard*.py -x -q` — 810 passed, 4 skipped (template + JS only; no server code touched).