### PR TITLE
feat(observability): phase 2 — central verbatim intent capture (IntentStore)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -162,6 +162,7 @@ class RuntimeContext:
         self.channel_manager = None
         self.event_bus = None
         self.trace_store = None
+        self.intent_store = None
         self.agent_urls: dict[str, str] = {}
         self._dispatch_loop = None
         # Post-completion verification wakes (success path) — sliding
@@ -213,6 +214,8 @@ class RuntimeContext:
             self.cost_tracker.close()
         if self.trace_store:
             self.trace_store.close()
+        if self.intent_store:
+            self.intent_store.close()
         if self.pubsub:
             self.pubsub.close()
         if self.blackboard:
@@ -392,6 +395,15 @@ class RuntimeContext:
             _trace_retention = 168
         self.trace_store = TraceStore(
             max_age_hours=_trace_retention if _trace_retention > 0 else None
+        )
+        # Durable verbatim-intent store (Phase 2, session observability).
+        # Captures the FULL inbound message centrally, keyed by trace_id +
+        # origin, so intent survives container wipes / resets / deploys
+        # (container-local chat_transcript.jsonl rotates and dies with the
+        # container). Append-only with a 90-day time-based GC.
+        from src.host.intent import IntentStore
+        self.intent_store = IntentStore(
+            db_path=os.environ.get("OPENLEGION_INTENT_DB", "data/intent.db")
         )
         self.blackboard = Blackboard(event_bus=self.event_bus)
         self.pubsub = PubSub(db_path="pubsub.db")
@@ -830,6 +842,26 @@ class RuntimeContext:
                     event_type="chat", detail=message[:200],
                     meta={"message_length": len(message)},
                 )
+            # Phase 2 (session observability): capture the FULL verbatim
+            # message centrally and durably, keyed by trace_id + origin, so
+            # intent survives container wipes / resets / deploys. Best-effort
+            # — a store failure must NEVER break dispatch. Redaction happens
+            # at storage inside IntentStore.record. Webhooks are machine
+            # origin (system_note / kind=system) — still captured, stamped
+            # with origin_kind so the reader can tell human from machine.
+            if self.intent_store is not None:
+                try:
+                    self.intent_store.record(
+                        trace_id=tid,
+                        origin_kind=(origin.kind if origin else ""),
+                        origin_channel=(origin.channel if origin else ""),
+                        origin_user=(origin.user if origin else ""),
+                        agent=agent_name,
+                        message=message,
+                        meta={"system_note": system_note},
+                    )
+                except Exception as _intent_err:
+                    logger.debug("intent capture failed: %s", _intent_err)
             import time as _time
             t0 = _time.time()
             extra_headers: dict[str, str] = {"x-trace-id": tid}
@@ -1396,6 +1428,7 @@ class RuntimeContext:
             self.transport,
             auth_tokens=self.runtime.auth_tokens,
             trace_store=self.trace_store,
+            intent_store=self.intent_store,
             event_bus=self.event_bus,
             health_monitor=self.health_monitor,
             cost_tracker=self.cost_tracker,

