### PR TITLE
fix(coordination): teach workers the pushback protocol via tool descriptions

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -137,7 +137,10 @@ _RESERVED_ENVELOPE_KEYS: frozenset[str] = frozenset(
         "lightweight handoffs where the summary is enough context, omit "
         "'data' and 'brief'.\n\n"
         "The target agent sees the task in their inbox (via check_inbox) "
-        "with your summary, your brief, and a pointer to your output."
+        "with your summary, your brief, and a pointer to your output.\n\n"
+        "If the recipient can't execute your task they will block it "
+        "with a question — you'll see it in check_inbox() events[]; "
+        "answer and re-hand-off rather than waiting."
     ),
     parameters={
         "to": {
@@ -517,7 +520,13 @@ async def hand_off(
         "- When you receive a coordination notification\n\n"
         "After reading a task, use read_blackboard to fetch the full "
         "output data via the output_key. When done processing, call "
-        "complete_task to mark it finished so it won't appear again."
+        "complete_task to mark it finished so it won't appear again.\n\n"
+        "The result also includes events[] — task_failed / task_blocked "
+        "notices for tasks YOU created via hand_off. For each one, read "
+        "blocker_note / error: if the recipient asked a question, answer "
+        "it with a corrected hand_off (new brief, same goal); if it "
+        "failed terminally, decide whether to retry, reroute, or report "
+        "the failure upstream. Do not ignore these events."
     ),
     parameters={},
 )
@@ -611,7 +620,15 @@ async def check_inbox(*, mesh_client=None) -> dict:
         "When you have multiple active tasks, pass task_id explicitly "
         "to disambiguate which one this status update applies to. "
         "Otherwise the call returns ambiguous_task with the active task "
-        "ids so you can pick the right one."
+        "ids so you can pick the right one.\n\n"
+        "'blocked' is your pushback channel. If a handed-off task is "
+        "malformed, missing inputs, or outside your role, call "
+        "update_status(state='blocked', summary='<the specific question "
+        "or missing input>', task_id=...) instead of guessing. Your "
+        "summary is delivered back to the task's creator as "
+        "blocker_note, and the operator is alerted on user-facing "
+        "chains. NEVER mark work done that you did not do, and NEVER "
+        "silently drop a task you can't execute."
     ),
     parameters={
         "state": {

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1745,3 +1745,29 @@ class TestHandOffThinking:
         assert "error" in result
         mc.create_task.assert_not_called()
         mc.write_blackboard.assert_not_called()
+
+
+class TestToolDescriptions:
+    """Contract tests pinning the pushback-protocol prose in the
+    LLM-visible tool descriptions. The transport for blocked-task
+    back-edges (blocker_note → inbox/{creator}/task_event/ →
+    check_inbox events[]) shipped without telling workers it exists;
+    these pins keep future description edits from silently dropping
+    the protocol documentation.
+    """
+
+    @staticmethod
+    def _description(name: str) -> str:
+        import src.agent.builtins.coordination_tool  # noqa: F401
+        from src.agent.tools import _tool_staging
+
+        return _tool_staging[name]["description"]
+
+    def test_update_status_description_mentions_pushback(self):
+        assert "pushback" in self._description("update_status")
+
+    def test_check_inbox_description_mentions_events(self):
+        assert "events[]" in self._description("check_inbox")
+
+    def test_hand_off_description_mentions_blocked_followup(self):
+        assert "re-hand-off" in self._description("hand_off")


### PR DESCRIPTION
## Summary
- `update_status` description now documents `blocked` as the pushback channel: block with the specific question/missing input instead of guessing; never claim undone work; never silently drop a task.
- `check_inbox` description now documents `events[]` (`task_failed` / `task_blocked` notices for tasks the caller created) and what to do with them: answer with a corrected `hand_off`, or retry/reroute/report.
- `hand_off` description closes the loop: a blocked handoff comes back via `check_inbox()` `events[]` — answer and re-hand-off.
- Contract tests pin the new prose so future description edits can't silently truncate the protocol documentation.

## Why
The transport for blocked-task back-edges shipped end-to-end (#1053, #1105): `blocker_note` persistence, `inbox/{creator}/task_event/` back-edge + creator wake, operator recovery wakes on human chains. But no worker was ever TOLD the protocol exists — `check_inbox`'s description never mentioned `events[]`; only the operator's heartbeat template explained it. Tool descriptions are re-read by every agent every turn, so this reaches all fleets with zero migration.

Deliberately NO `reject_task` verb — terminal refusal stays an operator disposition (recovery wake → manage_task retry/reroute/cancel). Revisit only if measurement shows blocked tasks rotting.

Part of #1012 — see `docs/plans/2026-06-11-self-improvement-loop-deltas.md` (Delta C).

## Test plan
- `tests/test_coordination.py`: 68 passed (includes 3 new contract tests).
- `ruff check .` clean.
