### PR TITLE
feat(chat): system wakes render as system rows, never as the user

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -429,7 +429,10 @@ class AgentLoop:
         # of distinct in-flight tasks (small); the entry for a task is wiped
         # in ``chat()`` when it reaches a terminal status.
         self._task_round_counts: dict[str, int] = {}
-        self._steer_queue: asyncio.Queue[str] = asyncio.Queue()
+        # Entries are (text, system_note) — system_note marks
+        # mesh-composed messages so transcript persistence uses the
+        # honest ``system`` role at every drain site.
+        self._steer_queue: asyncio.Queue[tuple[str, bool]] = asyncio.Queue()
         self._fleet_roster: list[dict] | None = None  # cached fleet info
         self._fleet_roster_ts: float = 0  # timestamp of last fetch
         self._introspect_cache: dict | None = None
@@ -921,17 +924,22 @@ class AgentLoop:
         )
         return block[:600]
 
-    async def inject_steer(self, message: str) -> bool:
-        """Inject a steer message. Returns True if agent is working."""
-        await self._steer_queue.put(message)
+    async def inject_steer(self, message: str, system_note: bool = False) -> bool:
+        """Inject a steer message. Returns True if agent is working.
+
+        ``system_note`` marks a SYSTEM-composed message (mesh wake, cron,
+        webhook) so the drained transcript entry uses role ``system``
+        instead of impersonating the user.
+        """
+        await self._steer_queue.put((message, system_note))
         return self.state == "working"
 
     def _has_pending_steers(self) -> bool:
         """Check if steer messages are waiting without draining them."""
         return not self._steer_queue.empty()
 
-    def _drain_steer_messages(self) -> list[str]:
-        """Non-blocking drain of all pending steer messages."""
+    def _drain_steer_messages(self) -> list[tuple[str, bool]]:
+        """Non-blocking drain of pending steers as (text, system_note)."""
         messages = []
         while not self._steer_queue.empty():
             try:
@@ -939,6 +947,29 @@ class AgentLoop:
             except asyncio.QueueEmpty:
                 break
         return messages
+
+    def _persist_steer_entries(self, steered: list[tuple[str, bool]]) -> None:
+        """Write drained steer entries to the transcript with honest roles.
+
+        Human steers keep the historical ``[steer]`` user-row rendering;
+        system-composed ones become ``system`` rows (dim divider in the
+        dashboard) so a wake prompt never renders as the user's bubble.
+        """
+        if not self.workspace:
+            return
+        for text, is_system in steered:
+            if is_system:
+                self.workspace.append_chat_message("system", text)
+            else:
+                self.workspace.append_chat_message("user", f"[steer] {text}")
+
+    @staticmethod
+    def _steer_interjection(steered: list[tuple[str, bool]]) -> str:
+        """LLM-facing join of drained steers, labelled by provenance."""
+        return "\n\n".join(
+            f"[System]: {text}" if is_system else f"[User interjection]: {text}"
+            for text, is_system in steered
+        )
 
     def _check_tool_loop_terminate(self, tool_calls) -> str | None:
         """Pre-scan all tool calls in a batch for the terminate condition.
@@ -2405,7 +2436,7 @@ class AgentLoop:
                 # Drain any pending coordination signals into the heartbeat
                 steered = self._drain_steer_messages()
                 if steered:
-                    steer_context = "\n".join(f"- {s}" for s in steered)
+                    steer_context = "\n".join(f"- {text}" for text, _ in steered)
                     message = (
                         f"{message}\n\n"
                         f"## Pending Coordination Signals\n\n{steer_context}"
@@ -2921,6 +2952,7 @@ class AgentLoop:
         self, user_message: str, *, trace_id: str | None = None,
         origin: "MessageOrigin | None" = None,
         task_id: str | None = None,
+        system_note: bool = False,
     ) -> dict:
         """Handle a single chat turn with persistent conversation history.
 
@@ -2970,7 +3002,7 @@ class AgentLoop:
                     "tool_outputs": [],
                     "tokens_used": 0,
                 }
