### PR TITLE
docs(plans): check in two orphaned plan docs

### DIFF
--- a/docs/plans/2026-06-09-operator-memory-context-overhaul.md
+++ b/docs/plans/2026-06-09-operator-memory-context-overhaul.md
@@ -1,0 +1,187 @@
+# Operator Memory & Context Overhaul — Implementation Plan
+
+**Created:** 2026-06-09. **Author:** Claude (principal-eng review, pre-implementation).
+**Status:** Plan approved in spirit ("we want all 4"); Phase-1 scope below is the authorized core. Phase 2 needs explicit go-ahead. Resolve the Decision Gates before coding.
+
+> **How to use this doc (post-compaction entry point):** This is self-contained. Read §1–§4 for context + diagnosis, resolve §5 Decision Gates with the user, then implement Phase 1 (§6) in the Sequencing order (§8). Every integration point is pinned to `file:line` against `origin/main` as of 2026-06-09 (HEAD `9dc1210`/`8cbfb55d` region) — re-grep to confirm line numbers haven't drifted before editing. Verify on cake using §9 (no-secrets discipline is mandatory).
+
+---
+
+## 1. The problem
+
+User report: the cake operator "is slow, doesn't act, doesn't understand." Diagnosis (live + code) showed the operator is *capable* (it correctly followed a 3-stage chain and diagnosed a dedup-skip) but is **drowning in stale, bloated context**:
+
+- **MEMORY.md = 29 KB** injected every turn — 17 near-duplicate "Proactive Flush"/"Extracted" sections describing a **dead fleet** (`openlegion-marketing`: strategist/seo-analyst/copywriter) that **contradicts the live fleet** (`openlegion-content-seo`: trend-scout/seo-strategist/page-writer). opus reads two conflicting fleet models every turn.
+- **~53 non-browser tool schemas** presented (76 allowlist − 23 browser_* gated off); operator uses ~10–20.
+- Real turns ~**56 K tokens** on **claude-opus-4-8** (slowest model), non-streaming for handoffs.
+
+The good news: **our memory architecture is already correct** — gbrain ("Compiled Truth + Timeline") and hermes-agent ("bounded files + Curator background consolidation") both independently arrive at the design we already have (compiled head + append-only log + an LLM consolidator). **The maintenance loop is what's broken**, not the architecture.
+
+### Guiding principle (the UX north star)
+"Users chat with the operator → it knows exactly what to do." Decompose that into three properties every change must preserve or improve:
+1. **Reasoning clarity** — the operator correctly maps user intent → action. Served by the **memory track** (clean, current, non-contradictory context). This is the bulk of "doesn't understand / doesn't act."
+2. **Capability awareness** — the operator always knows *what it can do*. A tool being expensive to load must NOT make the operator forget it exists. Served by an always-present **capability index** (Phase 2), never by removing tools.
+3. **Capability access** — the operator can actually use the right tool when needed, ideally without a visible search detour (intent-prefetch).
+
+Removing tools (the earlier "trim" idea) is **rejected** — it trades capability awareness for leanness. All tools are important across operator + worker scope; the lever is *grouping + lazy schema-loading*, not deletion.
+
+## 2. Environment / deploy mechanics (load-bearing — don't skip)
+
+- **cake** = `cake.engine.openlegion.ai`. SSH: `ssh -i ~/.ssh/provisioner_key -o IdentitiesOnly=yes -o BatchMode=yes root@cake.engine.openlegion.ai`. Repo at `/opt/openlegion/repo`, `.venv/bin/python`. Mesh = host systemd service `openlegion`; agents = Docker containers `openlegion_{agent}`; operator workspace = volume `openlegion_data_operator` → `/data/workspace/`; per-agent memory DB = `/data/{agent}.db`.
+- **cake is on the Anthropic OAuth subscription** (proven via `data/costs.db`: native `anthropic/*` = $0.00; gateway `openlegion/*`/`minimax`/`gpt` carry cost). Don't reason about per-token $ for Claude on cake — the lever is rate-limit headroom + latency.
+- **`PYTHONUNBUFFERED=1` drop-in** was added at `/etc/systemd/system/openlegion.service.d/unbuffered.conf` so mesh INFO logs actually flush. **cake INFO logs were below the effective level / buffered before** — do not trust INFO log greps for verification; use the **cost ledger** and `docker exec` file inspection instead.
+- **Deploy by code location:**
+  - **Host/mesh code** (`src/host/**`, `src/cli/config.py` launcher, `src/dashboard/**`): `cd /opt/openlegion/repo && git checkout . && git pull --ff-only && systemctl restart openlegion`. (`config/` is gitignored, so pull is safe.)
+  - **Agent code** (`src/agent/**` — memory.py, context.py, workspace.py, loop.py): **baked into `openlegion-agent:latest`** → must `docker build -t openlegion-agent:latest -f Dockerfile.agent .` **then** `systemctl restart openlegion`. A git-pull alone does NOT update agent code. First restart triggers a ~120 s browser-image rebuild.
+- **Conventions:** worktrees for ALL code changes (`isolation: "worktree"` for subagents). One PR per track. `gh pr create` → CI green (`gh pr checks N --watch`) → Codex review → squash-merge `gh pr merge N --squash --admin --delete-branch`. Never merge to main directly. No Co-Authored-By trailers. Run tests in subagents (worktrees) to keep output out of context.
+- **No-secrets discipline (hard rule):** never read `.env` values, keys, tokens, `docker inspect` env, auth_tokens. OK: service state, `docker ps`, config (agents.yaml / permissions / ALLOWED_TOOLS names), workspace markdown, transcripts (user's own data), cost aggregates, structural checks that print only booleans/lengths/fingerprints.
+
+## 3. Diagnosis — five compounding root causes (all pinned)
+
+1. **Consolidation never fires.** `_maybe_consolidate_memory` (context.py:411) runs *only* inside compaction `_do_compact` (context.py:268-318), which triggers at 60%/70% of the context window (context.py:31-33). Operator at ~28% of opus's 200 K never reaches it → head never re-derived.
+2. **When it does fire, it reads the OLDEST log.** `f"## Recent activity log (newest last)\n{log[:_SUMMARIZATION_INPUT_LIMIT]}"` (context.py:445) — `log[:20000]` is the *first* 20 K chars; the log is oldest-first, so the newest entries are truncated off. **Verified bug.**
+3. **Salience never decays in the chat path.** `decay_all` (memory.py:523) is called only on fresh *task* starts (loop.py:803, 848), never in the chat/operator path → `get_high_salience_facts` (memory.py:531, `ORDER BY decay_score DESC`) drifts permanently toward old, frequently-touched facts. These feed both consolidation (context.py:429) and task initial-context (loop.py:1542).
+4. **Fact dedup is exact-key only** (memory.py:266-303, `WHERE key = ?`). Free-form LLM keys (`preferred_language` vs `user_language_preference`) create separate rows; no embedding-similarity merge on write (the `facts_vec` index at memory.py:177 exists but is used only for category assignment + search).
+5. **The append-log never dedups.** `append_memory` (workspace.py:644) blindly appends every flush block; the injected `## Recent` 5 K slice (workspace.py:487, `_MEMORY_RECENT_LOG_CHARS=5000` at :106) re-surfaces near-duplicates every turn until consolidation folds them.
+
+**Bonus finding — caching connection:** #1073 marks `cache_control` mesh-side (credentials.py), but the agent's system prompt embeds per-turn-volatile content — round/context warnings (loop.py:4259-4272), operator playbooks (loop.py:4243-4251), the shifting `## Recent` memory slice, and 5-min runtime context. Any of these mutating busts the cached prefix. The bloated, churning system prompt both slows the model *and* defeats the caching we just shipped.
+
+## 4. What the prior art tells us (mapped, not copied)
+
+- **gbrain (garrytan/gbrain, master):** Compiled-Truth (rewritten on update) + Timeline (append-only) = our head + log. Injects **only the head**; ranks compiled-truth > timeline at read time. "Dream cycle" cron rewrites the head from the timeline with a **hard spend cap**, auto-applying safe merges and **escalating** risky contradictions (never blind-overwrite). Facts are **dated + sourced** (makes prefer-recent possible). Contradiction probe = date pre-filter → small-model judge (confidence floor 0.7) → cache by content-hash → severity tiers.
+- **hermes-agent (NousResearch, main):** Hard-capped memory files (MEMORY.md 2,200 chars) where the **write tool refuses overflow** ("consolidate now") = budget-forced dedup. **Frozen snapshot** at session start (mid-session edits defer to next session) protects the prompt-cache prefix. **Retrieve-cold/inject-hot** (FTS over cold history). **The Curator** = a background `AIAgent` fork on a 7-day interval that consolidates near-dup skills and archives stale (move, don't delete). **Tool Search** = core tools always loaded; long tail behind `tool_search`/`tool_describe`/`tool_call`, auto-activated only when deferrable schemas exceed ~10% of the window. **`execute_code`** = model writes one Python block; intermediate tool results never enter context, only `print()` — collapses N tool rounds into one turn.
+
+**Architectural note (load-bearing) — DG-1 resolved: background cron pass. [Codex-corrected]** Consolidation needs the agent's **in-container** workspace + memory DB + LLM, which the mesh-side cron scheduler can't reach directly. The user chose a **background cron pass** (off the live conversation, like gbrain's "dream cycle" / hermes' "Curator") over the heartbeat. **CORRECTION:** `CronScheduler` does NOT support calling an arbitrary endpoint — it dispatches a job only via `/invoke` (a tool), heartbeat, or chat (cron.py:308-336, 461-518). So model it **exactly** on the `ensure_summary_job` → `compose_work_summary` precedent: register a cron job with `tool_name="run_maintenance"` (or similar) that the scheduler dispatches over the **existing cron→`/invoke` path** to a new **maintenance builtin tool** which calls `ContextManager.run_maintenance()`. `/invoke` runs the tool directly (not a chat turn) → still off the live latency path, fleet-wide, observable via the cron audit log, and **reuses existing machinery (no new endpoint, no new scheduler mode).** *Alternative if the tool/invoke path proves awkward:* an agent-internal asyncio timer (hermes' Curator model) — self-contained, no cron job.
+
+---
+
+## 5. Decision Gates — RESOLVED (user, 2026-06-09)
+
+- **DG-1 — A2 trigger:** ✅ **Background cron pass** (mesh `CronScheduler` job → agent `/maintenance/consolidate` endpoint, off the live loop). See §4 architectural note.
+- **DG-2 — Operator model (C4):** ✅ **Keep opus-4-8 for now.** The bloat is the real latency driver; "doesn't understand" is context-pollution, not model weakness. Re-assess after Phase 1. (Reversible config change.)
+- **DG-3 — Phase 2 scope:** ✅ **Bigger bets approved for the NEXT roadmap phase** (not this effort). Phase 1 = memory + model. Phase 2 (its own authorized project, sequenced after Phase 1): Grouped Tool Search (the new centerpiece — see §7), `execute_code`, semantic dedup, dated-facts memory v2.
+- **DG-4 — A1 keep-list:** the curated current-fleet facts to retain — **show user before saving** (operational, at implementation time).
+- **DG-5 — C3 inclusion:** cache-prefix stabilization stays in Phase 1 as the **last/lowest-priority** item (protects #1073's value); defer to Phase 2 if its behavior risk feels high at implementation time.
+- **Tools (was B1):** ✅ **No tool removal.** Phase 1 makes **no tool changes**; the tool problem is solved properly in Phase 2 via Grouped Tool Search (capability index + lazy schemas + intent-prefetch). All tools remain available in the interim (their schemas are cached by #1073, so the interim cost is bounded; the memory track is the bigger latency win).
+
+---
+
+## 6. Phase 1 — authorized core
+
+### A1 — Immediate MEMORY.md hotfix (operational, cake-only; OPTIONAL relief)
+
+**Goal:** give the operator an instant clean baseline before A2 ships. *May be skipped* if we go straight to A2 and let its first run self-clean — but A1 also gives A2 a clean baseline to validate "maintain" against.
+
+**Approach (simplest):** with the operator **process stopped** (see risk), rewrite all three surfaces:
+- (a) Compiled head: replace with a tight, deduped, current-fleet fact set, written **in-format** so `_split_memory` (workspace.py:429) parses it (use `write_compiled_memory`, workspace.py:661, or write the exact `# Long-Term Memory\n\n<!-- compiled:begin -->\n{head}\n<!-- compiled:end -->\n\n{log}` shape).
+- (b) Log: truncate the 17 stale flush sections.
+- (c) DB: prune stale high-salience facts in `/data/operator.db` `facts` table (else they re-inject at the first consolidation via `get_high_salience_facts`, memory.py:531).
+
+**Codex must-fixes:** Stop the operator *process/container* (not just wait for idle — `execute_heartbeat` sets `state="working"` after its gate, loop.py:1956-1980, and there's no file lock on `append_memory`/`write_compiled_memory`). Clean **all three** surfaces, not just the markdown.
+
+**Risk/gaps:** losing genuinely-useful facts → mitigate with DG-4 (show before/after). Hand-editing prod memory is operational; do it with the container stopped, keep a backup copy of the originals first.
+
+**Deploy:** operational only (no PR). `docker stop openlegion_operator` → edit `/data/workspace/MEMORY.md` + prune DB → `docker start` (or `systemctl restart openlegion`).
+
+**Acceptance:** head < ~6 KB, describes only the live fleet, no `openlegion-marketing` references; operator's next turn is visibly leaner.
+
+### A2 — Fix + relocate consolidation (THE core memory fix) — PR, agent-side
+
+**Goal:** make consolidation actually run for a large-window, frequently-restarted operator, reading the *right* data, so the head stays current and deduped automatically. Reuse the existing `_maybe_consolidate_memory` LLM merge (it already says "merge duplicates, prefer recent, drop stale", context.py:438-445) — **fix the plumbing, don't rebuild the algorithm.**
+
+**Integration points:**
+- `context.py:445` — **fix the slice** `log[:_SUMMARIZATION_INPUT_LIMIT]` → `log[-_SUMMARIZATION_INPUT_LIMIT:]` (read NEWEST), re-aligned to a `\n## ` boundary so a section isn't split.
+- `context.py:411-468` — extract the body into a NEW public callable `ContextManager.run_maintenance()` (does not exist yet — create it) that runs **outside compaction**, keeping the `consolidation_due` (≥6 h, workspace.py:254/673) + `_CONSOLIDATION_MIN_LOG_CHARS` (1,500, context.py:37) gates.
+- **Trigger = background cron pass via a maintenance TOOL [Codex-corrected]:** create a maintenance **builtin tool** (e.g. `run_maintenance`) that calls `run_maintenance()`, and register a cron job with `tool_name="run_maintenance"` modeled on `ensure_summary_job`/`compose_work_summary`. The scheduler dispatches it over the **existing cron→`/invoke` path** (cron.py:308-336 + the callback wiring in **cli/runtime.py:1107-1187, 1329-1340**). No new endpoint, no new scheduler mode. Default every 6 h; fleet-wide; observable via cron audit log.
+- **Locking [Codex must-fix]:** chat holds `_chat_lock` (loop.py:383, 2639) but workspace memory writes are plain file read-modify-write (workspace.py:644-669) and `MemoryStore` uses a shared SQLite connection via executor with NO maintenance lock (memory.py:68-70, 254-258). `run_maintenance()` must **acquire `_chat_lock` (or skip if busy/mid-turn) AND hold a dedicated consolidation lock**, or it races `_flush_to_memory()` + salience updates. Cron has per-job locks but **nothing per-agent** to inherit (cron.py:441-453) — implement the busy/skip policy in the tool.
+- **Failure backoff [Codex must-fix]:** consolidation currently stamps the sentinel only on non-empty LLM output + write success and silently returns on failure (context.py:447-460). A cron firing every tick would **retry on every tick** after a failure. Add a failure backoff / error sentinel so repeated LLM/write failures don't hammer the model.
+- **Chat-path decay fix:** add a **time-gated** `decay_all` (memory.py:523) in the same maintenance pass, tracked by its own sentinel (mirror `consolidation_due`), so the operator's salience decays ~once per cycle. **Guard against double-decay** with the task-path decay (loop.py:803/848) — gate by the sentinel, don't decay if the task path decayed within the window.
+- **Log trim decision:** after writing the new head, trim the consolidated log sections (the head now subsumes them). `write_compiled_memory` preserves the log (workspace.py:661), so the log regrows otherwise. Decide explicitly: trim sections older than the newest-N, or archive them.
+
+**Simplest version that still solves it:** slice-fix + heartbeat trigger + lock + decay-fix + log-trim. **NOT** in A2: semantic dedup (A4), contradiction probe, dated facts — those are Phase 2. The existing LLM merge is sufficient for v1.
+
+**Load-bearing assumption (must validate first):** the existing consolidation prompt produces a *good* deduped head. It has **never run** for this operator. **Validate by running it once on a test/throwaway agent (or cake operator after A1) and inspecting the output** before trusting it in the heartbeat loop.
+
+**Risks/gaps:** extra LLM call per cycle (gated ≥6 h → ≤4×/day, acceptable; cap it). Failed consolidation doesn't stamp the sentinel (context.py:447-455) → rapid-failure could retry — add a short backoff. Consolidation reads `head + newest-log + high-salience-DB` — if A1 didn't clean the DB, stale-salient facts can still leak in (sequencing: A1 before A2, or accept the first run cleans imperfectly then converges).
+
+**Tests:** unit — slice now returns newest entries; `run_maintenance()` runs when gates met and skips otherwise; lock prevents re-entry; busy-skip works; decay is gated (no double-decay with the task-path decay); log trimmed after head rewrite; the `/maintenance/consolidate` endpoint rejects non-internal callers. Mock the LLM (return a known deduped head). Run in a worktree subagent.
+
+**Deploy [Codex-corrected split]:** spans both zones — the `run_maintenance` tool + `ContextManager.run_maintenance()` are **agent code → image rebuild + restart**; the cron job registration + its callback wiring (`src/host/cron.py` AND **`src/cli/runtime.py:1107-1187, 1329-1340`**) are **host code → git pull + `systemctl restart openlegion`**. Ship/deploy together.
+
+**Acceptance:** on cake, after deploy + one cron cycle (or a manual `/invoke` of `run_maintenance` via the internal path), `docker exec openlegion_operator cat /data/workspace/MEMORY.md` head is current + deduped and stays bounded across cycles; `.memory_consolidated` sentinel advances; cron audit log shows the job firing.
+
+### B1 — Tools — NO CHANGE in Phase 1 (deliberate)
+
+Per the user's direction (2026-06-09): do **not** remove or trim operator/worker tools. Removal trades capability-awareness for leanness (violates UX north star #2). All tools stay available in Phase 1; their schemas are part of the #1073-cached prefix, so the interim per-turn cost is bounded, and the memory track is the larger latency win. The tool-context problem is solved properly in **Phase 2 → Grouped Tool Search** (§7). *Nothing to build here in Phase 1* — this entry exists to record the decision and prevent a future "just trim it" regression.
+
+### C4 — Operator model — KEEP OPUS (DG-2 resolved)
+
+Keep `claude-opus-4-8`. Rationale: "doesn't understand" is context-pollution (fixed by the memory track), not model weakness; opus maximizes reasoning clarity (north star #1). Re-assess speed after Phase 1 lands. No code; revisit only if post-Phase-1 latency is still unacceptable (then it's a one-line `model:` config change + restart, validated by `is_model_compatible`).
+
+### C3 — Cache-prefix stabilization → MOVED to Phase 2 [Codex PT3a]
+
+Codex confirmed C3 reorders behavior-sensitive system-prompt content (loop.py:4168-4271, workspace.py:487-513) and is risky to ship alongside A1/A2. **Decision: move C3 to Phase 2** so Phase 1 stays a clean, low-risk memory-only effort. (It pairs naturally with A5's "inject head-only" anyway.) See §7.
+
+---
+
+## 7. Phase 2 — approved for the NEXT roadmap phase (DG-3); sequenced after Phase 1
+
+### B2 — Grouped Tool Search (the centerpiece; the *correct* fix for tool bloat)
+
+**Problem statement (principal-eng + CPO):** keep per-turn schema load lean WITHOUT losing the operator's "I know exactly what to do" property. The naive Tool Search trap: a model won't search for a tool it doesn't know exists → deferred capabilities become invisible → the operator fails to do what the user asked. So the design must separate **capability awareness** (always present, cheap) from **schema loading** (lazy).
+
+**Design — three layers:**
+1. **Always-loaded core (full schemas).** The ~15-20 daily-driver tools (orchestrate: hand_off/await_task_event/manage_task/list_agent_queue/workflow_snapshot; diagnose: inspect_agents/read_agent_config/get_system_status; memory: memory_save/search; comms: notify_user; http_request/web_search). The common case needs zero search.
+2. **Always-loaded capability INDEX (names + one-line purpose, grouped by job-to-be-done — NO full schemas, ~300-500 tokens).** This is the key innovation that answers the user's "out of context until searched" worry: the capability is **never invisible**, only its verbose schema is lazy. The index doubles as a self-documenting menu of what the operator can do. Groups (intent-named, not module-named):
+   - *Fleet setup* — create_agent, create_team, apply_template, list_templates, add_agents_to_team, manage_team … ("build or restructure a team")
+   - *Scheduling* — set_cron, list_cron, remove_cron ("recurring/timed work")
+   - *Credentials & access* — vault_list, request_credential, request_browser_login ("an agent needs to reach a service")
+   - *Goals & review* — set_team_goal, manage_goals, rate_delivery
+   - *Audit & undo* — list_pending, cancel_pending_action, archive_audit_before, undo_change
+   - *Web & browse* — browser_* (the 23) ("research / interact with sites")
+3. **On-demand schema loading.** Bridge tool `load_tools(group | tool_name)` (or hermes' `tool_search`/`tool_describe`/`tool_call`) pulls full schemas into context for subsequent turns. Two activation modes: **explicit** (operator calls it when it recognizes the intent) and **intent-prefetch** (the CPO touch — on a new user message, map intent → likely group(s) and pre-load, so the operator acts without a visible search round-trip: "set up an SEO team" → prefetch *Fleet setup*).
+
+**Budget-gated (hermes):** only activate index+defer when an agent's schemas exceed ~10% of the window; small-toolset agents present everything unchanged. **Applies to operator AND worker agents** ("operator scope and agent scope") — general per-agent capability in `get_tool_definitions` (tools.py:451), with a per-role core/deferred grouping.
+
+**Integration points:** `tools.py:451` `get_tool_definitions` (new grouped/index mode), `loop.py:472-501` `_tool_filter_kw` + `loop.py:940` request build (schema injection), the bridge-tool builtins, and the loop state that tracks "currently loaded" groups across turns. Define groups as data (a registry mapping group → tool names + intent string + role-eligibility).
+
+**Required design details [Codex PT2b/PT2d — specify before coding]:** (a) Grouped Tool Search must **extend the existing filter model** (`get_tool_definitions(exclude, allowed)` memoized on `(exclude, allowed)`, tools.py:451-463; `_tool_filter_kw`, loop.py:470-502) or introduce a separate schema-selection path — it can't bolt on without touching the filter logic. (b) "Loaded group persists for subsequent turns" is **not automatic** — tools are requested fresh at each LLM call (loop.py:940, 2120, 3484), so a new **loaded-groups set must live on the `AgentLoop` instance and be folded into the `get_tool_definitions` cache key / builder**; otherwise `load_tools` mutating state immediately would also change schemas *mid-turn* and bust the #1073 cache. Defer the load to the **next turn boundary** (mirrors hermes' "don't change toolsets mid-conversation" cache invariant). **Risk/gaps:** intent-prefetch misclassification → `load_tools` remains the always-available fallback (capability never lost); prefetch is practical on the chat path (user message available pre-build, loop.py:2974-3017) but task/heartbeat paths need separate design. This is the schema/exec decoupling B1 couldn't give (fewer schemas, everything still callable).
+
+### A4 — Semantic fact dedup + contradiction probe
+Vector-similarity merge on the consolidation/write path (`facts_vec` infra exists, memory.py:177). gbrain contradiction probe: date pre-filter → small-model judge (confidence floor 0.7) → content-hash cache → severity tiers (auto-merge safe, escalate identity-level). Hooks: `store_fact` (memory.py:305) / the maintenance pass. Strengthens A2's dedup beyond the LLM-merge.
+
+### A5 — Memory v2: dated + sourced facts, inject-head-only, read-time precedence
+Add `(source_type, date)` to facts (schema change + migration, memory.py:165) to enable real prefer-recent; drop/shrink the `## Recent` injection (gbrain injects only the head); rank head > log at retrieval. Pairs with C3.
+
+### C3 — Cache-prefix stabilization (moved here from Phase 1 per Codex PT3a)
+Make #1073's caching actually hit: move per-turn-volatile content OUT of the cached system block — context/round warnings (loop.py:4250-4271), operator playbooks (loop.py:4236-4248), the `## Recent` memory slice (loop.py:4168-4175 / workspace.py:487-513; subsumed by A5's inject-head-only), 5-min runtime context — appending after the cache breakpoint or into the first user message. **Behavior-sensitive (reordering instructions changes weighting)** → behind a flag, with before/after behavior checks. Sequence right after A5 (they share the head-only change).
+
+### C2 — `execute_code` (code-as-action)
+Highest-leverage *speed* lever for the orchestrator: collapse multi-tool-round workflows into one Python block; intermediate tool results never hit context, only `print()`. We already have Docker isolation. Significant build + security surface (env scrub for KEY/TOKEN/SECRET, tool whitelist, no recursion into execute_code/delegate). Directly attacks the operator's 10+ silent tool rounds per task.
+
+---
+
+## 8. Sequencing (each step testable; nothing blocked on later work)
+
+**Phase 1 (this effort) = MEMORY ONLY.** C4 = keep opus (no work). B1 = no tool changes (no work). C3 = moved to Phase 2.
+1. **A1 hotfix** — instant relief on cake; gives A2 a clean baseline (stop process → clean head+log+DB → restart). Optional but recommended.
+2. **A2 validate-once** — run the slice-fixed consolidation on a throwaway/cake operator and inspect the output BEFORE wiring the cron (load-bearing: the prompt has never run).
+3. **A2 PR** — create `ContextManager.run_maintenance()` (slice-fix + decay-fix + log-trim + chat-lock/busy-skip + consolidation-lock + failure-backoff) + a `run_maintenance` builtin tool + a cron job (`tool_name="run_maintenance"`, modeled on `ensure_summary_job`) wired in cron.py + cli/runtime.py. The core fix; makes A1 durable. Spans agent (image rebuild) + host (restart).
+
+**Phase 2 (next roadmap phase, separate authorized project):** B2 Grouped Tool Search (centerpiece) → A4 semantic dedup → A5 memory v2 (inject-head-only) → **C3 cache-prefix stabilization** (pairs with A5) → C2 execute_code. Each its own PR-set.
+
+Dependency notes: A1 should precede A2's first prod run (clean DB) OR accept that A2 converges over a few cycles. C3 pairs with A5's inject-head-only. Phase 2's A4/A5 build on A2's maintenance pass (extend it, don't replace).
+
+## 9. Verification playbook (cake, no-secrets)
+
+- **Memory:** `docker exec openlegion_operator sh -c 'wc -c /data/workspace/MEMORY.md; grep -c "^## " /data/workspace/MEMORY.md'` (size + section count); read the head to confirm current-fleet-only. Sentinel: `ls -la /data/workspace/.memory_consolidated`.
+- **OAuth still healthy / not silently billed:** `data/costs.db` — native `anthropic/*` rows stay $0.00 (subscription); gateway rows are the only billed ones.
+- **Tools:** `echo $ALLOWED_TOOLS | tr , '\n' | wc -l` in the operator container.
+- **Health after any deploy:** `systemctl is-active openlegion`, `docker ps | grep -c openlegion_` (expect 17), error scan `journalctl -u openlegion --since "-5 min" | grep -aiE "ERROR|Traceback"`. INFO logs now flush (PYTHONUNBUFFERED added) but remain unreliable — prefer file/ledger checks.
+- **Consolidation actually ran:** inspect the head changed + sentinel advanced after a heartbeat cycle (don't rely on the INFO log line).
+
+## 10. Decisions — status (mirror of §5, all resolved 2026-06-09)
+DG-1 ✅ background cron pass · DG-2 ✅ keep opus · DG-3 ✅ bigger bets → Phase 2 roadmap · DG-4 ⏳ A1 keep-list shown-before-save at implementation time · DG-5 ✅ C3 in Phase 1, lowest priority · Tools ✅ no removal, grouped Tool Search in Phase 2. **Only remaining at-implementation gate:** DG-4 (show the A1 keep-list before writing it).
+
+## 11. Reference: today's shipped context (2026-06-09)
+Merged to main: #1068 (await polls durable status), #1069 (result_summary on task row), #1072 (handoff prompt + envelope extraction), #1073 (Anthropic prompt caching, OAuth + litellm paths). All live-verified or deployed on cake. The await/handoff flow works at the primitive level; multi-hop chain-following is per-hop (operator awaits each task; workers can't await — operator-only). Do not regress these.

--- a/docs/plans/2026-06-11-chat-native-delivery-and-bell-removal.md
+++ b/docs/plans/2026-06-11-chat-native-delivery-and-bell-removal.md
@@ -1,0 +1,280 @@
+# Chat-native delivery + bell removal
+
+**Date:** 2026-06-11
+**Status:** planned — revised after two-pass pre-implementation review (self + independent
+fresh-context second pass; Codex proper quota-blocked until Jun 12)
+**Driver:** Dashboard users never see async operator activity. Chain outcomes go only to the
+bell (`notification_added`), wake-generated operator turns sit invisibly in the transcript until
+the user's next action, system wake prompts render as fake *user* bubbles, and there is no
+in-chat signal that a delegated pipeline is being watched. User verdict: make the chat the
+delivery surface, kill the bell ("completely useless across the entire app"), and never render
+system prompts as the user.
+
+## Verified root causes (current main, `65524416`)
+
+1. **Bell-only delivery for dashboard origins.** `RuntimeContext._deliver_chain_outcome`
+   (src/cli/runtime.py:976) writes the `NotificationStore` row — that write IS the
+   deliver-then-claim durability point (`ChainWatcher._process_root` claims only on `True`,
+   src/host/chain_watcher.py:164-190) — then emits `notification_added` (bell badge only) and
+   skips the channel push for `channel == "dashboard"`. No chat bubble ever.
+2. **Async operator turns are invisible.** Lane wakes (verification wake
+   `_maybe_wake_operator_verification` runtime.py:1126, recovery wake
+   `_wake_operator_for_human_chain` host/server.py, back-edge wakes, admin-action wakes) dispatch
+   via `_direct_dispatch` → agent `POST /chat`; the reply persists to the transcript with **no
+   event emitted**. The chat UI reloads history only on user actions (send / tab switch / WS
+   reconnect) — hence "I only got notified after I sent a message."
+3. **Wake prompts persist as `role="user"`** (`_prepare_chat_turn` →
+   `workspace.append_chat_message("user", ...)`, src/agent/loop.py) and the user template renders
+   every user row as the human's own bubble. Confirmed live on cake.
+4. **No watching affordance.** The Work tab's live pipeline card exists; the chat thread shows
+   nothing while a chain is in flight.
+
+Load-bearing facts (verified against code, incl. spot-checks during review):
+
+- The chat transcript (`chat_transcript.jsonl`, workspace.py) is **display-only** — LLM context is
+  the in-memory `_chat_messages` list, restored from memory-DB checkpoints (loop.py:2838-2849),
+  never from the transcript. New roles / extra fields on transcript rows cannot corrupt context.
+- **`append_chat_message` swallows ALL write failures at debug level** (workspace.py:1067-1076)
+  — any endpoint acking "written" must use a raising write path or the ack lies.
+- **`HttpTransport.request` never raises for the failures that matter** — HTTP errors, timeouts,
+  connect failures return `{"error": ...}` dicts (transport.py:137-145), HTTP errors with
+  `status_code`. Success/failure must be judged on the returned dict + a positive endpoint ack.
+- **HttpTransport keeps one AsyncClient per event loop** (`_clients` keyed by `id(loop)`,
+  transport.py:91-102) — awaiting `transport.request` on the chain watcher's own loop is safe.
+  The watcher runs its own loop in a daemon thread (runtime.py:1611-1621) and `_run_deliver`
+  already supports an async deliver fn (`iscoroutine`, chain_watcher.py:191-194).
+- The dashboard main chat template hides unknown roles (no fallback); existing `system` role
+  renders as a de-emphasized divider; `notification` role renders the amber bubble both from
+  history load and the live `notification` WS event (2s dedupe window). NOTE (second pass): a
+  worker-chat template variant has a catch-all that renders unknown roles unstyled — verify both
+  templates render `system` rows acceptably during PR 1.
+- The agent server has no auth (network isolation: icc=false + loopback-only port publish;
+  `x-mesh-internal` gates origin-kind trust only); `POST /message` is the pattern for a no-LLM
+  durable-write endpoint. `/chat/note` adds no new trust surface beyond existing `/chat`.
+- Bell producer inventory: P1 approval, P2/P3 credential requests, P4 health alerts,
+  P5 credit_exhausted all have alternate surfaces. **Bell-only:** P6 `connection_refresh_failed`,
+  P7 quarantine remediation text (written DIRECTLY by HealthMonitor, health.py:175-187 — not via
+  the producer, whose health branch covers only degraded/unhealthy/failed), P8 chain outcomes.
+  The desktop Browser-Notification hook (`_maybeFireBrowserNotification`,
+  `_browserNotifyKinds = ['approval','credential','alert','blocker']`) is fed exclusively by
+  bell rows — chain-`done` (kind `delivered`) never desktop-pinged even today (accident).
+- `GET /api/workplace/pipelines` omits `origin`/`updated_at`; the payload **filters out wholly
+  terminal chains immediately** (status-based, not claim-based) while the outcome bubble lands
+  only after settle (30s) + sweep — a 30-60s dead window PR 4 must bridge client-side.
+- Lane enqueue call-site audit: system-composed wakes = blackboard watch notifications
+  (**mode="steer"**, falls back to followup when idle), `hand_off` wakes, recovery wake,
+  back-edge wakes, admin-action wakes (reroute/retry/cancel), verification wake, cron dispatches,
+  webhook dispatches (via `async_dispatch` funnel). Human-relayed lane traffic = channel inbound
+  + steer paths. Recovery/verification wakes deliberately stamp `origin.kind="human"` (delivery
+  routing), so **origin kind cannot distinguish system wakes — an explicit flag must ride the
+  dispatch**. The flag must survive THREE paths: followup, the steer→followup fallback inside
+  `_handle_steer` (lanes.py:333-351, currently drops all kwargs), and the agent-side busy
+  steer-queue (`loop.chat` redirects to `_steer_queue` when `current_task` is set, loop.py:2973;
+  drained entries persist as `[steer]` **user** rows at loop.py:3428/3760/4017/5069).
+
+## Design principle
+
+**The chat watches, not the LLM.** No re-opened await loops, no held lanes, no token spend on
+progress UI. Real task state drives a frontend chip; real operator turns (verification, recovery)
+render live; the transcript becomes the durable delivery record, replacing the bell.
+
+---
+
+## PR 1 — System wakes stop rendering as the user
+
+Thread an explicit `system_note` flag (one name everywhere) from enqueue to transcript
+persistence; persist those inbound messages with transcript role `"system"` (existing
+de-emphasized divider rendering) while the in-memory LLM message stays `role="user"`.
+
+- `src/host/lanes.py`: `enqueue(..., system_note: bool = False)` → `QueuedTask.system_note` →
+  `dispatch_kwargs` only when True. **Must also thread through the steer arm**: `_handle_steer`'s
+  three followup fallbacks (no-steer_fn, idle-agent wakeup, steer-error) currently drop all
+  kwargs — carry `system_note` (and while there, keep the existing behavior for other kwargs
+  unchanged).
+- `src/cli/runtime.py`: `_direct_dispatch` accepts `system_note=False`, sends header
+  `x-system-wake: 1` (precedent: `x-task-id`, `X-Origin`). `dispatch` / `async_dispatch` funnels
+  gain the param (cron + webhooks route through them).
+- `src/agent/server.py` `POST /chat`: read the header — trusted only when `x-mesh-internal`
+  present (same gate as origin kind) — pass `system_note=True` into `loop.chat(...)`.
+  `/chat/stream` is NOT touched (no system wake rides the stream path).
+- `src/agent/loop.py`:
+  - `_prepare_chat_turn`: when `system_note`, persist transcript row as
+    `append_chat_message("system", user_message)`; in-memory append unchanged. Also **skip
+    correction-recording (`looks_like_correction`) and the first-message memory auto-search**
+    for system notes — wake boilerplate must not pollute the corrections store or seed memory.
+  - **Busy path**: `_steer_queue` entries become `(text, system_note)` tuples (internal queue +
+    `inject_steer` gains the flag, default False); the four drain persist sites write
+    role `"system"` (no `[steer]` prefix) for flagged entries, `[steer]` user rows as today
+    otherwise. Without this, a verification wake during a running task still renders as a user
+    bubble — the most common real case.
+- Flag at system-composed call sites: blackboard watch notify (steer), `wake_agent` (hand_off),
+  `_wake_operator_for_human_chain`, back-edge originator wake, `_try_wake_agent`
+  (reroute/retry/cancel), `_maybe_wake_operator_verification`, `cron_dispatch`, webhook dispatch.
+  Human-relayed paths (channel inbound, user steer endpoints) stay unflagged. Human-triggered
+  system-composed steers (credential saved/cancelled etc.) keep their `[steer]` rendering — out
+  of scope.
+- UI: long `system` rows get a line-clamp + click-to-expand in the system template; verify the
+  worker-chat catch-all template variant renders system rows acceptably (second-pass catch).
+- Historical `user`-role wake rows on existing deployments stay as-is (display-only; no
+  migration).
+
+Tests: lanes threading incl. steer-fallback kwarg carry, dispatch header emission, /chat
+header→kwarg trust gate, transcript role persist (flag on/off), busy-path steer-queue tuple
+drain, corrections-skip, template clamp presence.
+
+## PR 2 — Durable chat delivery + live async turns (bell replacement, load-bearing)
+
+- **New agent endpoint `POST /chat/note`** (`src/agent/server.py`, body `{"message": str}`,
+  bounded ~2000 chars mirroring `_NOTIFY_MAX_LEN`): appends a `"notification"`-role transcript
+  row via a **raising write path** — `append_chat_message` swallows failures by design, so add
+  `raise_on_error=True` (or equivalent) and return `{"ok": true}` only on a successful write.
+  The ack must not lie; it is the new durability point. Renders identically to `notify_user`
+  rows on history load — zero new frontend.
+- **`_deliver_chain_outcome` reroute** (src/cli/runtime.py:976): convert to **async def**
+  (`_run_deliver` supports coroutines; per-loop transport client makes awaiting on the watcher
+  loop safe) and replace the `NotificationStore.add` durability write with
+  `await transport.request("operator", "POST", "/chat/note", ...)` carrying `f"{title}\n{body}"`.
+  **Success = returned dict has no `"error"` key AND carries the endpoint's positive ack** —
+  transport never raises for HTTP/timeout/connect failures. Failure → log + `return False`
+  (watcher leaves the root unclaimed, retries next sweep — claim machinery untouched, pinned by
+  `test_chain_watcher.py::test_failed_delivery_is_retried_not_lost`). **`status_code == 404`
+  logs at ERROR with an explicit "agent image predates /chat/note — rebuild required" message**
+  (the git-pull-without-image-rebuild deploy trap would otherwise retry silently forever).
+  On success emit the existing **`notification`** DashboardEvent (`agent="operator"`) → live
+  amber bubble + toast. Keep: kind branches (done/stall/failed), 1500-char bound, channel push
+  for non-dashboard origins, verification wake. Drop: `notification_added` emit for chain
+  outcomes.
+  - Note target is **operator** unconditionally — second pass confirmed
+    `list_watchable_human_roots` is operator-rooted by construction; no fronting-worker case
+    exists today.
+- **ChainWatcher startup gate**: re-gate from `_notification_store is not None` to transport
+  availability.
+- **Live render of async turns**: in `_direct_dispatch`, after a successful dispatch, emit
+  `chat_done` with `data={"source": "dispatch"}` and **no `response` field**. JS handler changes
+  (required, the current handler is wrong for this): for `source === "dispatch"`, skip the
+  remote-bubble finalize branch entirely and call `_loadChatHistory(agent)` **without** deleting
+  `_chatFetchedAt[agent]` (the current handler deliberately bypasses the 5s debounce — a blanket
+  bypass on every lane dispatch fleet-wide would stampede history fetches in every connected
+  session).
+- **Desktop ping bridge (3 lines of JS, closes the PR2→PR3 window):**
+  `_maybeFireBrowserNotification` additionally fires on live `notification` WS events
+  (synthesized `{kind:'delivered', title}` row) so chain outcomes desktop-ping once bell rows
+  stop minting. Full fan-in lands in PR 3.
+
+Tests: `/chat/note` endpoint (success ack; raising-write failure → non-ok); rewritten
+`TestDeliverChainOutcomeBellKind` against the note write + `notification` emit, error-dict →
+`False`, 404 → ERROR log; `chat_done` dispatch-source emit + JS handler guard (template test).
+
+**Deploy note:** PRs 1–2 touch `src/agent/**` → agent image rebuild
+(`docker build -f Dockerfile.agent .`) + restart, not just git pull. Ship both in one deploy
+window.
+
+## PR 3 — Bell removal end-to-end (+ the two reroutes)
+
+Delete:
+
+- `src/dashboard/notifications.py` (store + `_KNOWN_KINDS`), runtime construction/wiring
+  (`_notification_store`, dashboard router param + auto-init, HealthMonitor injection),
+  endpoints `GET /api/notifications` + read/read-all, `_emit_notification_added` +
+  `_notifications_producer` (P1–P5 have alternate surfaces), `notification_added` literal in
+  `src/shared/types.py`, JS bell (state, 60s poll, WS handler, fetch/mark/icons), both bell
+  markup blocks, bell test surface (`tests/test_dashboard_notifications.py` whole file,
+  bell-markup UI tests, quarantine-bell test).
+
+Reroute (the two genuinely bell-only signals) via a slim event listener using the PR-2 note
+path — operator transcript note + `notification` event:
+
+- **P6 `connection_refresh_failed`** → "OAuth connection '{service}' is dead — reconnect it on
+  the Connectors page."
+- **P7 quarantine**: the listener needs an explicit `health_change` → `current == "quarantined"`
+  branch (today's bell row comes from HealthMonitor's direct store write, NOT the producer);
+  note carries the remediation text. `HealthMonitor` drops its `notifications_store` param.
+- **Threading + delivery semantics (second-pass catch):** EventBus callbacks are sync on the
+  emitter's thread — marshal the note POST via `run_coroutine_threadsafe` onto the dispatch loop
+  and reuse the bounded-retry pattern (`_channel_push_with_retry` numbers). After retries
+  exhaust, the signal is accepted-lost to the transcript (fleet badges / Connectors page remain)
+  — explicit decision, see flagged list.
+
+Rewire desktop notifications (don't delete): `_maybeFireBrowserNotification` moves from bell
+rows to a fan-in over the underlying WS events — `pending_action_created` (kind approval),
+`credential_request` / `browser_login_request` (credential), `health_change` degraded+quarantined
+(alert), and `notification` (delivered) — synthesizing the `{kind, id, title}` row the hook
+expects (live `notification` events carry only `message`; no kind/id — synthesize). This
+preserves today's approval/credential/alert coverage and ADDS completion pings (new behavior,
+flagged).
+
+Docs: update CLAUDE.md (`src/dashboard/notifications.py` row, kinds note). Existing
+`dashboard_notifications.db` files orphaned — harmless; remove manually on deploy.
+
+## PR 4 — In-chat watching chip + playbook v6
+
+- **Backend (one line):** pass `origin` and `updated_at` through in `/api/workplace/pipelines`.
+- **Chat UI chip:** operator thread, pipelines with `origin.channel === "dashboard"`: pinned
+  compact element — pulsing dot, root title, `stage k/n · <assignee> <status> · <age>`; amber +
+  "stalled" when flagged; click → Work tab drill-in; cap 3 chips + "+N more". Binds to existing
+  `workplacePipelines` state + WS task-event debounce refresh; also load on chat-tab
+  entry/initial mount (chat is the default tab).
+- **Dead-window bridge (second-pass catch):** the payload drops a chain the moment it's wholly
+  terminal, but the outcome bubble lands after settle(30s)+sweep. When a tracked chip's root
+  leaves the payload, keep a client-side "finishing…" ghost state, cleared by the matching
+  `notification` event or a 90s timeout — no backend change.
+- **Playbook v6** (`playbook_v6_chat_delivery`, established sentinel machinery; mind the
+  `_OPERATOR_CORE` size-cap test): after delegating, say exactly what the system now does —
+  *progress shows live in this chat (watch chip + stage updates), and the outcome plus my
+  verification are posted here automatically*. Never reference the bell; v5's
+  no-unbacked-promises rule stands.
+
+Tests: pipelines payload passthrough; chip render/hide + ghost-state; playbook sentinel tests
+pin `PLAYBOOK_SENTINELS[-1]` dynamically.
+
+---
+
+## Sequencing, verification, rollout
+
+- Order: PR 1 → PR 2 → PR 3 → PR 4 (3 depends on 2's note path; 2's desktop-ping bridge closes
+  the 2→3 gap; 4 last for copy). Worktrees for all code; tests in subagents; retarget stacked
+  PRs to main via REST before merging a base; CI waits check `fail` explicitly.
+- Cake live verification (through the real browser path — `/chat/stream` lesson from #1112):
+  (a) wake → transcript row role `system` incl. the BUSY case (wake during a running task must
+  not produce a `[steer]` user bubble); (b) chain done → operator transcript `notification` row
+  + live `notification` event + claim recorded; operator container stopped → delivery returns
+  False, root re-delivered next sweep after restart; stale-image 404 drill → ERROR log present;
+  (c) bell endpoints 404, no `notification_added` emits; desktop fan-in fires per kind;
+  (d) pipelines payload carries `origin`; chip visible during an in-flight probe chain; ghost
+  state bridges to the bubble; (e) verification turn appears live without any user message.
+- Fleet rollout: agent-image rebuild required (PRs 1–2); other 4 boxes get everything on their
+  next normal deploy — deploy MUST include the image rebuild or chain delivery 404-loops (the
+  ERROR log is the tripwire).
+
+## Flagged decisions (defaults chosen — confirm or veto)
+
+1. Outcome notes always land in the **operator** thread (forced today: watchable roots are
+   operator-rooted by construction).
+2. Human-triggered system-composed steers keep `[steer]` user-row rendering — out of scope.
+3. Historical wake rows already persisted as `user` are not migrated.
+4. Desktop browser notifications are kept via event fan-in; **chain completions now desktop-ping
+   for the first time** (success never pinged before — kind accident). New behavior.
+5. Non-dashboard (telegram/etc.) chains: if the channel push exhausts its 3 retries, the only
+   durable record is the operator-thread note — weaker than the old server-side bell row with
+   unread state. Accepted as the cost of bell removal.
+6. **Server-side unread state dies with the bell.** Unread is now per-browser-session; an
+   away-for-a-day user reloads into bubbles with no unread badge. Transcript presence + desktop
+   ping is the signal.
+7. P6/P7 reroutes are bounded-retry then accepted-lost if the operator container is down (bell
+   was host-side SQLite and ~never failed); fleet badges / Connectors page remain the fallback
+   surface.
+8. Webhook/cron inbound messages render as dim `system` dividers (previously fake user bubbles).
+   Webhook bodies are external input rendered in an "internal authority" style — content is
+   sanitized at the /chat boundary; accepted.
+
+## Review log (2026-06-11)
+
+Two-pass pre-implementation review. Self-pass caught: busy-path steer-queue gap, watcher
+loop/transport affinity (resolved by per-loop clients + async deliver), chat_done cross-session
+finalize risk. Independent fresh-context second pass (Codex quota-blocked; disclosed substitute)
+additionally caught: transport error-dict contract (no raise), swallowed transcript-write
+failures behind the ack, steer→followup fallback kwarg drop, chat_done debounce bypass, desktop
+notification fan-in being wrong on both ends, P7 quarantine direct-write (not producer), old-image
+404 trap, chip dead window, correction-store pollution by wake text. All incorporated above;
+spot-verified in code before adoption (workspace.py:1067-1076, lanes.py:333-351, app.js
+chat_done handler, transport.py:137-145).


### PR DESCRIPTION
Found during the repo-hygiene sweep: two plan docs sitting untracked in the working tree while the work they describe already shipped. Checking them in per the docs/plans convention — point-in-time records, content unmodified.

- `2026-06-09-operator-memory-context-overhaul.md` — shipped via #1115/#1116/#1119 and related PRs
- `2026-06-11-chat-native-delivery-and-bell-removal.md` — shipped via #1139/#1140