### PR TITLE
feat(observability): phase 1 — correlate sessions by trace_id across entry points + stores

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -1077,6 +1077,17 @@ class WorkspaceManager:
         """
         path = self.root / self.CHAT_TRANSCRIPT
         entry: dict = {"role": role, "content": content, "ts": time.time()}
+        # Session observability (Phase 1) — stamp the active per-turn
+        # correlation id so a transcript row JOINs to its central
+        # task/usage/trace rows by one key. The agent seeds
+        # ``current_trace_id`` from the inbound X-Trace-Id header in
+        # ``loop.chat`` / ``loop.chat_stream``; omitted when no trace is
+        # active (e.g. heartbeat-seeded rows) so legacy readers are
+        # unaffected.
+        from src.shared.trace import current_trace_id
+        _trace_id = current_trace_id.get()
+        if _trace_id:
+            entry["trace_id"] = _trace_id
         if tools:
             entry["tools"] = tools
         elif tool_names:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -252,6 +252,25 @@ class RuntimeContext:
 
         click.echo(" done.")
 
+    @staticmethod
+    def _resolve_dispatch_trace_id(trace_id: str | None) -> str:
+        """Resolve the per-turn trace_id for a dispatch (Phase 1).
+
+        Order of precedence — never clobber an existing trace (per the
+        session-observability plan):
+        1. An explicit ``trace_id`` argument (cron / CLI mint it upstream).
+        2. The active ``current_trace_id`` contextvar — set by
+           ``Channel.dispatch`` for channel-originated messages, so the
+           lane worker reuses it rather than losing it.
+        3. A freshly minted id — covers callers with neither (e.g. the
+           webhook manager dispatching directly), so every human/external
+           -rooted message correlates end-to-end.
+        """
+        if trace_id:
+            return trace_id
+        from src.shared.trace import current_trace_id, new_trace_id
+        return current_trace_id.get() or new_trace_id()
+
     def dispatch(
         self, agent: str, message: str, mode: str = "followup",
         trace_id: str | None = None,
@@ -264,6 +283,7 @@ class RuntimeContext:
         Schedules the coroutine on the dedicated dispatch loop and blocks
         until the result is ready.  For async callers, use async_dispatch().
         """