-            await self._steer_queue.put(user_message)
+            await self._steer_queue.put((user_message, system_note))
             return {
                 "response": (
                     "Agent is working on a task. Your message has been queued "
@@ -3008,7 +3040,9 @@ class AgentLoop:
                     await self._apply_task_thinking(task_id)
                 try:
                     try:
-                        result = await self._chat_inner(user_message)
+                        result = await self._chat_inner(
+                            user_message, system_note=system_note,
+                        )
                     except asyncio.CancelledError:
                         # Codex r10 (MEDIUM): _chat_inner re-raises
                         # CancelledError, which is BaseException and slips
@@ -3366,15 +3400,27 @@ class AgentLoop:
 
     # ── Chat helpers (shared by streaming and non-streaming) ────
 
-    async def _prepare_chat_turn(self, user_message: str) -> tuple[str, str]:
+    async def _prepare_chat_turn(
+        self, user_message: str, *, system_note: bool = False,
+    ) -> tuple[str, str]:
         """Set up chat context: corrections, memory, steer, system prompt.
 
         Returns (possibly-enriched user_message, system_prompt).
+
+        ``system_note`` marks a mesh-composed message (wake/cron/webhook).
+        Three behavioural differences: the transcript row gets role
+        ``system`` (never a fake user bubble), the correction detector is
+        skipped (wake boilerplate must not pollute the corrections store),
+        and the first-message memory auto-search is skipped (boilerplate
+        would seed irrelevant context). The in-memory LLM message stays
+        role ``user`` — the model API requires it and the transcript is
+        display-only.
         """
         # Correction check uses only workspace + _chat_messages — no I/O,
         # safe to run before the parallel fetch.
         if (
-            self.workspace
+            not system_note
+            and self.workspace
             and self._chat_messages
             and self.workspace.looks_like_correction(user_message)
         ):
@@ -3388,11 +3434,14 @@ class AgentLoop:
                     correction=user_message,
                 )
 
-        # Persist clean user message to transcript before enrichment
+        # Persist clean message to transcript before enrichment — honest
+        # role: ``system`` for mesh-composed notes, ``user`` otherwise.
         if self.workspace:
-            self.workspace.append_chat_message("user", user_message)
+            self.workspace.append_chat_message(
+                "system" if system_note else "user", user_message,
+            )
 
-        if not self._chat_messages and self.workspace:
+        if not system_note and not self._chat_messages and self.workspace:
             memory_hits = self.workspace.search(
                 user_message, max_results=3, exclude_files=_BOOTSTRAP_SEARCH_EXCLUDE,
             )
@@ -3412,7 +3461,7 @@ class AgentLoop:
         self._chat_messages.append({"role": "user", "content": llm_content, "_origin": "user"})
         steered = self._drain_steer_messages()
         if steered:
-            combined = "\n\n".join(steered)
+            combined = "\n\n".join(text for text, _ in steered)
             steer_suffix = f"\n\n[Additional context]: {combined}"
             current = self._chat_messages[-1]["content"]
             if isinstance(current, list):
@@ -3423,9 +3472,7 @@ class AgentLoop:
             else:
                 self._chat_messages[-1]["content"] += steer_suffix
             # Persist steers as separate transcript entries
-            if self.workspace:
-                for s in steered:
-                    self.workspace.append_chat_message("user", f"[steer] {s}")
+            self._persist_steer_entries(steered)
 
         self._age_operator_playbooks()
 
@@ -3753,11 +3800,9 @@ class AgentLoop:
 
         steered = self._drain_steer_messages()
         if steered:
-            combined = "\n\n".join(f"[User interjection]: {s}" for s in steered)
+            combined = self._steer_interjection(steered)
             self._chat_messages.append({"role": "user", "content": combined})
-            if self.workspace:
-                for s in steered:
-                    self.workspace.append_chat_message("user", f"[steer] {s}")
+            self._persist_steer_entries(steered)
 
     @staticmethod
     def _resolve_content(llm_response) -> str:
@@ -3858,7 +3903,9 @@ class AgentLoop:
 
     # ── Non-streaming chat ────────────────────────────────────
 
-    async def _chat_inner(self, user_message: str) -> dict:
+    async def _chat_inner(
+        self, user_message: str, *, system_note: bool = False,
+    ) -> dict:
         self.state = "working"
         total_tokens = 0
         tool_outputs: list[dict] = []
@@ -3880,7 +3927,9 @@ class AgentLoop:
         turn_content_parts: list[str] = []
 
         try:
-            user_message, system = await self._prepare_chat_turn(user_message)
+            user_message, system = await self._prepare_chat_turn(
+                user_message, system_note=system_note,
+            )
 
             # Pre-flight wedge guard (defense-in-depth). Reactive compaction
             # only runs at the BOTTOM of the round loop, so a turn that STARTS
@@ -4008,13 +4057,9 @@ class AgentLoop:
                         steer_interrupts += 1
                         self._chat_messages.append({"role": "assistant", "content": content})
                         steered = self._drain_steer_messages()
-                        combined = "\n\n".join(
-                            f"[User interjection]: {s}" for s in steered
-                        )
+                        combined = self._steer_interjection(steered)
                         self._chat_messages.append({"role": "user", "content": combined})
-                        if self.workspace:
-                            for s in steered:
-                                self.workspace.append_chat_message("user", f"[steer] {s}")
+                        self._persist_steer_entries(steered)
                         self._chat_total_rounds += 1
                         await self._compact_chat_context(system)
                         continue
@@ -4893,7 +4938,9 @@ class AgentLoop:
         """
         # Redirect to steer queue if a task is running.
         if self.current_task is not None:
-            await self._steer_queue.put(user_message)
+            # Stream path is human-only (dashboard/REPL) — never a
+            # system note.
+            await self._steer_queue.put((user_message, False))
             yield {
                 "type": "text_delta",
                 "content": (
@@ -5060,13 +5107,9 @@ class AgentLoop:
                             yield {"type": "text_delta", "content": content}
                         self._chat_messages.append({"role": "assistant", "content": content})
                         steered = self._drain_steer_messages()
-                        combined = "\n\n".join(
-                            f"[User interjection]: {s}" for s in steered
-                        )
+                        combined = self._steer_interjection(steered)
                         self._chat_messages.append({"role": "user", "content": combined})
-                        if self.workspace:
-                            for s in steered:
-                                self.workspace.append_chat_message("user", f"[steer] {s}")
+                        self._persist_steer_entries(steered)
                         self._chat_total_rounds += 1
                         await self._compact_chat_context(system)
                         continue

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -170,6 +170,21 @@ def _origin_from_mesh_request(request: Request):
     return parse_origin_header(raw)
 
 
+def _system_note_from_mesh_request(request: Request) -> bool:
+    """True when the mesh marked this message as SYSTEM-composed.
+
+    ``x-system-wake`` makes the transcript record the inbound message with
+    role ``system`` (a dim divider in the dashboard) instead of role
+    ``user`` (the human's own bubble). Same trust rule as the origin kind:
+    honoured only on the mesh-internal hop, so a direct caller can't make
+    its message vanish into the de-emphasized style.
+    """
+    return bool(
+        request.headers.get("x-system-wake")
+        and request.headers.get("x-mesh-internal")
+    )
+
+
 def create_agent_app(loop: AgentLoop) -> FastAPI:
     """Create the FastAPI application for an agent container."""
     # M19: disable interactive API docs / OpenAPI schema by default; gate dev
@@ -361,6 +376,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             trace_id=request.headers.get("x-trace-id"),
             origin=origin,
             task_id=task_id,
+            system_note=_system_note_from_mesh_request(request),
         )
         # Round-4 forensic trace (Bug 3 still reproduces post-PR#952).
         # The operator reported turns ending with no visible chat
@@ -384,9 +400,12 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         return ChatResponse(**result)
 
     @app.post("/chat/steer")
-    async def chat_steer(msg: SteerMessage) -> dict:
+    async def chat_steer(msg: SteerMessage, request: Request) -> dict:
         """Inject a message into the active conversation. Does NOT acquire _chat_lock."""
-        injected = await loop.inject_steer(sanitize_for_prompt(msg.message))
+        injected = await loop.inject_steer(
+            sanitize_for_prompt(msg.message),
+            system_note=_system_note_from_mesh_request(request),
+        )
         return {"injected": injected, "agent_state": loop.state}
 
     @app.post("/chat/stream")

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -257,6 +257,7 @@ class RuntimeContext:
         trace_id: str | None = None,
         origin: "MessageOrigin | None" = None,
         auto_notify: bool = False,
+        system_note: bool = False,
     ) -> str:
         """Thread-safe synchronous message dispatch.
 
@@ -267,6 +268,7 @@ class RuntimeContext:
             self.lane_manager.enqueue(
                 agent, message, mode=mode, trace_id=trace_id,
                 origin=origin, auto_notify=auto_notify,
+                system_note=system_note,
             ),
             self._dispatch_loop,
         )
@@ -277,12 +279,14 @@ class RuntimeContext:
         trace_id: str | None = None,
         origin: "MessageOrigin | None" = None,
         auto_notify: bool = False,
+        system_note: bool = False,
     ) -> str:
         """Async dispatch: schedules onto the dedicated dispatch loop."""
         future = asyncio.run_coroutine_threadsafe(
             self.lane_manager.enqueue(
                 agent, message, mode=mode, trace_id=trace_id,
                 origin=origin, auto_notify=auto_notify,
+                system_note=system_note,
             ),
             self._dispatch_loop,
         )
