### PR TITLE
fix(browser): run SSRF DNS resolution off the event loop

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5131,7 +5131,14 @@ class BrowserManager:
         # M21: SSRF parity — reject private/loopback/metadata/CGNAT hosts.
         # Second defence layer independent of the container iptables egress
         # filter. ``hostname`` strips port + userinfo; only public IPs pass.
-        if _browser_host_is_blocked(parsed.hostname or ""):
+        # Run blocking DNS resolution off the event loop — the browser service
+        # shares one asyncio loop across all agents, so a slow resolver here
+        # would head-of-line-block every agent's browser ops.
+        if await asyncio.get_running_loop().run_in_executor(
+            None,
+            _browser_host_is_blocked,
+            parsed.hostname or "",
+        ):
             return {
                 "success": False,
                 "error": "URL host resolves to a blocked (private/loopback/metadata) address",
@@ -10896,7 +10903,14 @@ class BrowserManager:
         if not parsed.netloc:
             return _err("invalid_input", "URL missing host component")
         # M21: SSRF parity — reject private/loopback/metadata/CGNAT hosts.
-        if _browser_host_is_blocked(parsed.hostname or ""):
+        # Run blocking DNS resolution off the event loop — the browser service
+        # shares one asyncio loop across all agents, so a slow resolver here
+        # would head-of-line-block every agent's browser ops.
+        if await asyncio.get_running_loop().run_in_executor(
+            None,
+            _browser_host_is_blocked,
+            parsed.hostname or "",
+        ):
             return _err(
                 "invalid_input",
                 "URL host resolves to a blocked (private/loopback/metadata) address",

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -861,9 +861,16 @@ def build_launch_options(
     # detection signal).
     try:
         from browserforge.fingerprints import Screen
+
         options["screen"] = Screen(max_width=width, max_height=height)
     except ImportError:
-        pass  # browserforge only available in browser container
+        # browserforge ships in the browser container; if it's ever missing we
+        # lose the window.innerWidth <= window.screen.width lock (a fingerprint
+        # coherence signal). Surface it rather than degrading stealth silently.
+        logger.warning(
+            "browserforge unavailable - screen fingerprint lock skipped; "
+            "innerWidth/screen.width coherence not enforced",
+        )
 
     # GeoIP: maps egress IP → timezone/locale for the fingerprint.
     # Only enable when a proxy is configured so the resolved location matches

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -9414,7 +9414,14 @@ def create_mesh_app(
             if nav_url:
                 from src.agent.builtins.http_tool import _resolve_and_pin
                 try:
-                    _resolve_and_pin(nav_url)
+                    # Blocking DNS resolution — run off the event loop so a slow
+                    # resolver can't stall the mesh's shared loop (it carries all
+                    # fleet traffic, not just browser commands).
+                    await asyncio.get_running_loop().run_in_executor(
+                        None,
+                        _resolve_and_pin,
+                        nav_url,
+                    )
                 except ValueError as e:
                     raise HTTPException(400, str(e))
 


### PR DESCRIPTION
## Problem

PR #1003 added synchronous `socket.getaddrinfo()` SSRF checks that run directly on asyncio event loops on the browser navigate hot path:

- `src/browser/service.py` — `_browser_host_is_blocked()` in both `navigate` and `open_tab`
- `src/host/server.py` — `_resolve_and_pin()` in `browser_command`

Both the browser service and the mesh host share **one** asyncio loop across all agents. A synchronous `getaddrinfo` on the navigate/open_tab path head-of-line-blocks every agent's browser ops; under a slow or unreachable resolver it freezes all in-flight browser operations for the full resolver timeout.

## Fix

Move the blocking DNS resolution off the loop via `loop.run_in_executor(None, ...)` at all three call sites. The SSRF helpers themselves are **unchanged** (still synchronous) — only the call sites now `await` them in the default thread-pool executor. The existing unit tests of those helpers are unaffected.

## Also

Surfaces a previously-silent stealth degradation: in `src/browser/stealth.py`, the `browserforge` `ImportError` fallback now logs a warning instead of silently dropping the `window.innerWidth <= window.screen.width` fingerprint-coherence lock.

## Validation

- `ruff check src/` passes (the CI lint gate). The diff is limited to the three intended call sites + the stealth log line (no whole-file reformat churn).
- Note: tests could not be executed in the local sandbox because the default interpreter is Python 3.10 and the repo's `MCPConnector | HttpConnector` Pydantic union at `src/shared/types.py:656` requires 3.11+ at runtime; CI runs 3.11/3.12 and will exercise the browser/navigate tests. The change is behavior-preserving (same helpers, just awaited in an executor).