### PR TITLE
feat(operator): set_agent_goals — operator-set per-agent goals + goals-namespace hardening

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -3056,6 +3056,138 @@ async def manage_goals(
     return {"error": f"Unknown action {action!r}"}
 
 
+# ── Per-agent standing goals (operator → worker direction) ───────────
+#
+# Writes the blackboard key every agent loop already reads
+# (``AgentLoop._fetch_goals`` → ``goals/{agent_id}``, 5-min cache) and
+# injects into all its prompts under "## Your Current Goals". Goals are
+# standing instructions in the target's persistent context, so the
+# write side is operator-only: the tool is gated here AND the
+# ``goals/`` namespace is hardened in ``host/permissions.py`` so a
+# worker's blackboard-write wildcard can never cover a peer's goals
+# key (prompt-injection channel). Scope resolution mirrors hand_off:
+# team agents read ``projects/{team}/goals/{id}``, solo/global agents
+# read the raw key.
+
+_MAX_AGENT_GOALS = 5
+_MAX_AGENT_GOAL_CHARS = 300
+
+
+@tool(
+    name="set_agent_goals",
+    operator_only=True,
+    description=(
+        "Assign standing goals to a worker agent. Goals appear in that "
+        "agent's every prompt (tasks, chats, heartbeats) under '## Your "
+        "Current Goals' and make its idle heartbeats pursue them instead "
+        "of sleeping. Replaces the agent's whole goal list (max 5 goals, "
+        "each one sentence). Pass goals=[] to clear. This is for WORKER "
+        "direction — your own fleet/business goals live in manage_goals."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "Worker agent to direct (not 'operator').",
+        },
+        "goals": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Full replacement goal list — max 5 entries, each a "
+                "single sentence (<=300 chars). Pass [] to clear the "
+                "agent's goals."
+            ),
+        },
+    },
+)
+async def set_agent_goals(
+    agent_id: str,
+    goals: list,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Operator-only writer for a worker's ``goals/{agent_id}`` key."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if agent_id == "operator":
+        return {
+            "error": (
+                "set_agent_goals targets WORKER agents. Your own fleet/"
+                "business goals live in manage_goals."
+            ),
+        }
+    if not isinstance(goals, list):
+        return {"error": "goals must be an array of strings"}
+    if len(goals) > _MAX_AGENT_GOALS:
+        return {
+            "error": (
+                f"goals exceeds max length {_MAX_AGENT_GOALS} — keep the "
+                "list short enough to act on every prompt"
+            ),
+        }
+    cleaned: list[str] = []
+    for g in goals:
+        if not isinstance(g, str):
+            return {"error": "each goal must be a string"}
+        s = sanitize_for_prompt(g).strip()
+        if not s:
+            return {"error": "each goal must be a non-empty string"}
+        if len(s) > _MAX_AGENT_GOAL_CHARS:
+            return {
+                "error": (
+                    f"each goal must be <={_MAX_AGENT_GOAL_CHARS} chars "
+                    "(one sentence)"
+                ),
+            }
+        cleaned.append(s)
+
+    # Resolve the target's blackboard scope — mirrors hand_off: team
+    # agents read goals under projects/{team}/, solo and fleet-global
+    # agents (scope == "global") read the raw key.
+    try:
+        registry = await mesh_client.list_agents()
+    except Exception as e:
+        return {"error": f"Cannot set goals: fleet roster unavailable ({e})"}
+    if agent_id not in registry:
+        available = ", ".join(sorted(registry.keys()))
+        return {"error": f"Agent '{agent_id}' not found. Available: {available}"}
+    info = registry.get(agent_id, {})
+    project = info.get("project") if isinstance(info, dict) else None
+
+    if not cleaned:
+        try:
+            await mesh_client.delete_blackboard(
+                f"goals/{agent_id}", project=project,
+            )
+        except Exception as e:
+            return {"error": f"Failed to clear goals for {agent_id}: {e}"}
+        return {"cleared": True, "agent_id": agent_id}
+
+    try:
+        await mesh_client.write_blackboard(
+            f"goals/{agent_id}",
+            {
+                "goals": cleaned,
+                "set_by": "operator",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+            project=project,
+        )
+    except Exception as e:
+        return {"error": f"Failed to set goals for {agent_id}: {e}"}
+    return {
+        "set": True,
+        "agent_id": agent_id,
+        "count": len(cleaned),
+        "note": (
+            "Takes effect on the agent's next prompt build (<=5 min cache)."
+        ),
+    }
+
+
 # ── Per-task outcome rating (PR 2 of Work tab rewrite) ───────────────
 #
 # Operator's programmatic per-task judgment. Replaces the human-driven

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -252,13 +252,25 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
-    async def delete_blackboard(self, key: str, *, global_scope: bool = False) -> dict:
+    async def delete_blackboard(
+        self, key: str, *, project: str | None = None, global_scope: bool = False,
+    ) -> dict:
         """Delete an entry from the shared blackboard.
 
-        If *global_scope* is True, the key is sent as-is, bypassing project
-        scoping. Used for keys in the fleet-global namespace.
+        If *project* is given, scope the key to that project instead of
+        this agent's own project.  Used by cross-project coordination
+        (e.g. operator clearing a project-scoped agent's goals key).
+
+        If *global_scope* is True, the key is sent as-is — bypassing both
+        the explicit ``project=`` override and the auto project prefix.
+        Used for keys in the fleet-global namespace.
         """
-        scoped = key if global_scope else self._scope_key(key)
+        if global_scope:
+            scoped = key
+        elif project is not None:
+            scoped = f"projects/{project}/{key}"
+        else:
+            scoped = self._scope_key(key)
         client = await self._get_client()
         response = await client.delete(
             f"{self.mesh_url}/mesh/blackboard/{scoped}",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1675,6 +1675,10 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # /api/workplace/goals. Operator-only — _is_operator() is enforced
     # at the tool boundary as well.
     "manage_goals",
+    # Per-agent standing goals — writes the goals/{agent_id} blackboard
+    # key every worker injects into its prompts. Deliberate planning act:
+    # intentionally NOT in _OPERATOR_HEARTBEAT_TOOLS.
+    "set_agent_goals",
     # Per-task outcome rating (PR 2 of Work tab rewrite). Replaces
     # the per-task 👍/➖/👎 buttons deleted from the Work tab —
     # operator scores tasks programmatically from the heartbeat

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11142,6 +11142,7 @@ function dashboard() {
         wallet_transfer: 'sending a wallet transfer',
         edit_agent: 'updating a teammate',
         read_agent_config: 'reviewing a teammate',
+        set_agent_goals: 'setting a teammate\'s goals',
         read_user_notifications: 'reviewing recent notifications',
         read_peer_artifact: 'reading a teammate\'s file',
         list_peer_artifacts: 'browsing a teammate\'s files',

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -242,6 +242,17 @@ class PermissionMatrix:
         # "inbox/dev-lead/task_event/...".
         if key.startswith(f"inbox/{agent_id}/task_event/"):
             return True
+        # Self-goals carve-out: an agent may ALWAYS read its OWN goals key
+        # (raw or team-scoped form) — goal delivery must never depend on
+        # per-template ACL variance. Tight match: exactly goals/{id} or
+        # projects/{team}/goals/{id} — not arbitrary keys that merely end
+        # in /goals/{id}.
+        if key == f"goals/{agent_id}":
+            return True
+        if key.startswith("projects/"):
+            p = key.split("/")
+            if len(p) == 4 and p[2] == "goals" and p[3] == agent_id:
+                return True
         perms = self.get_permissions(agent_id)
         return any(fnmatch.fnmatch(key, pattern) for pattern in perms.blackboard_read)
 
@@ -257,6 +268,15 @@ class PermissionMatrix:
         # writing agent can place output under their own prefix.
         if key.startswith(f"global/output/{agent_id}/"):
             return True
+        # Goals are standing instructions injected into the target agent's
+        # every prompt. Only the operator (endpoint carve-out in server.py)
+        # or the mesh itself may write them — a teammate's projects/{team}/*
+        # write wildcard must NOT cover a peer's goals key (prompt-injection
+        # channel into persistent context).
+        parts = key.split("/", 2)
+        tail = parts[2] if key.startswith("projects/") and len(parts) == 3 else key
+        if tail.startswith("goals/"):
+            return False
         perms = self.get_permissions(agent_id)
         return any(fnmatch.fnmatch(key, pattern) for pattern in perms.blackboard_write)
 

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1676,3 +1676,142 @@ class TestAwaitTaskEventTool:
                 ),
                 timeout=0.1,
             )
+
+
+# ── set_agent_goals tests ────────────────────────────────────
+
+
+def _goals_mesh_client(registry):
+    """MeshClient mock for set_agent_goals: roster + blackboard writes."""
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value=registry)
+    mc.write_blackboard = AsyncMock(
+        return_value={"key": "goals/x", "version": 1},
+    )
+    mc.delete_blackboard = AsyncMock(return_value={"deleted": True})
+    return mc
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_writes_scoped_key():
+    """Team agent target → write under its project scope, no TTL."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    mc = _goals_mesh_client({"researcher": {"project": "alpha"}})
+    result = await set_agent_goals(
+        "researcher", ["Find 10 qualified leads per week."], mesh_client=mc,
+    )
+    assert result == {
+        "set": True,
+        "agent_id": "researcher",
+        "count": 1,
+        "note": (
+            "Takes effect on the agent's next prompt build (<=5 min cache)."
+        ),
+    }
+    mc.write_blackboard.assert_awaited_once()
+    args, kwargs = mc.write_blackboard.call_args
+    assert args[0] == "goals/researcher"
+    value = args[1]
+    assert value["goals"] == ["Find 10 qualified leads per week."]
+    assert value["set_by"] == "operator"
+    assert "updated_at" in value
+    assert kwargs["project"] == "alpha"
+    # Goals persist until changed — no TTL on the write.
+    assert kwargs.get("ttl") is None
+    mc.delete_blackboard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_solo_agent_unscoped():
+    """Solo agent (no project in registry) → raw key, project=None."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    mc = _goals_mesh_client({"solo-bot": {}})
+    result = await set_agent_goals(
+        "solo-bot", ["Keep the changelog current."], mesh_client=mc,
+    )
+    assert result["set"] is True
+    args, kwargs = mc.write_blackboard.call_args
+    assert args[0] == "goals/solo-bot"
+    assert kwargs["project"] is None
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_clear_deletes_key():
+    """goals=[] clears via delete_blackboard with the same scoping."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    mc = _goals_mesh_client({"researcher": {"project": "alpha"}})
+    result = await set_agent_goals("researcher", [], mesh_client=mc)
+    assert result == {"cleared": True, "agent_id": "researcher"}
+    mc.delete_blackboard.assert_awaited_once_with(
+        "goals/researcher", project="alpha",
+    )
+    mc.write_blackboard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_rejects_operator_target():
+    """Operator's own goals live in manage_goals, not the blackboard."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    mc = _goals_mesh_client({"operator": {"scope": "global"}})
+    result = await set_agent_goals("operator", ["Run the fleet."], mesh_client=mc)
+    assert "error" in result
+    assert "manage_goals" in result["error"]
+    mc.write_blackboard.assert_not_awaited()
+    mc.delete_blackboard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_caps_count_and_length():
+    """Max 5 goals; each goal must be a non-empty string <=300 chars."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    mc = _goals_mesh_client({"researcher": {"project": "alpha"}})
+
+    result = await set_agent_goals(
+        "researcher", [f"goal {i}" for i in range(6)], mesh_client=mc,
+    )
+    assert "error" in result
+    assert "max" in result["error"].lower()
+
+    result = await set_agent_goals("researcher", ["x" * 301], mesh_client=mc)
+    assert "error" in result
+    assert "300" in result["error"]
+
+    result = await set_agent_goals("researcher", ["   "], mesh_client=mc)
+    assert "error" in result
+
+    result = await set_agent_goals("researcher", [42], mesh_client=mc)
+    assert "error" in result
+
+    mc.write_blackboard.assert_not_awaited()
+    mc.delete_blackboard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_unknown_agent_lists_available():
+    """Unknown target → error naming the available agents."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    mc = _goals_mesh_client({"writer": {}, "scout": {"project": "alpha"}})
+    result = await set_agent_goals("ghost", ["Do things."], mesh_client=mc)
+    assert "error" in result
+    assert "not found" in result["error"]
+    assert "scout" in result["error"]
+    assert "writer" in result["error"]
+    mc.write_blackboard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_agent_goals_requires_operator(monkeypatch):
+    """Defence-in-depth: non-operator env (no ALLOWED_TOOLS) is refused."""
+    from src.agent.builtins.operator_tools import set_agent_goals
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    mc = _goals_mesh_client({"researcher": {"project": "alpha"}})
+    result = await set_agent_goals("researcher", ["Goal."], mesh_client=mc)
+    assert "error" in result
+    mc.write_blackboard.assert_not_awaited()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1301,3 +1301,77 @@ class TestCanAccessCredentialSystemTier:
         # Even with an EMPTY tier registry, provider-key shapes stay blocked.
         cred_matrix.set_system_credential_names([])
         assert cred_matrix.can_access_credential("worker", "anthropic_api_key") is False
+
+
+# ── Goals namespace hardening (set_agent_goals PR) ─────────────────────
+#
+# Goals (``goals/{agent_id}`` / ``projects/{team}/goals/{agent_id}``) are
+# standing instructions injected into the target agent's every prompt.
+# The write side is operator-only (endpoint carve-out in server.py), so
+# ``can_write_blackboard`` fail-closes the namespace for workers — a
+# teammate's ``projects/{team}/*`` write wildcard must NOT cover a peer's
+# goals key (prompt-injection channel into persistent context). The read
+# side gets a tight self-carve-out so goal delivery never depends on
+# per-template ACL variance.
+
+
+@pytest.fixture()
+def goals_matrix(tmp_path):
+    """PermissionMatrix exercising the goals-namespace guards."""
+    cfg = {
+        "permissions": {
+            # Team-scoped write wildcard — must NOT reach the goals keys.
+            "dev": {
+                "blackboard_read": [],
+                "blackboard_write": ["projects/alpha/*"],
+            },
+            # Full write wildcard — must NOT reach the goals keys either.
+            "rogue": {
+                "blackboard_read": [],
+                "blackboard_write": ["*"],
+            },
+        },
+    }
+    path = tmp_path / "permissions.json"
+    path.write_text(json.dumps(cfg))
+    return PermissionMatrix(config_path=str(path))
+
+
+class TestGoalsNamespaceHardening:
+    def test_worker_cannot_write_peer_goals_key(self, goals_matrix):
+        """Wildcard ACLs do not cover the goals namespace (raw or scoped)."""
+        m = goals_matrix
+        assert m.can_write_blackboard("dev", "projects/alpha/goals/peer") is False
+        assert m.can_write_blackboard("dev", "projects/alpha/goals/dev") is False
+        assert m.can_write_blackboard("rogue", "goals/peer") is False
+        assert m.can_write_blackboard("rogue", "projects/alpha/goals/peer") is False
+        # Non-goals keys under the same wildcards still work.
+        assert m.can_write_blackboard("dev", "projects/alpha/context/x") is True
+        assert m.can_write_blackboard("rogue", "context/x") is True
+
+    def test_goals_write_guard_short_projects_key_no_error(self, goals_matrix):
+        """``projects/x`` (no third segment) must not IndexError."""
+        m = goals_matrix
+        assert m.can_write_blackboard("rogue", "projects/x") is True
+
+    def test_mesh_can_still_write_goals(self, goals_matrix):
+        """Trusted internal caller bypasses the namespace guard."""
+        assert goals_matrix.can_write_blackboard("mesh", "goals/dev") is True
+
+    def test_agent_can_always_read_own_goals_key(self, goals_matrix):
+        """Self-read carve-out: raw and team-scoped forms, empty ACL."""
+        m = goals_matrix
+        assert m.can_read_blackboard("dev", "goals/dev") is True
+        assert m.can_read_blackboard("dev", "projects/alpha/goals/dev") is True
+        assert m.can_read_blackboard("dev", "projects/beta/goals/dev") is True
+
+    def test_agent_cannot_read_other_agents_goals_via_carveout(self, goals_matrix):
+        """The carve-out is strictly self-scoped and shape-exact."""
+        m = goals_matrix
+        # Another agent's goals key — denied absent a matching ACL.
+        assert m.can_read_blackboard("dev", "goals/lead") is False
+        assert m.can_read_blackboard("dev", "projects/alpha/goals/lead") is False
+        # Deeper keys that merely END in /goals/{id} do NOT match.
+        assert m.can_read_blackboard("dev", "projects/alpha/x/goals/dev") is False
+        # ID-prefix collision: "dev" must not match "dev-lead".
+        assert m.can_read_blackboard("dev", "goals/dev-lead") is False

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -705,6 +705,7 @@ class TestMeshClientKeyScoping:
         mock_resp.raise_for_status = MagicMock()
         mock_http.get = AsyncMock(return_value=mock_resp)
         mock_http.put = AsyncMock(return_value=mock_resp)
+        mock_http.delete = AsyncMock(return_value=mock_resp)
         client._client = mock_http
         client._trace_headers = lambda: {}
         return client, mock_http
@@ -729,6 +730,24 @@ class TestMeshClientKeyScoping:
         await client.write_blackboard("goals/v1", {"objective": "test"})
         url = mock_http.put.call_args[0][0]
         assert "projects/alpha/goals/v1" in url
+
+    @pytest.mark.asyncio
+    async def test_delete_blackboard_project_scoping(self):
+        """delete_blackboard mirrors write_blackboard's three-way scoping."""
+        client, mock_http = self._mock_client("alpha", {"deleted": True})
+        # Default: caller's own project prefix.
+        await client.delete_blackboard("goals/researcher")
+        url = mock_http.delete.call_args[0][0]
+        assert "projects/alpha/goals/researcher" in url
+        # Explicit project= override (operator clearing a team agent's key).
+        await client.delete_blackboard("goals/researcher", project="beta")
+        url = mock_http.delete.call_args[0][0]
+        assert "projects/beta/goals/researcher" in url
+        # global_scope bypasses both.
+        await client.delete_blackboard("goals/researcher", global_scope=True)
+        url = mock_http.delete.call_args[0][0]
+        assert "projects/" not in url
+        assert "goals/researcher" in url
 
     @pytest.mark.asyncio
     async def test_list_blackboard_scopes_prefix_and_strips_keys(self):


### PR DESCRIPTION
## Summary
- New operator-only tool `set_agent_goals(agent_id, goals)`: full-replacement standing goals for a worker (max 5, ≤300 chars each, `goals=[]` clears), written to the blackboard key `goals/{agent_id}` that every agent loop already reads and injects into task/chat/heartbeat prompts. Scope resolution mirrors `hand_off` (registry `project` hint → `projects/{team}/goals/{id}` for team agents, raw key for solo/global).
- `mesh_client.delete_blackboard` gains `project=` mirroring `write_blackboard`'s three-way scoping, so the clear path scopes identically to the write path.
- Added to `_OPERATOR_ALLOWED_TOOLS`; deliberately NOT in `_OPERATOR_HEARTBEAT_TOOLS` — goal assignment is a deliberate planning act, not an unsupervised heartbeat act.

## Security note
Goals are standing instructions injected into the target agent's every prompt — the highest-value injection target this PR creates. Hardened in `PermissionMatrix`:
- **Write guard**: the `goals/` namespace (raw or team-scoped) fail-closes for all non-trusted callers — a teammate's `projects/{team}/*` write wildcard must NOT cover a peer's goals key (prompt-injection channel into persistent context). The operator path is unaffected (`_caller_is_operator` endpoint carve-out, verified present on both PUT and DELETE).
- **Self-read carve-out**: an agent may always read its OWN goals key (exact `goals/{id}` / `projects/{team}/goals/{id}` shapes only — no suffix matching, no `dev` vs `dev-lead` collisions), so goal delivery never depends on per-template ACL variance.
- Goal text is `sanitize_for_prompt`-ed at write time (defense-in-depth; the read side already sanitizes).

## Why
The read path was fully built and dormant: `AgentLoop._fetch_goals` injects `## Your Current Goals` everywhere and goals defeat the empty-heartbeat skip — but nothing in `src/` ever wrote the key. This converts empty-inbox idling into goal pursuit with zero autonomy risk: goals stay operator-set, agents choose tactics (issue #1012 Phase 2, smallest slice — agent-formed goals deliberately deferred).

Part of #1012 — see `docs/plans/2026-06-11-self-improvement-loop-deltas.md` (Delta B).

## Test plan
- `tests/test_operator_tools.py tests/test_permissions.py tests/test_teams.py tests/test_operator_manage_goals.py`: 251 passed (7 new tool tests, 5 new permission-hardening tests, 1 new mesh-client scoping test).
- `ruff check .` clean.
