### PR TITLE
refactor: single-source validation constants + unify wake dispatch

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -25,6 +25,7 @@ from src.agent.mesh_client import MeshClient
 from src.agent.server import create_agent_app, run_maintenance_loop
 from src.agent.tools import ToolRegistry
 from src.agent.workspace import WorkspaceManager
+from src.shared import limits
 from src.shared.trace import new_trace_id
 from src.shared.utils import setup_logging
 
@@ -59,7 +60,10 @@ def main() -> None:
     except ValueError:
         logger.warning("Invalid LLM_MAX_TOKENS, using default 16384")
         max_output_tokens = 16384
-    max_output_tokens = max(256, min(max_output_tokens, 200_000))
+    max_output_tokens = max(
+        limits.MAX_OUTPUT_TOKENS_MIN,
+        min(max_output_tokens, limits.MAX_OUTPUT_TOKENS_MAX),
+    )
     llm = LLMClient(
         mesh_url=mesh_url, agent_id=agent_id,
         default_model=llm_model, embedding_model=embedding_model,

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -9,6 +9,11 @@ import time as _time
 from datetime import datetime, timezone
 
 from src.agent.tools import tool
+from src.shared.limits import (
+    MAX_OUTPUT_TOKENS_MAX,
+    MAX_OUTPUT_TOKENS_MIN,
+    THINKING_LEVELS,
+)
 from src.shared.operator_ceiling import (
     _OPERATOR_PERMISSION_CEILING,  # noqa: F401 — re-exported for back-compat
     clamp_to_operator_ceiling,
@@ -44,12 +49,13 @@ _VALID_FIELDS = frozenset({
     "max_output_tokens", "max_tool_rounds", "llm_timeout_seconds",
 })
 
-# Per-agent output-token cap bounds. Mirrors the clamp in
+# Per-agent output-token cap bounds. Shared with the clamp in
 # ``src/agent/__main__.py`` (LLM_MAX_TOKENS) and the validation in the
 # agent ``/config`` endpoint + host ``/edit-soft`` so all three layers
-# reject the same out-of-range values identically.
-_MAX_OUTPUT_TOKENS_MIN = 256
-_MAX_OUTPUT_TOKENS_MAX = 200_000
+# reject the same out-of-range values identically (values single-sourced
+# in ``src.shared.limits``).
+_MAX_OUTPUT_TOKENS_MIN = MAX_OUTPUT_TOKENS_MIN
+_MAX_OUTPUT_TOKENS_MAX = MAX_OUTPUT_TOKENS_MAX
 
 # Heartbeat schedule validator. Accepts the same forms cron.py accepts:
 #  * 5-field cron expressions ("*/15 * * * *", "0 9 * * 1-5")
@@ -136,7 +142,7 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
             return {"error": f"daily_usd must be 0.01-1000, got {daily}"}
         if not isinstance(monthly, (int, float)) or not (0.10 <= monthly <= 30000):
             return {"error": f"monthly_usd must be 0.10-30000, got {monthly}"}
-    if field == "thinking" and value not in ("off", "low", "medium", "high"):
+    if field == "thinking" and value not in THINKING_LEVELS:
         return {
             "error": (
                 f"thinking must be 'off', 'low', 'medium', or 'high', "

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -44,7 +44,7 @@ class LLMClient:
     """LLM interface that routes all calls through the mesh API proxy."""
 
     _THINKING_BUDGETS = {"low": 5_000, "medium": 10_000, "high": 25_000}
-    VALID_THINKING_LEVELS = {"off", "low", "medium", "high"}
+    VALID_THINKING_LEVELS = set(limits.THINKING_LEVELS)
 
     def __init__(
         self,

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -774,13 +774,16 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
                 400,
                 f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
             )
+        from src.shared.limits import MAX_OUTPUT_TOKENS_MAX, MAX_OUTPUT_TOKENS_MIN
         if "max_tokens" in body and (
             not isinstance(max_tokens, int)
             or isinstance(max_tokens, bool)
-            or not (256 <= max_tokens <= 200_000)
+            or not (MAX_OUTPUT_TOKENS_MIN <= max_tokens <= MAX_OUTPUT_TOKENS_MAX)
         ):
             raise HTTPException(
-                400, "max_tokens must be an integer between 256 and 200000",
+                400,
+                f"max_tokens must be an integer between "
+                f"{MAX_OUTPUT_TOKENS_MIN} and {MAX_OUTPUT_TOKENS_MAX}",
             )
         if "internet_access_enabled" in body and not isinstance(internet, bool):
             raise HTTPException(

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import click
 import yaml
 
+from src.shared.limits import THINKING_LEVELS
 from src.shared.operator_playbooks import _OPERATOR_CORE
 from src.shared.types import RESERVED_AGENT_IDS
 from src.shared.utils import truncate
@@ -1389,18 +1390,18 @@ def _create_agent_from_template(
     # has no credentials in env. Mirrors the mesh-side check in
     # ``create_custom_agent`` so ``apply_template`` doesn't silently
     # mint dead-on-arrival agents (Bug 5).
-    from src.shared.models import get_available_providers, resolve_provider_for_model
+    from src.shared.models import (
+        get_available_providers,
+        missing_provider_key_message,
+        model_not_compatible_message,
+        resolve_provider_for_model,
+    )
     provider = resolve_provider_for_model(resolved_model)
     if provider:
         available = get_available_providers()
         if provider not in available:
-            available_list = sorted(available) if available else "none"
             raise ValueError(
-                f"Model '{resolved_model}' requires '{provider}' "
-                f"credentials, but no {provider.upper()} key is "
-                f"configured. Available providers: {available_list}. "
-                f"Set OPENLEGION_SYSTEM_{provider.upper()}_API_KEY or "
-                "pick a different model.",
+                missing_provider_key_message(resolved_model, provider, available),
             )
 
     # Credential-kind-aware check (Fix 2 in seam follow-up): OAuth-only
@@ -1413,7 +1414,7 @@ def _create_agent_from_template(
         _vault._load_credentials()
         _compatible, _reason = _vault.is_model_compatible(resolved_model)
         if not _compatible:
-            raise ValueError(_reason or f"Model '{resolved_model}' is not compatible.")
+            raise ValueError(_reason or model_not_compatible_message(resolved_model))
     except ImportError:
         # ``host`` package may not be importable in trimmed test harnesses;
         # the mesh-side check still fires on the create_agent path.
@@ -1481,7 +1482,7 @@ def _update_network_config(field: str, value) -> None:
         yaml.dump(data, f, default_flow_style=False)
 
 
-_THINKING_LEVELS = ["off", "low", "medium", "high"]
+_THINKING_LEVELS = list(THINKING_LEVELS)
 _THINKING_LABELS = {
     "off": "off",
     "low": "low (5K tokens)",

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -40,6 +40,15 @@ from src.host.orchestration import (
     Tasks,
 )
 from src.host.pending_actions import PendingActions
+from src.shared.limits import (
+    MAX_OUTPUT_TOKENS_MAX,
+    MAX_OUTPUT_TOKENS_MIN,
+    THINKING_LEVELS,
+)
+from src.shared.models import (
+    missing_provider_key_message,
+    model_not_compatible_message,
+)
 from src.shared.paths import resolve_under_root
 from src.shared.redaction import redact_text_with_urls, redact_url
 from src.shared.types import (
@@ -1352,7 +1361,7 @@ def create_mesh_app(
                     gate="api:model_incompatible",
                 )
                 raise HTTPException(
-                    403, reason or f"Model '{requested_model}' is not compatible.",
+                    403, reason or model_not_compatible_message(requested_model),
                 )
 
     def _resolve_browser_target(
@@ -1672,18 +1681,15 @@ def create_mesh_app(
                     )
 
         if lane_manager is not None and dispatch_loop is not None:
-            try:
-                asyncio.run_coroutine_threadsafe(
-                    lane_manager.enqueue(
-                        target, wake_msg, mode="followup",
-                        origin=origin, auto_notify=had_origin,
-                        task_id=task_id, system_note=True,
-                    ),
-                    dispatch_loop,
-                )
-            except Exception as e:
-                logger.warning("Wake enqueue for %s failed: %s", target, e)
-                return {"woken": False, "error": str(e)}
+            ok, err = _try_wake_agent(
+                target, wake_msg, origin,
+                task_id=task_id, auto_notify=had_origin,
+                on_fail=lambda e: logger.warning(
+                    "Wake enqueue for %s failed: %s", target, e,
+                ),
+            )
+            if not ok:
+                return {"woken": False, "error": err}
             return {"woken": True, "target": target}
         # Fallback: send via router (message-only, no task processing)
         await router.route(AgentMessage(
@@ -4130,21 +4136,16 @@ def create_mesh_app(
             if provider:
                 available = credential_vault.get_providers_with_credentials()
                 if provider not in available:
-                    available_list = sorted(available) if available else "none"
                     raise HTTPException(
                         400,
-                        f"Model '{model}' requires '{provider}' credentials, "
-                        f"but no {provider.upper()} key is configured. "
-                        f"Available providers: {available_list}. Set "
-                        f"OPENLEGION_SYSTEM_{provider.upper()}_API_KEY or "
-                        "pick a different model.",
+                        missing_provider_key_message(model, provider, available),
                     )
             # Credential-kind-aware check: OAuth-only providers only accept
             # specific models. Surface the allowed list so the operator
             # doesn't have to guess (see Fix 2 in the seam follow-up).
             compatible, reason = credential_vault.is_model_compatible(model)
             if not compatible:
-                raise HTTPException(400, reason or f"Model '{model}' is not compatible.")
+                raise HTTPException(400, reason or model_not_compatible_message(model))
 
         # Create agent config
         import random
@@ -5652,13 +5653,12 @@ def create_mesh_app(
                 channel=str(origin_dict.get("channel") or ""),
                 user=str(origin_dict.get("user") or ""),
             )
-            asyncio.run_coroutine_threadsafe(
-                lane_manager.enqueue(
-                    "operator", wake_msg, mode="followup",
-                    origin=wake_origin, auto_notify=False,
-                    task_id=None, system_note=True,
+            _try_wake_agent(
+                "operator", wake_msg, wake_origin,
+                auto_notify=False,
+                on_fail=lambda e: logger.warning(
+                    "Operator wake for task %s failed: %s", task_id, e,
                 ),
-                dispatch_loop,
             )
         except Exception as e:
             logger.warning(
@@ -5803,13 +5803,13 @@ def create_mesh_app(
                     f"Task {task_id} ({title}) reached {event_kind}. "
                     "Call check_inbox to see the event payload."
                 )
-                asyncio.run_coroutine_threadsafe(
-                    lane_manager.enqueue(
-                        origin_user, wake_msg, mode="followup",
-                        origin=wake_origin, auto_notify=False,
-                        task_id=task_id, system_note=True,
+                _try_wake_agent(
+                    origin_user, wake_msg, wake_origin,
+                    task_id=task_id, auto_notify=False,
+                    on_fail=lambda e: logger.warning(
+                        "Back-edge wake for %s on task %s failed: %s",
+                        origin_user, task_id, e,
                     ),
-                    dispatch_loop,
                 )
             except Exception as e:
                 logger.warning(
@@ -5886,7 +5886,7 @@ def create_mesh_app(
         artifact_refs = body.get("artifact_refs") or None
         # B4 — optional per-task reasoning depth for the assignee.
         thinking = body.get("thinking") or None
-        if thinking is not None and thinking not in ("off", "low", "medium", "high"):
+        if thinking is not None and thinking not in THINKING_LEVELS:
             raise HTTPException(
                 400, f"thinking must be off/low/medium/high, got {thinking!r}",
             )
@@ -6391,24 +6391,38 @@ def create_mesh_app(
 
     def _try_wake_agent(
         target: str, message: str, origin: "MessageOrigin | None",
-    ) -> bool:
+        *,
+        task_id: str | None = None,
+        auto_notify: bool | None = None,
+        on_fail=None,
+    ) -> tuple[bool, str | None]:
         """Best-effort lane enqueue so an operator state change is acted on now.
 
-        Used by reroute / retry / cancel: the task store is already
-        updated when this fires, so any failure here is logged but
-        non-fatal — the worker will pick the change up on its next
-        heartbeat. Fire-and-forget against ``dispatch_loop`` (same
-        pattern as ``/mesh/wake``) so the HTTP response doesn't block
-        on the agent finishing the work. ``auto_notify`` is only set
-        when a real origin was provided, so completion of the woken
-        work flows back to the originating human channel.
+        Used by reroute / retry / cancel (and the /mesh/wake body,
+        operator-recovery and back-edge wake paths): the task store is
+        already updated when this fires, so any failure here is logged
+        but non-fatal — the worker will pick the change up on its next
+        heartbeat. Fire-and-forget against ``dispatch_loop`` so the HTTP
+        response doesn't block on the agent finishing the work.
+
+        ``auto_notify=None`` (default) preserves the original semantics:
+        notify only when a real origin was provided, so completion of
+        the woken work flows back to the originating human channel.
+        Pass an explicit bool to override. ``task_id`` is threaded to
+        the lane so the recipient's loop can auto-close the task
+        (Constraint #6). ``on_fail`` is an optional ``(exc) -> None``
+        callback that replaces the default failure log line so callers
+        keep their site-specific log text.
+
+        Returns ``(ok, error_str)`` — ``error_str`` is set only on an
+        enqueue-dispatch failure.
         """
         from src.shared.types import MessageOrigin
 
         if lane_manager is None or dispatch_loop is None:
-            return False
+            return False, None
         if not target or target not in router.agent_registry:
-            return False
+            return False, None
         had_origin = origin is not None
         eff_origin = origin if origin is not None else MessageOrigin(
             kind="agent", channel="", user="",
@@ -6418,15 +6432,20 @@ def create_mesh_app(
         # would emit a "coroutine was never awaited" warning.
         coro = lane_manager.enqueue(
             target, sanitize_for_prompt(message), mode="followup",
-            origin=eff_origin, auto_notify=had_origin, system_note=True,
+            origin=eff_origin,
+            auto_notify=had_origin if auto_notify is None else auto_notify,
+            task_id=task_id, system_note=True,
         )
         try:
             asyncio.run_coroutine_threadsafe(coro, dispatch_loop)
-            return True
+            return True, None
         except Exception as e:
             coro.close()
-            logger.warning("Operator wake enqueue for %s failed: %s", target, e)
-            return False
+            if on_fail is not None:
+                on_fail(e)
+            else:
+                logger.warning("Operator wake enqueue for %s failed: %s", target, e)
+            return False, str(e)
 
     @app.post("/mesh/tasks/{task_id}/reroute")
     async def reroute_task(task_id: str, request: Request) -> dict:
@@ -8246,29 +8265,24 @@ def create_mesh_app(
                 if _provider:
                     _available = credential_vault.get_providers_with_credentials()
                     if _provider not in _available:
-                        _available_list = sorted(_available) if _available else "none"
                         raise HTTPException(
                             400,
-                            f"Model '{new_value}' requires '{_provider}' "
-                            f"credentials, but no {_provider.upper()} key is "
-                            f"configured. Available providers: "
-                            f"{_available_list}. Set "
-                            f"OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or "
-                            f"pick a different model.",
+                            missing_provider_key_message(
+                                new_value, _provider, _available,
+                            ),
                         )
                 # Credential-kind-aware check: OAuth-only providers only
                 # accept specific models. See Fix 2 in seam follow-up.
                 _compatible, _reason = credential_vault.is_model_compatible(new_value)
                 if not _compatible:
                     raise HTTPException(
-                        400, _reason or f"Model '{new_value}' is not compatible.",
+                        400, _reason or model_not_compatible_message(new_value),
                     )
         elif field == "thinking":
-            from src.agent.llm import LLMClient
-            if new_value not in LLMClient.VALID_THINKING_LEVELS:
+            if new_value not in THINKING_LEVELS:
                 raise HTTPException(
                     400,
-                    f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
+                    f"thinking must be one of: {sorted(THINKING_LEVELS)}",
                 )
         elif field == "max_output_tokens":
             # Re-enforce server-side (mirrors operator_tools._validate_edit and
@@ -8279,9 +8293,11 @@ def create_mesh_app(
                 raise HTTPException(
                     400, "max_output_tokens must be an integer",
                 )
-            if not (256 <= new_value <= 200_000):
+            if not (MAX_OUTPUT_TOKENS_MIN <= new_value <= MAX_OUTPUT_TOKENS_MAX):
                 raise HTTPException(
-                    400, "max_output_tokens must be between 256 and 200000",
+                    400,
+                    f"max_output_tokens must be between "
+                    f"{MAX_OUTPUT_TOKENS_MIN} and {MAX_OUTPUT_TOKENS_MAX}",
                 )
         elif field in ("max_tool_rounds", "llm_timeout_seconds"):
             # Per-agent operational caps. Re-enforce server-side; range is the

--- a/src/shared/limits.py
+++ b/src/shared/limits.py
@@ -90,6 +90,26 @@ DASHBOARD_GLOBAL_KEYS: tuple[str, ...] = (
 )
 
 
+# ── Shared validation values ─────────────────────────────────────────
+# These rules are deliberately enforced in MULTIPLE trust zones (agent
+# container + mesh host + CLI — defense in depth). The enforcement sites
+# stay where they are; only the VALUES live here so the copies can't
+# drift.
+
+# Per-agent LLM output-token cap bounds. Enforced identically by the
+# agent ``/config`` endpoint, the host ``/edit-soft`` route and
+# ``operator_tools._validate_edit``, and used as the clamp range for the
+# ``LLM_MAX_TOKENS`` env read in ``src/agent/__main__.py``.
+MAX_OUTPUT_TOKENS_MIN = 256
+MAX_OUTPUT_TOKENS_MAX = 200_000
+
+# Valid agent "thinking" levels, in display order (the CLI interactive
+# editor renders them 1..N in this order). Consumers wrap in set()/
+# list() as needed; ``LLMClient.VALID_THINKING_LEVELS`` derives from
+# this.
+THINKING_LEVELS: tuple[str, ...] = ("off", "low", "medium", "high")
+
+
 def clamp(key: str, value: int) -> int:
     """Clamp ``value`` into the spec range for ``key`` (logs if it moved)."""
     _default, lo, hi = LIMIT_SPECS[key]

--- a/src/shared/models.py
+++ b/src/shared/models.py
@@ -609,3 +609,27 @@ def resolve_slot_model(
     if not isinstance(tmpl_model, str) or not tmpl_model.strip():
         tmpl_model = default_model
     return tmpl_model.replace("{default_model}", default_model)
+
+
+def missing_provider_key_message(model: str, provider: str, available) -> str:
+    """Canonical BYOK rejection text for a model whose provider has no key.
+
+    The CHECKS deliberately stay at each trust zone with their own data
+    source (CLI reads env via ``get_available_providers()``, host reads
+    the live vault) — only the message text is single-sourced here so
+    the hand-copied wording can't drift. ``available`` is the caller's
+    provider set/list (falsy renders as ``none``).
+    """
+    available_list = sorted(available) if available else "none"
+    return (
+        f"Model '{model}' requires '{provider}' credentials, "
+        f"but no {provider.upper()} key is configured. "
+        f"Available providers: {available_list}. "
+        f"Set OPENLEGION_SYSTEM_{provider.upper()}_API_KEY or "
+        "pick a different model."
+    )
+
+
+def model_not_compatible_message(model: str) -> str:
+    """Canonical fallback when ``is_model_compatible`` returns no reason."""
+    return f"Model '{model}' is not compatible."

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2554,9 +2554,14 @@ class TestSystemNoteCallSites:
 
     def test_mesh_server_wake_sites_flagged(self):
         src = self._src("src/host/server.py")
-        # Five system-composed sites: blackboard watch steer, hand_off
-        # wake, operator recovery wake, back-edge wake, admin-action wake.
-        assert src.count("system_note=True") == 5
+        # Two literal sites: blackboard watch steer + ``_try_wake_agent``
+        # (the single enqueue funnel for the hand_off wake, operator
+        # recovery wake, back-edge wake and admin-action wakes — all of
+        # which inherit the flag from the helper).
+        assert src.count("system_note=True") == 2
+        # Pin that the consolidated wake paths actually route through
+        # the flagged helper rather than hand-rolling an enqueue.
+        assert src.count("_try_wake_agent(") >= 7  # def + 6 call sites
 
     def test_runtime_sites_flagged(self):
         src = self._src("src/cli/runtime.py")


### PR DESCRIPTION
## Why

Several validation rules are deliberately enforced in multiple trust zones (agent container + mesh host + CLI — defense in depth). The enforcement is correct and stays; the rule **values** were hand-copied at each site and had started to drift in form (set vs list vs tuple literals, inline magic numbers, hand-assembled multi-line error strings). This PR single-sources the values and routes the three remaining hand-rolled wake-enqueue sites through the existing `_try_wake_agent` helper.

## Item 1 — shared validation values

**(a) Thinking-level enum** → `src/shared/limits.py:THINKING_LEVELS = ("off", "low", "medium", "high")`
- `agent/llm.py` — `LLMClient.VALID_THINKING_LEVELS = set(THINKING_LEVELS)` (name kept; agent/server.py + dashboard/server.py + tests keep referencing it and now derive from shared)
- `cli/config.py` — `_THINKING_LEVELS = list(THINKING_LEVELS)` (display order preserved)
- `agent/builtins/operator_tools.py` — membership check now uses the shared tuple
- `host/server.py` `/edit-soft` — now imports the shared constant instead of importing `LLMClient` from the agent trust zone (bonus: removes the only code use of a host→agent-module import)
- **Bonus 5th copy found**: `host/server.py` `/mesh/tasks` create path (B4 per-task thinking) had another hardcoded tuple — also switched to the shared constant

**(b) max_output_tokens bounds 256–200000** → `src/shared/limits.py:MAX_OUTPUT_TOKENS_MIN/MAX`
- `operator_tools.py` (module constants now alias shared), `host/server.py` `/edit-soft`, `agent/server.py` `/config`, `agent/__main__.py` clamp — all four sites read the shared values. Error-message text rendered from the constants is byte-identical to before.

**(c) BYOK missing-provider message** → `src/shared/models.py:missing_provider_key_message()`
- `cli/config.py` (env-sourced check), `host/server.py` create-agent + `/edit-soft` (vault-sourced checks). The checks and their data sources stay put; only the text is unified.
- **Canonical-wording decision: none needed** — all three hand copies assembled to a byte-identical string (drift was in f-string fragmentation only, not wording). Verified by assertion against the old literal.

**(d) `is_model_compatible` fallback** → `src/shared/models.py:model_not_compatible_message()`
- 4 sites: `cli/config.py`, `host/server.py` LLM-proxy model gate (403), create-agent (400), `/edit-soft` (400).

No test pinned any of these strings (the only test occurrences are mock return values); all messages stay byte-identical.

## Item 2 — unify wake dispatch through `_try_wake_agent`

Three sites in `host/server.py` hand-rolled the `lane_manager.enqueue` + `run_coroutine_threadsafe` pattern **without** the helper's coroutine-close-on-failure guard: the `/mesh/wake` body path, the operator-recovery wake (`_wake_operator_for_human_chain`), and the back-edge wake (`_write_task_event_back_edge`). All three now call `_try_wake_agent`.

Helper extended with keyword-only params so each site keeps exact semantics:
- `task_id=` (threaded to the lane for auto-close, Constraint #6; default `None` = previous behavior for the 3 existing callers)
- `auto_notify=` (`None` = legacy notify-iff-origin behavior; recovery/back-edge wakes pass explicit `False` as before)
- `on_fail=` callback so each site keeps its site-specific failure log line verbatim
- return changed `bool` → `(ok, error_str)` so `/mesh/wake` keeps its `{"woken": False, "error": ...}` response shape (the 3 existing callers ignore the return; their behavior is bit-identical)

**⚠️ Flagged deliberate behavior change:** the 3 refactored sites gain the coroutine-leak guard they were missing — on a dead dispatch loop the enqueue coroutine is now closed explicitly instead of leaking a "coroutine was never awaited" warning.

Two incidental side effects worth noting (both strictly hardening, no observable change for well-formed data):
- the recovery/back-edge wake messages now pass through `sanitize_for_prompt` inside the helper (strip-only and idempotent; embedded task titles were previously unsanitized on these two paths — `/mesh/wake`'s message was already sanitized, double-apply is a no-op)
- `/mesh/wake` would now report `woken: False` instead of enqueueing in the (already-404-guarded, practically unreachable) race where the target deregisters between the endpoint's registry check and dispatch

## Test change

`tests/test_runtime.py::TestSystemNoteCallSites::test_mesh_server_wake_sites_flagged` pinned `system_note=True` literal count == 5 in `host/server.py`; the consolidation funnels 3 of those sites through the helper, so the count is now 2 (blackboard watch steer + the helper). Updated the pin to 2 and added a companion pin that the wake paths route through `_try_wake_agent` (`count >= 7`: def + 6 call sites), preserving the test's intent.

## Skipped items

None — all clusters and all three wake sites were expressible without distorting the helper.

## Verification

- `ruff check src/ tests/` clean
- Full fast suite, post-rebase onto current main:

```
7624 passed, 28 skipped, 3670 warnings in 559.13s (0:09:21)
```

- Rebased twice during work as main advanced (#1139, #1140); `git diff origin/main --stat` contains only the 9 intended files, no reversions of in-flight main work (neither commit touched `host/server.py`).