### PR TITLE
fix(chat): harden the stream pump's exit path — deterministic finalize + safe resets

### DIFF
--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -438,11 +438,28 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
                     next_event.cancel()
                     with contextlib.suppress(asyncio.CancelledError, Exception):
                         await next_event
+                # Deterministically finalize the inner generator. On a
+                # client disconnect it is suspended INSIDE loop.chat_stream
+                # while still holding _chat_lock — without an explicit
+                # aclose() the lock is only released when the GC's
+                # async-gen finalizer eventually runs, and until then the
+                # agent's next chat blocks on the lock. aclose() also runs
+                # chat_stream's finally (session checkpoint) now, in this
+                # context, instead of at an unspecified later point.
+                with contextlib.suppress(Exception):
+                    await stream_iter.aclose()
                 # Tokens were minted in THIS context, so the resets are
-                # safe (unlike the in-generator reset, which lands in a
-                # per-step context copy and is suppressed there).
-                current_origin.reset(_origin_token)
-                current_trace_id.reset(_tid_token)
+                # safe for normal completion AND client-disconnect
+                # cancellation (Starlette cancels the same task). The
+                # suppress covers the one remaining path: a GC-driven
+                # async-generator finalization can run this ``finally``
+                # in a different context, where reset raises ValueError —
+                # functionally irrelevant (the context dies anyway) but
+                # it would surface as 'Exception ignored in <async_gen>'
+                # noise during cleanup.
+                with contextlib.suppress(ValueError):
+                    current_origin.reset(_origin_token)
+                    current_trace_id.reset(_tid_token)
         return StreamingResponse(event_generator(), media_type="text/event-stream")
 
     @app.post("/chat/reset")


### PR DESCRIPTION
Two follow-ups from the post-merge adversarial review of #1112:

1. Explicitly aclose() the inner chat_stream generator in the pump's
   finally. On a client disconnect the generator is suspended INSIDE
   loop.chat_stream while still holding _chat_lock — without an
   explicit close the lock is released only when the GC's async-gen
   finalizer eventually runs, and until then the agent's next chat
   blocks on the lock. Closing here also runs the session checkpoint
   deterministically instead of at an unspecified later point.
   (Pre-existing gap in the pump architecture; surfaced by the
   independent second-pass review.)

2. Wrap the pump's contextvar resets in suppress(ValueError). They are
   same-context-safe for normal completion and disconnect cancellation,
   but a GC-driven generator finalization can run the finally in a
   foreign context, where reset raises — functionally irrelevant (the
   context dies anyway) but it surfaces as 'Exception ignored in
   <async_generator>' cleanup noise.

Reviewed-and-rejected alternative from the same pass: switching the
verification wake's origin to kind='operator' to prevent verification-
spawned rework from becoming new watched human roots. Rejected — the
wake origin copies the ROOT's real channel/user, so rework outcomes
correctly deliver to the original user's channel; an operator-kind
origin would make verification-spawned fixes invisible to the user.
The 'loop' only sustains while verification keeps failing, which the
user should hear about.

Full fast suite on this tree: 7430 passed / 0 failed.
