### PR TITLE
fix(dashboard): watch chip outlives outcome + stale bell docs (final review)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,6 @@ Alpine.js SPA + Tailwind via CDN (no build step) with Jinja `autoescape=True` an
 | `server.py` | Dashboard FastAPI router with 160 API endpoints + VNC URL injection. Top-nav tabs: Chat / Teams / Work / Settings (internal IDs `chat` / `fleet` / `workplace` / `system` — frozen for URL stability). |
 | `events.py` | `EventBus` for real-time WebSocket streaming on `/ws/events` (mounted on the mesh app, not the dashboard router). |
 | `auth.py` | Session cookie verification — HMAC-SHA256 over `{expiry}.{signature}`, 24h max lifetime, 5-min skew tolerance. |
-| `notifications.py` | Persistent notifications store (SQLite WAL) — backs the top-nav bell. |
 | `telemetry.py` | Telemetry event sink for the SPA (`dashboard_telemetry` table). |
 | `platform_success.py` | Per-tenant success scoring. |
 
@@ -224,7 +223,7 @@ All persistent state is SQLite (WAL mode, `busy_timeout=30000` except `traces` w
 | `data/captcha_costs.json` | CAPTCHA cost ledger in millicents (1/100,000 USD) | `src/browser/captcha_cost_counter.py` |
 | Mesh-side blackboard / pubsub / audit-log SQLite | Inter-agent state, atomic CAS, undo/archive | `src/host/mesh.py` |
 | `data/traces.db` | Request traces (lower `busy_timeout=5000`) | `src/host/traces.py` |
-| `data/dashboard.db` | Notifications + telemetry | `src/dashboard/notifications.py`, `src/dashboard/telemetry.py` |
+| `data/dashboard.db` | Telemetry | `src/dashboard/telemetry.py` |
 | Per-agent Docker volume `openlegion_data_{name}` → `/data` | Agent workspace markdown, memory DB, daily logs | `src/agent/workspace.py`, `src/agent/memory.py` |
 | `config/agents.yaml` | Per-agent config (model, role, instructions, budget, resources) | `src/cli/config.py` |
 | `config/permissions.json` | Per-agent ACL matrix | `src/host/permissions.py` |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -25,9 +25,16 @@ The defaults — `tabs` array and `activeTab: 'chat'` — live in `src/dashboard
 
 A command palette (**Cmd+K** / **Ctrl+K**) provides quick access to agents, actions, and navigation. The search button in the nav bar also opens it.
 
-### Top-Nav Bell
+### Chat-native delivery (replaced the top-nav bell)
 
-- **Notifications bell** (top-right) — driven by `/dashboard/api/notifications`. Subtle gray dot when unread items exist; click to open the dropdown. See [Notifications](#notifications-system).
+The top-nav notifications bell was **removed** (2026-06 chat-native delivery overhaul). Delegated-work results now arrive in the operator chat instead:
+
+- **Chain outcomes** are written into the operator transcript as a `notification`-role row (via the agent `POST /chat/note` endpoint — the durability point the ChainWatcher claims on) and surfaced live via the `notification` WebSocket event (amber bubble + toast).
+- **Live progress** shows as a watch chip pinned above the operator composer while a delegated chain is in flight (stage k/n, amber when stalled).
+- **Off-tab desktop notifications** fire from a fan-in over the underlying WS events (approval / credential / health alert / credit) plus chain outcomes, gated on the user's opt-in.
+- The two formerly bell-only signals — `connection_refresh_failed` and agent quarantine — reroute into operator-thread notes via `runtime._system_signal_producer`.
+
+See [Notifications](#notifications-system).
 
 ## Team Management
 
@@ -294,44 +301,16 @@ When an agent's LLM call fails due to depleted credits (HTTP 402), a styled card
 - "Use Own API Key" button navigates to Settings → API Keys
 - Deduplicates against the last 3 messages so rapid-fire failures don't stack identical cards
 
-## Notifications System
+## Notifications System (chat-native, bell removed)
 
-Phase 2 Board UX overhaul added a persistent notifications store (separate from transient toasts and the Needs-You badge). A notification represents a past event the user should know about; the bell badge survives page reloads and cross-device viewing.
+The persistent notifications bell + store (`src/dashboard/notifications.py`, the `/dashboard/api/notifications` endpoints, and the `notification_added` WS event) were **removed** in the 2026-06 chat-native delivery overhaul. There is no longer a separate notifications surface — events the user should know about are delivered into the chat or as desktop pings.
 
-### Endpoints
+### Delivery surfaces
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/dashboard/api/notifications` | Top 10 notifications, unread first then by `ts DESC` |
-| `POST` | `/dashboard/api/notifications/{notification_id}/read` | Mark a single notification read |
-| `POST` | `/dashboard/api/notifications/read-all` | Mark every unread notification read |
-
-### Storage
-
-SQLite-backed via `src/dashboard/notifications.py` (`NotificationStore`). Schema:
-
-```
-dashboard_notifications(
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    agent_id     TEXT,                 -- optional originating agent (NULL = system)
-    ts           REAL NOT NULL,        -- Unix epoch seconds
-    kind         TEXT NOT NULL,        -- short tag from _KNOWN_KINDS
-    title        TEXT NOT NULL,        -- one-line headline
-    body         TEXT,                 -- optional longer body
-    read_at      REAL,                 -- Unix epoch when read (NULL = unread)
-    payload_json TEXT                  -- optional JSON for click-through targets
-)
-```
-
-WAL mode, `busy_timeout=30000`. Composite index `idx_notifications_unread_ts(read_at, ts DESC)` optimises the unread-first read pattern.
-
-### Frozen Kinds
-
-`_KNOWN_KINDS = {"delivered", "approval", "alert", "info", "blocker", "credential"}`. Unknown kinds are **accepted** (the log warns) so a producer typo never drops an event — the bell falls back to a generic icon. Add a value to `_KNOWN_KINDS` rather than coining ad-hoc kinds; the bell renders an icon per kind.
-
-### Live Updates
-
-The mesh emits `notification_added` immediately after each `NotificationStore.add` call (via `_notifications_producer`) so the bell badge updates without waiting for the 60-second poll cycle. Subscribers listen for the WS event and refetch `/dashboard/api/notifications` for the top page.
+- **Chain outcomes** → a `notification`-role row in the operator transcript, written by the agent `POST /chat/note` endpoint. This write is the deliver-then-claim durability point: the ChainWatcher claims the chain only on a positive `{ "ok": true }` ack, so a failed write is retried, never silently lost. On success the mesh emits the `notification` WebSocket event (agent `operator`, `data.message` + `data.root_task_id`), rendered as the amber notification bubble + a toast.
+- **Live progress** → the watch chip pinned above the operator composer for in-flight dashboard-origin chains (binds to `workplacePipelines`; refreshed by the WS task-event debounce). A `_chipDelivered` guard + a "finishing…" ghost bridge the settle window so the chip clears exactly as the outcome bubble lands.
+- **Off-tab desktop notifications** → `_maybeFireBrowserNotification`, fed by a fan-in in `onWsEvent` over the underlying events (`pending_action_created` → approval, `credential_request` / `browser_login_request` → credential, `health_change` degraded/unhealthy/failed → alert, `credit_exhausted`) plus the `notification` chain-outcome event. Triple-gated on opt-in + OS permission + tab-hidden, and replay-guarded on `_initTs` so a fresh load doesn't ping for buffered events.
+- **Rerouted system signals** → `connection_refresh_failed` and `health_change → quarantined` are turned into operator-thread `/chat/note` rows by `runtime._system_signal_producer` (sync EventBus listener; the POST is marshalled onto the dispatch loop with bounded retry). `quarantined` is intentionally excluded from the desktop fan-in so it doesn't double-ping.
 
 ## Telemetry System
 
@@ -436,7 +415,7 @@ The dashboard connects to the mesh via WebSocket at `/ws/events`. Events are str
 |--------|--------|
 | **Agent runtime** | `agent_state`, `tool_start`, `tool_result`, `text_delta`, `llm_call`, `health_change`, `workspace_updated`, `heartbeat_complete` |
 | **Chat** | `chat_user_message`, `chat_done`, `chat_reset`, `message_sent`, `message_received`, `credit_exhausted` |
-| **Notifications** | `notification`, `notification_added` |
+| **Notifications** | `notification` (chain outcomes + `notify_user`; the bell's `notification_added` was removed) |
 | **Blackboard** | `blackboard_write`, `blackboard_delete` |
 | **Automation** | `cron_change` |
 | **Credentials / handoffs** | `credential_request`, `credential_request_cancelled`, `credential_stored`, `browser_login_request`, `browser_login_completed`, `browser_login_cancelled`, `browser_captcha_help_request`, `browser_captcha_help_completed`, `browser_captcha_help_cancelled` |
@@ -617,13 +596,7 @@ These endpoints power the Work tab. They cover the summary cards, Needs-You pane
 | `POST` | `/dashboard/api/workplace/pending/{nonce}/cancel` | Cancel a pending action |
 | `POST` | `/dashboard/api/changes/undo/{undo_token}` | Undo a soft-edit change inside its TTL window |
 
-**Notifications**
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/dashboard/api/notifications` | Top 10 notifications, unread first then `ts DESC` |
-| `POST` | `/dashboard/api/notifications/{notification_id}/read` | Mark a single notification read |
-| `POST` | `/dashboard/api/notifications/read-all` | Mark every unread notification read |
+**Notifications** — removed (chat-native delivery; see [Notifications System](#notifications-system-chat-native-bell-removed)). The `/dashboard/api/notifications*` endpoints no longer exist.
 
 **Telemetry**
 
@@ -856,6 +829,5 @@ The dashboard includes several accessibility features:
 | `src/dashboard/static/css/dashboard.css` | Custom styles |
 | `src/dashboard/events.py` | EventBus for real-time event distribution (ring buffer, lock-protected emit, in-process listener API) |
 | `src/dashboard/auth.py` | `ol_session` cookie verification, hosted-mode detection via `/opt/openlegion/.subdomain`, 24h `COOKIE_MAX_AGE` + 5m skew |
-| `src/dashboard/notifications.py` | Persistent SQLite notifications store backing the top-nav bell |
 | `src/dashboard/telemetry.py` | Frontend telemetry sink with `_MAX_EVENTS=100_000` retention + 60/min per-session rate limit |
 | `src/dashboard/platform_success.py` | Per-tenant success scoring (backs `/dashboard/api/dashboard/platform-success`) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -420,7 +420,6 @@ openlegion/
 │   │   ├── server.py            # FastAPI router + API endpoints
 │   │   ├── events.py            # EventBus for real-time streaming
 │   │   ├── auth.py              # Session cookie verification
-│   │   ├── notifications.py     # Persistent notifications store
 │   │   ├── telemetry.py         # SPA telemetry event sink
 │   │   ├── platform_success.py  # Per-tenant success scoring
 │   │   ├── templates/           # Dashboard HTML (Alpine.js + Tailwind)

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -464,6 +464,11 @@ function dashboard() {
     // by the notification event or a 90s timeout.
     _chipGhosts: {},
     _chipPrevDash: {},
+    // Root ids whose outcome bubble already landed — suppresses a
+    // "finishing…" ghost that would otherwise be (re)created when the
+    // now-terminal chain drops out of the pipelines payload AFTER its
+    // notification fired (the two arrive in either order).
+    _chipDelivered: {},
     // Per-summary inline feedback box state. Keyed by summary id;
     // value is the current draft feedback string. The user opens the
     // box by clicking the rework icon → enters reason → submits →
@@ -4032,13 +4037,21 @@ function dashboard() {
         }
       }
       for (const [id, p] of Object.entries(this._chipPrevDash || {})) {
-        if (!current[id]) {
-          this._chipGhosts[id] = {
-            root_task_id: id, title: p.title || '',
-            _ghost: true, stalled: false, stages: [],
-          };
-          setTimeout(() => { delete this._chipGhosts[id]; }, 90_000);
+        if (current[id]) continue;
+        // Chain left the in-flight payload (terminal). Only bridge with a
+        // "finishing…" ghost if the outcome bubble hasn't ALREADY landed —
+        // otherwise the ghost would reappear right after its notification
+        // cleared it and linger the full 90s past completion.
+        if (this._chipDelivered[id]) {
+          delete this._chipDelivered[id];
+          delete this._chipGhosts[id];
+          continue;
         }
+        this._chipGhosts[id] = {
+          root_task_id: id, title: p.title || '',
+          _ghost: true, stalled: false, stages: [],
+        };
+        setTimeout(() => { delete this._chipGhosts[id]; }, 90_000);
       }
       this._chipPrevDash = current;
     },
@@ -5061,9 +5074,24 @@ function dashboard() {
       // page loaded) — _loadChatHistory handles restoring them from the
       // server transcript and localStorage.
       if (evt.type === 'notification' && agent && evt.data && evt.data.message) {
-        // Chain outcome arrived — its watch-chip ghost can go.
+        // Chain outcome arrived — clear its watch chip. Mark it delivered
+        // so _trackChipGhosts won't recreate a "finishing…" ghost when the
+        // terminal chain later drops out of the pipelines payload, and
+        // refresh the live pipelines so the in-flight chip clears even if
+        // this chain's task-lifecycle event was dropped.
         if (evt.data.root_task_id) {
-          delete this._chipGhosts[evt.data.root_task_id];
+          const rid = evt.data.root_task_id;
+          this._chipDelivered[rid] = true;
+          delete this._chipGhosts[rid];
+          // Backstop cleanup: _trackChipGhosts clears the flag promptly in
+          // the common ordering (notification before the chain drops out),
+          // but in the reverse ordering the id is already gone from
+          // _chipPrevDash and would never be re-evaluated — so expire it.
+          setTimeout(() => { delete this._chipDelivered[rid]; }, 5000);
+          if (typeof this.loadWorkplacePipelines === 'function') {
+            if (this._pipelinesDebounce) clearTimeout(this._pipelinesDebounce);
+            this._pipelinesDebounce = setTimeout(() => this.loadWorkplacePipelines(), 300);
+          }
         }
         const msg = evt.data.message;
         const evtTs = this._normalizeEventTs(evt);

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2543,7 +2543,7 @@ class TestDispatchChatDoneContract:
         assert "'delivered'" in js.split("_browserNotifyKinds:")[1].split("]")[0]
         # The live notification handler synthesizes the hook's row shape.
         idx = js.index("evt.type === 'notification' && agent")
-        block = js[idx:idx + 1600]
+        block = js[idx:idx + 2400]
         assert "_maybeFireBrowserNotification" in block
 
 
@@ -2567,8 +2567,23 @@ class TestChatWatchChips:
             assert marker in js, marker
         # Ghost lifecycle: created when a dashboard chain leaves the
         # payload, cleared by the outcome notification or a 90s timeout.
-        assert "delete this._chipGhosts[evt.data.root_task_id]" in js
+        assert "delete this._chipGhosts[rid]" in js
         assert "90_000" in js
+
+    def test_chip_ghost_not_recreated_after_outcome(self):
+        """Ordering fix: when the outcome notification arrives before the
+        terminal chain drops out of the pipelines payload, _trackChipGhosts
+        must NOT recreate a 'finishing…' ghost (which would linger 90s past
+        completion). The notification marks the root in _chipDelivered, and
+        _trackChipGhosts skips ghost creation for a delivered root."""
+        js = _read(_APP_JS)
+        assert "_chipDelivered" in js
+        # notification handler marks delivered + refreshes live pipelines
+        assert "this._chipDelivered[rid] = true" in js
+        # _trackChipGhosts honours the delivered guard
+        track = js[js.index("_trackChipGhosts(pipelines) {"):]
+        track = track[:track.index("},")]
+        assert "this._chipDelivered[id]" in track
 
     def test_chips_filter_dashboard_origin(self):
         js = _read(_APP_JS)


### PR DESCRIPTION
Final Codex review pass over the complete merged chat-native-delivery stack (#1137/#1139/#1140/#1143/#1144), **including the interleaved #1141 "unify wake dispatch" refactor** — which both Codex and I independently confirmed preserved every `system_note=True` flag (the three hand-rolled wake sites now inherit it from `_try_wake_agent`; the source-pin test was correctly updated to `count == 2` + a `_try_wake_agent(` routing assertion). Two findings actioned:

## 1. Watch chip could survive the outcome bubble (~90s)

The notification handler cleared the ghost for `root_task_id`, but the terminal chain dropping out of the `/api/workplace/pipelines` payload (a separate, often *later*, debounced refresh) made `_trackChipGhosts` **recreate** a "finishing…" ghost — *after* the notification had already cleared it — so it lingered the full 90s past completion.

Fix: the outcome notification marks the root in a `_chipDelivered` set (5s self-cleanup backstop for the reverse ordering) so `_trackChipGhosts` skips ghost creation for an already-delivered chain, and it kicks a debounced `loadWorkplacePipelines` so the live chip clears even if the chain's task-lifecycle event was dropped.

## 2. Stale bell docs

`docs/dashboard.md` (the whole Notifications section + Top-Nav Bell + two endpoint tables + support-modules row), plus `architecture.md` and `development.md`, still pointed at the deleted `src/dashboard/notifications.py`. Rewritten to describe chat-native delivery.

## Flagged, NOT fixed (out of scope)

- **Pre-existing back-edge blocked-reopen** (Codex MUST-FIX 1): the back-edge originator wake on `task_blocked` passes the downstream `task_id`, which the recipient's loop reopens (`blocked→working` is valid, orchestration.py:121) and can auto-close `done`, silently clearing the blocked state. **The `task_id` plumbing predates this stack** (verified at `33883b48^`) — it's the Bug-2/3 auto-close path (Constraint #6), not the chat-delivery feature. Failed/done/cancelled correctly reject the reopen; only `blocked` is exposed. Deserves its own focused PR against the auto-close contract — flagging rather than scope-creeping a sensitive state-machine change into a chat-delivery review.
- **Sandbox 404 diagnostic**: `SandboxTransport.request` omits `status_code`, so `_deliver_chain_outcome`'s 404 deploy-trap ERROR degrades to a generic rejection on the microVM backend (fails closed; all prod is DockerBackend).

## Confirmed intentional (no change)

Chain desktop-notification click → operator chat (where the result bubble is), not the task drill-in modal — correct for "show me the result."

## Tests

+1 ghost-reappear-guard pin; widened the desktop-ping assertion window. 200 passed in test_dashboard_ui; ruff clean; JS syntax checked.