+        trace_id = self._resolve_dispatch_trace_id(trace_id)
         future = asyncio.run_coroutine_threadsafe(
             self.lane_manager.enqueue(
                 agent, message, mode=mode, trace_id=trace_id,
@@ -282,6 +302,7 @@ class RuntimeContext:
         system_note: bool = False,
     ) -> str:
         """Async dispatch: schedules onto the dedicated dispatch loop."""
+        trace_id = self._resolve_dispatch_trace_id(trace_id)
         future = asyncio.run_coroutine_threadsafe(
             self.lane_manager.enqueue(
                 agent, message, mode=mode, trace_id=trace_id,

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3615,7 +3615,13 @@ def create_dashboard_router(
         # the resulting LLM/task/transcript rows were uncorrelatable.
         from src.shared.trace import current_trace_id, new_trace_id, origin_header, trace_headers
         from src.shared.types import MessageOrigin
-        current_trace_id.set(new_trace_id())
+        # Mint + seed, then RESET via token after the awaited outbound call.
+        # Without the reset, this minted trace_id stays on the (worker-reused)
+        # context and contaminates a later handler that calls trace_headers()
+        # without minting (e.g. /api/broadcast), so its rows inherit a trace
+        # from an unrelated chat. The finally runs after transport.request,
+        # so the outbound trace_headers() still carries X-Trace-Id.
+        _trace_tok = current_trace_id.set(new_trace_id())
         origin = MessageOrigin(
             kind="human",
             channel="dashboard",
@@ -3638,6 +3644,8 @@ def create_dashboard_router(
                 event_bus.emit("chat_done", agent=agent_id,
                     data={"response": "", "session": chat_session})
             raise HTTPException(status_code=502, detail=str(e))
+        finally:
+            current_trace_id.reset(_trace_tok)
 
     @api_router.post("/api/agents/{agent_id}/chat/stream")
     async def api_chat_stream(agent_id: str, request: Request):
@@ -3663,16 +3671,23 @@ def create_dashboard_router(
         # Session observability (Phase 1): mint a per-turn trace_id and
         # seed the contextvar before trace_headers() so the outbound
         # /chat/stream call carries X-Trace-Id (see api_chat above).
+        # The X-Trace-Id is baked into ``_hdrs`` synchronously here, so the
+        # generator reads ``_hdrs`` (not the contextvar) — set + reset around
+        # the header build, no leak onto the worker-reused context that a
+        # later non-minting handler (e.g. /api/broadcast) would inherit.
         from src.shared.trace import current_trace_id, new_trace_id, origin_header, trace_headers
         from src.shared.types import MessageOrigin
-        current_trace_id.set(new_trace_id())
-        _origin = MessageOrigin(
-            kind="human",
-            channel="dashboard",
-            user=_operator_session_id(request),
-        )
-        _hdrs = trace_headers()
-        _hdrs.update(origin_header(_origin))
+        _trace_tok = current_trace_id.set(new_trace_id())
+        try:
+            _origin = MessageOrigin(
+                kind="human",
+                channel="dashboard",
+                user=_operator_session_id(request),
+            )
+            _hdrs = trace_headers()
+            _hdrs.update(origin_header(_origin))
+        finally:
+            current_trace_id.reset(_trace_tok)
 
         async def event_generator():
             final_response = ""

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3608,8 +3608,14 @@ def create_dashboard_router(
         # Task 2b: stamp dashboard chat as human-origin so downstream
         # authorization gates can distinguish a user-driven chat from
         # an agent-initiated wake.
-        from src.shared.trace import origin_header, trace_headers
+        # Session observability (Phase 1): mint a per-turn trace_id and
+        # seed the contextvar BEFORE trace_headers() — mirrors the CLI
+        # (repl.py: current_trace_id.set(new_trace_id())). Without this the
+        # dashboard's outbound /chat call carried an empty X-Trace-Id and
+        # the resulting LLM/task/transcript rows were uncorrelatable.
+        from src.shared.trace import current_trace_id, new_trace_id, origin_header, trace_headers
         from src.shared.types import MessageOrigin
+        current_trace_id.set(new_trace_id())
         origin = MessageOrigin(
             kind="human",
             channel="dashboard",
@@ -3654,8 +3660,12 @@ def create_dashboard_router(
                 data={"message": message, "session": chat_session})
 
         # Task 2b: stamp dashboard streaming chat as human-origin.
-        from src.shared.trace import origin_header, trace_headers
+        # Session observability (Phase 1): mint a per-turn trace_id and
+        # seed the contextvar before trace_headers() so the outbound
+        # /chat/stream call carries X-Trace-Id (see api_chat above).
+        from src.shared.trace import current_trace_id, new_trace_id, origin_header, trace_headers
         from src.shared.types import MessageOrigin
+        current_trace_id.set(new_trace_id())
         _origin = MessageOrigin(
             kind="human",
             channel="dashboard",

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -148,10 +148,21 @@ class CostTracker:
                 completion_tokens INTEGER DEFAULT 0,
                 total_tokens INTEGER DEFAULT 0,
                 cost_usd REAL DEFAULT 0.0,
-                timestamp TEXT DEFAULT (datetime('now'))
+                timestamp TEXT DEFAULT (datetime('now')),
+                trace_id TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_usage_agent_ts ON usage(agent, timestamp);
         """)
+        # Session observability (Phase 1) — additive, nullable trace_id so
+        # a cost row JOINs to its task/trace by the per-turn correlation
+        # id. ALTER ... ADD COLUMN is a metadata-only op in SQLite, fast
+        # and safe to re-run (we filter on the introspected column set so
+        # an already-migrated DB is a no-op). Existing rows keep NULL.
+        existing = {
+            row[1] for row in self.db.execute("PRAGMA table_info(usage)").fetchall()
+        }
+        if "trace_id" not in existing:
+            self.db.execute("ALTER TABLE usage ADD COLUMN trace_id TEXT")
         self.db.commit()
 
     def close(self) -> None:
@@ -217,10 +228,16 @@ class CostTracker:
             if bill else 0.0
         )
 
+        # Session observability (Phase 1) — stamp the active per-turn
+        # trace_id (seeded from the inbound X-Trace-Id header on the mesh
+        # proxy path) so spend attributes to a task/session. NULL when no
+        # trace is active.
+        from src.shared.trace import current_trace_id
+        trace_id = current_trace_id.get()
         self.db.execute(
-            "INSERT INTO usage (agent, model, prompt_tokens, completion_tokens, total_tokens, cost_usd) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (agent, model, prompt_tokens, completion_tokens, total, cost),
+            "INSERT INTO usage (agent, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, trace_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (agent, model, prompt_tokens, completion_tokens, total, cost, trace_id),
         )
         self.db.commit()
 
@@ -237,10 +254,12 @@ class CostTracker:
         Inserts a row with zero tokens and the given USD cost.
         Returns {"cost": float, "over_budget": bool}.
         """
+        from src.shared.trace import current_trace_id
+        trace_id = current_trace_id.get()
         self.db.execute(
-            "INSERT INTO usage (agent, model, prompt_tokens, completion_tokens, total_tokens, cost_usd) "
-            "VALUES (?, ?, 0, 0, 0, ?)",
-            (agent, model, cost_usd),
+            "INSERT INTO usage (agent, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, trace_id) "
+            "VALUES (?, ?, 0, 0, 0, ?, ?)",
+            (agent, model, cost_usd, trace_id),
         )
         self.db.commit()
 

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -399,6 +399,13 @@ class Tasks:
                 # B4 — per-task reasoning depth ("off"/"low"/"medium"/
                 # "high", NULL = use the assignee's configured default).
                 ("thinking", "TEXT"),
+                # Session observability (Phase 1) — the per-turn
+                # correlation id (``tr_<hex12>``) that minted this task so
+                # a session can be reconstructed by JOINing tasks / usage /
+                # traces on one key instead of timestamp archaeology.
+                # Nullable: pre-existing rows and paths with no active
+                # trace keep NULL.
+                ("trace_id", "TEXT"),
             )
             for col_name, col_type in outcome_columns:
                 if col_name not in existing:
@@ -713,6 +720,7 @@ class Tasks:
             "outcome_set_at": row[22],
             "result_summary": row[23],
             "thinking": row[24],
+            "trace_id": row[25],
         }
 
     # ``{team_col}`` is filled in at query time from ``self._team_col``
@@ -725,7 +733,7 @@ class Tasks:
         "blocker_note, origin_kind, origin_channel, origin_user, "
         "created_at, updated_at, completed_at, retention_until, "
         "outcome, feedback_text, previous_task_id, outcome_set_at, "
-        "result_summary, thinking"
+        "result_summary, thinking, trace_id"
     )
 
     @property
@@ -867,6 +875,13 @@ class Tasks:
         kind = origin.get("kind") if isinstance(origin, dict) else None
         channel = origin.get("channel") if isinstance(origin, dict) else None
         user = origin.get("user") if isinstance(origin, dict) else None
+        # Session observability (Phase 1) — stamp the active per-turn
+        # correlation id so this task JOINs to its usage/trace rows.
+        # Read from the contextvar at write time: it is seeded from the
+        # inbound X-Trace-Id header on the lane / mesh paths. NULL when no
+        # trace is active (purely internal task creation).
+        from src.shared.trace import current_trace_id
+        trace_id = current_trace_id.get()
 
         with self._conn() as conn:
             conn.execute(
@@ -875,16 +890,16 @@ class Tasks:
                 f"creator, assignee, status, priority, dependencies_json, "
                 f"artifact_refs_json, blocker_note, origin_kind, "
                 f"origin_channel, origin_user, created_at, updated_at, "
-                f"completed_at, retention_until, thinking) "
+                f"completed_at, retention_until, thinking, trace_id) "
                 f"VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, NULL, "
-                f"?, ?, ?, ?, ?, NULL, NULL, ?)",
+                f"?, ?, ?, ?, ?, NULL, NULL, ?, ?)",
                 (
                     tid, project_id, parent_task_id, title, description,
                     creator, assignee, priority,
                     json.dumps(dependencies) if dependencies else None,
                     json.dumps(artifact_refs) if artifact_refs else None,
                     kind, channel, user,
-                    now, now, thinking,
+                    now, now, thinking, trace_id,
                 ),
             )
             self._emit_event(
@@ -1985,6 +2000,10 @@ class Tasks:
             )
         new_id = f"task_{uuid.uuid4().hex[:12]}"
         now = time.time()
+        # Session observability (Phase 1) — a rework is a continuation of
+        # the same human-rooted session, so inherit the original task's
+        # trace_id (NULL if the source predates trace stamping).
+        inherited_trace_id = previous.get("trace_id")
         with self._conn() as conn:
             conn.execute(
                 f"INSERT INTO tasks "
@@ -1993,9 +2012,9 @@ class Tasks:
                 f"artifact_refs_json, blocker_note, origin_kind, "
                 f"origin_channel, origin_user, created_at, updated_at, "
                 f"completed_at, retention_until, outcome, feedback_text, "
-                f"previous_task_id) "
+                f"previous_task_id, trace_id) "
                 f"VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL, NULL, "
-                f"NULL, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
+                f"NULL, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)",
                 (
                     new_id,
                     previous.get("project_id"),
@@ -2010,6 +2029,7 @@ class Tasks:
                     (previous.get("origin") or {}).get("user"),
                     now, now,
                     previous_task_id,
+                    inherited_trace_id,
                 ),
             )
             self._emit_event(

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2016,6 +2016,14 @@ def create_mesh_app(
             )
 
         req_trace_id = request.headers.get("x-trace-id")
+        # Session observability (Phase 1) — seed the trace contextvar from
+        # the inbound header so the cost write inside execute_api_call
+        # (CostTracker.track) stamps the usage row with the originating
+        # trace_id. The endpoint runs in its own request task context, so
+        # the set is request-scoped and self-cleaning.
+        if req_trace_id:
+            from src.shared.trace import current_trace_id
+            current_trace_id.set(req_trace_id)
         prompt_preview = _extract_prompt_preview(api_request.params)
         t0 = time.time()
         result = await credential_vault.execute_api_call(api_request, agent_id=agent_id)
@@ -2141,6 +2149,14 @@ def create_mesh_app(
             )
 
         req_trace_id = request.headers.get("x-trace-id")
+        # Session observability (Phase 1) — seed the trace contextvar so
+        # the cost write inside stream_llm (CostTracker.track, fired on the
+        # terminal 'done' chunk) stamps the usage row. Set here, before the
+        # generator is created, so it is captured into the streaming
+        # context that Starlette later iterates.
+        if req_trace_id:
+            from src.shared.trace import current_trace_id
+            current_trace_id.set(req_trace_id)
         prompt_preview = _extract_prompt_preview(api_request.params)
 
         try:
@@ -5934,6 +5950,16 @@ def create_mesh_app(
         origin = _validated_origin(request, caller)
         origin_dict = origin.model_dump() if origin is not None else None
 
+        # Session observability (Phase 1) — seed the trace contextvar from
+        # the inbound header so ``store.create`` stamps the task row with
+        # the originating per-turn trace_id (the agent forwards X-Trace-Id
+        # on its hand_off / create_task calls). Request-scoped, self-
+        # cleaning; NULL when the caller carried no trace.
+        _req_trace_id = request.headers.get("x-trace-id")
+        if _req_trace_id:
+            from src.shared.trace import current_trace_id
+            current_trace_id.set(_req_trace_id)
+
         try:
             record = store.create(
                 creator=caller,
@@ -6576,6 +6602,14 @@ def create_mesh_app(
             )
         origin = _validated_origin(request, caller)
         origin_dict = origin.model_dump() if origin is not None else None
+        # Session observability (Phase 1) — a retry continues the original
+        # human-rooted session, so seed the contextvar with the original
+        # task's trace_id (falling back to the inbound header) before the
+        # clone so ``store.create`` stamps the same correlation id.
+        _retry_trace_id = original.get("trace_id") or request.headers.get("x-trace-id")
+        if _retry_trace_id:
+            from src.shared.trace import current_trace_id
+            current_trace_id.set(_retry_trace_id)
         try:
             clone = store.create(
                 creator=caller,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2016,107 +2016,113 @@ def create_mesh_app(
             )
 
         req_trace_id = request.headers.get("x-trace-id")
-        # Session observability (Phase 1) — seed the trace contextvar from
-        # the inbound header so the cost write inside execute_api_call
-        # (CostTracker.track) stamps the usage row with the originating
-        # trace_id. The endpoint runs in its own request task context, so
-        # the set is request-scoped and self-cleaning.
-        if req_trace_id:
-            from src.shared.trace import current_trace_id
-            current_trace_id.set(req_trace_id)
-        prompt_preview = _extract_prompt_preview(api_request.params)
-        t0 = time.time()
-        result = await credential_vault.execute_api_call(api_request, agent_id=agent_id)
-        duration_ms = int((time.time() - t0) * 1000)
-        response_preview = ""
-        if result.success and result.data:
-            resp_content = result.data.get("content", "")
-            if isinstance(resp_content, str):
-                response_preview = resp_content[:500]
-            elif isinstance(resp_content, list):
-                for block in resp_content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        response_preview = (block.get("text") or "")[:500]
-                        break
+        # Session observability (Phase 1) — seed the trace contextvar to the
+        # request's effective value (header, or None when absent) so the cost
+        # write inside execute_api_call (CostTracker.track) stamps the usage
+        # row with the originating trace_id. Set UNCONDITIONALLY + reset via
+        # token: a conditional set leaves a stale trace_id from a prior
+        # request in the (worker-reused) context, so a no-header request
+        # would silently inherit it. set(None) is a valid NULL stamp. The
+        # finally runs AFTER execute_api_call (and its CostTracker.track) —
+        # the call is awaited inside this same coroutine.
+        from src.shared.trace import current_trace_id
+        _trace_tok = current_trace_id.set(req_trace_id)
         try:
-            if req_trace_id and trace_store:
-                trace_meta = {
-                    "service": api_request.service,
-                    "action": api_request.action,
-                }
-                if prompt_preview:
-                    trace_meta["prompt_preview"] = prompt_preview
-                if response_preview:
-                    trace_meta["response_preview"] = response_preview
-                trace_status = "ok"
-                trace_error = ""
-                if result.success and result.data:
-                    trace_meta["model"] = result.data.get("model", "")
-                    trace_meta["tokens_used"] = result.data.get("tokens_used", 0)
-                    trace_meta["input_tokens"] = result.data.get("input_tokens", 0)
-                    trace_meta["output_tokens"] = result.data.get("output_tokens", 0)
-                elif not result.success:
-                    trace_status = "error"
-                    trace_error = result.error or "Unknown error"
-                trace_store.record(
-                    trace_id=req_trace_id,
-                    source="mesh.api_proxy",
-                    agent=agent_id,
-                    event_type="llm_call",
-                    detail=f"{api_request.service}/{api_request.action}",
-                    duration_ms=duration_ms,
-                    status=trace_status,
-                    error=trace_error,
-                    meta=trace_meta,
+            prompt_preview = _extract_prompt_preview(api_request.params)
+            t0 = time.time()
+            result = await credential_vault.execute_api_call(api_request, agent_id=agent_id)
+            duration_ms = int((time.time() - t0) * 1000)
+            response_preview = ""
+            if result.success and result.data:
+                resp_content = result.data.get("content", "")
+                if isinstance(resp_content, str):
+                    response_preview = resp_content[:500]
+                elif isinstance(resp_content, list):
+                    for block in resp_content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            response_preview = (block.get("text") or "")[:500]
+                            break
+            try:
+                if req_trace_id and trace_store:
+                    trace_meta = {
+                        "service": api_request.service,
+                        "action": api_request.action,
+                    }
+                    if prompt_preview:
+                        trace_meta["prompt_preview"] = prompt_preview
+                    if response_preview:
+                        trace_meta["response_preview"] = response_preview
+                    trace_status = "ok"
+                    trace_error = ""
+                    if result.success and result.data:
+                        trace_meta["model"] = result.data.get("model", "")
+                        trace_meta["tokens_used"] = result.data.get("tokens_used", 0)
+                        trace_meta["input_tokens"] = result.data.get("input_tokens", 0)
+                        trace_meta["output_tokens"] = result.data.get("output_tokens", 0)
+                    elif not result.success:
+                        trace_status = "error"
+                        trace_error = result.error or "Unknown error"
+                    trace_store.record(
+                        trace_id=req_trace_id,
+                        source="mesh.api_proxy",
+                        agent=agent_id,
+                        event_type="llm_call",
+                        detail=f"{api_request.service}/{api_request.action}",
+                        duration_ms=duration_ms,
+                        status=trace_status,
+                        error=trace_error,
+                        meta=trace_meta,
+                    )
+            except Exception:
+                logger.error(
+                    "Post-processing failed (trace) for %s/%s agent=%s",
+                    api_request.service, api_request.action, agent_id, exc_info=True,
                 )
-        except Exception:
-            logger.error(
-                "Post-processing failed (trace) for %s/%s agent=%s",
-                api_request.service, api_request.action, agent_id, exc_info=True,
-            )
-        try:
-            if event_bus is not None and not result.success and result.status_code == 402:
-                event_bus.emit("credit_exhausted", agent=agent_id, data={
-                    "error": result.error or "Insufficient credits",
-                })
-            if event_bus is not None and result.success and result.data:
-                model = result.data.get("model", "")
-                tokens = result.data.get("tokens_used", 0)
-                input_tok = result.data.get("input_tokens", 0)
-                output_tok = result.data.get("output_tokens", 0)
-                from src.host.costs import estimate_cost
-                fixed_cost = result.data.get("fixed_cost_usd", 0)
-                # OAuth (Anthropic/OpenAI subscription) calls have no per-call
-                # cost — the authoritative usage table already skips them in
-                # CredentialVault.execute_api_call. Mirror that here so the
-                # dashboard activity/trace feed doesn't show a metered estimate
-                # for subscription traffic.
-                is_oauth = bool(result.data.get("oauth"))
-                event_data = {
-                    "service": api_request.service, "action": api_request.action,
-                    "duration_ms": duration_ms,
-                    "model": model,
-                    "total_tokens": tokens,
-                    "input_tokens": input_tok,
-                    "output_tokens": output_tok,
-                    "oauth": is_oauth,
-                    "cost_usd": 0.0 if is_oauth else (
-                        fixed_cost if fixed_cost else estimate_cost(
-                            model, input_tokens=input_tok, output_tokens=output_tok, total_tokens=tokens,
-                        )
-                    ),
-                }
-                if prompt_preview:
-                    event_data["prompt_preview"] = prompt_preview
-                if response_preview:
-                    event_data["response_preview"] = response_preview
-                event_bus.emit("llm_call", agent=agent_id, data=event_data)
-        except Exception:
-            logger.error(
-                "Post-processing failed (events) for %s/%s agent=%s",
-                api_request.service, api_request.action, agent_id, exc_info=True,
-            )
-        return result
+            try:
+                if event_bus is not None and not result.success and result.status_code == 402:
+                    event_bus.emit("credit_exhausted", agent=agent_id, data={
+                        "error": result.error or "Insufficient credits",
+                    })
+                if event_bus is not None and result.success and result.data:
+                    model = result.data.get("model", "")
+                    tokens = result.data.get("tokens_used", 0)
+                    input_tok = result.data.get("input_tokens", 0)
+                    output_tok = result.data.get("output_tokens", 0)
+                    from src.host.costs import estimate_cost
+                    fixed_cost = result.data.get("fixed_cost_usd", 0)
+                    # OAuth (Anthropic/OpenAI subscription) calls have no per-call
+                    # cost — the authoritative usage table already skips them in
+                    # CredentialVault.execute_api_call. Mirror that here so the
+                    # dashboard activity/trace feed doesn't show a metered estimate
+                    # for subscription traffic.
+                    is_oauth = bool(result.data.get("oauth"))
+                    event_data = {
+                        "service": api_request.service, "action": api_request.action,
+                        "duration_ms": duration_ms,
+                        "model": model,
+                        "total_tokens": tokens,
+                        "input_tokens": input_tok,
+                        "output_tokens": output_tok,
+                        "oauth": is_oauth,
+                        "cost_usd": 0.0 if is_oauth else (
+                            fixed_cost if fixed_cost else estimate_cost(
+                                model, input_tokens=input_tok, output_tokens=output_tok, total_tokens=tokens,
+                            )
+                        ),
+                    }
+                    if prompt_preview:
+                        event_data["prompt_preview"] = prompt_preview
+                    if response_preview:
+                        event_data["response_preview"] = response_preview
+                    event_bus.emit("llm_call", agent=agent_id, data=event_data)
+            except Exception:
+                logger.error(
+                    "Post-processing failed (events) for %s/%s agent=%s",
+                    api_request.service, api_request.action, agent_id, exc_info=True,
+                )
+            return result
+        finally:
+            current_trace_id.reset(_trace_tok)
 
     @app.post("/mesh/api/stream")
     async def proxy_api_stream(request: Request, api_request: APIProxyRequest, agent_id: str) -> StreamingResponse:
@@ -2149,14 +2155,19 @@ def create_mesh_app(
             )
 
         req_trace_id = request.headers.get("x-trace-id")
-        # Session observability (Phase 1) — seed the trace contextvar so
-        # the cost write inside stream_llm (CostTracker.track, fired on the
-        # terminal 'done' chunk) stamps the usage row. Set here, before the
-        # generator is created, so it is captured into the streaming
-        # context that Starlette later iterates.
-        if req_trace_id:
-            from src.shared.trace import current_trace_id
-            current_trace_id.set(req_trace_id)
+        # Session observability (Phase 1) — the cost write inside stream_llm
+        # (CostTracker.track, fired AFTER the terminal 'done' chunk is
+        # yielded) must read this request's trace_id from the contextvar.
+        #
+        # The seed CANNOT live at the endpoint level with a finally-reset:
+        # the body generator is iterated by Starlette AFTER this coroutine
+        # returns, so an endpoint-level reset would NULL the stamp before
+        # track() runs. Instead the generator owns the lifecycle — it sets
+        # on entry (in its own execution context, so track() sees it) and
+        # resets when the stream ends (no leak into a later handler). The
+        # synchronous trace_store.record below uses req_trace_id directly,
+        # not the contextvar, so it needs no seed.
+        from src.shared.trace import current_trace_id
         prompt_preview = _extract_prompt_preview(api_request.params)
 
         try:
@@ -2181,7 +2192,7 @@ def create_mesh_app(
                 api_request.service, api_request.action, agent_id, exc_info=True,
             )
 
-        async def _stream_with_events():
+        async def _inner_stream():
             start = time.monotonic()
             done_data: dict = {}
             credit_error = False
@@ -2254,6 +2265,18 @@ def create_mesh_app(
                     "Post-processing failed (trace) for %s/%s agent=%s",
                     api_request.service, api_request.action, agent_id, exc_info=True,
                 )
+
+        async def _stream_with_events():
+            # Own the trace-contextvar lifecycle INSIDE the generator so the
+            # seed survives into the iteration Starlette drives after this
+            # endpoint returns — and resets when the stream ends. set(None)
+            # is a valid NULL stamp; reset prevents cross-request bleed.
+            _trace_tok = current_trace_id.set(req_trace_id)
+            try:
+                async for chunk in _inner_stream():
+                    yield chunk
+            finally:
+                current_trace_id.reset(_trace_tok)
 
         return StreamingResponse(_stream_with_events(), media_type="text/event-stream")
 
@@ -5950,16 +5973,17 @@ def create_mesh_app(
         origin = _validated_origin(request, caller)
         origin_dict = origin.model_dump() if origin is not None else None
 
-        # Session observability (Phase 1) — seed the trace contextvar from
-        # the inbound header so ``store.create`` stamps the task row with
-        # the originating per-turn trace_id (the agent forwards X-Trace-Id
-        # on its hand_off / create_task calls). Request-scoped, self-
-        # cleaning; NULL when the caller carried no trace.
+        # Session observability (Phase 1) — seed the trace contextvar to the
+        # inbound header value (or None when absent) so ``store.create``
+        # stamps the task row with the originating per-turn trace_id (the
+        # agent forwards X-Trace-Id on its hand_off / create_task calls).
+        # Set UNCONDITIONALLY + reset via token: a conditional set leaves a
+        # stale trace_id from a prior request in the (worker-reused) context,
+        # so a no-header request would silently inherit it. The finally runs
+        # right after ``store.create`` (the only contextvar reader here).
         _req_trace_id = request.headers.get("x-trace-id")
-        if _req_trace_id:
-            from src.shared.trace import current_trace_id
-            current_trace_id.set(_req_trace_id)
-
+        from src.shared.trace import current_trace_id
+        _trace_tok = current_trace_id.set(_req_trace_id)
         try:
             record = store.create(
                 creator=caller,
@@ -5993,6 +6017,8 @@ def create_mesh_app(
             # "Internal Server Error" placeholder.
             logger.error("tasks.create raised RuntimeError: %s", e)
             raise HTTPException(500, str(e))
+        finally:
+            current_trace_id.reset(_trace_tok)
         # Belt-and-suspenders verify (Bug 1 post-mortem): ``Tasks.create``
         # already asserts the row exists via its own post-write SELECT and
         # returns that fresh record. Use the returned record (no second
@@ -6605,11 +6631,14 @@ def create_mesh_app(
         # Session observability (Phase 1) — a retry continues the original
         # human-rooted session, so seed the contextvar with the original
         # task's trace_id (falling back to the inbound header) before the
-        # clone so ``store.create`` stamps the same correlation id.
+        # clone so ``store.create`` stamps the same correlation id. Set
+        # UNCONDITIONALLY + reset via token (precedence preserved: original's
+        # trace_id wins, else the inbound header, else None): a conditional
+        # set would leak a stale trace_id from a prior request into a retry
+        # whose original carried no trace and that arrived header-less.
         _retry_trace_id = original.get("trace_id") or request.headers.get("x-trace-id")
-        if _retry_trace_id:
-            from src.shared.trace import current_trace_id
-            current_trace_id.set(_retry_trace_id)
+        from src.shared.trace import current_trace_id
+        _trace_tok = current_trace_id.set(_retry_trace_id)
         try:
             clone = store.create(
                 creator=caller,
@@ -6627,6 +6656,8 @@ def create_mesh_app(
             # conversion as the /mesh/tasks POST path above.
             logger.error("tasks.retry store.create RuntimeError: %s", e)
             raise HTTPException(500, str(e))
+        finally:
+            current_trace_id.reset(_trace_tok)
         # Wake the (possibly new) assignee on the clone so the retry
         # starts immediately rather than waiting for a heartbeat.
         _try_wake_agent(

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -135,6 +135,110 @@ class TestCostTracking:
         assert models == []
 
 
+class TestTraceIdStamping:
+    """Session observability (Phase 1) — usage rows carry the active
+    per-turn ``trace_id`` from the contextvar, and the migration is
+    idempotent on a pre-existing (trace-less) DB.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "costs.db")
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+
+    def teardown_method(self):
+        self.tracker.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _trace_ids(self, agent: str) -> list:
+        rows = self.tracker.db.execute(
+            "SELECT trace_id FROM usage WHERE agent = ? ORDER BY id", (agent,)
+        ).fetchall()
+        return [r[0] for r in rows]
+
+    def test_track_stamps_active_trace_id(self):
+        from src.shared.trace import current_trace_id
+
+        token = current_trace_id.set("tr_abc123abc123")
+        try:
+            self.tracker.track("agent1", "openai/gpt-4o-mini", 100, 50)
+        finally:
+            current_trace_id.reset(token)
+        assert self._trace_ids("agent1") == ["tr_abc123abc123"]
+
+    def test_track_fixed_cost_stamps_active_trace_id(self):
+        from src.shared.trace import current_trace_id
+
+        token = current_trace_id.set("tr_fixed0000001")
+        try:
+            self.tracker.track_fixed_cost("agent1", "openai/dall-e-3", 0.04)
+        finally:
+            current_trace_id.reset(token)
+        assert self._trace_ids("agent1") == ["tr_fixed0000001"]
+
+    def test_track_without_trace_is_null(self):
+        # No active trace → NULL column, never an empty string.
+        from src.shared.trace import current_trace_id
+
+        assert current_trace_id.get() is None
+        self.tracker.track("agent1", "openai/gpt-4o-mini", 100, 50)
+        assert self._trace_ids("agent1") == [None]
+
+    def test_migration_idempotent_on_legacy_db(self):
+        """A pre-existing usage table without trace_id gets the column
+        added once; re-opening the same DB is a no-op (no duplicate ALTER).
+        """
+        import sqlite3
+
+        legacy_path = os.path.join(self._tmpdir, "legacy_costs.db")
+        # Build a legacy schema WITHOUT the trace_id column + seed a row.
+        conn = sqlite3.connect(legacy_path)
+        conn.executescript(
+            """
+            CREATE TABLE usage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent TEXT NOT NULL,
+                model TEXT NOT NULL,
+                prompt_tokens INTEGER DEFAULT 0,
+                completion_tokens INTEGER DEFAULT 0,
+                total_tokens INTEGER DEFAULT 0,
+                cost_usd REAL DEFAULT 0.0,
+                timestamp TEXT DEFAULT (datetime('now'))
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO usage (agent, model, total_tokens) VALUES (?, ?, ?)",
+            ("legacy", "openai/gpt-4o-mini", 100),
+        )
+        conn.commit()
+        conn.close()
+
+        # First open migrates: adds the nullable column, old row keeps NULL.
+        t1 = CostTracker(
+            db_path=legacy_path,
+            budgets_path=os.path.join(self._tmpdir, "legacy_budgets.json"),
+        )
+        cols = {r[1] for r in t1.db.execute("PRAGMA table_info(usage)").fetchall()}
+        assert "trace_id" in cols
+        old = t1.db.execute(
+            "SELECT trace_id FROM usage WHERE agent = 'legacy'"
+        ).fetchone()
+        assert old[0] is None
+        t1.close()
+
+        # Second open over the same file is a no-op (the introspection
+        # guard skips the ALTER) and does not raise.
+        t2 = CostTracker(
+            db_path=legacy_path,
+            budgets_path=os.path.join(self._tmpdir, "legacy_budgets.json"),
+        )
+        cols2 = {r[1] for r in t2.db.execute("PRAGMA table_info(usage)").fetchall()}
+        assert "trace_id" in cols2
+        t2.close()
+
+
 class TestBudgetEnforcement:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6016,3 +6016,59 @@ class TestAgentGoalsEndpoints:
             "/dashboard/api/agents/alpha/goals", json={"goals": ["x"]},
         )
         assert resp.status_code == 403
+
+
+class TestDashboardChatMintsTraceId:
+    """Session observability (Phase 1) — the dashboard chat entry points
+    mint a per-turn trace_id and forward it as the ``X-Trace-Id`` header
+    on the outbound agent call. Regression for the dashboard-untraceable
+    defect (server.py:3611 region) where trace_headers() ran without a
+    seeded contextvar and emitted an empty correlation id.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        # Capture the headers the dashboard forwards to the agent.
+        self._captured: dict = {}
+
+        async def _fake_request(agent_id, method, path, **kwargs):
+            self._captured["headers"] = kwargs.get("headers") or {}
+            self._captured["agent_id"] = agent_id
+            self._captured["path"] = path
+            return {"response": "ack"}
+
+        self.components["transport"].request = AsyncMock(side_effect=_fake_request)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_chat_forwards_minted_trace_id(self):
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "hi"},
+        )
+        assert resp.status_code == 200
+        hdrs = self._captured["headers"]
+        # The fix: a non-empty trace_id is minted and forwarded. Header
+        # keys can be either case; the trace module emits "X-Trace-Id".
+        trace_val = hdrs.get("X-Trace-Id") or hdrs.get("x-trace-id")
+        assert trace_val, f"expected X-Trace-Id header, got {hdrs!r}"
+        assert trace_val.startswith("tr_")
+        # Origin is still stamped human/dashboard alongside the trace.
+        origin_val = hdrs.get("X-Origin") or hdrs.get("x-origin")
+        assert origin_val and "dashboard" in origin_val
+
+    def test_two_chats_get_distinct_trace_ids(self):
+        self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "first"},
+        )
+        first = (self._captured["headers"].get("X-Trace-Id")
+                 or self._captured["headers"].get("x-trace-id"))
+        self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "second"},
+        )
+        second = (self._captured["headers"].get("X-Trace-Id")
+                  or self._captured["headers"].get("x-trace-id"))
+        assert first and second and first != second

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6072,3 +6072,32 @@ class TestDashboardChatMintsTraceId:
         second = (self._captured["headers"].get("X-Trace-Id")
                   or self._captured["headers"].get("x-trace-id"))
         assert first and second and first != second
+
+    def test_chat_trace_does_not_leak_into_broadcast(self):
+        """Sequential attribution: after a /chat mints + seeds a trace, a
+        /api/broadcast (which calls trace_headers() WITHOUT minting) forwards
+        no stale X-Trace-Id. The /chat endpoint resets the contextvar via
+        token in its finally.
+
+        Honesty note (mutation-verified): the dashboard router is mounted on
+        the mesh app, which runs requests under Starlette BaseHTTPMiddleware
+        — and the bare-FastAPI TestClient harness here also isolates the
+        per-request context. So removing the /chat reset does NOT actually
+        make this fail; the set+reset is defense-in-depth (explicit, not
+        reliant on the middleware). This test guards the
+        mint-here / no-mint-there attribution contract."""
+        self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "chat first"},
+        )
+        chat_trace = (self._captured["headers"].get("X-Trace-Id")
+                      or self._captured["headers"].get("x-trace-id"))
+        assert chat_trace and chat_trace.startswith("tr_")
+        # Broadcast does NOT mint a trace — it must carry no inherited one.
+        resp = self.client.post(
+            "/dashboard/api/broadcast", json={"message": "to everyone"},
+        )
+        assert resp.status_code == 200, resp.text
+        bc_trace = (self._captured["headers"].get("X-Trace-Id")
+                    or self._captured["headers"].get("x-trace-id"))
+        assert bc_trace != chat_trace
+        assert not bc_trace, f"broadcast leaked a stale trace_id: {bc_trace!r}"

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2278,3 +2278,174 @@ async def test_proxy_api_metered_call_still_reports_cost(tmp_path):
         assert data["cost_usd"] > 0.0
     finally:
         cleanup()
+
+
+# ── Session observability (Phase 1): X-Trace-Id seed → stamped usage row ──
+#
+# Store-level tests (test_costs.py::TestTraceIdStamping) already verify
+# ``CostTracker.track`` stamps ``trace_id`` when the contextvar is pre-set.
+# These close the end-to-end gap: the proxy endpoint must seed
+# ``current_trace_id`` from the inbound ``X-Trace-Id`` header so the cost
+# write fired *inside* ``execute_api_call`` / ``stream_llm`` — which run as
+# the same request task (non-stream) or a later-iterated streaming context
+# (stream) — observes it. If the seed (or, for streaming, the context copy
+# into the generator) regresses, the usage row silently gets a NULL
+# trace_id and the session can no longer be JOINed across stores.
+
+
+def _build_proxy_trace_app(tmp_path, *, streaming: bool):
+    """Build a mesh app wired to a REAL CostTracker behind a fake vault.
+
+    The fake vault mirrors production: its ``execute_api_call`` /
+    ``stream_llm`` call ``cost_tracker.track`` (which reads the trace
+    contextvar internally), so the row written reflects whatever trace the
+    endpoint seeded. Returns ``(app, tracker, cleanup)``; read back the
+    stamped trace via ``_usage_trace_ids(tracker)``.
+    """
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.shared.types import APIProxyResponse
+
+    tracker = CostTracker(
+        db_path=str(tmp_path / "costs.db"),
+        budgets_path=str(tmp_path / "budgets.json"),
+    )
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    perms.permissions["scout"] = AgentPermissions(
+        agent_id="scout", allowed_apis=["llm"],
+    )
+    router = MessageRouter(perms, {})
+    router.register_agent("scout", "http://scout:8400", [])
+
+    from unittest.mock import MagicMock
+
+    vault = MagicMock()
+    vault.is_model_compatible.return_value = (True, None)
+
+    if streaming:
+        async def _fake_stream(api_request, agent_id=""):
+            # Mirror stream_llm: emit content chunks, then track() on the
+            # terminal 'done' frame. track() reads current_trace_id, which
+            # the endpoint must have seeded into this generator's context.
+            yield 'data: {"type": "delta", "content": "hi"}\n\n'
+            tracker.track(agent_id, "anthropic/claude-sonnet-4-6", 700, 300)
+            yield (
+                'data: {"type": "done", "model": "anthropic/claude-sonnet-4-6", '
+                '"tokens_used": 1000, "content": "hi"}\n\n'
+            )
+        vault.stream_llm = _fake_stream
+    else:
+        async def _fake_call(api_request, agent_id=""):
+            # Mirror execute_api_call's cost write: track() reads the
+            # contextvar the endpoint seeded from X-Trace-Id.
+            tracker.track(agent_id, "anthropic/claude-sonnet-4-6", 700, 300)
+            return APIProxyResponse(
+                success=True,
+                data={
+                    "content": "hi", "tokens_used": 1000,
+                    "input_tokens": 700, "output_tokens": 300,
+                    "model": "anthropic/claude-sonnet-4-6",
+                },
+            )
+        vault.execute_api_call = _fake_call
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        credential_vault=vault, cost_tracker=tracker,
+    )
+
+    def _cleanup():
+        tracker.close()
+        bb.close()
+
+    return app, tracker, _cleanup
+
+
+def _usage_trace_ids(tracker) -> list:
+    return [
+        r[0] for r in tracker.db.execute(
+            "SELECT trace_id FROM usage ORDER BY id"
+        ).fetchall()
+    ]
+
+
+async def _post_proxy(app, *, path: str, trace_id: str | None):
+    from httpx import ASGITransport, AsyncClient
+
+    headers = {} if trace_id is None else {"X-Trace-Id": trace_id}
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(
+            path,
+            params={"agent_id": "scout"},
+            json={
+                "service": "llm", "action": "chat",
+                "params": {
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            },
+            headers=headers,
+        )
+
+
+@pytest.mark.asyncio
+async def test_proxy_api_call_stamps_usage_trace_id_from_header(tmp_path):
+    """``POST /mesh/api`` with ``X-Trace-Id`` → the usage row written by the
+    cost tracker inside ``execute_api_call`` carries that trace_id."""
+    from src.shared.trace import current_trace_id
+
+    app, tracker, cleanup = _build_proxy_trace_app(tmp_path, streaming=False)
+    token = current_trace_id.set(None)
+    try:
+        resp = await _post_proxy(app, path="/mesh/api", trace_id="tr_proxy0000001")
+        assert resp.status_code == 200, resp.text
+        assert _usage_trace_ids(tracker) == ["tr_proxy0000001"]
+    finally:
+        current_trace_id.reset(token)
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_api_call_without_trace_id_usage_is_null(tmp_path):
+    """Negative guard: no ``X-Trace-Id`` → the usage row's trace_id is NULL."""
+    from src.shared.trace import current_trace_id
+
+    app, tracker, cleanup = _build_proxy_trace_app(tmp_path, streaming=False)
+    token = current_trace_id.set(None)
+    try:
+        resp = await _post_proxy(app, path="/mesh/api", trace_id=None)
+        assert resp.status_code == 200, resp.text
+        assert _usage_trace_ids(tracker) == [None]
+    finally:
+        current_trace_id.reset(token)
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_api_stream_stamps_usage_trace_id_from_header(tmp_path):
+    """FRAGILE PATH: ``POST /mesh/api/stream`` seeds the contextvar before
+    the SSE generator is created; the cost write fired inside the
+    later-iterated ``stream_llm`` generator must still see the seeded
+    trace. Guards the contextvar-survives-into-the-streaming-context
+    invariant the endpoint comment promises."""
+    from src.shared.trace import current_trace_id
+
+    app, tracker, cleanup = _build_proxy_trace_app(tmp_path, streaming=True)
+    token = current_trace_id.set(None)
+    try:
+        resp = await _post_proxy(
+            app, path="/mesh/api/stream", trace_id="tr_stream0000001",
+        )
+        assert resp.status_code == 200, resp.text
+        # Drain the SSE body so the generator (and its track() call) runs.
+        body = resp.text
+        assert '"type": "done"' in body
+        assert _usage_trace_ids(tracker) == ["tr_stream0000001"]
+    finally:
+        current_trace_id.reset(token)
+        cleanup()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2327,15 +2327,18 @@ def _build_proxy_trace_app(tmp_path, *, streaming: bool):
 
     if streaming:
         async def _fake_stream(api_request, agent_id=""):
-            # Mirror stream_llm: emit content chunks, then track() on the
-            # terminal 'done' frame. track() reads current_trace_id, which
-            # the endpoint must have seeded into this generator's context.
+            # Mirror production stream_llm ORDERING (credentials.py ~4194):
+            # emit content chunks, YIELD the terminal 'done' frame, THEN
+            # track(). track() reads current_trace_id, which the generator
+            # wrapper must keep seeded through the whole iteration (it fires
+            # AFTER 'done' is yielded, so an endpoint-level finally-reset
+            # would NULL it — the trap this ordering guards against).
             yield 'data: {"type": "delta", "content": "hi"}\n\n'
-            tracker.track(agent_id, "anthropic/claude-sonnet-4-6", 700, 300)
             yield (
                 'data: {"type": "done", "model": "anthropic/claude-sonnet-4-6", '
                 '"tokens_used": 1000, "content": "hi"}\n\n'
             )
+            tracker.track(agent_id, "anthropic/claude-sonnet-4-6", 700, 300)
         vault.stream_llm = _fake_stream
     else:
         async def _fake_call(api_request, agent_id=""):
@@ -2411,18 +2414,29 @@ async def test_proxy_api_call_stamps_usage_trace_id_from_header(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_proxy_api_call_without_trace_id_usage_is_null(tmp_path):
-    """Negative guard: no ``X-Trace-Id`` → the usage row's trace_id is NULL."""
-    from src.shared.trace import current_trace_id
+async def test_proxy_api_call_sequential_trace_attribution(tmp_path):
+    """Sequential attribution (non-stream): a request WITH ``X-Trace-Id``
+    followed by one WITHOUT, on the same app, stamp ``tr_first0000001`` then
+    NULL. No manual contextvar clearing — the second row's NULL is the
+    request-scoping contract, end-to-end.
 
+    Honesty note (mutation-verified): this asserts the *contract*, not the
+    raw leak. The mesh app installs Starlette ``@app.middleware("http")``
+    middlewares; ``BaseHTTPMiddleware`` runs each request in its OWN
+    contextvars context that does not propagate back, so even the pre-fix
+    conditional set could not bleed across requests here. The unconditional
+    set + token reset is therefore defense-in-depth: it makes attribution
+    explicit and independent of that middleware detail. Reverting the reset
+    does NOT fail this test (the harness isolates the context regardless) —
+    so this is a contract regression guard, not a leak trap."""
     app, tracker, cleanup = _build_proxy_trace_app(tmp_path, streaming=False)
-    token = current_trace_id.set(None)
     try:
-        resp = await _post_proxy(app, path="/mesh/api", trace_id=None)
-        assert resp.status_code == 200, resp.text
-        assert _usage_trace_ids(tracker) == [None]
+        r1 = await _post_proxy(app, path="/mesh/api", trace_id="tr_first0000001")
+        assert r1.status_code == 200, r1.text
+        r2 = await _post_proxy(app, path="/mesh/api", trace_id=None)
+        assert r2.status_code == 200, r2.text
+        assert _usage_trace_ids(tracker) == ["tr_first0000001", None]
     finally:
-        current_trace_id.reset(token)
         cleanup()
 
 
@@ -2448,4 +2462,30 @@ async def test_proxy_api_stream_stamps_usage_trace_id_from_header(tmp_path):
         assert _usage_trace_ids(tracker) == ["tr_stream0000001"]
     finally:
         current_trace_id.reset(token)
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_api_stream_sequential_trace_attribution(tmp_path):
+    """Sequential attribution (stream): a streamed request WITH ``X-Trace-Id``
+    followed by one WITHOUT stamp ``tr_first0000001`` then NULL. The generator
+    owns the contextvar (set on entry / reset on exit), so the SECOND stream's
+    late track() (fired AFTER the 'done' frame) sees its OWN value, not the
+    first's. Same honesty caveat as the non-stream sibling: BaseHTTPMiddleware
+    isolates the per-request context (incl. the streaming body), so this is a
+    contract guard, not a raw-leak trap (mutation-verified: removing the
+    generator reset does not fail it). The generator-owned set+reset is still
+    required for the late track() to see the RIGHT value at all."""
+    app, tracker, cleanup = _build_proxy_trace_app(tmp_path, streaming=True)
+    try:
+        r1 = await _post_proxy(
+            app, path="/mesh/api/stream", trace_id="tr_first0000001",
+        )
+        assert r1.status_code == 200, r1.text
+        assert '"type": "done"' in r1.text  # drain so track() fires
+        r2 = await _post_proxy(app, path="/mesh/api/stream", trace_id=None)
+        assert r2.status_code == 200, r2.text
+        assert '"type": "done"' in r2.text
+        assert _usage_trace_ids(tracker) == ["tr_first0000001", None]
+    finally:
         cleanup()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -951,6 +951,124 @@ def test_row_to_dict_exposes_new_fields_default_null(tmp_path):
     assert rec["previous_task_id"] is None
 
 
+# ── Session observability (Phase 1) — trace_id stamping ───────────
+
+
+def test_trace_id_column_exists_after_init(tmp_path):
+    t = _make_store(tmp_path)
+    with t._conn() as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+    assert "trace_id" in cols
+
+
+def test_create_stamps_active_trace_id(tmp_path):
+    """create() reads the contextvar at write time and persists it."""
+    from src.shared.trace import current_trace_id
+
+    t = _make_store(tmp_path)
+    token = current_trace_id.set("tr_task00000001")
+    try:
+        rec = t.create(creator="scout", assignee="analyst", title="dig")
+    finally:
+        current_trace_id.reset(token)
+    assert rec["trace_id"] == "tr_task00000001"
+    # And it round-trips through get().
+    assert t.get(rec["id"])["trace_id"] == "tr_task00000001"
+
+
+def test_create_without_trace_is_null(tmp_path):
+    from src.shared.trace import current_trace_id
+
+    assert current_trace_id.get() is None
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    assert rec["trace_id"] is None
+
+
+def test_rework_inherits_original_trace_id(tmp_path):
+    """A rework continues the same session — it inherits the parent's
+    trace_id regardless of whether a trace is active at rework time.
+    """
+    from src.shared.trace import current_trace_id
+
+    t = _make_store(tmp_path)
+    token = current_trace_id.set("tr_session00001")
+    try:
+        rec = t.create(creator="scout", assignee="analyst", title="dig")
+    finally:
+        current_trace_id.reset(token)
+    # No active trace when the rework is spawned — inheritance must still
+    # carry the original session's id.
+    assert current_trace_id.get() is None
+    rework = t.create_rework_task(rec["id"], "go deeper on the legal angle")
+    assert rework["trace_id"] == "tr_session00001"
+
+
+def test_trace_id_migration_idempotent_on_legacy_db(tmp_path):
+    """A pre-existing tasks DB without trace_id gets the column added once;
+    re-opening the same file is a no-op and existing rows keep NULL.
+    """
+    import sqlite3
+
+    db_path = str(tmp_path / "legacy_tasks.db")
+    # Minimal legacy schema WITHOUT trace_id + a seeded row.
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            team_id TEXT,
+            parent_task_id TEXT,
+            title TEXT NOT NULL,
+            description TEXT,
+            creator TEXT NOT NULL,
+            assignee TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            priority INTEGER NOT NULL DEFAULT 0,
+            dependencies_json TEXT,
+            artifact_refs_json TEXT,
+            blocker_note TEXT,
+            origin_kind TEXT,
+            origin_channel TEXT,
+            origin_user TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            completed_at REAL,
+            retention_until REAL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks (id, title, creator, assignee, created_at, updated_at) "
+        "VALUES ('task_legacy01', 'old', 'scout', 'analyst', 1.0, 1.0)",
+    )
+    conn.commit()
+    conn.close()
+
+    # First open migrates (adds trace_id); old row keeps NULL.
+    t1 = Tasks(db_path=db_path)
+    legacy = t1.get("task_legacy01")
+    assert legacy is not None
+    assert legacy["trace_id"] is None
+    t1.close()
+
+    # Second open is a no-op — the introspection guard skips the ALTER.
+    t2 = Tasks(db_path=db_path)
+    with t2._conn() as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+    assert "trace_id" in cols
+    # New writes against the migrated DB stamp the active trace.
+    from src.shared.trace import current_trace_id
+
+    token = current_trace_id.set("tr_postmigrate1")
+    try:
+        new_rec = t2.create(creator="scout", assignee="analyst", title="fresh")
+    finally:
+        current_trace_id.reset(token)
+    assert new_rec["trace_id"] == "tr_postmigrate1"
+    t2.close()
+
+
 def test_set_outcome_happy_path_done(tmp_path):
     t = _make_store(tmp_path)
     rec = t.create(creator="scout", assignee="analyst", title="dig")

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1405,3 +1405,90 @@ async def test_task_run_aggregates_traces_in_window(tmp_path, monkeypatch):
         traces.close()
         monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
         importlib.reload(server_module)
+
+
+# ── Session observability (Phase 1): X-Trace-Id seed → stamped task row ──
+#
+# Store-level tests (test_orchestration.py) already verify ``Tasks.create``
+# stamps ``trace_id`` when the contextvar is pre-set. These tests close the
+# end-to-end gap: the HTTP endpoint must seed ``current_trace_id`` from the
+# inbound ``X-Trace-Id`` header so the row the store writes carries the
+# originating per-turn trace. If that seed regresses, the row silently gets
+# a NULL trace_id (no crash) and sessions can no longer be JOINed.
+
+
+@pytest.mark.asyncio
+async def test_create_task_stamps_trace_id_from_header(v2_app):
+    """``POST /mesh/tasks`` with ``X-Trace-Id`` → the created task row's
+    ``trace_id`` equals the header value (endpoint → contextvar → store
+    → row chain)."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "traced handoff"},
+            headers={"X-Agent-ID": "scout", "X-Trace-Id": "tr_test00000001"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["trace_id"] == "tr_test00000001"
+
+
+@pytest.mark.asyncio
+async def test_create_task_without_trace_id_is_null(v2_app):
+    """Negative guard: no ``X-Trace-Id`` header → the row's ``trace_id``
+    stays NULL (the seed must be header-driven, never invented)."""
+    from src.shared.trace import current_trace_id
+
+    app, _, _ = v2_app
+    # ASGITransport runs the endpoint in the test's own task context, so a
+    # trace set by an earlier request could otherwise bleed in — reset to
+    # the genuine "no active trace" state this guard is asserting about.
+    token = current_trace_id.set(None)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/tasks",
+                json={"assignee": "analyst", "title": "untraced handoff"},
+                headers={"X-Agent-ID": "scout"},
+            )
+    finally:
+        current_trace_id.reset(token)
+    assert r.status_code == 200, r.text
+    assert r.json()["trace_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_retry_clone_inherits_original_trace_id(v2_app):
+    """``POST /mesh/tasks/{id}/retry`` clones the failed task into a fresh
+    pending one that continues the SAME session — the clone must inherit
+    the original's ``trace_id`` even when the retry request itself carries
+    no header (the endpoint seeds from ``original.get('trace_id')``)."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Create the original WITH a trace, then drive it to failed.
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "retry target"},
+            headers={"X-Agent-ID": "scout", "X-Trace-Id": "tr_retry0000001"},
+        )
+        assert r.status_code == 200, r.text
+        tid = r.json()["id"]
+        assert r.json()["trace_id"] == "tr_retry0000001"
+        for status in ("working", "failed"):
+            r = await c.post(
+                f"/mesh/tasks/{tid}/status",
+                json={"status": status},
+                headers={"X-Agent-ID": "analyst"},
+            )
+            assert r.status_code == 200, r.text
+        # Retry as operator, deliberately WITHOUT an X-Trace-Id header —
+        # the clone must still inherit the original's trace.
+        r = await c.post(
+            f"/mesh/tasks/{tid}/retry",
+            json={},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        clone = r.json()["clone"]
+        assert clone["id"] != tid
+        assert clone["trace_id"] == "tr_retry0000001"

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1434,27 +1434,36 @@ async def test_create_task_stamps_trace_id_from_header(v2_app):
 
 
 @pytest.mark.asyncio
-async def test_create_task_without_trace_id_is_null(v2_app):
-    """Negative guard: no ``X-Trace-Id`` header → the row's ``trace_id``
-    stays NULL (the seed must be header-driven, never invented)."""
-    from src.shared.trace import current_trace_id
+async def test_create_task_sequential_trace_attribution(v2_app):
+    """Sequential attribution: a ``POST /mesh/tasks`` WITH ``X-Trace-Id``
+    followed by one WITHOUT stamp the first's trace then NULL. No manual
+    contextvar clearing — the second row's NULL is the request-scoping
+    contract end-to-end (the old negative test had to ``set(None)`` by hand,
+    which masked whatever the real per-request behavior was).
 
+    Honesty note (mutation-verified): the mesh app's Starlette
+    ``BaseHTTPMiddleware`` isolates contextvars per request, so even a
+    conditional set + no reset could not actually bleed across requests here
+    — reverting the reset does NOT fail this test. The unconditional set +
+    token reset in the endpoint is defense-in-depth (explicit request-scoping
+    that does not depend on the middleware), and this test guards the
+    attribution contract rather than trapping a raw leak."""
     app, _, _ = v2_app
-    # ASGITransport runs the endpoint in the test's own task context, so a
-    # trace set by an earlier request could otherwise bleed in — reset to
-    # the genuine "no active trace" state this guard is asserting about.
-    token = current_trace_id.set(None)
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
-            r = await c.post(
-                "/mesh/tasks",
-                json={"assignee": "analyst", "title": "untraced handoff"},
-                headers={"X-Agent-ID": "scout"},
-            )
-    finally:
-        current_trace_id.reset(token)
-    assert r.status_code == 200, r.text
-    assert r.json()["trace_id"] is None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r1 = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "traced handoff"},
+            headers={"X-Agent-ID": "scout", "X-Trace-Id": "tr_first0000001"},
+        )
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["trace_id"] == "tr_first0000001"
+        r2 = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "untraced handoff"},
+            headers={"X-Agent-ID": "scout"},
+        )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["trace_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -907,6 +907,28 @@ class TestChatTranscript:
         msgs = self.ws.load_chat_transcript()
         assert "tools" not in msgs[0]
 
+    def test_trace_id_stamped_from_contextvar(self):
+        """Session observability (Phase 1): an active per-turn trace_id is
+        written onto the transcript row.
+        """
+        from src.shared.trace import current_trace_id
+
+        token = current_trace_id.set("tr_chat00000001")
+        try:
+            self.ws.append_chat_message("user", "Hello")
+        finally:
+            current_trace_id.reset(token)
+        msgs = self.ws.load_chat_transcript()
+        assert msgs[0]["trace_id"] == "tr_chat00000001"
+
+    def test_trace_id_omitted_when_no_active_trace(self):
+        from src.shared.trace import current_trace_id
+
+        assert current_trace_id.get() is None
+        self.ws.append_chat_message("user", "Hello")
+        msgs = self.ws.load_chat_transcript()
+        assert "trace_id" not in msgs[0]
+
     def test_notification_role(self):
         self.ws.append_chat_message("notification", "Task complete")
         msgs = self.ws.load_chat_transcript()


### PR DESCRIPTION
## Phase 1 of 4 — Session Observability

Plan: `docs/plans/2026-06-18-session-observability.md` (#1147). This is **Phase 1 of 4**; it does NOT implement the central intent store (P2), the reader command (P3), agent-side trace events, or log-formatter changes (P4).

### Problem
Every human-rooted interaction should be joinable across stores by ONE key — the per-turn `trace_id` (`tr_<hex12>`). Two gaps blocked that:
1. **The dashboard (primary UI) minted no `trace_id`.** Its `/chat` + `/chat/stream` called `trace_headers()` without first seeding the contextvar, so the outbound agent call carried an empty `X-Trace-Id` and every dashboard session produced uncorrelatable LLM traces. A genuine defect for every operator.
2. **No common key across stores.** `tasks`, `usage` (costs), and chat transcripts shared no `trace_id`, so a session could only be reconstructed by fuzzy timestamp+agent archaeology.

### What changed

**Entry points — mint `trace_id` where missing** (mirrors the CLI's `new_trace_id()` / `current_trace_id.set()`):
- `src/dashboard/server.py` — `/chat` + `/chat/stream` seed the contextvar **before** `trace_headers()`. Core defect fix.
- `src/cli/runtime.py` — `dispatch` / `async_dispatch` resolve the trace via a new `_resolve_dispatch_trace_id`: explicit arg wins → else the active contextvar (`Channel.dispatch` already sets it) → else a fresh mint. **Never clobbers an existing trace** (Constraint), and covers the webhook manager's direct dispatch.

**Stores — stamp `trace_id`** (additive, nullable columns; idempotent `ALTER`-if-missing migrations):
- `tasks` (`src/host/orchestration.py`) — new column + SELECT/`_row_to_dict`; `create()` reads the contextvar at write time; `create_rework_task` inherits the parent's `trace_id` (a rework continues the same session).
- `usage`/costs (`src/host/costs.py`) — new column + migration; `track()` + `track_fixed_cost()` stamp from the contextvar.
- chat transcript rows (`src/agent/workspace.py`) — `append_chat_message` stamps from the agent's contextvar (omitted when no trace is active, so legacy readers are unaffected).

### Propagation chain (and the links I had to fix so the columns actually populate)
```
dashboard mints + sets contextvar
  → trace_headers() → X-Trace-Id on the direct agent call
    → agent server.py /chat|/chat/stream seed current_trace_id from the header
      → loop.chat sets it → append_chat_message stamps the transcript row
      → agent LLM calls (llm.py trace_headers()) carry X-Trace-Id back to the mesh
        → mesh LLM proxy (proxy_api_call / proxy_api_stream) NOW seed current_trace_id
          from the inbound header → CostTracker.track() stamps the usage row   [FIXED]
    → agent hand_off / create_task → mesh POST /mesh/tasks NOW seeds current_trace_id
      from the header → Tasks.create() stamps the task row                      [FIXED]
    → mesh POST /mesh/tasks/{id}/retry seeds from the original task's trace_id   [FIXED]
```
The two `track()` sites and the task-create/retry endpoints did not previously seed the contextvar, so without these fixes the new columns would have been NULL for dashboard-originated sessions. All links now populate; nothing was left unpopulatable.

### Migration safety
Every new column is **nullable** and added via `ALTER TABLE ADD COLUMN` guarded by a `PRAGMA table_info` introspection check (the existing repo pattern). Re-running is a no-op; pre-existing prod rows keep `NULL`. Verified by an idempotency test that builds a legacy trace-less DB, opens it twice, and asserts the old row stays NULL.

### Tests
New coverage:
- `tests/test_costs.py` — `track` / `track_fixed_cost` stamp the active trace; NULL when none; **migration idempotent on a legacy DB**.
- `tests/test_orchestration.py` — column exists; `create` stamps; rework inherits; NULL when none; **migration idempotent on a legacy DB**.
- `tests/test_workspace.py` — transcript row stamped from the contextvar; omitted when no trace.
- `tests/test_dashboard.py` — chat entry **mints + forwards a non-empty `X-Trace-Id`**, and two chats get distinct ids.

Results (run from the worktree with the main venv interpreter + `PYTHONPATH` pinned to the worktree):
- Targeted (costs/orchestration/workspace/chat_workspace/dashboard): **744 passed**.
- Full fast suite (CI parity, e2e excluded): **7616 passed, 20 skipped, 0 failed**.
- `ruff check src/ tests/`: clean.

Do not merge — leaving for CI + human review.