### PR TITLE
feat(observability): phase 3 — openlegion session/sessions reader

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -54,6 +54,12 @@ def _find_project_root() -> Path:
 
 
 PROJECT_ROOT = _find_project_root()
+# Canonical on-box data directory holding the SQLite stores (tasks.db,
+# traces.db, costs.db, intent.db, …). Historically DB paths were bare
+# strings (``data/<name>.db``) relative to CWD in runtime.py/server.py;
+# this constant makes the location resolvable for read-only tooling like
+# the session reader (``openlegion session``).
+DATA_DIR = PROJECT_ROOT / "data"
 ENV_FILE = PROJECT_ROOT / ".env"
 CONFIG_FILE = PROJECT_ROOT / "config" / "mesh.yaml"
 AGENTS_FILE = PROJECT_ROOT / "config" / "agents.yaml"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -756,6 +756,68 @@ def tasks_cmd(agent, team, status, port, as_json):
         )
 
 
+# ── Session observability — read-only forensic reader (Phase 3) ──
+#
+# Unlike sibling read commands these do NOT go through the mesh HTTP API
+# (``_mesh_get``). They open the on-box SQLite stores read-only so the reader
+# works even when the mesh is down or wedged — exactly when you debug. See
+# src/cli/session_reader.py for the read-only-direct-SQLite rationale.
+
+
+@cli.command("session")
+@click.argument("trace_id")
+@click.option(
+    "--data-dir", "data_dir", default=None,
+    help="Path to the on-box data dir holding the SQLite stores (default: ./data)",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def session_cmd(trace_id: str, data_dir: str | None, as_json: bool):
+    """Reconstruct one session's full timeline by trace_id (read-only).
+
+    Assembles intent + actions + task transitions + cost from the host SQLite
+    stores. Works even when the mesh is down. NOTE: per-turn chat transcript
+    text is container-local, so this host-side timeline does not include the
+    full conversation — only intent, traces, tasks, and costs.
+    """
+    from src.cli.session_reader import assemble_session, render_session
+
+    as_json = as_json or _json_mode
+    base = Path(data_dir) if data_dir else cli_config.DATA_DIR
+    session = assemble_session(base, trace_id)
+    if as_json:
+        click.echo(dumps_safe(session))
+        return
+    click.echo(render_session(session))
+
+
+@cli.command("sessions")
+@click.option("--since", default="7d", help="Window: today, Nh/Nd/Nm/Ns, or an ISO date (default: 7d)")
+@click.option("--user", default=None, help="Filter by originating user")
+@click.option("--agent", default=None, help="Filter by agent")
+@click.option("--limit", default=50, type=int, help="Max sessions to list")
+@click.option(
+    "--data-dir", "data_dir", default=None,
+    help="Path to the on-box data dir holding the SQLite stores (default: ./data)",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def sessions_cmd(since: str, user, agent, limit, data_dir, as_json):
+    """List recent sessions, one summary row each, to find a trace_id (read-only).
+
+    Driven off the intent store (the human-rooted index). NOTE: per-turn chat
+    transcript text is container-local and not part of this host-side listing.
+    """
+    from src.cli.session_reader import list_sessions, parse_since, render_sessions
+
+    as_json = as_json or _json_mode
+    base = Path(data_dir) if data_dir else cli_config.DATA_DIR
+    floor = parse_since(since)
+    summaries = list_sessions(base, since=floor, user=user, agent=agent, limit=limit)
+    if as_json:
+        click.echo(dumps_safe({"sessions": summaries}))
+        return
+    click.echo(render_sessions(summaries))
+
+
 @cli.command("pending")
 @click.option("--port", default=8420, type=int, help="Mesh host port")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -162,6 +162,7 @@ class RuntimeContext:
         self.channel_manager = None
         self.event_bus = None
         self.trace_store = None
+        self.intent_store = None
         self.agent_urls: dict[str, str] = {}
         self._dispatch_loop = None
         # Post-completion verification wakes (success path) — sliding
@@ -213,6 +214,8 @@ class RuntimeContext:
             self.cost_tracker.close()
         if self.trace_store:
             self.trace_store.close()
+        if self.intent_store:
+            self.intent_store.close()
         if self.pubsub:
             self.pubsub.close()
         if self.blackboard:
@@ -392,6 +395,15 @@ class RuntimeContext:
             _trace_retention = 168
         self.trace_store = TraceStore(
             max_age_hours=_trace_retention if _trace_retention > 0 else None
+        )
+        # Durable verbatim-intent store (Phase 2, session observability).
+        # Captures the FULL inbound message centrally, keyed by trace_id +
+        # origin, so intent survives container wipes / resets / deploys
+        # (container-local chat_transcript.jsonl rotates and dies with the
+        # container). Append-only with a 90-day time-based GC.
+        from src.host.intent import IntentStore
+        self.intent_store = IntentStore(
+            db_path=os.environ.get("OPENLEGION_INTENT_DB", "data/intent.db")
         )
         self.blackboard = Blackboard(event_bus=self.event_bus)
         self.pubsub = PubSub(db_path="pubsub.db")
@@ -830,6 +842,26 @@ class RuntimeContext:
                     event_type="chat", detail=message[:200],
                     meta={"message_length": len(message)},
                 )
+            # Phase 2 (session observability): capture the FULL verbatim
+            # message centrally and durably, keyed by trace_id + origin, so
+            # intent survives container wipes / resets / deploys. Best-effort
+            # — a store failure must NEVER break dispatch. Redaction happens
+            # at storage inside IntentStore.record. Webhooks are machine
+            # origin (system_note / kind=system) — still captured, stamped
+            # with origin_kind so the reader can tell human from machine.
+            if self.intent_store is not None:
+                try:
+                    self.intent_store.record(
+                        trace_id=tid,
+                        origin_kind=(origin.kind if origin else ""),
+                        origin_channel=(origin.channel if origin else ""),
+                        origin_user=(origin.user if origin else ""),
+                        agent=agent_name,
+                        message=message,
+                        meta={"system_note": system_note},
+                    )
+                except Exception as _intent_err:
+                    logger.debug("intent capture failed: %s", _intent_err)
             import time as _time
             t0 = _time.time()
             extra_headers: dict[str, str] = {"x-trace-id": tid}
@@ -1396,6 +1428,7 @@ class RuntimeContext:
             self.transport,
             auth_tokens=self.runtime.auth_tokens,
             trace_store=self.trace_store,
+            intent_store=self.intent_store,
             event_bus=self.event_bus,
             health_monitor=self.health_monitor,
             cost_tracker=self.cost_tracker,

--- a/src/cli/session_reader.py
+++ b/src/cli/session_reader.py
@@ -1,0 +1,452 @@
+"""Read-only session reconstruction reader (Phase 3 of session observability).
+
+This module assembles a *session* — a single human-rooted interaction — from
+the host-side SQLite stores so an engineer can answer "what happened in this
+session?" after the fact, typically over SSH on a hosted VPS.
+
+Design decisions (see docs/plans/2026-06-18-session-observability.md, Phase 3):
+
+* **Read host SQLite DIRECTLY, read-only.** Each DB is opened with
+  ``sqlite3.connect("file:<path>?mode=ro", uri=True)`` and queried with raw
+  ``SELECT``s. We deliberately do NOT instantiate the store classes
+  (IntentStore / TraceStore / Tasks / CostTracker): they open read-write and
+  may run GC / migrations on a prod DB. Read-only + raw SQL is the whole point
+  — the reader must work *even when the mesh is down* (forensics happen exactly
+  then) and must never mutate prod data.
+
+  This couples the reader to the on-disk schema of those stores. That coupling
+  is acceptable and intentional: the alternative (going through the live store
+  classes or the mesh HTTP API) sacrifices the down-mesh and never-mutate
+  guarantees that are the reason this tool exists. The columns read here are the
+  stable, long-lived ones; the per-store ``CREATE TABLE`` is the source of truth
+  (src/host/intent.py, traces.py, orchestration.py, costs.py). Missing DBs /
+  missing columns degrade gracefully rather than crashing.
+
+* A *session* is, for now, the per-turn ``trace_id`` (the derived-grouping
+  decision in the plan — no stored ``session_id`` yet). ``session <trace_id>``
+  reconstructs one; ``sessions --since`` lists recent trace_ids to drill into.
+
+Known limitation (surfaced in --help and output): chat transcripts are
+container-local (per-agent ``chat_transcript.jsonl``), so the host-side timeline
+= intent + traces + tasks + costs. Full per-turn transcript text needs a
+separate per-container fetch.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# One-line caveat reused in --help text and the rendered footer.
+TRANSCRIPT_CAVEAT = (
+    "Note: per-turn chat transcript text is container-local; this host-side "
+    "timeline = intent + traces + tasks + costs (not the full conversation)."
+)
+
+
+# ── time parsing ─────────────────────────────────────────────
+
+
+def parse_since(since: str | None) -> float:
+    """Parse a ``--since`` value into an epoch-seconds floor.
+
+    Accepts (case-insensitive):
+    * ``""`` / ``None`` → last 7 days.
+    * ``today`` → local midnight today.
+    * a duration ``Nh`` / ``Nd`` / ``Nm`` / ``Ns`` → now minus that span.
+    * an ISO date / timestamp (``2026-06-18`` or ``2026-06-18T12:00:00``).
+
+    Mirrors the mesh-side ``_parse_since`` (src/host/server.py) so flag
+    semantics stay consistent across the CLI; unparseable input falls back to
+    the 7-day default rather than erroring.
+    """
+    default = time.time() - (7 * 24 * 60 * 60)
+    if not since:
+        return default
+    s = since.strip().lower()
+    if not s:
+        return default
+    if s == "today":
+        now = datetime.now()
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return midnight.timestamp()
+    # Duration form: Ns / Nm / Nh / Nd
+    if s[-1] in {"s", "m", "h", "d"} and s[:-1].isdigit():
+        n = int(s[:-1])
+        mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}[s[-1]]
+        return time.time() - (n * mult)
+    # ISO date / timestamp
+    try:
+        dt = datetime.fromisoformat(s.replace("z", "+00:00"))
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return default
+
+
+def _fmt_ts(ts: float | None) -> str:
+    """Format an epoch-seconds timestamp as a UTC ``YYYY-MM-DD HH:MM:SS`` string."""
+    if not ts:
+        return "-"
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, OSError, OverflowError, TypeError):
+        return str(ts)
+
+
+# ── read-only DB access ──────────────────────────────────────
+
+
+def _connect_ro(path: str | Path) -> sqlite3.Connection | None:
+    """Open a SQLite DB read-only (``mode=ro``). Returns None if it can't be opened.
+
+    ``mode=ro`` guarantees the reader never creates or mutates the DB — opening
+    a *missing* file with ``mode=ro`` raises (unlike default connect, which would
+    create it), which is exactly the safety we want: a missing store degrades to
+    "this layer is unavailable", never to a freshly-created empty file in the
+    prod data dir.
+    """
+    if not path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except sqlite3.OperationalError:
+        return None
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    """Return the column names of *table*, or an empty set if it doesn't exist."""
+    try:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    except sqlite3.OperationalError:
+        return set()
+
+
+# ── per-store fetchers (each degrades gracefully) ────────────
+
+
+def _fetch_intent(data_dir: Path, trace_id: str) -> list[dict]:
+    conn = _connect_ro(data_dir / "intent.db")
+    if conn is None:
+        return []
+    try:
+        cols = _columns(conn, "intent")
+        if not cols:
+            return []
+        rows = conn.execute(
+            "SELECT timestamp, origin_kind, origin_channel, origin_user, agent, message "
+            "FROM intent WHERE trace_id = ? ORDER BY id",
+            (trace_id,),
+        ).fetchall()
+        return [
+            {
+                "timestamp": r["timestamp"],
+                "origin_kind": r["origin_kind"],
+                "origin_channel": r["origin_channel"],
+                "origin_user": r["origin_user"],
+                "agent": r["agent"],
+                "message": r["message"],
+            }
+            for r in rows
+        ]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
+def _fetch_actions(data_dir: Path, trace_id: str) -> list[dict]:
+    conn = _connect_ro(data_dir / "traces.db")
+    if conn is None:
+        return []
+    try:
+        cols = _columns(conn, "traces")
+        if not cols:
+            return []
+        # Read only columns that exist (older DBs predate status/error).
+        wanted = ["timestamp", "source", "agent", "event_type", "detail", "duration_ms", "status", "error"]
+        present = [c for c in wanted if c in cols]
+        rows = conn.execute(
+            f"SELECT {', '.join(present)} FROM traces WHERE trace_id = ? ORDER BY timestamp, rowid",
+            (trace_id,),
+        ).fetchall()
+        return [{c: r[c] for c in present} for r in rows]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
+def _fetch_tasks(data_dir: Path, trace_id: str) -> list[dict]:
+    conn = _connect_ro(data_dir / "tasks.db")
+    if conn is None:
+        return []
+    try:
+        cols = _columns(conn, "tasks")
+        if not cols or "trace_id" not in cols:
+            # Pre-Phase-1 DB without the trace_id column — can't correlate.
+            return []
+        wanted = [
+            "id", "title", "status", "assignee", "blocker_note", "result_summary",
+            "outcome", "parent_task_id", "previous_task_id", "created_at", "updated_at",
+            "completed_at",
+        ]
+        present = [c for c in wanted if c in cols]
+        rows = conn.execute(
+            f"SELECT {', '.join(present)} FROM tasks WHERE trace_id = ? ORDER BY created_at",
+            (trace_id,),
+        ).fetchall()
+        return [{c: r[c] for c in present} for r in rows]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
+def _fetch_cost(data_dir: Path, trace_id: str) -> dict:
+    """Return a cost rollup for a trace_id: totals + per-model breakdown."""
+    empty = {"total_tokens": 0, "total_cost_usd": 0.0, "by_model": []}
+    conn = _connect_ro(data_dir / "costs.db")
+    if conn is None:
+        return empty
+    try:
+        cols = _columns(conn, "usage")
+        if not cols or "trace_id" not in cols:
+            return empty
+        rows = conn.execute(
+            "SELECT model, "
+            "SUM(COALESCE(total_tokens, 0)), "
+            "SUM(COALESCE(cost_usd, 0.0)) "
+            "FROM usage WHERE trace_id = ? GROUP BY model ORDER BY SUM(cost_usd) DESC",
+            (trace_id,),
+        ).fetchall()
+        by_model = [
+            {"model": r[0], "tokens": int(r[1] or 0), "cost_usd": round(float(r[2] or 0.0), 6)}
+            for r in rows
+        ]
+        return {
+            "total_tokens": sum(m["tokens"] for m in by_model),
+            "total_cost_usd": round(sum(m["cost_usd"] for m in by_model), 6),
+            "by_model": by_model,
+        }
+    except sqlite3.OperationalError:
+        return empty
+    finally:
+        conn.close()
+
+
+# ── assembly ─────────────────────────────────────────────────
+
+
+def assemble_session(data_dir: str | Path, trace_id: str) -> dict:
+    """Assemble a full session object for one ``trace_id`` from the four stores.
+
+    Each layer is fetched independently; a missing DB or missing column yields an
+    empty/zeroed layer rather than raising. The ``found`` flag is False only when
+    *no* store has any row for the trace_id.
+    """
+    data_dir = Path(data_dir)
+    intent = _fetch_intent(data_dir, trace_id)
+    actions = _fetch_actions(data_dir, trace_id)
+    tasks = _fetch_tasks(data_dir, trace_id)
+    cost = _fetch_cost(data_dir, trace_id)
+    found = bool(intent or actions or tasks or cost["by_model"])
+    return {
+        "trace_id": trace_id,
+        "found": found,
+        "intent": intent,
+        "actions": actions,
+        "tasks": tasks,
+        "cost": cost,
+    }
+
+
+def list_sessions(
+    data_dir: str | Path,
+    *,
+    since: float,
+    user: str | None = None,
+    agent: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Return recent sessions (one summary row per intent), newest first.
+
+    The ``intent`` table is the human-rooted index, so we drive the listing off
+    it. For each row we add a cheap per-trace outcome + cost lookup so the
+    summary is useful without drilling in. A missing intent.db yields an empty
+    list (the reader still works for direct ``session <trace_id>`` lookups
+    against the other stores).
+    """
+    data_dir = Path(data_dir)
+    conn = _connect_ro(data_dir / "intent.db")
+    if conn is None:
+        return []
+    try:
+        cols = _columns(conn, "intent")
+        if not cols:
+            return []
+        conditions = ["timestamp >= ?"]
+        params: list = [since]
+        if user is not None:
+            conditions.append("origin_user = ?")
+            params.append(user)
+        if agent is not None:
+            conditions.append("agent = ?")
+            params.append(agent)
+        where = " WHERE " + " AND ".join(conditions)
+        params.append(max(1, min(limit, 1000)))
+        rows = conn.execute(
+            "SELECT trace_id, timestamp, origin_kind, origin_channel, origin_user, agent, message "
+            f"FROM intent{where} ORDER BY id DESC LIMIT ?",
+            params,
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+    summaries: list[dict] = []
+    for r in rows:
+        trace_id = r["trace_id"]
+        tasks = _fetch_tasks(data_dir, trace_id)
+        cost = _fetch_cost(data_dir, trace_id)
+        # The terminal task's status/outcome is the most useful one-line signal.
+        outcome = ""
+        if tasks:
+            last = tasks[-1]
+            outcome = last.get("status") or ""
+            if last.get("outcome"):
+                outcome = f"{outcome}/{last['outcome']}"
+        message = (r["message"] or "").replace("\n", " ").strip()
+        summaries.append(
+            {
+                "trace_id": trace_id,
+                "timestamp": r["timestamp"],
+                "origin_kind": r["origin_kind"],
+                "origin_channel": r["origin_channel"],
+                "origin_user": r["origin_user"],
+                "agent": r["agent"],
+                "preview": message[:80],
+                "outcome": outcome,
+                "total_cost_usd": cost["total_cost_usd"],
+                "total_tokens": cost["total_tokens"],
+            }
+        )
+    return summaries
+
+
+# ── rendering ────────────────────────────────────────────────
+
+
+def render_session(session: dict) -> str:
+    """Render one assembled session as a human-readable chronological timeline."""
+    trace_id = session["trace_id"]
+    if not session["found"]:
+        return f"No session found for {trace_id}."
+
+    lines: list[str] = []
+    lines.append(f"Session {trace_id}")
+    lines.append("=" * (8 + len(trace_id)))
+    lines.append("")
+
+    # Intent
+    lines.append("INTENT")
+    if session["intent"]:
+        for it in session["intent"]:
+            who = it.get("origin_user") or "?"
+            chan = it.get("origin_channel") or it.get("origin_kind") or "?"
+            lines.append(f"  [{_fmt_ts(it.get('timestamp'))}] {who} via {chan} → {it.get('agent') or '?'}")
+            lines.append(f"    {it.get('message') or ''}")
+    else:
+        lines.append("  (no verbatim intent captured for this trace)")
+    lines.append("")
+
+    # Chronological actions + task transitions, merged on timestamp.
+    lines.append("TIMELINE")
+    events: list[tuple[float, str]] = []
+    for a in session["actions"]:
+        ts = a.get("timestamp") or 0
+        detail = a.get("detail") or ""
+        status = a.get("status") or ""
+        dur = a.get("duration_ms") or 0
+        agent = a.get("agent") or ""
+        bits = [a.get("event_type") or "event"]
+        if agent:
+            bits.append(f"agent={agent}")
+        if detail:
+            bits.append(detail[:120])
+        tail = []
+        if dur:
+            tail.append(f"{dur}ms")
+        if status:
+            tail.append(status)
+        if a.get("error"):
+            tail.append(f"error={a['error'][:80]}")
+        suffix = f" ({', '.join(tail)})" if tail else ""
+        events.append((ts, f"  [{_fmt_ts(ts)}] {' '.join(bits)}{suffix}"))
+    for t in session["tasks"]:
+        ts = t.get("created_at") or 0
+        line = (
+            f"  [{_fmt_ts(ts)}] task {t.get('id') or '?'} → {t.get('status') or '?'} "
+            f"(assignee={t.get('assignee') or '?'})"
+        )
+        events.append((ts, line))
+    if events:
+        for _ts, line in sorted(events, key=lambda e: e[0]):
+            lines.append(line)
+    else:
+        lines.append("  (no actions or task transitions recorded)")
+    lines.append("")
+
+    # Outcome
+    lines.append("OUTCOME")
+    if session["tasks"]:
+        for t in session["tasks"]:
+            lines.append(
+                f"  task {t.get('id') or '?'}: status={t.get('status') or '?'}"
+                + (f", outcome={t['outcome']}" if t.get("outcome") else "")
+            )
+            if t.get("blocker_note"):
+                lines.append(f"    blocker: {t['blocker_note']}")
+            if t.get("result_summary"):
+                lines.append(f"    result: {t['result_summary']}")
+    else:
+        lines.append("  (no task records for this trace)")
+    lines.append("")
+
+    # Cost rollup
+    cost = session["cost"]
+    lines.append("COST")
+    lines.append(
+        f"  total: {cost['total_tokens']} tokens, ${cost['total_cost_usd']:.6f}"
+    )
+    for m in cost["by_model"]:
+        lines.append(f"    {m['model']}: {m['tokens']} tokens, ${m['cost_usd']:.6f}")
+    lines.append("")
+    lines.append(TRANSCRIPT_CAVEAT)
+    return "\n".join(lines)
+
+
+def render_sessions(summaries: list[dict]) -> str:
+    """Render the ``sessions --since`` listing as a one-row-per-session table."""
+    if not summaries:
+        return "No sessions found."
+    lines: list[str] = []
+    header = f"{'Trace':<16} {'When (UTC)':<20} {'User':<14} {'Outcome':<14} {'Cost':<10} Preview"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for s in summaries:
+        lines.append(
+            f"{(s['trace_id'] or '')[:16]:<16} "
+            f"{_fmt_ts(s['timestamp']):<20} "
+            f"{(s['origin_user'] or '-')[:14]:<14} "
+            f"{(s['outcome'] or '-')[:14]:<14} "
+            f"${s['total_cost_usd']:<9.4f} "
+            f"{s['preview']}"
+        )
+    lines.append("")
+    lines.append(TRANSCRIPT_CAVEAT)
+    return "\n".join(lines)

--- a/src/host/intent.py
+++ b/src/host/intent.py
@@ -1,0 +1,177 @@
+"""IntentStore — SQLite append-only store for verbatim inbound messages.
+
+Persists the FULL verbatim inbound message centrally, keyed by ``trace_id``
+plus the originating ``MessageOrigin`` (kind/channel/user), so that *intent*
+— what the human actually typed — survives container wipes, ``/chat/reset``,
+and deploys. Today the user's words live only in container-local
+``chat_transcript.jsonl`` (``src/agent/workspace.py``), which rotates (drops
+the oldest half) and dies with the container; central stores keep only a
+normalized task title and a short redacted preview. This store is the durable
+intent layer that makes hosted-VPS reconstruction trustworthy after a deploy
+(Phase 2 of docs/plans/2026-06-18-session-observability.md).
+
+Follows the same SQLite-WAL pattern as ``TraceStore`` (``src/host/traces.py``).
+Intent is append-only like traces — there is no per-row lifecycle terminal to
+anchor a ``retention_until`` against (unlike ``tasks``, where reaping keys off a
+terminal status), so retention is a TraceStore-style throttled time-based GC,
+not a tasks-style ``retention_until`` reaper. Default window is 90 days, which
+matches the session/forensic semantics (vs. traces' shorter rolling window).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from src.shared.redaction import deep_redact, redact_text_with_urls
+from src.shared.sqlite_helpers import open_db
+from src.shared.utils import dumps_safe, setup_logging
+
+logger = setup_logging("host.intent")
+
+
+class IntentStore:
+    """SQLite-backed append-only store for verbatim inbound messages."""
+
+    def __init__(self, db_path: str = "data/intent.db", max_age_hours: int | None = 24 * 90):
+        self.max_age_hours = max_age_hours
+        # ensure first GC runs regardless of monotonic() epoch
+        self._last_age_gc: float = -300.0
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = open_db(db_path, busy_timeout_ms=5000)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS intent (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                trace_id       TEXT NOT NULL,
+                timestamp      REAL NOT NULL,
+                origin_kind    TEXT NOT NULL DEFAULT '',
+                origin_channel TEXT NOT NULL DEFAULT '',
+                origin_user    TEXT NOT NULL DEFAULT '',
+                agent          TEXT NOT NULL DEFAULT '',
+                message        TEXT NOT NULL DEFAULT '',
+                meta_json      TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_intent_trace_id ON intent (trace_id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_intent_timestamp ON intent (timestamp)"
+        )
+        self._conn.commit()
+
+    def record(
+        self,
+        *,
+        trace_id: str,
+        origin_kind: str = "",
+        origin_channel: str = "",
+        origin_user: str = "",
+        agent: str = "",
+        message: str = "",
+        meta: dict | None = None,
+    ) -> None:
+        """Insert a verbatim-intent row.
+
+        The verbatim ``message`` and every string inside ``meta`` are redacted
+        at capture so a credential or URL with sensitive query params pasted in
+        chat is never persisted in plaintext (H16). Redaction is centralized
+        here rather than at the dispatch callsite so no path can regress.
+        ``sanitize_for_prompt`` is already applied upstream at every surface;
+        this is the additional at-storage layer.
+        """
+        message = redact_text_with_urls(message or "")
+        meta_json = dumps_safe(deep_redact(meta)) if meta else ""
+        self._conn.execute(
+            "INSERT INTO intent "
+            "(trace_id, timestamp, origin_kind, origin_channel, origin_user, agent, message, meta_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                trace_id, time.time(), origin_kind, origin_channel,
+                origin_user, agent, message, meta_json,
+            ),
+        )
+        self._conn.commit()
+        self._maybe_gc_old()
+
+    def _maybe_gc_old(self) -> None:
+        """Remove rows older than max_age_hours, throttled to once per 5 minutes.
+
+        Time-based GC (mirrors ``TraceStore._maybe_gc_old``) rather than a
+        tasks-style ``retention_until`` + reaper: intent is append-only with no
+        terminal lifecycle status to anchor a per-row retention deadline.
+        """
+        if self.max_age_hours is None:
+            return
+        now = time.monotonic()
+        if now - self._last_age_gc < 300:
+            return
+        self._last_age_gc = now
+        cutoff = time.time() - (self.max_age_hours * 3600)
+        self._conn.execute("DELETE FROM intent WHERE timestamp < ?", (cutoff,))
+        self._conn.commit()
+
+    def _row_to_dict(self, row: tuple) -> dict:
+        """Convert a query row to an intent dict."""
+        meta_json = row[7] if len(row) > 7 else ""
+        meta = json.loads(meta_json) if meta_json else {}
+        return {
+            "trace_id": row[0],
+            "timestamp": row[1],
+            "origin_kind": row[2],
+            "origin_channel": row[3],
+            "origin_user": row[4],
+            "agent": row[5],
+            "message": row[6],
+            "meta": meta,
+        }
+
+    _INTENT_COLS = (
+        "trace_id, timestamp, origin_kind, origin_channel, "
+        "origin_user, agent, message, meta_json"
+    )
+
+    def get_by_trace(self, trace_id: str) -> list[dict]:
+        """Return all intent rows for a trace_id, ordered by time."""
+        cur = self._conn.execute(
+            f"SELECT {self._INTENT_COLS} FROM intent WHERE trace_id = ? ORDER BY id",
+            (trace_id,),
+        )
+        return [self._row_to_dict(row) for row in cur.fetchall()]
+
+    def list_recent(
+        self,
+        *,
+        since: float | None = None,
+        user: str | None = None,
+        agent: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Return recent intent rows (newest first), with optional filters.
+
+        Built for Phase 3's ``sessions --since`` reader.
+        """
+        conditions = []
+        params: list = []
+        if since is not None:
+            conditions.append("timestamp >= ?")
+            params.append(since)
+        if user is not None:
+            conditions.append("origin_user = ?")
+            params.append(user)
+        if agent is not None:
+            conditions.append("agent = ?")
+            params.append(agent)
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.append(max(1, min(limit, 1000)))
+        cur = self._conn.execute(
+            f"SELECT {self._INTENT_COLS} FROM intent{where} ORDER BY id DESC LIMIT ?",
+            params,
+        )
+        return [self._row_to_dict(row) for row in cur.fetchall()]
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -283,6 +283,7 @@ if TYPE_CHECKING:
     from src.host.credentials import CredentialVault
     from src.host.cron import CronScheduler
     from src.host.health import HealthMonitor
+    from src.host.intent import IntentStore
     from src.host.lanes import LaneManager
     from src.host.mcp_gateway import MCPGateway
     from src.host.mesh import Blackboard, MessageRouter, PubSub
@@ -764,6 +765,7 @@ def create_mesh_app(
     transport: Transport | None = None,
     auth_tokens: dict[str, str] | None = None,
     trace_store: TraceStore | None = None,
+    intent_store: "IntentStore | None" = None,
     event_bus: EventBus | None = None,
     health_monitor: HealthMonitor | None = None,
     cost_tracker: CostTracker | None = None,
@@ -892,6 +894,11 @@ def create_mesh_app(
         db_path=_summaries_db_path, event_bus=event_bus,
     )
     app.summaries_store = summaries_store  # exposed for tests/dashboard
+
+    # Durable verbatim-intent store (Phase 2, session observability).
+    # Instantiated in cli/runtime and passed in; attached here so the
+    # Phase 3 read endpoints / reader can reach it off the app.
+    app.intent_store = intent_store  # exposed for tests/Phase 3 reader
 
     # Observation log of agent→user notifications. NOT a message channel:
     # agents call ``notify_user`` (intent: tell the human) and the mesh

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,214 @@
+"""Tests for IntentStore + verbatim-intent capture wiring at _direct_dispatch.
+
+Phase 2 of docs/plans/2026-06-18-session-observability.md: the verbatim
+inbound message is persisted centrally (keyed by trace_id + MessageOrigin),
+redacted at storage, so intent survives container wipes / resets / deploys.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.host.intent import IntentStore
+from src.shared.types import MessageOrigin
+
+# ── IntentStore ──────────────────────────────────────────────
+
+
+class TestIntentStore:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "intent.db")
+        self.store = IntentStore(db_path=self.db_path)
+
+    def teardown_method(self):
+        self.store.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_record_and_get_by_trace(self):
+        self.store.record(
+            trace_id="tr_abc", origin_kind="human", origin_channel="dashboard",
+            origin_user="u1", agent="alpha", message="build me a report",
+        )
+        self.store.record(
+            trace_id="tr_abc", origin_kind="human", origin_channel="dashboard",
+            origin_user="u1", agent="alpha", message="and email it",
+        )
+        rows = self.store.get_by_trace("tr_abc")
+        assert len(rows) == 2
+        assert rows[0]["trace_id"] == "tr_abc"
+        assert rows[0]["origin_kind"] == "human"
+        assert rows[0]["origin_channel"] == "dashboard"
+        assert rows[0]["origin_user"] == "u1"
+        assert rows[0]["agent"] == "alpha"
+        assert rows[0]["message"] == "build me a report"
+        # ordered by time
+        assert rows[1]["message"] == "and email it"
+
+    def test_get_by_trace_empty(self):
+        assert self.store.get_by_trace("tr_nope") == []
+
+    def test_full_message_not_truncated(self):
+        # Realistic prose (no long unbroken alnum blob that redaction would
+        # collapse) — assert the FULL message is stored, not a preview.
+        long_msg = ("please build a detailed quarterly report. " * 200).strip()
+        assert len(long_msg) > 4000
+        self.store.record(trace_id="tr_long", message=long_msg, agent="alpha")
+        rows = self.store.get_by_trace("tr_long")
+        assert rows[0]["message"] == long_msg
+
+    def test_list_recent_newest_first(self):
+        for i in range(3):
+            self.store.record(trace_id=f"tr_{i}", message=f"m{i}", agent="alpha")
+        rows = self.store.list_recent(limit=10)
+        assert [r["trace_id"] for r in rows] == ["tr_2", "tr_1", "tr_0"]
+
+    def test_list_recent_filter_since(self):
+        self.store.record(trace_id="tr_old", message="old", agent="alpha")
+        cut = time.time()
+        time.sleep(0.01)
+        self.store.record(trace_id="tr_new", message="new", agent="alpha")
+        rows = self.store.list_recent(since=cut)
+        assert [r["trace_id"] for r in rows] == ["tr_new"]
+
+    def test_list_recent_filter_user(self):
+        self.store.record(trace_id="tr_a", message="a", agent="alpha", origin_user="alice")
+        self.store.record(trace_id="tr_b", message="b", agent="alpha", origin_user="bob")
+        rows = self.store.list_recent(user="alice")
+        assert [r["trace_id"] for r in rows] == ["tr_a"]
+
+    def test_list_recent_filter_agent(self):
+        self.store.record(trace_id="tr_a", message="a", agent="alpha")
+        self.store.record(trace_id="tr_b", message="b", agent="beta")
+        rows = self.store.list_recent(agent="beta")
+        assert [r["trace_id"] for r in rows] == ["tr_b"]
+
+    def test_redaction_at_storage(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(trace_id="tr_sec", message=f"my key is {secret}", agent="alpha")
+        # raw SQLite bytes must not contain the secret
+        raw = self.store._conn.execute(
+            "SELECT message FROM intent WHERE trace_id = ?", ("tr_sec",)
+        ).fetchone()[0]
+        assert secret not in raw
+        assert "[REDACTED]" in raw
+        rows = self.store.get_by_trace("tr_sec")
+        assert secret not in rows[0]["message"]
+
+    def test_meta_redacted_at_storage(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(
+            trace_id="tr_meta", message="hi", agent="alpha",
+            meta={"note": f"creds {secret}", "system_note": False},
+        )
+        raw = self.store._conn.execute(
+            "SELECT meta_json FROM intent WHERE trace_id = ?", ("tr_meta",)
+        ).fetchone()[0]
+        assert secret not in raw
+        rows = self.store.get_by_trace("tr_meta")
+        assert secret not in rows[0]["meta"]["note"]
+
+    def test_time_based_gc_drops_old_rows(self):
+        store = IntentStore(
+            db_path=os.path.join(self._tmpdir, "gc.db"), max_age_hours=1,
+        )
+        try:
+            # Insert an ancient row directly, bypassing the GC throttle.
+            store._conn.execute(
+                "INSERT INTO intent (trace_id, timestamp, message) VALUES (?, ?, ?)",
+                ("tr_ancient", time.time() - 7200, "old"),
+            )
+            store._conn.commit()
+            assert store.get_by_trace("tr_ancient")
+            # Force GC to run (reset throttle), then a fresh record triggers it.
+            store._last_age_gc = -300.0
+            store.record(trace_id="tr_fresh", message="new", agent="alpha")
+            assert store.get_by_trace("tr_ancient") == []
+            assert store.get_by_trace("tr_fresh")
+        finally:
+            store.close()
+
+    def test_idempotent_schema_init(self):
+        # Re-open the same DB; CREATE TABLE/INDEX IF NOT EXISTS must not raise.
+        self.store.record(trace_id="tr_x", message="hi", agent="alpha")
+        self.store.close()
+        store2 = IntentStore(db_path=self.db_path)
+        try:
+            assert store2.get_by_trace("tr_x")
+            store2.record(trace_id="tr_y", message="yo", agent="alpha")
+            assert store2.get_by_trace("tr_y")
+        finally:
+            self.store = store2  # so teardown closes it
+
+
+# ── Capture wiring at _direct_dispatch ───────────────────────
+
+
+def _dispatch_with_intent(monkeypatch, intent_store, *, response="done"):
+    """Build the real ``_direct_dispatch`` closure via test_runtime's proven
+    harness, then attach our intent-store mock and a stubbed transport reply.
+    Returns ``(dispatch_fn, ctx, transport_mock)``."""
+    from tests.test_runtime import _capture_dispatch_fn
+
+    dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+    ctx.intent_store = intent_store
+    transport.request = AsyncMock(return_value={"response": response})
+    return dispatch_fn, ctx, transport
+
+
+@pytest.mark.asyncio
+async def test_dispatch_captures_full_verbatim_intent(monkeypatch):
+    intent_store = MagicMock()
+    dispatch_fn, _ctx, _t = _dispatch_with_intent(monkeypatch, intent_store)
+
+    origin = MessageOrigin(kind="human", channel="dashboard", user="u9")
+    long_message = "please build a detailed quarterly report. " * 50
+    await dispatch_fn("alpha", long_message, origin=origin)
+
+    assert intent_store.record.called
+    kwargs = intent_store.record.call_args.kwargs
+    # FULL message, not truncated, with origin + agent stamped.
+    assert kwargs["message"] == long_message
+    assert kwargs["agent"] == "alpha"
+    assert kwargs["origin_kind"] == "human"
+    assert kwargs["origin_channel"] == "dashboard"
+    assert kwargs["origin_user"] == "u9"
+    assert kwargs["trace_id"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_capture_marks_system_note(monkeypatch):
+    intent_store = MagicMock()
+    dispatch_fn, _ctx, _t = _dispatch_with_intent(
+        monkeypatch, intent_store, response="ok",
+    )
+
+    # Webhook path: machine origin, no MessageOrigin object.
+    await dispatch_fn("alpha", "webhook fired", system_note=True)
+
+    kwargs = intent_store.record.call_args.kwargs
+    assert kwargs["meta"]["system_note"] is True
+    assert kwargs["origin_kind"] == ""  # no origin object
+    assert kwargs["origin_channel"] == ""
+    assert kwargs["origin_user"] == ""
+
+
+@pytest.mark.asyncio
+async def test_dispatch_survives_intent_store_failure(monkeypatch):
+    intent_store = MagicMock()
+    intent_store.record.side_effect = RuntimeError("disk full")
+    dispatch_fn, _ctx, _t = _dispatch_with_intent(
+        monkeypatch, intent_store, response="still works",
+    )
+
+    result = await dispatch_fn("alpha", "hi", origin=None)
+
+    # A failing intent store must NEVER break dispatch.
+    assert result == "still works"
+    assert intent_store.record.called

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1853,6 +1853,7 @@ def _capture_dispatch_fn(monkeypatch, *, app=None):
     transport_mock = AsyncMock()
     ctx.transport = transport_mock
     ctx.trace_store = None
+    ctx.intent_store = None
     ctx.event_bus = None
     ctx.health_monitor = None
     ctx._app = app

--- a/tests/test_session_reader.py
+++ b/tests/test_session_reader.py
@@ -1,0 +1,274 @@
+"""Tests for the Phase 3 read-only session reader (openlegion session/sessions).
+
+Seeds temp DBs by WRITING with the real store classes (IntentStore, Tasks,
+TraceStore, CostTracker) into a tmp data dir, then invokes the reader pointed at
+that dir via ``--data-dir`` and asserts the assembled timeline / --json shape.
+
+The reader opens the host DBs read-only (mode=ro) and degrades gracefully when a
+DB file is missing — both correctness-critical bits are asserted here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+
+from click.testing import CliRunner
+
+from src.cli import cli
+from src.cli.session_reader import assemble_session, parse_since
+from src.host.costs import CostTracker
+from src.host.intent import IntentStore
+from src.host.orchestration import Tasks
+from src.host.traces import TraceStore
+from src.shared.trace import current_trace_id
+
+TRACE_A = "tr_aaaaaaaaaaaa"
+TRACE_B = "tr_bbbbbbbbbbbb"
+
+
+def _seed(data_dir: str) -> None:
+    """Write rows for TRACE_A and TRACE_B across all four stores."""
+    intent = IntentStore(db_path=os.path.join(data_dir, "intent.db"))
+    traces = TraceStore(db_path=os.path.join(data_dir, "traces.db"))
+    tasks = Tasks(os.path.join(data_dir, "tasks.db"))
+    costs = CostTracker(db_path=os.path.join(data_dir, "costs.db"))
+
+    # TRACE_A — a full human-rooted session.
+    intent.record(
+        trace_id=TRACE_A, origin_kind="human", origin_channel="dashboard",
+        origin_user="alice", agent="alpha", message="build me a sales report",
+    )
+    traces.record(TRACE_A, "mesh", "alpha", "chat", detail="dispatch to alpha")
+    traces.record(TRACE_A, "mesh", "alpha", "llm_call", detail="opus call", duration_ms=1200)
+
+    token = current_trace_id.set(TRACE_A)
+    try:
+        tasks.create(creator="alice", assignee="alpha", title="Sales report",
+                     origin={"kind": "human", "channel": "dashboard", "user": "alice"})
+        costs.track("alpha", "anthropic/claude-opus-4-8", 1000, 500)
+        costs.track("alpha", "anthropic/claude-opus-4-8", 200, 100)
+    finally:
+        current_trace_id.reset(token)
+
+    # TRACE_B — a different session; must be excluded from TRACE_A's view.
+    intent.record(
+        trace_id=TRACE_B, origin_kind="human", origin_channel="telegram",
+        origin_user="bob", agent="beta", message="unrelated request",
+    )
+    traces.record(TRACE_B, "mesh", "beta", "chat", detail="other dispatch")
+    token = current_trace_id.set(TRACE_B)
+    try:
+        tasks.create(creator="bob", assignee="beta", title="Other task",
+                     origin={"kind": "human", "channel": "telegram", "user": "bob"})
+        costs.track("beta", "anthropic/claude-opus-4-8", 50, 50)
+    finally:
+        current_trace_id.reset(token)
+
+    intent.close()
+    traces.close()
+    tasks.close()
+    costs.close()
+
+
+class _Dir:
+    def __init__(self):
+        self.path = tempfile.mkdtemp()
+
+    def cleanup(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+
+
+class TestParseSince:
+    def test_duration_and_today_and_iso(self):
+        import time as _t
+        now = _t.time()
+        assert parse_since("1h") <= now - 3500
+        assert parse_since("2d") <= now - (2 * 86400) + 5
+        assert parse_since("today") <= now
+        assert parse_since("2020-01-01") < now
+        # Empty / garbage → 7-day default (within a small window).
+        default = now - (7 * 86400)
+        assert abs(parse_since("") - default) < 5
+        assert abs(parse_since("nonsense") - default) < 5
+
+
+class TestAssemble:
+    def setup_method(self):
+        self.d = _Dir()
+        _seed(self.d.path)
+
+    def teardown_method(self):
+        self.d.cleanup()
+
+    def test_session_assembles_all_layers(self):
+        s = assemble_session(self.d.path, TRACE_A)
+        assert s["found"] is True
+        assert len(s["intent"]) == 1
+        assert s["intent"][0]["message"] == "build me a sales report"
+        assert s["intent"][0]["origin_user"] == "alice"
+        # two trace events
+        assert len(s["actions"]) == 2
+        # one task
+        assert len(s["tasks"]) == 1
+        assert s["tasks"][0]["assignee"] == "alpha"
+        # cost rollup summed across the two usage rows
+        assert s["cost"]["total_tokens"] == 1800
+        assert s["cost"]["total_cost_usd"] > 0
+        assert s["cost"]["by_model"][0]["model"] == "anthropic/claude-opus-4-8"
+
+    def test_other_trace_excluded(self):
+        s = assemble_session(self.d.path, TRACE_A)
+        users = {i["origin_user"] for i in s["intent"]}
+        assert "bob" not in users
+        assignees = {t["assignee"] for t in s["tasks"]}
+        assert "beta" not in assignees
+
+    def test_not_found(self):
+        s = assemble_session(self.d.path, "tr_does_not_exist")
+        assert s["found"] is False
+        assert s["intent"] == []
+        assert s["actions"] == []
+        assert s["tasks"] == []
+        assert s["cost"]["total_tokens"] == 0
+
+
+class TestGracefulDegradation:
+    def setup_method(self):
+        self.d = _Dir()
+        _seed(self.d.path)
+
+    def teardown_method(self):
+        self.d.cleanup()
+
+    def test_missing_intent_db_still_assembles_other_layers(self):
+        os.remove(os.path.join(self.d.path, "intent.db"))
+        s = assemble_session(self.d.path, TRACE_A)
+        # intent gone, but actions/tasks/cost still present → found is True
+        assert s["intent"] == []
+        assert len(s["actions"]) == 2
+        assert len(s["tasks"]) == 1
+        assert s["found"] is True
+
+    def test_all_dbs_missing_does_not_crash(self):
+        empty = tempfile.mkdtemp()
+        try:
+            s = assemble_session(empty, TRACE_A)
+            assert s["found"] is False
+        finally:
+            shutil.rmtree(empty, ignore_errors=True)
+
+
+class TestReadOnly:
+    def test_reader_does_not_mutate_or_create_dbs(self):
+        d = _Dir()
+        try:
+            _seed(d.path)
+            # mtimes + size before
+            before = {}
+            for name in ("intent.db", "traces.db", "tasks.db", "costs.db"):
+                p = os.path.join(d.path, name)
+                st = os.stat(p)
+                before[name] = (st.st_mtime_ns, st.st_size)
+            # Run a missing-db scenario too: ensure no file is created.
+            assemble_session(d.path, TRACE_A)
+            assemble_session(d.path, "tr_missing")
+            for name, (mtime, size) in before.items():
+                st = os.stat(os.path.join(d.path, name))
+                assert st.st_mtime_ns == mtime, f"{name} mtime changed"
+                assert st.st_size == size, f"{name} size changed"
+            # The reader must NOT create a file for a non-existent DB.
+            assemble_session(d.path, TRACE_A)
+            assert not os.path.exists(os.path.join(d.path, "nonexistent.db"))
+        finally:
+            d.cleanup()
+
+    def test_missing_db_not_created_by_reader(self):
+        empty = tempfile.mkdtemp()
+        try:
+            assemble_session(empty, TRACE_A)
+            # mode=ro must never create the files
+            assert os.listdir(empty) == []
+        finally:
+            shutil.rmtree(empty, ignore_errors=True)
+
+
+class TestCli:
+    def setup_method(self):
+        self.d = _Dir()
+        _seed(self.d.path)
+        self.runner = CliRunner()
+
+    def teardown_method(self):
+        self.d.cleanup()
+
+    def test_session_text_output(self):
+        r = self.runner.invoke(cli, ["session", TRACE_A, "--data-dir", self.d.path])
+        assert r.exit_code == 0, r.output
+        assert "build me a sales report" in r.output
+        assert "alice" in r.output
+        assert "COST" in r.output
+        assert "container-local" in r.output  # the surfaced caveat
+
+    def test_session_json_shape(self):
+        r = self.runner.invoke(cli, ["session", TRACE_A, "--data-dir", self.d.path, "--json"])
+        assert r.exit_code == 0, r.output
+        obj = json.loads(r.output)
+        assert obj["trace_id"] == TRACE_A
+        assert obj["found"] is True
+        assert {"intent", "actions", "tasks", "cost"} <= set(obj.keys())
+        assert obj["cost"]["total_tokens"] == 1800
+
+    def test_session_not_found_exits_zero(self):
+        r = self.runner.invoke(cli, ["session", "tr_missing", "--data-dir", self.d.path])
+        assert r.exit_code == 0
+        assert "No session found" in r.output
+
+    def test_sessions_lists_newest_first(self):
+        r = self.runner.invoke(
+            cli, ["sessions", "--since", "1d", "--data-dir", self.d.path],
+        )
+        assert r.exit_code == 0, r.output
+        # TRACE_B was seeded last → newest → appears before TRACE_A
+        assert r.output.index(TRACE_B[:16]) < r.output.index(TRACE_A[:16])
+
+    def test_sessions_filter_by_user(self):
+        r = self.runner.invoke(
+            cli, ["sessions", "--since", "1d", "--user", "alice", "--data-dir", self.d.path],
+        )
+        assert r.exit_code == 0, r.output
+        assert TRACE_A[:16] in r.output
+        assert TRACE_B[:16] not in r.output
+
+    def test_sessions_filter_by_agent(self):
+        r = self.runner.invoke(
+            cli, ["sessions", "--since", "1d", "--agent", "beta", "--data-dir", self.d.path],
+        )
+        assert r.exit_code == 0, r.output
+        assert TRACE_B[:16] in r.output
+        assert TRACE_A[:16] not in r.output
+
+    def test_sessions_limit(self):
+        r = self.runner.invoke(
+            cli, ["sessions", "--since", "1d", "--limit", "1", "--data-dir", self.d.path],
+        )
+        assert r.exit_code == 0, r.output
+        # newest only
+        assert TRACE_B[:16] in r.output
+        assert TRACE_A[:16] not in r.output
+
+    def test_sessions_json_array(self):
+        r = self.runner.invoke(
+            cli, ["sessions", "--since", "1d", "--data-dir", self.d.path, "--json"],
+        )
+        assert r.exit_code == 0, r.output
+        obj = json.loads(r.output)
+        assert "sessions" in obj
+        traces = {s["trace_id"] for s in obj["sessions"]}
+        assert TRACE_A in traces and TRACE_B in traces
+        # outcome + cost surfaced in the summary
+        a = next(s for s in obj["sessions"] if s["trace_id"] == TRACE_A)
+        assert a["origin_user"] == "alice"
+        assert a["total_tokens"] == 1800


### PR DESCRIPTION
## What this is

Phase 3 of Session Observability: a **read-only forensic reader** that reconstructs a session from the host-side SQLite stores. The tool an engineer runs over SSH on a hosted VPS to answer *"what happened in this session?"* — including when the mesh is down.

Two commands (both honor the global `--json`):
- `openlegion session <trace_id>` — full chronological timeline for one session: verbatim **intent** → time-ordered **actions + task transitions** → **outcome** (status / blocker_note / result_summary) → a **cost** rollup footer.
- `openlegion sessions --since <when> [--user X] [--agent X] [--limit N]` — recent sessions, one summary row each (trace_id, when, user, outcome, cost, message preview), to find a trace_id worth drilling into.

## Why read host SQLite directly, read-only (the key design call)

The reader opens each DB with `sqlite3.connect("file:<path>?mode=ro", uri=True)` and runs raw `SELECT`s — it deliberately does **not** instantiate the store classes (IntentStore / TraceStore / Tasks / CostTracker). Those open read-write and may run GC / migrations on a prod DB. Read-only + raw SQL preserves the two guarantees this tool exists for:

1. It must work **even when the mesh is down or wedged** — forensics happen exactly then; the normal `_mesh_get` read path hard-exits with "Mesh is not running".
2. It must **never mutate prod data**.

`mode=ro` plus an `exists()` guard also means a *missing* store is never silently re-created in the data dir. The (acceptable, intentional) on-disk schema coupling is documented in a module comment.

## Graceful degradation

Each of the four layers is fetched independently. A missing DB file or a missing column (e.g. a pre-Phase-1 DB with no `trace_id`) yields an empty/zeroed layer rather than crashing. `found` is False only when no store has any row for the trace_id — `session <trace_id>` then prints a friendly "no session found" and exits 0.

## Path resolution

Adds a canonical `DATA_DIR = PROJECT_ROOT / "data"` to `src/cli/config.py` (none existed — DB paths were bare strings in runtime.py/server.py). A `--data-dir PATH` option (default `DATA_DIR`) lets the reader target a specific box's data dir and lets tests point at a tmp dir.

## `--since` parsing

`session_reader.parse_since` accepts `today` (local midnight), `Nh`/`Nd`/`Nm`/`Ns` durations, an ISO date/timestamp, or empty → last 7 days. Unparseable input falls back to the 7-day default (mirrors the mesh-side `_parse_since` semantics so flag behavior stays consistent).

## Known limitation (surfaced, not hidden)

Per-turn chat transcripts are container-local, so the host-side timeline = **intent + traces + tasks + costs**. Full per-turn transcript text needs a separate per-container fetch. This caveat is printed in `--help` and in the rendered output footer — the reader doesn't pretend it's the whole picture.

## Tests

`tests/test_session_reader.py` seeds temp DBs by **writing with the real store classes** into a tmp data dir, then invokes the reader via `--data-dir`:
- happy-path assembly (all four layers; rows for other trace_ids excluded);
- graceful degradation (missing intent.db still assembles the rest; all-DBs-missing doesn't crash; not-found → exit 0);
- `sessions --since` filters (user/agent), newest-first, limit;
- `--json` shapes for both commands;
- **read-only**: asserts mtimes + sizes unchanged and that no DB file is created for a missing store.

Results:
- `tests/test_session_reader.py` → **16 passed**
- sanity (`test_cli_commands.py` + `test_intent.py` + `test_traces.py`) → **164 passed**
- `ruff check` on changed files → clean

## Stacking

Phase 3 of 4; **stacked on #1153 — merge that first** (its diff vs main includes Phase 2's commits until Phase 2 merges; the reader's tasks/usage `trace_id` joins only become non-null on builds running Phase 1 #1149).

Plan: `docs/plans/2026-06-18-session-observability.md` (Phase 3).