@@ -785,6 +789,7 @@ class RuntimeContext:
             agent_name: str, message: str,
             origin: "MessageOrigin | None" = None,
             task_id: str | None = None,
+            system_note: bool = False,
             **_kwargs,
         ) -> str:
             from src.shared.trace import (
@@ -820,6 +825,11 @@ class RuntimeContext:
             # specific task once its loop returns.
             if task_id:
                 extra_headers["x-task-id"] = task_id
+            # System-composed message (wake/cron/webhook — no human typed
+            # it): the agent persists it with transcript role ``system``
+            # so the dashboard never renders it as the user's own bubble.
+            if system_note:
+                extra_headers["x-system-wake"] = "1"
             effective_cap = (
                 self.lane_manager.timeout_for(agent_name)
                 if self.lane_manager is not None
@@ -877,10 +887,18 @@ class RuntimeContext:
                     await self._close_task_on_dispatch_error(task_id, e)
                 return note
 
-        async def _direct_steer(agent_name: str, message: str) -> dict:
+        async def _direct_steer(
+            agent_name: str, message: str, system_note: bool = False,
+        ) -> dict:
             try:
+                # Same marker as _direct_dispatch: a system-composed steer
+                # (e.g. blackboard watch hitting a BUSY agent) must drain
+                # from the steer queue as a ``system`` transcript row, not
+                # a "[steer]" user bubble.
+                headers = {"x-system-wake": "1"} if system_note else None
                 return await self.transport.request(
                     agent_name, "POST", "/chat/steer", json={"message": message},
+                    headers=headers,
                 )
             except Exception as e:
                 return {"injected": False, "error": str(e)}
@@ -1176,6 +1194,7 @@ class RuntimeContext:
                 self.lane_manager.enqueue(
                     "operator", msg, mode="followup",
                     origin=wake_origin, auto_notify=False,
+                    system_note=True,
                 ),
                 self._dispatch_loop,
             )
@@ -1373,6 +1392,7 @@ class RuntimeContext:
                 agent_name, message,
                 trace_id=new_trace_id(),
                 origin=origin,
+                system_note=True,
             )
             return result
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -869,15 +869,21 @@
                 </div>
                 <template x-for="(msg, i) in visibleChatHistory('operator')" :key="i">
                   <div class="mb-4 last:mb-0">
-                    <!-- System event: compaction / session divider -->
+                    <!-- System event: compaction / session divider / system wake.
+                         Long content (wake prompts) truncates to one dim line;
+                         click to expand the full text. -->
                     <template x-if="msg.role === 'system'">
-                      <div class="flex items-center gap-2 py-1 select-none">
-                        <div class="flex-1 border-t border-dashed border-gray-800"></div>
-                        <span class="text-[11px] text-gray-500 uppercase tracking-wider whitespace-nowrap flex items-center gap-1">
-                          <svg class="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-                          <span x-text="msg.content"></span>
-                        </span>
-                        <div class="flex-1 border-t border-dashed border-gray-800"></div>
+                      <div class="py-1 select-none" x-data="{ open: false }">
+                        <div class="flex items-center gap-2" :class="(msg.content || '').length > 96 ? 'cursor-pointer' : ''" @click="(msg.content || '').length > 96 && (open = !open)">
+                          <div class="flex-1 border-t border-dashed border-gray-800"></div>
+                          <span class="text-[11px] text-gray-500 uppercase tracking-wider whitespace-nowrap flex items-center gap-1 max-w-[75%] min-w-0">
+                            <svg class="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+                            <span class="truncate" x-text="msg.content"></span>
+                            <svg x-show="(msg.content || '').length > 96" class="w-2.5 h-2.5 shrink-0 transition-transform" :class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                          </span>
+                          <div class="flex-1 border-t border-dashed border-gray-800"></div>
+                        </div>
+                        <div x-show="open" class="mt-1 mx-8 px-3 py-2 rounded-lg bg-gray-900/60 border border-gray-800 text-[11px] text-gray-500 whitespace-pre-wrap break-words" x-text="msg.content"></div>
                       </div>
                     </template>
                     <!-- User message -->
@@ -8541,15 +8547,20 @@
           <template x-for="(msg, i) in visibleChatHistory(activeChatId)" :key="i">
             <!-- Single root wrapper required by Alpine x-for. -->
             <div class="mb-4 last:mb-0">
