### PR TITLE
review: three follow-ups stranded by the #1120-#1123 merge race

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1902,10 +1902,13 @@ class AgentLoop:
         # sites run inside the tool-execution except handlers, where a raise
         # here would replace the error envelope the LLM needs to see.
         try:
+            # limit=50 matches the tool_outcomes prune cap so the logged
+            # count stays truthful — limit=5 would report count=5 on the
+            # 10th identical failure.
             repeats = len(self.memory.get_tool_history(
                 tool_name=tool_name,
                 params_hash=self.memory._compute_params_hash(arguments or {}),
-                limit=5,
+                limit=50,
                 success=False,
             ))
             if repeats >= 3:

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1758,7 +1758,14 @@ class TestToolDescriptions:
 
     @staticmethod
     def _description(name: str) -> str:
-        import src.agent.builtins.coordination_tool  # noqa: F401
+        # Reload rather than import: other test modules (test_grouped_tools)
+        # clear the _tool_staging registry in their setup, and a cached
+        # module import would then leave it empty. Re-running the @tool
+        # decorators makes the lookup order-independent.
+        import importlib
+
+        import src.agent.builtins.coordination_tool as ct
+        importlib.reload(ct)
         from src.agent.tools import _tool_staging
 
         return _tool_staging[name]["description"]

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -572,6 +572,11 @@ class TestOperatorConstants:
             _OPERATOR_HEARTBEAT,
             _OPERATOR_HEARTBEAT_TOOLS,
         )
+        from src.shared.types import HEARTBEAT_SENTINELS
+
+        # Roll-forward keys off HEARTBEAT_SENTINELS[-1] — v6 must be the
+        # newest entry or deployed fleets never pick the step up.
+        assert HEARTBEAT_SENTINELS[-1] == "heartbeat_v6_agent_retro"
         assert "Agent retro" in _OPERATOR_HEARTBEAT
         assert "at most ONE agent per heartbeat" in _OPERATOR_HEARTBEAT
         assert (


### PR DESCRIPTION
## Summary
PRs #1120–#1123 were merged while the final review pass (Codex second-pass reconciliation) was still landing fixes — three commits arrived seconds after the merges and were stranded on the auto-deleted-then-recreated head branches. This PR cherry-picks them onto current main:

- **Truthful `repeat_failure` counts** (`src/agent/loop.py`): `limit=5` saturated the logged count (count=5 on the 10th identical failure); `limit=50` matches the `tool_outcomes` per-tool prune cap so the count is exact up to retention. Threshold semantics unchanged.
- **Order-independent description contract tests** (`tests/test_coordination.py`): `test_grouped_tools` clears the `_tool_staging` registry in its setup; a cached import then KeyErrors the description lookups when that file runs first in the same process. Reload the module so the `@tool` decorators re-register. Proven by running the two files in the failing order (94 passed).
- **Sentinel-ordering pin** (`tests/test_operator_config.py`): roll-forward keys off `HEARTBEAT_SENTINELS[-1]`; one assertion makes the "v6 is newest" contract executable so a future sentinel added in the wrong tuple position can't silently strand deployed fleets.

The two must-fix review items (best-effort `repeat_failure` guard, `set_agent_goals` verbForTool entry) DID make it into the merged squashes — verified by grep against `origin/main`.

Part of #1012 follow-through.

## Test plan
- ruff clean on all three files
- `tests/test_loop.py`: 209 passed
- order proof (`test_grouped_tools` then `test_coordination` in one process): 94 passed
- combined-state check of the four merged PRs (`test_operator_config + test_dashboard_ui + test_operator_tools + test_permissions`): 398 passed, 4 skipped