--- a/src/host/intent.py
+++ b/src/host/intent.py
@@ -1,0 +1,177 @@
+"""IntentStore — SQLite append-only store for verbatim inbound messages.
+
+Persists the FULL verbatim inbound message centrally, keyed by ``trace_id``
+plus the originating ``MessageOrigin`` (kind/channel/user), so that *intent*
+— what the human actually typed — survives container wipes, ``/chat/reset``,
+and deploys. Today the user's words live only in container-local
+``chat_transcript.jsonl`` (``src/agent/workspace.py``), which rotates (drops
+the oldest half) and dies with the container; central stores keep only a
+normalized task title and a short redacted preview. This store is the durable
+intent layer that makes hosted-VPS reconstruction trustworthy after a deploy
+(Phase 2 of docs/plans/2026-06-18-session-observability.md).
+
+Follows the same SQLite-WAL pattern as ``TraceStore`` (``src/host/traces.py``).
+Intent is append-only like traces — there is no per-row lifecycle terminal to
+anchor a ``retention_until`` against (unlike ``tasks``, where reaping keys off a
+terminal status), so retention is a TraceStore-style throttled time-based GC,
+not a tasks-style ``retention_until`` reaper. Default window is 90 days, which
+matches the session/forensic semantics (vs. traces' shorter rolling window).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from src.shared.redaction import deep_redact, redact_text_with_urls
+from src.shared.sqlite_helpers import open_db
+from src.shared.utils import dumps_safe, setup_logging
+
+logger = setup_logging("host.intent")
+
+
+class IntentStore:
+    """SQLite-backed append-only store for verbatim inbound messages."""
+
+    def __init__(self, db_path: str = "data/intent.db", max_age_hours: int | None = 24 * 90):
+        self.max_age_hours = max_age_hours
+        # ensure first GC runs regardless of monotonic() epoch
+        self._last_age_gc: float = -300.0
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = open_db(db_path, busy_timeout_ms=5000)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS intent (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                trace_id       TEXT NOT NULL,
+                timestamp      REAL NOT NULL,
+                origin_kind    TEXT NOT NULL DEFAULT '',
+                origin_channel TEXT NOT NULL DEFAULT '',
+                origin_user    TEXT NOT NULL DEFAULT '',
+                agent          TEXT NOT NULL DEFAULT '',
+                message        TEXT NOT NULL DEFAULT '',
+                meta_json      TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_intent_trace_id ON intent (trace_id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_intent_timestamp ON intent (timestamp)"
+        )
+        self._conn.commit()
+
+    def record(
+        self,
+        *,
+        trace_id: str,
+        origin_kind: str = "",
+        origin_channel: str = "",
+        origin_user: str = "",
+        agent: str = "",
+        message: str = "",
+        meta: dict | None = None,
+    ) -> None:
+        """Insert a verbatim-intent row.
+
+        The verbatim ``message`` and every string inside ``meta`` are redacted
+        at capture so a credential or URL with sensitive query params pasted in
+        chat is never persisted in plaintext (H16). Redaction is centralized
+        here rather than at the dispatch callsite so no path can regress.
+        ``sanitize_for_prompt`` is already applied upstream at every surface;
+        this is the additional at-storage layer.
+        """
+        message = redact_text_with_urls(message or "")
+        meta_json = dumps_safe(deep_redact(meta)) if meta else ""
+        self._conn.execute(
+            "INSERT INTO intent "
+            "(trace_id, timestamp, origin_kind, origin_channel, origin_user, agent, message, meta_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                trace_id, time.time(), origin_kind, origin_channel,
+                origin_user, agent, message, meta_json,
+            ),
+        )
+        self._conn.commit()
+        self._maybe_gc_old()
+
+    def _maybe_gc_old(self) -> None:
+        """Remove rows older than max_age_hours, throttled to once per 5 minutes.
+
+        Time-based GC (mirrors ``TraceStore._maybe_gc_old``) rather than a
+        tasks-style ``retention_until`` + reaper: intent is append-only with no
+        terminal lifecycle status to anchor a per-row retention deadline.
+        """
+        if self.max_age_hours is None:
+            return
+        now = time.monotonic()
+        if now - self._last_age_gc < 300:
+            return
+        self._last_age_gc = now
+        cutoff = time.time() - (self.max_age_hours * 3600)
+        self._conn.execute("DELETE FROM intent WHERE timestamp < ?", (cutoff,))
+        self._conn.commit()
+
+    def _row_to_dict(self, row: tuple) -> dict:
+        """Convert a query row to an intent dict."""
+        meta_json = row[7] if len(row) > 7 else ""
+        meta = json.loads(meta_json) if meta_json else {}
+        return {
+            "trace_id": row[0],
+            "timestamp": row[1],
+            "origin_kind": row[2],
+            "origin_channel": row[3],
+            "origin_user": row[4],
+            "agent": row[5],
+            "message": row[6],
+            "meta": meta,
+        }
+
+    _INTENT_COLS = (
+        "trace_id, timestamp, origin_kind, origin_channel, "
+        "origin_user, agent, message, meta_json"
+    )
+
+    def get_by_trace(self, trace_id: str) -> list[dict]:
+        """Return all intent rows for a trace_id, ordered by time."""
+        cur = self._conn.execute(
+            f"SELECT {self._INTENT_COLS} FROM intent WHERE trace_id = ? ORDER BY id",
+            (trace_id,),
+        )
+        return [self._row_to_dict(row) for row in cur.fetchall()]
+
+    def list_recent(
+        self,
+        *,
+        since: float | None = None,
+        user: str | None = None,
+        agent: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Return recent intent rows (newest first), with optional filters.
+
+        Built for Phase 3's ``sessions --since`` reader.
+        """
+        conditions = []
+        params: list = []
+        if since is not None:
+            conditions.append("timestamp >= ?")
+            params.append(since)
+        if user is not None:
+            conditions.append("origin_user = ?")
+            params.append(user)
+        if agent is not None:
+            conditions.append("agent = ?")
+            params.append(agent)
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.append(max(1, min(limit, 1000)))
+        cur = self._conn.execute(
+            f"SELECT {self._INTENT_COLS} FROM intent{where} ORDER BY id DESC LIMIT ?",
+            params,
+        )
+        return [self._row_to_dict(row) for row in cur.fetchall()]
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -283,6 +283,7 @@ if TYPE_CHECKING:
     from src.host.credentials import CredentialVault
     from src.host.cron import CronScheduler
     from src.host.health import HealthMonitor