-              <!-- System event: compaction / session divider — rendered as a separator, not a bubble -->
+              <!-- System event: compaction / session divider / system wake — separator,
+                   not a bubble. Long content truncates; click to expand. -->
               <template x-if="msg.role === 'system'">
-                <div class="flex items-center gap-2 py-1 select-none">
-                  <div class="flex-1 border-t border-dashed border-gray-800"></div>
-                  <span class="text-[11px] text-gray-500 uppercase tracking-wider whitespace-nowrap flex items-center gap-1">
-                    <svg class="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-                    <span x-text="msg.content"></span>
-                  </span>
-                  <div class="flex-1 border-t border-dashed border-gray-800"></div>
+                <div class="py-1 select-none" x-data="{ open: false }">
+                  <div class="flex items-center gap-2" :class="(msg.content || '').length > 96 ? 'cursor-pointer' : ''" @click="(msg.content || '').length > 96 && (open = !open)">
+                    <div class="flex-1 border-t border-dashed border-gray-800"></div>
+                    <span class="text-[11px] text-gray-500 uppercase tracking-wider whitespace-nowrap flex items-center gap-1 max-w-[75%] min-w-0">
+                      <svg class="w-2.5 h-2.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+                      <span class="truncate" x-text="msg.content"></span>
+                      <svg x-show="(msg.content || '').length > 96" class="w-2.5 h-2.5 shrink-0 transition-transform" :class="open ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                    </span>
+                    <div class="flex-1 border-t border-dashed border-gray-800"></div>
+                  </div>
+                  <div x-show="open" class="mt-1 mx-8 px-3 py-2 rounded-lg bg-gray-900/60 border border-gray-800 text-[11px] text-gray-500 whitespace-pre-wrap break-words" x-text="msg.content"></div>
                 </div>
               </template>
               <!-- Credit exhausted card -->

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -61,6 +61,7 @@ class QueuedTask:
     origin: MessageOrigin | None = None
     auto_notify: bool = False
     task_id: str | None = None
+    system_note: bool = False
     future: asyncio.Future = field(default_factory=asyncio.Future)
 
 
@@ -259,6 +260,7 @@ class LaneManager:
         origin: MessageOrigin | None = None,
         auto_notify: bool = False,
         task_id: str | None = None,
+        system_note: bool = False,
     ) -> str:
         """Queue a message for an agent with the specified mode.
 
@@ -274,15 +276,22 @@ class LaneManager:
         call so the recipient agent's loop can auto-close the task on
         completion. Only honoured for ``followup`` mode; steer
         intentionally doesn't wire it (it isn't single-task semantics).
+
+        ``system_note=True`` marks a SYSTEM-composed message (mesh wakes,
+        cron, webhooks — anything no human typed). It rides the dispatch
+        to the agent so the chat transcript records it with role
+        ``system`` instead of impersonating the user. Threaded through
+        BOTH modes: steer needs it because its idle-agent/error paths
+        fall back to a full followup dispatch.
         """
         self._ensure_lane(agent)
 
         if mode == "steer":
-            return await self._handle_steer(agent, message)
+            return await self._handle_steer(agent, message, system_note=system_note)
         return await self._handle_followup(
             agent, message, trace_id=trace_id,
             origin=origin, auto_notify=auto_notify,
-            task_id=task_id,
+            task_id=task_id, system_note=system_note,
         )
 
     async def _handle_followup(
@@ -290,6 +299,7 @@ class LaneManager:
         origin: MessageOrigin | None = None,
         auto_notify: bool = False,
         task_id: str | None = None,
+        system_note: bool = False,
     ) -> str:
         """Standard FIFO enqueue."""
         task = QueuedTask(
@@ -301,6 +311,7 @@ class LaneManager:
             origin=origin,
             auto_notify=auto_notify,
             task_id=task_id,
+            system_note=system_note,
         )
         # H7 — non-blocking put so a full lane surfaces backpressure
         # (LaneQueueFull → HTTP 429) instead of silently awaiting forever
@@ -323,18 +334,30 @@ class LaneManager:
         self._emit_queue_changed(agent)
         return await task.future
 
-    async def _handle_steer(self, agent: str, message: str) -> str:
+    async def _handle_steer(
+        self, agent: str, message: str, *, system_note: bool = False,
+    ) -> str:
         """Inject a steer message into the agent's active conversation.
 
         If a steer_fn is available, calls it directly (bypasses queue).
         Falls back to followup if no steer_fn is configured.
+
+        ``system_note`` must survive every exit: the direct steer_fn call
+        (so the agent's steer queue records the honest role) AND all three
+        followup fallbacks — dropping it on the idle-agent wakeup path
+        would render a system wake as a fake user bubble.
         """
         if self._steer_fn is None:
             logger.debug(f"No steer_fn configured, falling back to followup for '{agent}'")
-            return await self._handle_followup(agent, message)
+            return await self._handle_followup(agent, message, system_note=system_note)
 
         try:
-            result = await self._steer_fn(agent, message)
+            # Conditional kwarg — mirrors the worker's lazy dispatch_kwargs:
+            # legacy steer_fn signatures accept only (agent, message).
+            if system_note:
+                result = await self._steer_fn(agent, message, system_note=True)
+            else:
+                result = await self._steer_fn(agent, message)
             injected = result.get("injected", False) if isinstance(result, dict) else False
             if injected:
                 return f"Steered: message injected into {agent}'s active conversation"
@@ -343,12 +366,12 @@ class LaneManager:
                 # Rate-limited to prevent event storms from draining budget.
                 if self._check_steer_wakeup_rate(agent):
                     logger.debug(f"Waking idle agent '{agent}' via followup (steer not injected)")
-                    return await self._handle_followup(agent, message)
+                    return await self._handle_followup(agent, message, system_note=system_note)
                 logger.debug(f"Steer wakeup rate-limited for idle agent '{agent}', dropping")
                 return SILENT_REPLY_TOKEN
         except Exception as e:
             logger.warning(f"Steer to '{agent}' failed, falling back to followup: {e}")
