### PR TITLE
fix(operator): heartbeat roll-forward must sync the runtime-consumed initial_heartbeat key

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1970,15 +1970,29 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         # refresh to receive the new instructions.
         op_entry = agents_cfg["agents"].get(_OPERATOR_AGENT_ID, {}) or {}
         existing_heartbeat = op_entry.get("heartbeat") or ""
+        # ``initial_heartbeat`` is the key the runtime actually consumes:
+        # cli/runtime.py builds the INITIAL_HEARTBEAT container env from it,
+        # and the workspace-side sentinel refresh fires only when that env
+        # carries the latest marker. Refreshing ``heartbeat`` alone never
+        # reaches deployed containers — the v2→v5 bumps silently missed
+        # every pre-existing operator (found live on cake 2026-06-11; same
+        # class of gap as the playbook initial_instructions roll-forward
+        # fixed in #1110). Both keys must be rolled forward together.
+        existing_initial = op_entry.get("initial_heartbeat") or ""
         from src.shared.types import HEARTBEAT_SENTINELS
         latest_sentinel = HEARTBEAT_SENTINELS[-1] if HEARTBEAT_SENTINELS else None
         new_has_latest = (
             latest_sentinel is not None
             and f"<!-- {latest_sentinel} -->" in _OPERATOR_HEARTBEAT
         )
+        # Current only when BOTH copies carry the latest marker — a stale
+        # ``initial_heartbeat`` next to a current ``heartbeat`` still needs
+        # the refresh (that exact split is what the consumed-key gap left
+        # behind on deployed boxes).
         old_has_latest = (
             latest_sentinel is not None
             and f"<!-- {latest_sentinel} -->" in existing_heartbeat
+            and f"<!-- {latest_sentinel} -->" in existing_initial
         )
         # Roll forward ONLY when the existing heartbeat carries at
         # least one prior sentinel — proves it's a system-managed
@@ -2007,6 +2021,7 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
             or existing_is_empty
         ):
             op_entry["heartbeat"] = _OPERATOR_HEARTBEAT
+            op_entry["initial_heartbeat"] = _OPERATOR_HEARTBEAT
             agents_cfg["agents"][_OPERATOR_AGENT_ID] = op_entry
             AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
             with open(AGENTS_FILE, "w") as f:

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -171,6 +171,11 @@ class TestEnsureOperatorModelSync(_TempConfigMixin):
             "role": "Existing operator",
             "model": "openai/gpt-4o-mini",
             "heartbeat": _OPERATOR_HEARTBEAT,
+            # Both heartbeat copies must be current for the no-write path:
+            # a missing/stale ``initial_heartbeat`` next to a current
+            # ``heartbeat`` is exactly the consumed-key split the refresh
+            # now repairs (one legitimate write).
+            "initial_heartbeat": _OPERATOR_HEARTBEAT,
             "initial_instructions": _OPERATOR_CORE,
         }}}
         with open(self._agents_path, "w") as f:
@@ -214,6 +219,68 @@ class TestEnsureOperatorModelSync(_TempConfigMixin):
         assert refreshed == _OPERATOR_HEARTBEAT
         assert "<!-- heartbeat_v6_agent_retro -->" in refreshed
         assert "Old v5 revision text" not in refreshed
