### PR TITLE
feat(dashboard): standing-goals section on the agent Memory tab

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -7400,6 +7400,138 @@ def create_dashboard_router(
         except Exception as e:
             raise HTTPException(status_code=502, detail=str(e))
 
+    # ── Agent standing goals (blackboard ``goals/{agent_id}``) ─
+
+    # Human/dashboard surface for the per-agent standing goals the
+    # operator writes via ``set_agent_goals`` — injected into the
+    # agent's every prompt as "## Your Current Goals" and pursued
+    # during idle heartbeats. Trust model: the dashboard is the
+    # full-trust human surface writing through the trusted store
+    # directly, so the ``goals/``-namespace fail-close in
+    # ``PermissionMatrix.can_write_blackboard`` (which blocks AGENT
+    # writers — a worker's wildcard can never cover a peer's goals
+    # key) is not bypassed-for-agents by this path: no agent identity
+    # is involved here.
+
+    _MAX_AGENT_GOALS = 5
+    _MAX_AGENT_GOAL_CHARS = 300
+
+    def _agent_goals_key(agent_id: str) -> str:
+        """Resolve the scoped goals key for an agent.
+
+        Mirrors the agent-side reader (``AgentLoop._fetch_goals`` reads
+        via ``mesh_client._scope_key``): team agents read
+        ``projects/{team}/goals/{agent_id}``, solo agents read the raw
+        ``goals/{agent_id}`` key.
+        """
+        from src.cli.config import _load_projects
+        for pname, pdata in _load_projects().items():
+            if agent_id in pdata.get("members", []):
+                return f"projects/{pname}/goals/{agent_id}"
+        return f"goals/{agent_id}"
+
+    @api_router.get("/api/agents/{agent_id}/goals")
+    async def api_agent_goals_get(agent_id: str) -> dict:
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        entry = blackboard.read(_agent_goals_key(agent_id))
+        if entry is None:
+            return {"goals": [], "updated_at": None}
+        value = entry.value if isinstance(entry.value, dict) else {}
+        raw = value.get("goals", [])
+        goals = [str(g) for g in raw] if isinstance(raw, list) else []
+        return {
+            "goals": goals,
+            "updated_at": value.get("updated_at"),
+            "set_by": value.get("set_by"),
+        }
+
+    @api_router.put("/api/agents/{agent_id}/goals")
+    async def api_agent_goals_put(agent_id: str, request: Request) -> dict:
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        if agent_id == "operator":
+            # Parity with the ``set_agent_goals`` tool, which refuses
+            # the operator — its fleet/business goals live in GOALS.json
+            # and are managed from the Work tab.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "The operator's fleet/business goals live in "
+                    "GOALS.json — manage them from the Work tab's goals "
+                    "strip, not here."
+                ),
+            )
+        body = await request.json()
+        goals = body.get("goals")
+        if not isinstance(goals, list):
+            raise HTTPException(status_code=400, detail="goals must be a list of strings")
+        if len(goals) > _MAX_AGENT_GOALS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"goals exceeds max length {_MAX_AGENT_GOALS}",
+            )
+        cleaned: list[str] = []
+        for g in goals:
+            if not isinstance(g, str):
+                raise HTTPException(status_code=400, detail="each goal must be a string")
+            s = sanitize_for_prompt(g).strip()
+            if not s:
+                raise HTTPException(status_code=400, detail="each goal must be a non-empty string")
+            if len(s) > _MAX_AGENT_GOAL_CHARS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"each goal must be <={_MAX_AGENT_GOAL_CHARS} chars (one sentence)",
+                )
+            cleaned.append(s)
+
+        key = _agent_goals_key(agent_id)
+        prior = blackboard.read(key)
+        prior_goals = []
+        if prior is not None and isinstance(prior.value, dict):
+            prior_goals = prior.value.get("goals", []) or []
+
+        if not cleaned:
+            # Blackboard.delete is idempotent — clearing unset goals is fine.
+            blackboard.delete(key, deleted_by="user")
+            blackboard.log_audit(
+                action="clear_goals",
+                target=agent_id,
+                field="goals",
+                before_value="\n".join(str(g) for g in prior_goals),
+                actor="user",
+                provenance="dashboard",
+            )
+            return {"cleared": True, "agent_id": agent_id}
+
+        from datetime import datetime, timezone
+        blackboard.write(
+            key,
+            {
+                "goals": cleaned,
+                "set_by": "user",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+            written_by="user",
+        )
+        blackboard.log_audit(
+            action="edit_goals",
+            target=agent_id,
+            field="goals",
+            before_value="\n".join(str(g) for g in prior_goals),
+            after_value="\n".join(cleaned),
+            actor="user",
+            provenance="dashboard",
+        )
+        return {
+            "set": True,
+            "agent_id": agent_id,
+            "count": len(cleaned),
+            "note": (
+                "Takes effect on the agent's next prompt build (<=5 min cache)."
+            ),
+        }
+
     # ── Agent Activity Log ────────────────────────────────────
 
     @api_router.get("/api/agents/{agent_id}/activity")

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -393,6 +393,14 @@ function dashboard() {
     identityLearnings: null,
     identityLearningsLoading: false,
 
+    // Standing goals (Memory tab) — blackboard goals/{agent_id}
+    agentGoals: [],
+    agentGoalsMeta: null,
+    agentGoalsLoading: false,
+    agentGoalsEditing: false,
+    agentGoalsBuffer: '',
+    agentGoalsSaving: false,
+
     // Files tab
     agentFiles: [],
     agentFilesLoading: false,
@@ -5567,6 +5575,9 @@ function dashboard() {
       const fileMap = _IDENTITY_FILE_MAP[tab.id];
       if (fileMap) {
         this.identityContentLoading = true;
+        // Standing goals live alongside the memory files — fire the
+        // fetch before the file loop so it lands in parallel.
+        if (tab.id === 'memory') this.loadAgentGoals(agentId);
         for (const entry of fileMap) {
           try {
             const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/workspace/${entry.file}`);
@@ -6015,6 +6026,56 @@ function dashboard() {
         if (resp.ok) this.identityLearnings = await resp.json();
       } catch (e) { console.warn('fetchIdentityLearnings failed:', e); }
       this.identityLearningsLoading = false;
+    },
+
+    async loadAgentGoals(agentId) {
+      this.agentGoalsLoading = true;
+      this.agentGoalsEditing = false;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/goals`);
+        if (resp.ok) {
+          const data = await resp.json();
+          this.agentGoals = data.goals || [];
+          this.agentGoalsMeta = data;
+        }
+      } catch (e) { console.warn('loadAgentGoals failed:', e); }
+      this.agentGoalsLoading = false;
+    },
+
+    startAgentGoalsEdit() {
+      this.agentGoalsBuffer = this.agentGoals.join('\n');
+      this.agentGoalsEditing = true;
+    },
+
+    cancelAgentGoalsEdit() {
+      this.agentGoalsEditing = false;
+      this.agentGoalsBuffer = '';
+    },
+
+    async saveAgentGoals(agentId) {
+      if (this.agentGoalsSaving) return;
+      const goals = this.agentGoalsBuffer.split('\n').map(g => g.trim()).filter(g => g);
+      this.agentGoalsSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/goals`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ goals }),
+        });
+        if (resp.ok) {
+          this.agentGoals = goals;
+          this.agentGoalsMeta = { ...(this.agentGoalsMeta || {}), updated_at: new Date().toISOString(), set_by: 'user' };
+          this.agentGoalsEditing = false;
+          this.agentGoalsBuffer = '';
+          this.showToast(goals.length ? 'Saved standing goals' : 'Cleared standing goals');
+        } else {
+          try {
+            const err = await resp.json();
+            this.showToast(`Save failed: ${err.detail || 'Unknown error'}`);
+          } catch (_) { this.showToast('Save failed'); }
+        }
+      } catch (e) { this.showToast(`Save failed: ${e.message}`); }
+      this.agentGoalsSaving = false;
     },
 
     async fetchAgentActivity(agentId) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2828,6 +2828,52 @@
                       </div>
                     </template>
                   </div>
+                  <!-- ═══ Standing goals (Memory tab) — blackboard goals/{agent_id} ═══ -->
+                  <div x-show="identityTab === 'memory' && !identityContentLoading && !identityLoading"
+                    data-testid="agent-goals-section"
+                    class="border border-gray-800 rounded-lg p-3 mt-4">
+                    <div class="flex items-center justify-between mb-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-xs font-medium text-gray-300">Standing goals</span>
+                        <span class="setting-hint setting-hint-sm" tabindex="0">?<span class="setting-hint-text">Standing direction for this agent — injected into every prompt and pursued during idle heartbeats. One goal per line, max 5. The operator can also manage these via set_agent_goals.</span></span>
+                      </div>
+                      <button x-show="selectedAgent !== 'operator' && !agentGoalsEditing"
+                        @click="startAgentGoalsEdit()"
+                        class="text-xs px-3 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors">Edit</button>
+                    </div>
+                    <!-- Operator: standing goals don't apply — its goals live in GOALS.json -->
+                    <div x-show="selectedAgent === 'operator'" class="text-sm text-gray-500">
+                      The operator's fleet and business goals live on the Work tab.
+                    </div>
+                    <!-- Read view -->
+                    <div x-show="selectedAgent !== 'operator' && !agentGoalsEditing">
+                      <div x-show="agentGoals.length > 0" class="flex flex-wrap gap-1.5">
+                        <template x-for="(g, gi) in agentGoals" :key="gi">
+                          <span class="inline-flex items-center text-[11px] px-2 py-0.5 rounded-full bg-gray-800/60 border border-gray-700/50 text-gray-200"
+                            data-testid="agent-goal-chip" x-text="g"></span>
+                        </template>
+                      </div>
+                      <div x-show="agentGoals.length === 0" class="text-sm text-gray-500">No standing goals set.</div>
+                      <div x-show="agentGoalsMeta && agentGoalsMeta.updated_at" class="text-[11px] text-gray-500 mt-1.5"
+                        x-text="'Updated ' + (agentGoalsMeta?.updated_at || '')"></div>
+                    </div>
+                    <!-- Edit view -->
+                    <div x-show="selectedAgent !== 'operator' && agentGoalsEditing">
+                      <textarea x-model="agentGoalsBuffer"
+                        placeholder="One goal per line (max 5, one sentence each)"
+                        class="w-full bg-gray-800 border border-gray-700 rounded p-3 text-sm text-gray-200 font-mono resize-y focus:border-indigo-500 focus:outline-none"
+                        rows="4" spellcheck="false"></textarea>
+                      <div class="flex items-center gap-2 mt-2 justify-end">
+                        <button @click="saveAgentGoals(selectedAgent)"
+                          :disabled="agentGoalsSaving"
+                          class="px-3 py-1 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded disabled:opacity-50 transition-colors">
+                          <span x-text="agentGoalsSaving ? 'Saving...' : 'Save'"></span>
+                        </button>
+                        <button @click="cancelAgentGoalsEdit()" :disabled="agentGoalsSaving"
+                          class="px-3 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition-colors disabled:opacity-50">Cancel</button>
+                      </div>
+                    </div>
+                  </div>
                   <!-- ═══ Activity tab: Heartbeat + autonomous work timeline ═══ -->
                   <div x-show="identityTab === 'activity' && !agentActivityLoading && !identityLoading" class="space-y-2">
                     <div class="flex items-center justify-between mb-2">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5892,3 +5892,123 @@ class TestDashboardFileDownload:
         )
         assert resp.status_code == 200
         assert resp.content == b"stuck"  # exactly one page, loop terminated
+
+
+class TestAgentGoalsEndpoints:
+    """Standing-goals read/edit surface (Memory tab → blackboard goals/{id})."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_get_unknown_agent_404(self):
+        resp = self.client.get("/dashboard/api/agents/ghost/goals")
+        assert resp.status_code == 404
+
+    def test_get_empty_when_nothing_set(self):
+        with patch("src.cli.config._load_projects", return_value={}):
+            resp = self.client.get("/dashboard/api/agents/alpha/goals")
+        assert resp.status_code == 200
+        assert resp.json() == {"goals": [], "updated_at": None}
+
+    def test_put_and_get_roundtrip_solo_key(self):
+        with patch("src.cli.config._load_projects", return_value={}):
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals",
+                json={"goals": ["Ship the weekly report."]},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["set"] is True
+            assert data["count"] == 1
+            get_resp = self.client.get("/dashboard/api/agents/alpha/goals")
+        body = get_resp.json()
+        assert body["goals"] == ["Ship the weekly report."]
+        assert body["set_by"] == "user"
+        assert body["updated_at"]
+        # Solo agent (no team) → the raw key, no projects/ prefix.
+        entry = self.components["blackboard"].read("goals/alpha")
+        assert entry is not None
+        assert entry.value["goals"] == ["Ship the weekly report."]
+        assert entry.ttl is None
+
+    def test_team_agent_writes_scoped_key(self):
+        with patch("src.cli.config._load_projects", return_value={
+            "team-a": {"members": ["alpha"]},
+        }):
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals",
+                json={"goals": ["Watch the inbox."]},
+            )
+            assert resp.status_code == 200
+            # Team agents read via _scope_key → projects/{team}/goals/{id}.
+            entry = self.components["blackboard"].read("projects/team-a/goals/alpha")
+            assert entry is not None
+            assert entry.value["goals"] == ["Watch the inbox."]
+            get_resp = self.client.get("/dashboard/api/agents/alpha/goals")
+            assert get_resp.json()["goals"] == ["Watch the inbox."]
+        # Nothing leaked to the unscoped key.
+        assert self.components["blackboard"].read("goals/alpha") is None
+
+    def test_put_validation_rejects_bad_payloads(self):
+        with patch("src.cli.config._load_projects", return_value={}):
+            # Not a list.
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals", json={"goals": "do it"},
+            )
+            assert resp.status_code == 400
+            # Too many entries (max 5).
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals",
+                json={"goals": [f"goal {i}" for i in range(6)]},
+            )
+            assert resp.status_code == 400
+            # A single goal over 300 chars.
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals", json={"goals": ["a" * 301]},
+            )
+            assert resp.status_code == 400
+            # Blank after strip.
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals", json={"goals": [" "]},
+            )
+            assert resp.status_code == 400
+
+    def test_put_empty_clears(self):
+        with patch("src.cli.config._load_projects", return_value={}):
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals", json={"goals": ["Keep going."]},
+            )
+            assert resp.status_code == 200
+            resp = self.client.put(
+                "/dashboard/api/agents/alpha/goals", json={"goals": []},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"cleared": True, "agent_id": "alpha"}
+            get_resp = self.client.get("/dashboard/api/agents/alpha/goals")
+        assert get_resp.json()["goals"] == []
+        assert self.components["blackboard"].read("goals/alpha") is None
+
+    def test_put_operator_rejected(self):
+        # The registry dict is shared by reference with the router closure.
+        self.components["agent_registry"]["operator"] = "http://localhost:8409"
+        resp = self.client.put(
+            "/dashboard/api/agents/operator/goals", json={"goals": ["x"]},
+        )
+        assert resp.status_code == 400
+        # Parity with set_agent_goals: point at the Work-tab goals.
+        assert "Work tab" in resp.json()["detail"]
+
+    def test_put_without_csrf_header_403(self):
+        # Raw TestClient against the same app — no auto-injected
+        # X-Requested-With header.
+        raw = TestClient(self.client.app)
+        resp = raw.put(
+            "/dashboard/api/agents/alpha/goals", json={"goals": ["x"]},
+        )
+        assert resp.status_code == 403

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2593,3 +2593,18 @@ class TestLimitsConfigUICompleteness:
         # The three per-agent caps must be bound in the agent edit panel.
         for field in ("max_output_tokens", "max_tool_rounds", "llm_timeout_seconds"):
             assert f"editForm.{field}" in _INDEX_HTML, f"{field} missing from agent edit UI"
+
+
+class TestAgentGoalsSection:
+    """Standing-goals section on the agent Memory tab (Fleet → detail)."""
+
+    def test_agent_goals_section_present(self, index_html: str, app_js: str):
+        assert 'data-testid="agent-goals-section"' in index_html
+        assert 'data-testid="agent-goal-chip"' in index_html
+        # Gated to the Memory sub-tab of the agent settings panel.
+        idx = index_html.find('data-testid="agent-goals-section"')
+        slice_ = index_html[max(0, idx - 300):idx + 300]
+        assert "identityTab === 'memory'" in slice_
+        # Loader + save handler wired into the SPA.
+        assert "loadAgentGoals" in app_js
+        assert "saveAgentGoals" in app_js


### PR DESCRIPTION
## Summary
- Adds a **Standing goals** section to the agent settings Memory tab (Fleet → agent detail → left column), surfacing the per-agent standing goals stored at blackboard `goals/{agent_id}` — previously writable only via the operator's `set_agent_goals` tool.
- Two new dashboard endpoints: `GET`/`PUT /api/agents/{agent_id}/goals`. They use the Blackboard directly (no transport hop) and write to the same scoped key the agent-side reader (`AgentLoop._fetch_goals` via `_scope_key`) uses: `projects/{team}/goals/{id}` for team agents, raw `goals/{id}` for solo agents.
- Validation mirrors the tool: list of strings, max 5 entries, each non-empty and ≤300 chars after strip, `sanitize_for_prompt` on every goal. `goals: []` deletes the key (idempotent). Writes carry no TTL and land in the audit log (`edit_goals` / `clear_goals`, actor=user, provenance=dashboard).
- The operator agent is excluded with a 400 (parity with `set_agent_goals`): its fleet/business goals live in GOALS.json, managed from the Work tab. The UI shows a one-line pointer instead of an editor.

Part of #1012 follow-through.

## UX note
Goals render as read-only pills with an updated-at stamp; Edit swaps in a textarea (one goal per line, max 5) with Save/Cancel mirroring the identity-file editor. Saving notes that changes take effect on the agent's next prompt build (≤5 min goals cache). Loading is wired into the Memory sub-tab fetch alongside the memory files.

## Test plan
- `tests/test_dashboard.py::TestAgentGoalsEndpoints` — 404 unknown agent, empty GET shape, PUT/GET round-trip on the raw solo key, team-scoped key placement (`projects/team-a/goals/alpha`), all 400 validation paths, clear-on-empty, operator 400, missing-CSRF 403.
- `tests/test_dashboard_ui.py::TestAgentGoalsSection` — pins the section/chip test-ids, the `identityTab === 'memory'` gate, and the JS handlers.
- `ruff check src/dashboard/ tests/` clean; targeted dashboard files 595 passed / 4 skipped; full fast suite 7467 passed / 49 skipped.