-            return await self._handle_followup(agent, message)
+            return await self._handle_followup(agent, message, system_note=system_note)
 
     def _check_steer_wakeup_rate(self, agent: str) -> bool:
         """Return True if the agent hasn't exceeded the steer-wakeup rate limit."""
@@ -449,6 +472,8 @@ class LaneManager:
                     dispatch_kwargs["origin"] = task.origin
                 if task.task_id is not None:
                     dispatch_kwargs["task_id"] = task.task_id
+                if task.system_note:
+                    dispatch_kwargs["system_note"] = True
                 # Bug 4: per-task wall-clock cap. A hung LLM stream or
                 # stuck tool previously blocked the lane forever — every
                 # subsequent task for this agent would queue forever.

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1084,7 +1084,12 @@ def create_mesh_app(
 
         async def _do_notify():
             results = await asyncio.gather(
-                *(lane_manager.enqueue(wid, msg, mode="steer") for wid in watcher_ids),
+                *(
+                    lane_manager.enqueue(
+                        wid, msg, mode="steer", system_note=True,
+                    )
+                    for wid in watcher_ids
+                ),
                 return_exceptions=True,
             )
             for wid, result in zip(watcher_ids, results, strict=True):
@@ -1667,7 +1672,7 @@ def create_mesh_app(
                     lane_manager.enqueue(
                         target, wake_msg, mode="followup",
                         origin=origin, auto_notify=had_origin,
-                        task_id=task_id,
+                        task_id=task_id, system_note=True,
                     ),
                     dispatch_loop,
                 )
@@ -5556,7 +5561,7 @@ def create_mesh_app(
                 lane_manager.enqueue(
                     "operator", wake_msg, mode="followup",
                     origin=wake_origin, auto_notify=False,
-                    task_id=None,
+                    task_id=None, system_note=True,
                 ),
                 dispatch_loop,
             )
@@ -5707,7 +5712,7 @@ def create_mesh_app(
                     lane_manager.enqueue(
                         origin_user, wake_msg, mode="followup",
                         origin=wake_origin, auto_notify=False,
-                        task_id=task_id,
+                        task_id=task_id, system_note=True,
                     ),
                     dispatch_loop,
                 )
@@ -6318,7 +6323,7 @@ def create_mesh_app(
         # would emit a "coroutine was never awaited" warning.
         coro = lane_manager.enqueue(
             target, sanitize_for_prompt(message), mode="followup",
-            origin=eff_origin, auto_notify=had_origin,
+            origin=eff_origin, auto_notify=had_origin, system_note=True,
         )
         try:
             asyncio.run_coroutine_threadsafe(coro, dispatch_loop)

--- a/src/host/webhooks.py
+++ b/src/host/webhooks.py
@@ -255,7 +255,11 @@ class WebhookManager:
             message = _build_message(hook, dumps_safe(body, indent=2))
 
             if manager.dispatch_fn:
-                await manager.dispatch_fn(hook["agent"], message)
+                # system_note: webhook payloads are machine-delivered —
+                # the transcript must not render them as the user.
+                await manager.dispatch_fn(
+                    hook["agent"], message, system_note=True,
+                )
 
             return {"status": "processed", "hook": hook["name"]}
 
@@ -272,6 +276,8 @@ class WebhookManager:
         )
 
         if self.dispatch_fn:
-            response = await self.dispatch_fn(hook["agent"], message)
+            response = await self.dispatch_fn(
+                hook["agent"], message, system_note=True,
+            )
             return {"status": "processed", "response": response}
         return {"status": "no_dispatch_fn"}

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -1092,3 +1092,76 @@ class TestChatStreamContextSeeding:
             ) as resp:
                 lines = [ln async for ln in resp.aiter_lines() if ln]
         assert any("ok" in ln for ln in lines)