+    from src.host.intent import IntentStore
     from src.host.lanes import LaneManager
     from src.host.mcp_gateway import MCPGateway
     from src.host.mesh import Blackboard, MessageRouter, PubSub
@@ -764,6 +765,7 @@ def create_mesh_app(
     transport: Transport | None = None,
     auth_tokens: dict[str, str] | None = None,
     trace_store: TraceStore | None = None,
+    intent_store: "IntentStore | None" = None,
     event_bus: EventBus | None = None,
     health_monitor: HealthMonitor | None = None,
     cost_tracker: CostTracker | None = None,
@@ -892,6 +894,11 @@ def create_mesh_app(
         db_path=_summaries_db_path, event_bus=event_bus,
     )
     app.summaries_store = summaries_store  # exposed for tests/dashboard
+
+    # Durable verbatim-intent store (Phase 2, session observability).
+    # Instantiated in cli/runtime and passed in; attached here so the
+    # Phase 3 read endpoints / reader can reach it off the app.
+    app.intent_store = intent_store  # exposed for tests/Phase 3 reader
 
     # Observation log of agent→user notifications. NOT a message channel:
     # agents call ``notify_user`` (intent: tell the human) and the mesh

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,214 @@
+"""Tests for IntentStore + verbatim-intent capture wiring at _direct_dispatch.
+
+Phase 2 of docs/plans/2026-06-18-session-observability.md: the verbatim
+inbound message is persisted centrally (keyed by trace_id + MessageOrigin),
+redacted at storage, so intent survives container wipes / resets / deploys.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.host.intent import IntentStore
+from src.shared.types import MessageOrigin
+
+# ── IntentStore ──────────────────────────────────────────────
+
+
+class TestIntentStore:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "intent.db")
+        self.store = IntentStore(db_path=self.db_path)
+
+    def teardown_method(self):
+        self.store.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_record_and_get_by_trace(self):
+        self.store.record(
+            trace_id="tr_abc", origin_kind="human", origin_channel="dashboard",
+            origin_user="u1", agent="alpha", message="build me a report",
+        )
+        self.store.record(
+            trace_id="tr_abc", origin_kind="human", origin_channel="dashboard",
+            origin_user="u1", agent="alpha", message="and email it",
+        )
+        rows = self.store.get_by_trace("tr_abc")
+        assert len(rows) == 2
+        assert rows[0]["trace_id"] == "tr_abc"
+        assert rows[0]["origin_kind"] == "human"
+        assert rows[0]["origin_channel"] == "dashboard"
+        assert rows[0]["origin_user"] == "u1"
+        assert rows[0]["agent"] == "alpha"
+        assert rows[0]["message"] == "build me a report"
+        # ordered by time
+        assert rows[1]["message"] == "and email it"
+
+    def test_get_by_trace_empty(self):
+        assert self.store.get_by_trace("tr_nope") == []
+
+    def test_full_message_not_truncated(self):
+        # Realistic prose (no long unbroken alnum blob that redaction would
+        # collapse) — assert the FULL message is stored, not a preview.
+        long_msg = ("please build a detailed quarterly report. " * 200).strip()
+        assert len(long_msg) > 4000
+        self.store.record(trace_id="tr_long", message=long_msg, agent="alpha")
+        rows = self.store.get_by_trace("tr_long")
+        assert rows[0]["message"] == long_msg
+
+    def test_list_recent_newest_first(self):
+        for i in range(3):
+            self.store.record(trace_id=f"tr_{i}", message=f"m{i}", agent="alpha")
+        rows = self.store.list_recent(limit=10)
+        assert [r["trace_id"] for r in rows] == ["tr_2", "tr_1", "tr_0"]
+
+    def test_list_recent_filter_since(self):
+        self.store.record(trace_id="tr_old", message="old", agent="alpha")
+        cut = time.time()
+        time.sleep(0.01)
+        self.store.record(trace_id="tr_new", message="new", agent="alpha")
+        rows = self.store.list_recent(since=cut)
+        assert [r["trace_id"] for r in rows] == ["tr_new"]
+
+    def test_list_recent_filter_user(self):
+        self.store.record(trace_id="tr_a", message="a", agent="alpha", origin_user="alice")
+        self.store.record(trace_id="tr_b", message="b", agent="alpha", origin_user="bob")
+        rows = self.store.list_recent(user="alice")
+        assert [r["trace_id"] for r in rows] == ["tr_a"]
+
+    def test_list_recent_filter_agent(self):
+        self.store.record(trace_id="tr_a", message="a", agent="alpha")
+        self.store.record(trace_id="tr_b", message="b", agent="beta")
+        rows = self.store.list_recent(agent="beta")
+        assert [r["trace_id"] for r in rows] == ["tr_b"]
+
+    def test_redaction_at_storage(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(trace_id="tr_sec", message=f"my key is {secret}", agent="alpha")
+        # raw SQLite bytes must not contain the secret
+        raw = self.store._conn.execute(
+            "SELECT message FROM intent WHERE trace_id = ?", ("tr_sec",)
+        ).fetchone()[0]
+        assert secret not in raw
+        assert "[REDACTED]" in raw
+        rows = self.store.get_by_trace("tr_sec")
+        assert secret not in rows[0]["message"]
+
+    def test_meta_redacted_at_storage(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(
+            trace_id="tr_meta", message="hi", agent="alpha",
+            meta={"note": f"creds {secret}", "system_note": False},
+        )
+        raw = self.store._conn.execute(
+            "SELECT meta_json FROM intent WHERE trace_id = ?", ("tr_meta",)
+        ).fetchone()[0]
+        assert secret not in raw
+        rows = self.store.get_by_trace("tr_meta")
+        assert secret not in rows[0]["meta"]["note"]
+
+    def test_time_based_gc_drops_old_rows(self):
+        store = IntentStore(
+            db_path=os.path.join(self._tmpdir, "gc.db"), max_age_hours=1,
+        )
+        try:
+            # Insert an ancient row directly, bypassing the GC throttle.
+            store._conn.execute(
+                "INSERT INTO intent (trace_id, timestamp, message) VALUES (?, ?, ?)",
+                ("tr_ancient", time.time() - 7200, "old"),
+            )
+            store._conn.commit()
+            assert store.get_by_trace("tr_ancient")
+            # Force GC to run (reset throttle), then a fresh record triggers it.
+            store._last_age_gc = -300.0
+            store.record(trace_id="tr_fresh", message="new", agent="alpha")
+            assert store.get_by_trace("tr_ancient") == []
+            assert store.get_by_trace("tr_fresh")
+        finally:
+            store.close()
+
+    def test_idempotent_schema_init(self):
+        # Re-open the same DB; CREATE TABLE/INDEX IF NOT EXISTS must not raise.
+        self.store.record(trace_id="tr_x", message="hi", agent="alpha")
+        self.store.close()
+        store2 = IntentStore(db_path=self.db_path)
+        try:
+            assert store2.get_by_trace("tr_x")
+            store2.record(trace_id="tr_y", message="yo", agent="alpha")
+            assert store2.get_by_trace("tr_y")
+        finally:
+            self.store = store2  # so teardown closes it
+
+
+# ── Capture wiring at _direct_dispatch ───────────────────────
+
+
+def _dispatch_with_intent(monkeypatch, intent_store, *, response="done"):
+    """Build the real ``_direct_dispatch`` closure via test_runtime's proven
+    harness, then attach our intent-store mock and a stubbed transport reply.
+    Returns ``(dispatch_fn, ctx, transport_mock)``."""
+    from tests.test_runtime import _capture_dispatch_fn
+
+    dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+    ctx.intent_store = intent_store
+    transport.request = AsyncMock(return_value={"response": response})
+    return dispatch_fn, ctx, transport
+
+
+@pytest.mark.asyncio
+async def test_dispatch_captures_full_verbatim_intent(monkeypatch):
+    intent_store = MagicMock()
+    dispatch_fn, _ctx, _t = _dispatch_with_intent(monkeypatch, intent_store)
+
+    origin = MessageOrigin(kind="human", channel="dashboard", user="u9")
+    long_message = "please build a detailed quarterly report. " * 50
+    await dispatch_fn("alpha", long_message, origin=origin)
+
+    assert intent_store.record.called
+    kwargs = intent_store.record.call_args.kwargs
+    # FULL message, not truncated, with origin + agent stamped.
+    assert kwargs["message"] == long_message
+    assert kwargs["agent"] == "alpha"
+    assert kwargs["origin_kind"] == "human"
+    assert kwargs["origin_channel"] == "dashboard"
+    assert kwargs["origin_user"] == "u9"
+    assert kwargs["trace_id"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_capture_marks_system_note(monkeypatch):
+    intent_store = MagicMock()
+    dispatch_fn, _ctx, _t = _dispatch_with_intent(
+        monkeypatch, intent_store, response="ok",
+    )
+
+    # Webhook path: machine origin, no MessageOrigin object.
+    await dispatch_fn("alpha", "webhook fired", system_note=True)
+
+    kwargs = intent_store.record.call_args.kwargs
+    assert kwargs["meta"]["system_note"] is True
+    assert kwargs["origin_kind"] == ""  # no origin object
+    assert kwargs["origin_channel"] == ""
+    assert kwargs["origin_user"] == ""
+
+
+@pytest.mark.asyncio
+async def test_dispatch_survives_intent_store_failure(monkeypatch):
+    intent_store = MagicMock()
+    intent_store.record.side_effect = RuntimeError("disk full")
+    dispatch_fn, _ctx, _t = _dispatch_with_intent(
+        monkeypatch, intent_store, response="still works",
+    )
+
+    result = await dispatch_fn("alpha", "hi", origin=None)
+
+    # A failing intent store must NEVER break dispatch.
+    assert result == "still works"
+    assert intent_store.record.called

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1853,6 +1853,7 @@ def _capture_dispatch_fn(monkeypatch, *, app=None):
     transport_mock = AsyncMock()
     ctx.transport = transport_mock
     ctx.trace_store = None
+    ctx.intent_store = None
     ctx.event_bus = None
     ctx.health_monitor = None
     ctx._app = app


### PR DESCRIPTION
## What

Phase 2 of session observability: persist the **verbatim inbound message** centrally and durably, keyed by `trace_id` + `MessageOrigin`, so **intent** (what the human actually typed) survives container wipes, `/chat/reset`, and deploys.

Today the user's words live only in container-local `chat_transcript.jsonl`, which rotates (drops the oldest half), archives on `/chat/reset`, and dies with the container — exactly the layer most likely lost when you SSH a hosted box to investigate *after* a deploy. Central stores keep only a normalized task title and a short redacted preview. This phase gives intent a durable central home, making hosted-VPS reconstruction trustworthy post-deploy.

## Changes

- **New `IntentStore` (`src/host/intent.py`)** — mirrors the `TraceStore` SQLite-WAL idiom (append-only; `open_db` + `journal_mode=WAL` + `CREATE … IF NOT EXISTS` + indexes on `trace_id`/`timestamp`). Schema: `intent(id, trace_id, timestamp, origin_kind, origin_channel, origin_user, agent, message, meta_json)`. Readers: `get_by_trace(trace_id)` and `list_recent(since/user/agent/limit)` (built for Phase 3's `sessions --since`).
- **Redaction at storage** — `record()` runs `redact_text_with_urls` on the message and `deep_redact` on meta *inside* the insert method (mirrors `TraceStore.record`, rationale tag H16), so a credential/URL pasted in chat never persists in plaintext and no callsite can regress. `sanitize_for_prompt` is already applied upstream; this is the additional at-storage layer.
- **Capture point: `_direct_dispatch`** — alongside the existing `trace_store.record(... detail=message[:200])`, writes the **FULL** verbatim message stamped with origin (`kind`/`channel`/`user`) and `agent`. Wrapped in best-effort `try/except` so a store failure **never** breaks dispatch. Captures all dispatched messages (human + agent + webhook); webhooks are machine origin (`system_note`) and stamped accordingly so the Phase 3 reader can tell human from machine triggers.
- **Wiring mirrors `trace_store`** — instantiated in `cli/runtime` `_create_components` (env `OPENLEGION_INTENT_DB` → `data/intent.db`), closed in shutdown, passed into `create_mesh_app`, attached as `app.intent_store` for the Phase 3 reader.

## Retention choice

A TraceStore-style throttled **time-based GC** (90-day window), **not** a tasks-style `retention_until` + reaper: intent is append-only with no terminal lifecycle status to anchor a per-row retention deadline. Documented in code.

## Tests

`tests/test_intent.py` (new) — store round-trip, `list_recent` filters (since/user/agent), redaction-at-storage (secret in message + meta never persists raw), time-based GC drops old rows, idempotent schema init, full-message-not-truncated; plus capture-wiring tests (full verbatim message + origin + agent land on a dispatch; `system_note` marked for webhooks; failing store does not break dispatch). The capture tests reuse `test_runtime.py`'s proven `_capture_dispatch_fn` harness (extended with `intent_store=None`).

Results (run in subagents per repo convention; summary line authoritative):
- `tests/test_intent.py`: **14 passed**
- `tests/test_runtime.py tests/test_lanes.py tests/test_traces.py`: **260 passed**
- Full suite (e2e deselected): **7597 passed, 20 skipped, 66 deselected**
- `ruff check` on changed files: clean.

Additive only; no behavior change to dispatch beyond the new best-effort write.

Phase 2 of 4. Plan: `docs/plans/2026-06-18-session-observability.md`