+        # The consumed key MUST roll forward too: cli/runtime.py builds the
+        # INITIAL_HEARTBEAT container env from ``initial_heartbeat``, and
+        # the workspace-side refresh keys off that env. Refreshing only
+        # ``heartbeat`` left every deployed operator on its creation-era
+        # checklist (found live on cake 2026-06-11).
+        assert result["agents"]["operator"]["initial_heartbeat"] == _OPERATOR_HEARTBEAT
+
+    def test_stale_initial_heartbeat_refreshes_when_heartbeat_current(self):
+        """The consumed-key gap's exact residue: ``heartbeat`` already
+        carries the latest sentinel (a prior partial refresh) while
+        ``initial_heartbeat`` is stuck on an older revision. The refresh
+        must still fire and sync both keys."""
+        from src.cli.config import _OPERATOR_HEARTBEAT
+
+        agents_cfg = {"agents": {"operator": {
+            "role": "Existing operator",
+            "model": "openai/gpt-4o-mini",
+            "heartbeat": _OPERATOR_HEARTBEAT,
+            "initial_heartbeat": (
+                "<!-- heartbeat_v5_fleet_health -->\n"
+                "Old v5 revision text\n"
+            ),
+        }}}
+        with open(self._agents_path, "w") as f:
+            yaml.dump(agents_cfg, f)
+
+        with self._mock_config():
+            from src.cli.config import _ensure_operator_agent
+            _ensure_operator_agent(default_model="openai/gpt-4o-mini")
+
+        with open(self._agents_path) as f:
+            result = yaml.safe_load(f)
+        op = result["agents"]["operator"]
+        assert op["heartbeat"] == _OPERATOR_HEARTBEAT
+        assert op["initial_heartbeat"] == _OPERATOR_HEARTBEAT
+
+    def test_customised_heartbeat_field_still_skipped(self):
+        """A marker-less non-empty ``heartbeat`` is user-customised — the
+        refresh must keep skipping it even when ``initial_heartbeat``
+        carries old markers (the customisation guard stays keyed on the
+        authoritative ``heartbeat`` field)."""
+        agents_cfg = {"agents": {"operator": {
+            "role": "Existing operator",
+            "model": "openai/gpt-4o-mini",
+            "heartbeat": "My fully custom heartbeat, no markers\n",
+            "initial_heartbeat": (
+                "<!-- heartbeat_v5_fleet_health -->\n"
+                "Old v5 revision text\n"
+            ),
+        }}}
+        with open(self._agents_path, "w") as f:
+            yaml.dump(agents_cfg, f)
+
+        with self._mock_config():
+            from src.cli.config import _ensure_operator_agent
+            _ensure_operator_agent(default_model="openai/gpt-4o-mini")
+
+        with open(self._agents_path) as f:
+            result = yaml.safe_load(f)
+        op = result["agents"]["operator"]
+        assert op["heartbeat"] == "My fully custom heartbeat, no markers\n"
+        assert "Old v5 revision text" in op["initial_heartbeat"]
 
     def test_empty_heartbeat_is_bootstrapped_to_canonical_template(self):
         """Codex r3 (PR 972) catch — the WARN for no-sentinel files


### PR DESCRIPTION
## Summary
Production bug found during the live verification of #1123 on cake: the operator's `HEARTBEAT.md` was untouched since **May 23** — none of the v2→v6 heartbeat upgrades (rate-delivery cadence, goal seeding, fleet health, agent retro) ever reached it, or any other pre-existing deployment.

**Root cause — a consumed-key split:** the config-side sentinel refresh rewrites agents.yaml `heartbeat`, but `cli/runtime.py` builds the `INITIAL_HEARTBEAT` container env from `initial_heartbeat` (frozen at agent creation), and the workspace-side `HEARTBEAT.md` refresh fires only when that env carries the latest sentinel. The two halves were each tested in isolation; the key mapping between them never was. Same class of gap as the playbook `initial_instructions` roll-forward fixed in #1110.

**Fix:** the refresh writes both keys, and "already current" requires the latest marker in **both** — so a box left with a current `heartbeat` but stale `initial_heartbeat` (the gap's exact residue, which today's deploys created on cake before manual remediation) self-repairs on next boot. The customisation guard stays keyed on the authoritative `heartbeat` field: marker-less user-customised heartbeats are still never touched.

## Live verification on cake
- agents.yaml `initial_heartbeat` synced manually (atomic write), stale `HEARTBEAT.md` backed up + removed, container re-seeded
- v6 sentinel + Agent retro step confirmed in the operator's live `HEARTBEAT.md`
- goals-guard probes: unauthenticated worker write 401, operator write/delete 200/200; logs clean

## Test plan
- New: `test_stale_initial_heartbeat_refreshes_when_heartbeat_current` (the gap's residue), `test_customised_heartbeat_field_still_skipped` (guard preserved)
- Updated: roll-forward test asserts the consumed key; no-write test seeds both keys current
- `test_operator_config.py + test_operator_heartbeat.py + test_workspace.py + test_runtime.py`: 314 passed; ruff clean