+
+
+class TestChatSystemNoteHeader:
+    """``x-system-wake`` marks mesh-composed messages so the transcript
+    records them with role ``system``. Same trust rule as the origin
+    kind: honoured only with ``x-mesh-internal`` present."""
+
+    def _chat_app(self):
+        app, mock_loop = _make_app()
+        mock_loop.chat = AsyncMock(return_value={
+            "response": "ok", "tool_outputs": [], "tokens_used": 0,
+        })
+        mock_loop.current_task = None
+        return app, mock_loop
+
+    @pytest.mark.asyncio
+    async def test_trusted_header_passes_system_note(self):
+        app, mock_loop = self._chat_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat", json={"message": "wake"},
+                headers={"x-system-wake": "1", "x-mesh-internal": "1"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.chat.call_args.kwargs.get("system_note") is True
+
+    @pytest.mark.asyncio
+    async def test_header_without_mesh_internal_is_ignored(self):
+        """A direct caller can't push its message into the de-emphasized
+        system style — the marker is mesh-internal only."""
+        app, mock_loop = self._chat_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat", json={"message": "wake"},
+                headers={"x-system-wake": "1"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.chat.call_args.kwargs.get("system_note") is False
+
+    @pytest.mark.asyncio
+    async def test_no_header_defaults_false(self):
+        app, mock_loop = self._chat_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat", json={"message": "hello"},
+                headers={"x-mesh-internal": "1"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.chat.call_args.kwargs.get("system_note") is False
+
+    @pytest.mark.asyncio
+    async def test_steer_endpoint_threads_system_note(self):
+        app, mock_loop = _make_app()
+        mock_loop.inject_steer = AsyncMock(return_value=True)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat/steer", json={"message": "watch update"},
+                headers={"x-system-wake": "1", "x-mesh-internal": "1"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.inject_steer.call_args.kwargs.get("system_note") is True
+
+    @pytest.mark.asyncio
+    async def test_steer_endpoint_untrusted_header_ignored(self):
+        app, mock_loop = _make_app()
+        mock_loop.inject_steer = AsyncMock(return_value=False)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat/steer", json={"message": "watch update"},
+                headers={"x-system-wake": "1"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.inject_steer.call_args.kwargs.get("system_note") is False

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -861,7 +861,7 @@ class TestChatTaskIsolationGuard:
         assert result["tool_outputs"] == []
         assert result["tokens_used"] == 0
         # Message should be in the steer queue
-        assert loop._steer_queue.get_nowait() == "hello"
+        assert loop._steer_queue.get_nowait() == ("hello", False)
 
     @pytest.mark.asyncio
     async def test_chat_normal_when_idle(self):
@@ -903,7 +903,7 @@ class TestChatTaskIsolationGuard:
         assert len(done_events) == 1
         assert done_events[0]["tokens_used"] == 0
         # Message should be in the steer queue
-        assert loop._steer_queue.get_nowait() == "hello stream"
+        assert loop._steer_queue.get_nowait() == ("hello stream", False)
 
     @pytest.mark.asyncio
     async def test_chat_stream_normal_when_idle(self):

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2608,3 +2608,26 @@ class TestAgentGoalsSection:
         # Loader + save handler wired into the SPA.
         assert "loadAgentGoals" in app_js
         assert "saveAgentGoals" in app_js
+
+
+class TestSystemDividerExpandable:
+    """System-role transcript rows (compaction markers, system wakes)
+    render as a dim divider; long content (wake prompts) truncates to
+    one line with a click-to-expand block. Pins the PR-1 'system wakes
+    stop rendering as the user' UI contract."""
+
+    def test_system_template_truncates_and_expands(self):
+        # Both chat surfaces (operator panel + messenger panel) carry the
+        # upgraded system template: truncated label + expandable block.
+        assert _INDEX_HTML.count('x-if="msg.role === \'system\'"') >= 2
+        # Expand block: full content, pre-wrap, gated on the local `open`.
+        assert _INDEX_HTML.count(
+            'whitespace-pre-wrap break-words" x-text="msg.content"'
+        ) >= 2
+        # Truncated label line.
+        assert _INDEX_HTML.count('<span class="truncate" x-text="msg.content">') >= 2
+
+    def test_system_template_click_gated_on_length(self):
+        # Short markers (session-continued etc.) stay non-interactive;
+        # only long content gets the pointer + toggle.
+        assert _INDEX_HTML.count("(msg.content || '').length > 96") >= 4

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -1035,3 +1035,72 @@ async def test_lane_unbounded_when_maxsize_zero():
     release.set()
     await asyncio.gather(*pending)
     await lm.stop()
+
+
+# ── system_note threading (PR: system wakes render as system rows) ──
+
+
+@pytest.mark.asyncio
+async def test_followup_system_note_threads_to_dispatch():
+    """Flagged followups pass system_note=True to the dispatch fn."""
+    dispatch = AsyncMock(return_value="ok")
+    lm = LaneManager(dispatch_fn=dispatch)
+
+    await lm.enqueue("agent1", "wake msg", system_note=True)
+    dispatch.assert_awaited_once_with("agent1", "wake msg", system_note=True)
+
+
+@pytest.mark.asyncio
+async def test_followup_unflagged_keeps_legacy_signature():
+    """Unflagged dispatches must not pass the kwarg (legacy dispatch fns
+    accept only (agent, message))."""
+    dispatch = AsyncMock(return_value="ok")
+    lm = LaneManager(dispatch_fn=dispatch)
+
+    await lm.enqueue("agent1", "hi")
+    dispatch.assert_awaited_once_with("agent1", "hi")
+
+
+@pytest.mark.asyncio
+async def test_steer_system_note_reaches_steer_fn():
+    """Flagged steers pass system_note to steer_fn so a busy agent's
+    steer queue records the honest role."""
+    steer = AsyncMock(return_value={"injected": True})
+    lm = LaneManager(dispatch_fn=AsyncMock(), steer_fn=steer)
+
+    await lm.enqueue("agent1", "watch update", mode="steer", system_note=True)
+    steer.assert_awaited_once_with("agent1", "watch update", system_note=True)
+
+
+@pytest.mark.asyncio
+async def test_steer_unflagged_uses_legacy_two_arg_call():
+    """Human steers keep the legacy (agent, message) steer_fn call."""
+    steer = AsyncMock(return_value={"injected": True})
+    lm = LaneManager(dispatch_fn=AsyncMock(), steer_fn=steer)
+
+    await lm.enqueue("agent1", "user steer", mode="steer")
+    steer.assert_awaited_once_with("agent1", "user steer")
+
+
+@pytest.mark.asyncio
+async def test_steer_idle_fallback_carries_system_note():
+    """The idle-agent steer→followup conversion must not drop the flag —
+    a blackboard wake to an idle operator would otherwise render as a
+    fake user bubble."""
+    dispatch = AsyncMock(return_value="ok")
+    steer = AsyncMock(return_value={"injected": False})
+    lm = LaneManager(dispatch_fn=dispatch, steer_fn=steer)
+
+    await lm.enqueue("agent1", "watch update", mode="steer", system_note=True)
+    dispatch.assert_awaited_once_with("agent1", "watch update", system_note=True)
+
+
+@pytest.mark.asyncio
+async def test_steer_error_fallback_carries_system_note():
+    """The steer-error followup fallback must not drop the flag either."""
+    dispatch = AsyncMock(return_value="ok")
+    steer = AsyncMock(side_effect=RuntimeError("boom"))
+    lm = LaneManager(dispatch_fn=dispatch, steer_fn=steer)
+
+    await lm.enqueue("agent1", "watch update", mode="steer", system_note=True)
+    dispatch.assert_awaited_once_with("agent1", "watch update", system_note=True)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2064,7 +2064,7 @@ async def test_steer_appended_correctly_to_multimodal_content():
         [LLMResponse(content="Sure, I can see the image.", tokens_used=50)],
     )
     # Inject a steer message as if the user typed it mid-turn
-    loop._steer_queue.put_nowait("Please focus on the chart legend.")
+    loop._steer_queue.put_nowait(("Please focus on the chart legend.", False))
 
     # Inject a multimodal content list directly (simulates enrichment result)
     multimodal_content = [
@@ -2077,7 +2077,7 @@ async def test_steer_appended_correctly_to_multimodal_content():
     steered = loop._drain_steer_messages()
     assert steered  # steer was present
 
-    combined = "\n\n".join(steered)
+    combined = "\n\n".join(text for text, _ in steered)
     steer_suffix = f"\n\n[Additional context]: {combined}"
     current = loop._chat_messages[-1]["content"]
     if isinstance(current, list):
@@ -3096,7 +3096,7 @@ class TestChatEmptyResponseFallback:
     async def test_chat_empty_response_with_tools_gets_fallback(self):
         loop = _make_loop()
 
-        async def fake_inner(_msg):
+        async def fake_inner(_msg, **_kw):
             return {
                 "response": "",
                 "tool_outputs": [{"name": "noop"}, {"name": "noop2"}],
@@ -3121,7 +3121,7 @@ class TestChatEmptyResponseFallback:
         leaves it alone — covered by the silent-token tests)."""
         loop = _make_loop()
 
-        async def fake_inner(_msg):
+        async def fake_inner(_msg, **_kw):
             return {"response": "", "tool_outputs": [], "tokens_used": 0}
         loop._chat_inner = fake_inner
 
@@ -3139,7 +3139,7 @@ class TestChatEmptyResponseFallback:
         ``chat()`` final net rescues it even in task_id mode."""
         loop = _make_loop()
 
-        async def fake_inner(_msg):
+        async def fake_inner(_msg, **_kw):
             return {
                 "response": "",
                 "tool_outputs": [{"name": "x"}],
@@ -3534,7 +3534,7 @@ class TestOutboundEffectLazyGuard:
         guard strengthening."""
         loop = _make_loop()
 
-        async def fake_inner(_msg):
+        async def fake_inner(_msg, **_kw):
             return {
                 "response": "",
                 "tool_outputs": [
@@ -3582,7 +3582,7 @@ class TestOutboundEffectLazyGuard:
         ``done`` (the outbound work proves the turn wasn't lazy)."""
         loop = _make_loop()
 
-        async def fake_inner(_msg):
+        async def fake_inner(_msg, **_kw):
             return {
                 "response": "",
                 "tool_outputs": [
@@ -3623,7 +3623,7 @@ class TestOutboundEffectLazyGuard:
         instead of ``failed`` (which polluted failure metrics)."""
         loop = _make_loop()
 
-        async def fake_inner(_msg):
+        async def fake_inner(_msg, **_kw):
             return {
                 "response": (
                     "Already a pending dedup entry on the blackboard for "
@@ -5219,3 +5219,115 @@ async def test_apply_task_thinking_sets_validates_and_survives_errors():
     loop.mesh_client.get_task = AsyncMock(return_value=None)
     await loop._apply_task_thinking("t4")
     assert loop.llm.thinking_override is None
+
+
+# ── system_note: honest transcript roles for mesh-composed messages ──
+
+
+class TestSystemNoteTranscriptRole:
+    """A system wake (``system_note=True``) persists to the transcript with
+    role ``system`` — never as the user's own bubble. The in-memory LLM
+    message stays role ``user`` (model API requirement)."""
+
+    @pytest.mark.asyncio
+    async def test_system_note_chat_persists_system_role(self, tmp_path):
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop([LLMResponse(content="verified", tokens_used=10)])
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        loop.tools.get_tool_definitions = MagicMock(return_value=[])
+
+        await loop.chat("WAKE-MARKER chain completed, verify it", system_note=True)
+
+        rows = loop.workspace.load_chat_transcript()
+        inbound = [r for r in rows if "WAKE-MARKER" in (r.get("content") or "")]
+        assert inbound, "wake message missing from transcript"
+        assert inbound[0]["role"] == "system"
+        assert not [
+            r for r in rows
+            if r["role"] == "user" and "WAKE-MARKER" in (r.get("content") or "")
+        ], "wake message must not persist as a user row"
+        # LLM still saw it as a user message (API requires the role).
+        assert loop._chat_messages[0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_default_chat_persists_user_role(self, tmp_path):
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop([LLMResponse(content="hi", tokens_used=10)])
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        loop.tools.get_tool_definitions = MagicMock(return_value=[])
+
+        await loop.chat("USER-MARKER hello")
+
+        rows = loop.workspace.load_chat_transcript()
+        inbound = [r for r in rows if "USER-MARKER" in (r.get("content") or "")]
+        assert inbound and inbound[0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_system_note_skips_correction_recording(self, tmp_path):
+        """Wake boilerplate must not pollute the corrections store even when
+        it pattern-matches the correction detector."""
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop([LLMResponse(content="ok", tokens_used=10)])
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        loop.tools.get_tool_definitions = MagicMock(return_value=[])
+        loop._chat_messages = [{"role": "assistant", "content": "prior reply"}]
+        loop.workspace.looks_like_correction = MagicMock(return_value=True)
+        loop.workspace.record_correction = MagicMock()
+
+        await loop.chat("no, that's wrong — do NOT re-announce", system_note=True)
+
+        loop.workspace.looks_like_correction.assert_not_called()
+        loop.workspace.record_correction.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_system_note_skips_memory_auto_search(self, tmp_path):
+        """First-message memory auto-search is boilerplate pollution for a
+        wake — skipped when system_note is set, kept for real users."""
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop([LLMResponse(content="ok", tokens_used=10)])
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        loop.tools.get_tool_definitions = MagicMock(return_value=[])
+        loop.workspace.search = MagicMock(return_value=[])
+
+        await loop.chat("wake text", system_note=True)
+        loop.workspace.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_busy_system_wake_queues_flagged_tuple(self):
+        """A system wake hitting a busy agent (current_task set) rides the
+        steer queue WITH its flag — the drain must not render it as a
+        '[steer]' user bubble."""
+        loop = _make_loop()
+        loop.current_task = "task_in_flight"
+
+        result = await loop.chat("wake while busy", system_note=True)
+
+        assert "queued" in result["response"].lower()
+        assert loop._drain_steer_messages() == [("wake while busy", True)]
+
+    @pytest.mark.asyncio
+    async def test_inject_steer_round_trips_flag(self):
+        loop = _make_loop()
+        await loop.inject_steer("watch update", system_note=True)
+        await loop.inject_steer("human ping")
+        assert loop._drain_steer_messages() == [
+            ("watch update", True), ("human ping", False),
+        ]
+
+    def test_persist_steer_entries_uses_honest_roles(self):
+        loop = _make_loop()
+        loop.workspace = MagicMock()
+        loop._persist_steer_entries([("sys note", True), ("human", False)])
+        calls = loop.workspace.append_chat_message.call_args_list
+        assert calls[0].args == ("system", "sys note")
+        assert calls[1].args == ("user", "[steer] human")
+
+    def test_steer_interjection_labels_by_provenance(self):
+        from src.agent.loop import AgentLoop
+        out = AgentLoop._steer_interjection([("a", True), ("b", False)])
+        assert "[System]: a" in out
+        assert "[User interjection]: b" in out

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2471,3 +2471,40 @@ class TestVerificationWake:
             assert ok is True  # bell already written — delivery stands
         finally:
             loop.call_soon_threadsafe(loop.stop)
+
+
+class TestSystemNoteCallSites:
+    """Source-level pin (grep-style, same pattern as the operator-bypass
+    pin): every SYSTEM-composed wake/dispatch site must flag
+    ``system_note=True`` so the recipient transcript never renders it as
+    the user. Human-relayed paths must stay unflagged."""
+
+    def _src(self, rel: str) -> str:
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[1]
+        return (root / rel).read_text(encoding="utf-8")
+
+    def test_mesh_server_wake_sites_flagged(self):
+        src = self._src("src/host/server.py")
+        # Five system-composed sites: blackboard watch steer, hand_off
+        # wake, operator recovery wake, back-edge wake, admin-action wake.
+        assert src.count("system_note=True") == 5
+
+    def test_runtime_sites_flagged(self):
+        src = self._src("src/cli/runtime.py")
+        # cron_dispatch + verification wake.
+        assert src.count("system_note=True") == 2
+
+    def test_webhooks_flagged(self):
+        src = self._src("src/host/webhooks.py")
+        assert src.count("system_note=True") == 2
+
+    def test_channel_inbound_not_flagged(self):
+        """Genuine human messages relayed from chat channels must never
+        carry the system marker."""
+        src = self._src("src/channels/base.py")
+        assert "system_note" not in src
+
+    def test_direct_dispatch_emits_header(self):
+        src = self._src("src/cli/runtime.py")
+        assert 'extra_headers["x-system-wake"] = "1"' in src

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -465,7 +465,7 @@ async def test_chat_without_task_id_while_busy_still_queues_for_chat_ux():
     # No task to close (no task_id).
     loop.mesh_client.set_task_status.assert_not_awaited()
     # And the queue WAS exercised.
-    loop._steer_queue.put.assert_awaited_once_with("hey can you also do X?")
+    loop._steer_queue.put.assert_awaited_once_with(("hey can you also do X?", False))
 
 
 # ── 4c. _auto_close_task log-severity discriminates 4xx vs 5xx ────


### PR DESCRIPTION
## What

Part 1 of the chat-native delivery overhaul (`docs/plans/2026-06-11-chat-native-delivery-and-bell-removal.md`, committed here).

Every mesh-composed message — hand_off wakes, recovery/verification wakes, blackboard watch notifications, cron ticks, webhook payloads — was persisted to the agent chat transcript as role `user`, so the dashboard rendered wake prompts as the user's own bubbles ("User chain task_X completed…" shown as if the human typed it).

## How

A `system_note` flag rides the dispatch end-to-end:

- `LaneManager.enqueue` → `QueuedTask` → worker dispatch kwargs, **including all three steer→followup fallbacks** (which previously dropped every kwarg — the idle-agent wakeup path would otherwise re-introduce the bug for blackboard wakes).
- `dispatch`/`async_dispatch` funnels (cron + webhooks) and `_direct_dispatch`/`_direct_steer` → `x-system-wake: 1` header (precedent: `x-task-id`).
- Agent side: honoured only with `x-mesh-internal` present — the exact trust gate origin-kind parsing uses, so a direct caller can't hide its message in the de-emphasized style.
- `loop.chat` → `_prepare_chat_turn` persists the transcript row as role `system`; the in-memory LLM message stays role `user` (model API requirement; transcript is display-only — verified, it never feeds context restore).
- **Busy path covered**: steer-queue entries are now `(text, system_note)` tuples, so a wake arriving while a task runs drains as a `system` row, not a `[steer]` user bubble. All five drain sites updated; mid-turn LLM interjections label by provenance (`[System]:` vs `[User interjection]:`).
- System notes skip the correction detector + first-message memory auto-search (wake boilerplate must not pollute the corrections store or seed memory).

UI: both system-divider templates truncate long content to one dim line with click-to-expand (short markers like "session continued" stay non-interactive).

Flagged sites: blackboard watch steer, `wake_agent`, operator recovery wake, back-edge wake, `_try_wake_agent`, verification wake, `cron_dispatch`, webhooks ×2. Human-relayed paths (channel inbound, user steers) stay unflagged — pinned by a source-level test.

## Tests

Full fast suite: **7521 passed, 49 skipped, 0 failed** (after aligning 10 pre-existing stubs/assertions to the tuple/kwarg contracts). New coverage: lane threading incl. fallback carries, header trust gate (/chat + /chat/steer), transcript role on idle AND busy paths, corrections/memory-search skips, interjection labels, UI contract, call-site source pins.