### PR TITLE
feat(operator): heartbeat v6 — threshold-gated agent retro (propose-don't-apply)

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1770,6 +1770,7 @@ _OPERATOR_HEARTBEAT = """\
 <!-- heartbeat_v3_rate_delivery -->
 <!-- heartbeat_v4_goal_seeding -->
 <!-- heartbeat_v5_fleet_health -->
+<!-- heartbeat_v6_agent_retro -->
 You are running an autonomous fleet health check. You have access ONLY to monitoring tools.
 
 Step budget: stay at or under 8 tool calls per cycle (HEARTBEAT_MAX_ITERATIONS=12
@@ -1852,6 +1853,20 @@ helps focus. Outcomes:
   learnings; feedback required, no spawn
 
 DEFAULT TO `acknowledged` WHEN UNCERTAIN. Never guess.
+
+## Agent retro (at most ONE agent per heartbeat)
+
+If the Fleet Health digest or rating history shows an agent with
+rework >= 3 or rejected > 0 in the window: drill in with
+`inspect_agents` and read the repeated feedback. If the SAME
+correction keeps appearing, do not edit anything from the heartbeat —
+instead `notify_user` with a one-line proposed instruction delta,
+e.g. 'research-1 keeps omitting source links (3x rework). Proposed
+INSTRUCTIONS.md addition: "Always end reports with a Sources
+section." Reply to approve, or tell me to apply it.' Apply via
+`edit_agent(field="instructions")` only in a normal (non-heartbeat)
+turn, as ONE appended dated bullet — never a rewrite. Skip this step
+entirely when no agent crosses the thresholds.
 
 ## Workspace-as-source-of-truth
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -103,6 +103,7 @@ HEARTBEAT_SENTINELS: tuple[str, ...] = (
     "heartbeat_v3_rate_delivery",
     "heartbeat_v4_goal_seeding",
     "heartbeat_v5_fleet_health",
+    "heartbeat_v6_agent_retro",
 )
 
 # Same contract for the operator's INSTRUCTIONS playbook

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -186,6 +186,35 @@ class TestEnsureOperatorModelSync(_TempConfigMixin):
         mtime_after = self._agents_path.stat().st_mtime
         assert mtime_before == mtime_after
 
+    def test_prior_sentinel_heartbeat_rolls_forward_to_latest(self):
+        """A stored heartbeat carrying only a prior sentinel (e.g. a
+        deployed v5 operator after we ship v6) must be rewritten from
+        the canonical template on next ``_ensure`` — this is how the
+        agent-retro step reaches existing fleets on restart."""
+        from src.cli.config import _OPERATOR_HEARTBEAT
+
+        agents_cfg = {"agents": {"operator": {
+            "role": "Existing operator",
+            "model": "openai/gpt-4o-mini",
+            "heartbeat": (
+                "<!-- heartbeat_v5_fleet_health -->\n"
+                "Old v5 revision text\n"
+            ),
+        }}}
+        with open(self._agents_path, "w") as f:
+            yaml.dump(agents_cfg, f)
+
+        with self._mock_config():
+            from src.cli.config import _ensure_operator_agent
+            _ensure_operator_agent(default_model="openai/gpt-4o-mini")
+
+        with open(self._agents_path) as f:
+            result = yaml.safe_load(f)
+        refreshed = result["agents"]["operator"]["heartbeat"]
+        assert refreshed == _OPERATOR_HEARTBEAT
+        assert "<!-- heartbeat_v6_agent_retro -->" in refreshed
+        assert "Old v5 revision text" not in refreshed
+
     def test_empty_heartbeat_is_bootstrapped_to_canonical_template(self):
         """Codex r3 (PR 972) catch — the WARN for no-sentinel files
         instructs operators to clear ``heartbeat:`` in agents.yaml to
@@ -531,6 +560,29 @@ class TestOperatorConstants:
             "Cap at 3 snapshot calls" in _OPERATOR_HEARTBEAT
             or "cap at 3 snapshot calls" in _OPERATOR_HEARTBEAT
         )
+
+    def test_heartbeat_v6_mentions_agent_retro(self):
+        """v6 — threshold-gated agent retro is propose-don't-apply: the
+        heartbeat may PROPOSE an instruction delta via notify_user but
+        must never apply it. ``edit_agent`` stays OUT of the heartbeat
+        allowlist (unsupervised instruction edits are the Misevolution
+        failure mode — the recovery-wake brief authorizes edit_agent in
+        full chat turns instead)."""
+        from src.cli.config import (
+            _OPERATOR_HEARTBEAT,
+            _OPERATOR_HEARTBEAT_TOOLS,
+        )
+        assert "Agent retro" in _OPERATOR_HEARTBEAT
+        assert "at most ONE agent per heartbeat" in _OPERATOR_HEARTBEAT
+        assert (
+            "`notify_user` with a one-line proposed instruction delta"
+            in _OPERATOR_HEARTBEAT
+        )
+        assert "do not edit anything from the heartbeat" in _OPERATOR_HEARTBEAT
+        assert "never a rewrite" in _OPERATOR_HEARTBEAT
+        # The propose-don't-apply boundary: edit_agent must NOT be
+        # heartbeat-reachable.
+        assert "edit_agent" not in _OPERATOR_HEARTBEAT_TOOLS
 
     def test_core_has_key_sections(self):
         from src.shared.operator_playbooks import _OPERATOR_CORE


### PR DESCRIPTION
## Summary
- `HEARTBEAT_SENTINELS` += `heartbeat_v6_agent_retro`; matching marker added to `_OPERATOR_HEARTBEAT`.
- New checklist step, slotted after the rating cadence: **agent retro**, at most ONE agent per heartbeat, skipped entirely unless an agent shows `rework >= 3` or `rejected > 0` in the window. When the SAME correction keeps appearing, the operator proposes a one-line INSTRUCTIONS.md delta via `notify_user` — it does NOT edit from the heartbeat. Application happens only in a normal turn via `edit_agent`, as ONE appended dated bullet, never a rewrite.

## Why
Closes the meta-layer gap from #1012: today the operator only considers instruction edits inside failure-triggered recovery wakes; rework/rejection *patterns* had no cadence. Propose-don't-apply is deliberate — unsupervised self/agent instruction edits are the documented "Misevolution" failure mode, so `edit_agent` stays OUT of `_OPERATOR_HEARTBEAT_TOOLS` (pinned by a test).

## Roll-forward
Rides the existing sentinel machinery unchanged: config-side heartbeat-field refresh + workspace-side template overwrite both key off `HEARTBEAT_SENTINELS[-1]`, so deployed fleets pick up the step on restart with no manual migration. New test proves a stored v5 heartbeat rolls forward to the v6 template.

Part of #1012 — see `docs/plans/2026-06-11-self-improvement-loop-deltas.md` (Delta D).

## Test plan
- `tests/test_operator_config.py tests/test_workspace.py tests/test_operator_heartbeat.py`: 164 passed (new: v6 content pin + propose-don't-apply boundary pin + v5→v6 roll-forward).
- `ruff check .` clean.
