### PR TITLE
fix(dashboard): kill quarantine double desktop-ping + fan-in replay guard

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -434,7 +434,7 @@ function dashboard() {
     // Goals chip strip renders above when the operator has tracked
     // any business goals. Needs You panel sits on top; Stuck Tasks
     // panel below summaries; Cancel modal + Task drill-in are
-    // reachable from Needs You and the notification bell.
+    // reachable from Needs You and the Work tab.
     // ``workplaceEnabled`` reflects whether the tasks store
     // responded — kept for graceful empty-state rendering on
     // transient errors.
@@ -4491,16 +4491,25 @@ function dashboard() {
       }
 
       // Desktop-ping fan-in (bell removed): synthesize the row shape
-      // _maybeFireBrowserNotification expects from the underlying
-      // events, preserving the old bell coverage (approval / credential
-      // / health alert / credit) — chain outcomes + notify_user ping
-      // via the `notification` handler below. Replays are already
-      // filtered by the event-id dedupe above; the hook itself gates on
-      // opt-in + permission + tab-hidden.
+      // _maybeFireBrowserNotification expects from the underlying events,
+      // preserving the old bell coverage (approval / credential / health
+      // alert / credit). Chain outcomes + notify_user ping via the
+      // `notification` handler below. The hook gates on opt-in +
+      // permission + tab-hidden. Replay guard: the event-id dedupe above
+      // covers in-session reconnects, but a fresh page load has an empty
+      // _seenEventIds and the bus replays its ring buffer — so skip events
+      // older than _initTs (matching the `notification` handler), else a
+      // backgrounded fresh load could ping for stale buffered events.
+      // ``quarantined`` is intentionally absent: it reroutes via
+      // _system_signal_producer into a /chat/note whose notification event
+      // already pings (with richer remediation text) — listing it here too
+      // would double-ping.
       try {
         const fanAgent = evt.agent || '';
         const d = evt.data || {};
-        if (evt.type === 'pending_action_created') {
+        if (this._normalizeEventTs(evt) < this._initTs - 5000) {
+          // replayed buffered event (fresh load) — no desktop ping
+        } else if (evt.type === 'pending_action_created') {
           this._maybeFireBrowserNotification({
             kind: 'approval',
             id: 'pa-' + (d.action_id || d.id || Date.now()),
@@ -4517,7 +4526,7 @@ function dashboard() {
             payload: { agent_id: fanAgent },
           });
         } else if (evt.type === 'health_change'
-                   && ['degraded', 'unhealthy', 'failed', 'quarantined'].includes(d.current)) {
+                   && ['degraded', 'unhealthy', 'failed'].includes(d.current)) {
           this._maybeFireBrowserNotification({
             kind: 'alert',
             id: 'hc-' + fanAgent + '-' + d.current,

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -923,9 +923,10 @@ class DashboardEvent(BaseModel):
         "credential_stored",
         # OAuth connection refresh hard-failed (e.g. ``invalid_grant`` after
         # the user revoked access at the provider). Emitted once per failure
-        # episode from the mesh ``/mesh/vault/resolve`` catch site; the
-        # notifications producer maps it to a ``credential`` bell entry so
-        # the operator knows to reconnect via Settings → Integrations.
+        # episode from the mesh ``/mesh/vault/resolve`` catch site;
+        # ``runtime._system_signal_producer`` reroutes it into a ``/chat/note``
+        # in the operator thread so the operator knows to reconnect via the
+        # Connectors page.
         "connection_refresh_failed",
         "browser_login_request",
         "browser_login_completed",
@@ -960,8 +961,8 @@ class DashboardEvent(BaseModel):
         # ``task_outcome`` is emitted by ``host/orchestration.py:set_outcome``
         # when an operator (or system) rates a delivered task. Without this
         # literal, ``DashboardEvent`` validation rejects the emit and the
-        # event silently disappears (swallowed by ``_safe_emit``), so the
-        # notifications producer below never sees deliveries.
+        # event silently disappears (swallowed by ``_safe_emit``), so
+        # Work-tab consumers never see deliveries.
         "task_outcome",
         "task_artifact_added",
         # Work summaries — emitted by ``host/summaries.WorkSummariesStore``

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -427,6 +427,27 @@ class TestNotificationsBellRemoved:
         ):
             assert evt in block, evt
 
+    def test_fan_in_excludes_quarantined_to_avoid_double_ping(self):
+        """`quarantined` reroutes through _system_signal_producer into a
+        /chat/note whose `notification` event already pings — so it must
+        NOT be in the fan-in health_change kinds, or it double-pings."""
+        js = _read(_APP_JS)
+        idx = js.index("Desktop-ping fan-in (bell removed)")
+        block = js[idx:idx + 2600]
+        # the health_change branch lists degraded/unhealthy/failed only
+        assert "['degraded', 'unhealthy', 'failed']" in block
+        assert "'quarantined'].includes" not in block
+
+    def test_fan_in_skips_replayed_events_on_fresh_load(self):
+        """A fresh page load has an empty _seenEventIds and the bus replays
+        its ring buffer — the fan-in must guard on _initTs (like the
+        `notification` handler) so a backgrounded fresh load doesn't ping
+        for stale buffered events."""
+        js = _read(_APP_JS)
+        idx = js.index("Desktop-ping fan-in (bell removed)")
+        block = js[idx:idx + 2600]
+        assert "this._normalizeEventTs(evt) < this._initTs - 5000" in block
+
 
 # ── Activity translation (formatActivityForUser) ──────────────────────
 


### PR DESCRIPTION
Post-merge review follow-ups for the chat-native delivery stack (#1137/#1139/#1140/#1143). Two independent review passes (self + Codex) cleared every integration point — steer_fn single-instance, tuple producer/consumer completeness, async deliver/await, listener registration, full bell-removal completeness. These are the residual nits.

## Fixes

1. **Quarantine double desktop-ping** (Codex behavior-change catch). `health_change → quarantined` fired a desktop ping via the `onWsEvent` fan-in (kind=alert) **and** got rerouted through `_system_signal_producer` into a `/chat/note` whose `notification` event pinged again (kind=delivered, richer remediation text). Dropped `quarantined` from the fan-in health_change kinds — the reroute is the single richer surface. `degraded`/`unhealthy`/`failed` stay (no reroute).

2. **Fan-in replay guard** (self catch). The event-id dedupe covers in-session reconnects, but a fresh page load has an empty `_seenEventIds` and the EventBus replays its ring buffer — a backgrounded fresh load could ping for stale buffered events. Guard on `_initTs` matching the existing `notification` handler. (Restores parity with the bell's removed `_lastNotifiedId` high-water mark; my original "replays already filtered" comment was wrong for fresh loads.)

3. **Stale bell comments** (Codex hygiene catch). types.py (`connection_refresh_failed`, `task_outcome`) and app.js (Work-tab nav) still referenced the removed bell. Updated.

## Flagged, NOT fixed (out of scope)

`SandboxTransport.request` doesn't populate `status_code`, so `_deliver_chain_outcome`'s loud 404 deploy-trap ERROR is downgraded to a generic rejection on the microVM backend. Still fails closed; all current prod uses DockerBackend/HttpTransport (which sets it). Fixing means changing sandbox curl parsing for a non-deployed backend — deliberately deferred.

## Confirmed intentional (no change)

Chain outcomes emit the generic `notification` event (not a distinct `chain_outcome` type) — reuses the amber-bubble renderer; no consumer waits for a `chain_outcome` type.

## Tests

+2 fan-in pins (quarantine-excluded, replay-guard present). 390 passed across dashboard_ui/runtime/health; ruff clean. JS syntax checked.