### PR TITLE
fix(cli): repair references broken by the shim cleanup (#1128/#1132 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Only modules with non-obvious behavior are listed. The rest are visible by readi
 | `src/agent/loop.py` | Agent execution loop (task + chat). Auto-closes handed-off tasks when `x-task-id` rides the wake chain. |
 | `src/agent/server.py` | `_FILE_CAPS` enforced on workspace writes; `_WORKSPACE_ALLOWLIST` gates reads/writes. |
 | `src/agent/context.py` | Context window management (write-then-compact); empty summary falls back to hard prune. |
-| `src/agent/workspace.py` | Persistent markdown workspace. Bootstrap files: TEAM.md (legacy `PROJECT.md` resolves read-only), SOUL/USER/INSTRUCTIONS/MEMORY/INTERFACE/HEARTBEAT. |
+| `src/agent/workspace.py` | Persistent markdown workspace. Bootstrap files: TEAM.md (a legacy `PROJECT.md` is renamed to TEAM.md at startup by `team_migration.py`), SOUL/USER/INSTRUCTIONS/MEMORY/INTERFACE/HEARTBEAT. |
 | `src/agent/mesh_client.py` | `wake_agent` / `create_task` accept optional `origin: MessageOrigin` and merge it into headers (Constraint #4). |
 | `src/agent/builtins/coordination_tool.py` | `hand_off` propagates origin and forwards `task_id` so the recipient's loop auto-closes. `check_inbox` surfaces back-edge `events[]` from `inbox/{agent}/task_event/`. Failure envelopes: Constraint #10. |
 | `src/agent/builtins/file_tool.py` | Two-stage path-traversal protection (`lstat()` for symlink safety). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,7 @@ The SSO callback (`/__auth/callback`) is **not implemented in this repo** — it
 
 | Module | Purpose |
 |--------|---------|
-| `main.py` | Click commands and entry point (`start`, `stop`, `status`, `chat`, `version`, `wallet`, `teams` (alias `projects`), `team` (alias `project`), `tasks`, `pending`, `confirm`, `cancel`, `reset`). |
+| `main.py` | Click commands and entry point (`start`, `stop`, `status`, `chat`, `version`, `wallet`, `teams`, `team`, `tasks`, `pending`, `confirm`, `cancel`, `reset`). |
 | `config.py` | Config loading, Docker helpers, fleet template system (`_load_templates()`, `_create_agent_from_template()`, `_apply_template()`). |
 | `runtime.py` | `RuntimeContext` — full lifecycle management. Auto-creates the `operator` agent, enforces `RESERVED_AGENT_IDS`, falls back from `SandboxBackend` to `DockerBackend` on init failure. |
 | `repl.py` | `REPLSession` — interactive command dispatch. **Talks directly to agent endpoints** (`/chat`, `/chat/stream`), not through a mesh router hop. |
@@ -250,7 +250,7 @@ through PR 2 of the project→team rename.)
 - **Permission management on agent create**: `POST /mesh/agents/create` writes defaults of `blackboard_read=["*"]`, `blackboard_write=["tasks/*","context/*","status/*","output/*","artifacts/*"]`, `can_publish=["*"]`, `can_subscribe=["*"]` (`src/host/server.py:4020-4021`). The effective per-team scope comes from the MeshClient's auto-prefix at runtime, not from the on-disk permission file.
 - **Remove from team**: When an agent is removed from a team, `blackboard_read` and `blackboard_write` are cleared to `[]`.
 - **Solo agents**: Agents not assigned to any team have no scoped blackboard prefix, see only themselves in `list_agents`, and receive no `TEAM.md`.
-- **Cross-team blackboard counter**: `_blackboard_xproject_count` is a process-lifetime observability counter (no enforcement) surfaced on `/mesh/system/metrics` as `blackboard_cross_project_total`.
+- **Cross-team blackboard counter**: `_blackboard_xteam_count` is a process-lifetime observability counter (no enforcement) surfaced on `/mesh/system/metrics` as `blackboard_cross_project_total`.
 
 ### Team Data
 

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -509,7 +509,7 @@ class REPLSession:
             assigned = {m for pdata in projects.values() for m in pdata.get("members", [])} & all_agents
 
             if not projects:
-                click.echo("  No projects configured. Create with: openlegion project create")
+                click.echo("  No projects configured. Create one from the dashboard or ask the operator agent.")
                 return
 
             for pname, pdata in sorted(projects.items()):


### PR DESCRIPTION
Post-merge principal review of #1128 + #1132 (own pass + an independent fresh-context review; Codex pass deferred — usage limit until Jun 12 02:55).

**Must-fix found and fixed:**
- `src/cli/repl.py` — the `/project` empty-state hint told users to run `openlegion project create`: #1128 deleted that command, and it never had a `create` subcommand anyway. Hint now points at the real creation paths (dashboard / operator agent).

**Doc rot fixed (rode along):**
- `docs/architecture.md:194` — still listed the deleted `projects`/`project` CLI aliases.
- `docs/architecture.md:253` — renamed `_blackboard_xproject_count` → `_blackboard_xteam_count`.
- `CLAUDE.md` workspace row — `PROJECT.md` is migrated at startup by `team_migration.py`, not 'resolved read-only' (workspace.py has no PROJECT.md handling).

**Review verdict on the merged cleanup, for the record:** full fast suite re-proven green on merged main (7,479 passed, 0 failed); every deleted Python/JS symbol grep-verified zero-reference including Alpine-expression and string-dispatch paths; the two hasattr-guard removals confirmed behavior-identical for every reachable cost_tracker; `get_team_outputs` rewire signature/return-parity confirmed. Deferred/flagged (not applied): `_messengerSidePanelPrevFocus` orphan (part of the intentionally-kept side-panel cleanup cluster), `trackEmptyStateCta` placeholder, app.js `case 'archive_project'` (pre-existing), test_team_goal.py stale comment header (pre-existing).

Verified: ruff clean; `tests/test_cli_commands.py` + `tests/test_connectors.py` (REPL coverage) + `tests/test_dashboard_ui.py` (CLAUDE.md pins): **341 passed, 4 skipped, 0 failed**.