### PR TITLE
feat(observability): phase 4 — agent-side traces + correlated logs

### DIFF
--- a/docs/internal/session-observability.md
+++ b/docs/internal/session-observability.md
@@ -1,9 +1,11 @@
 # Session Observability
 
-> **Status:** partly built. **Phase 1** (trace_id correlation) shipped in PR #1149.
-> Everything else on this page is the documented *design* — see the
-> [Availability / phase status](#availability--phase-status) table for what works
-> today. Design doc: [`../plans/2026-06-18-session-observability.md`](../plans/2026-06-18-session-observability.md) (plan #1147).
+> **Status:** shipped (Phases 1–4). `trace_id` correlation (#1149), verbatim
+> intent capture (#1153), the `openlegion session`/`sessions` reader (#1154),
+> and agent-side traces + log correlation (Phase 4) are all on `main`. See the
+> [Availability / phase status](#availability--phase-status) table for the
+> per-capability breakdown. Design doc:
+> [`../plans/2026-06-18-session-observability.md`](../plans/2026-06-18-session-observability.md) (plan #1147).
 
 ## What it is & why
 
@@ -54,10 +56,10 @@ conversation around it.
 
 | Store | Holds | Keyed / filtered by |
 |---|---|---|
-| `data/traces.db` | trace events (the action timeline) | `trace_id` |
+| `data/traces.db` | trace events (the action timeline): `llm_call` (mesh-recorded) + `tool_call` / `handoff` / `iteration` (agent-emitted, Phase 4) | `trace_id` |
 | `data/tasks.db` | tasks: `status`, `blocker_note`, `result_summary`, the DAG, `origin_user` | `trace_id` (Phase 1 column), task id |
 | `data/costs.db` | per-call token usage / cost | `trace_id` (Phase 1 column on `usage`) |
-| `data/intent.db` | verbatim user intent | `trace_id` (**Phase 2 — planned**) |
+| `data/intent.db` | verbatim user intent | `trace_id` (Phase 2) |
 
 > **Transcripts are container-local.** Full agent transcripts live inside each
 > agent container, not on the host. The host-side reconstruction is built from
@@ -65,11 +67,6 @@ conversation around it.
 > cost, but not the agent's full internal transcript.
 
 ## Using the reader
-
-> **Phase 3 — planned.** The `openlegion session` / `openlegion sessions`
-> commands below are the documented design. They are **not available today**;
-> until Phase 3 ships, reconstruct sessions with raw SQL (see
-> [Finding the data manually](#finding-the-data-manually)).
 
 ### One session, full timeline — `openlegion session <trace_id>`
 
@@ -137,21 +134,20 @@ runs on its own box.
    directory on that box.
 
    ```bash
-   openlegion session tr_9f3a1c0b7e21    # (Phase 3 — planned)
+   openlegion session tr_9f3a1c0b7e21
    ```
 
-The reader opens the SQLite stores **read-only**, so it **works even when the
-mesh is down** — which is exactly when forensics matter most. You do not need to
-restart, and you cannot make things worse by reading.
-
-> Until the Phase 3 reader ships, do the same investigation on-box with the raw
-> SQL below — `sqlite3` is also read-only when you only `SELECT`.
+The reader opens the SQLite stores **read-only** (`mode=ro` + an existence
+guard — it never creates, migrates, or GCs), so it **works even when the mesh is
+down** — which is exactly when forensics matter most. You do not need to restart,
+and you cannot make things worse by reading. Pass `--data-dir <path>` if the
+stores are not under `./data`, and `--json` for machine-readable output.
 
 ### Getting a `trace_id` to investigate
 
 - **From the dashboard** — a turn's `trace_id` is surfaced in the UI (the
   dashboard mints/propagates it correctly as of Phase 1).
-- **From `sessions --since`** (Phase 3) — list recent sessions and copy the id.
+- **From `sessions --since`** — list recent sessions and copy the id.
 - **From raw SQL** — query `tasks` / `usage` for the user/time window and read
   the `trace_id` column (below).
 
@@ -164,7 +160,7 @@ under `data/` on the host:
 - `data/tasks.db` — `tasks` table: filter `WHERE trace_id = ?`, then read
   `status`, `blocker_note`, `result_summary` (and the DAG / `origin_user`).
 - `data/costs.db` — `usage` table: filter `WHERE trace_id = ?` to roll up cost.
-- `data/intent.db` — verbatim intent (**Phase 2 — planned**).
+- `data/intent.db` — verbatim intent, `intent` table: filter `WHERE trace_id = ?`.
 
 Example — outcome + cost for one turn:
 
@@ -185,6 +181,29 @@ sqlite3 data/costs.db \
 (Open with `sqlite3 -readonly` if you want to be certain you can't mutate the
 live DB.)
 
+## Correlated logs
+
+As of Phase 4 every structured log line carries the active correlation IDs when
+they are set, so logs join to the same session as the stores:
+
+```json
+{"timestamp": "...", "level": "INFO", "module": "agent.loop",
+ "message": "...", "trace_id": "tr_9f3a1c0b7e21", "task_id": "t_4412",
+ "agent_id": "analyst"}
+```
+
+- `trace_id` / `task_id` / `agent_id` are injected by `StructuredFormatter`
+  (and appended as a `[trace_id=… task_id=… agent_id=…]` suffix by the
+  human-readable `TextFormatter`) from the request contextvars. An explicit
+  `extra_data` key always wins over the injected value.
+- `agent_id` inside an agent container falls back to the `AGENT_ID` env var, so
+  every container line is attributable even for code paths that never set the
+  contextvar. The mesh host has no `AGENT_ID`, so host lines omit it (the agent
+  is carried per-event instead).
+- To trace one session through the logs: `grep tr_9f3a1c0b7e21` across the host
+  and container stdout. (Container logs are still ephemeral — off-box shipping
+  is a deliberately deferred, out-of-MVP hook.)
+
 ## Limitations
 
 - **Transcripts are container-local.** The host timeline is reconstructed from
@@ -204,14 +223,10 @@ live DB.)
 | Capability | Phase | Status |
 |---|---|---|
 | `trace_id` correlation across tasks + usage (`trace_id` columns) | Phase 1 | **Shipped — PR #1149** |
-| Verbatim intent capture (`data/intent.db`) | Phase 2 | Planned |
-| `openlegion session` / `openlegion sessions` reader CLI | Phase 3 | Planned |
-| Agent-side tool/handoff traces + log correlation | Phase 4 | Planned |
-
-> Commands marked **(Phase 3 — planned)** above do **not** work today. Until
-> they ship, use the [raw SQL](#finding-the-data-manually) path. Phase 1 is the
-> only shipped piece — it makes the correlation key (`trace_id`) present in the
-> data so the later phases can read it.
+| Verbatim intent capture (`data/intent.db`) | Phase 2 | **Shipped — PR #1153** |
+| `openlegion session` / `openlegion sessions` reader CLI | Phase 3 | **Shipped — PR #1154** |
+| Agent-side tool/handoff/iteration traces + log correlation | Phase 4 | **Shipped** |
+| Off-box log shipping | Phase 4 | Deferred (out-of-MVP hook) |
 
 ---
 

--- a/docs/plans/2026-06-18-session-observability.md
+++ b/docs/plans/2026-06-18-session-observability.md
@@ -1,7 +1,7 @@
 # Session Observability — durable, correlated session reconstruction
 
 **Date:** 2026-06-18
-**Status:** Phase 1 SHIPPED in PR #1149 (CI green; not yet merged). Phases 2–4 detailed below, not yet implemented.
+**Status:** SHIPPED. Phase 1 (#1149), Phase 2 (#1153), Phase 3 (#1154), and Phase 4 (agent-side traces + log correlation) are all merged to `main`. Off-box log shipping is the one deliberately deferred out-of-MVP hook.
 
 ## Motivation
 

--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -45,6 +45,13 @@ def main() -> None:
     agent_id = os.environ["AGENT_ID"]
     role = os.environ["AGENT_ROLE"]
     mesh_url = os.environ["MESH_URL"]
+
+    # Phase 4 log correlation: stamp this process's identity so every log line
+    # in the container is attributable. The structured formatter also falls
+    # back to the AGENT_ID env var for per-request contexts that never inherit
+    # this set(), but setting it here covers code that reads the contextvar.
+    from src.shared.trace import current_agent_id
+    current_agent_id.set(agent_id)
     tools_dir = os.environ.get("TOOLS_DIR", "/app/tools")
 
     llm_model = os.environ.get("LLM_MODEL", "openai/gpt-4o-mini")

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -418,21 +418,6 @@ async def hand_off(
         record.get("parent_task_id"), record.get("project_id"),
     )
 
-    # Phase 4 trace: the handoff edge (creator → assignee) under the active
-    # trace_id, so a session timeline shows where work crossed agents. The
-    # task summary is redacted at storage (H16). Best-effort — record_trace
-    # swallows errors and no-ops without a trace context.
-    record_trace = getattr(mesh_client, "record_trace", None)
-    if asyncio.iscoroutinefunction(record_trace):
-        try:
-            await record_trace(
-                "handoff",
-                detail=f"{mesh_client.agent_id} → {to}",
-                meta={"task_id": task_id, "to": to, "summary": summary[:200]},
-            )
-        except Exception as e:
-            logger.debug("hand_off trace emit failed (non-fatal): %s", e)
-
     # Wake the target so they pick up the task immediately. The task
     # is queued in SQLite either way; wake failures surface via
     # ``handed_off=False`` + ``task_queued=True`` so the caller can
@@ -456,6 +441,23 @@ async def hand_off(
         # genuine infra failure (500 / network) below.
         wake_status = getattr(getattr(e, "response", None), "status_code", None)
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
+
+    # Phase 4 trace: the handoff edge (creator → assignee) under the active
+    # trace_id, so a session timeline shows where work crossed agents. Emitted
+    # AFTER the wake so a slow trace ingest never delays the actual wake — the
+    # durable task already exists, so the edge is real regardless of wake
+    # outcome. Task summary is redacted at storage (H16); best-effort —
+    # record_trace swallows errors and no-ops without a trace context.
+    record_trace = getattr(mesh_client, "record_trace", None)
+    if asyncio.iscoroutinefunction(record_trace):
+        try:
+            await record_trace(
+                "handoff",
+                detail=f"{mesh_client.agent_id} → {to}",
+                meta={"task_id": task_id, "to": to, "summary": summary[:200]},
+            )
+        except Exception as e:
+            logger.debug("hand_off trace emit failed (non-fatal): %s", e)
 
     result = {
         "handed_off": wake_error is None,

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -12,6 +12,7 @@ production fleet was running with the kill-switch off.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 
@@ -416,6 +417,21 @@ async def hand_off(
         record.get("assignee"), record.get("creator"),
         record.get("parent_task_id"), record.get("project_id"),
     )
+
+    # Phase 4 trace: the handoff edge (creator → assignee) under the active
+    # trace_id, so a session timeline shows where work crossed agents. The
+    # task summary is redacted at storage (H16). Best-effort — record_trace
+    # swallows errors and no-ops without a trace context.
+    record_trace = getattr(mesh_client, "record_trace", None)
+    if asyncio.iscoroutinefunction(record_trace):
+        try:
+            await record_trace(
+                "handoff",
+                detail=f"{mesh_client.agent_id} → {to}",
+                meta={"task_id": task_id, "to": to, "summary": summary[:200]},
+            )
+        except Exception as e:
+            logger.debug("hand_off trace emit failed (non-fatal): %s", e)
 
     # Wake the target so they pick up the task immediately. The task
     # is queued in SQLite either way; wake failures surface via

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3581,6 +3581,13 @@ class AgentLoop:
             result_str = json.dumps({"error": block_error})
             result = {"error": block_error}
             self._loop_detector.record(tool_call.name, tool_call.arguments, result_str)
+            # A blocked loop IS a tool-call outcome — emit it so the session
+            # timeline shows the silent repeated-tool failure that observability
+            # exists to diagnose (rather than a gap before the loop stops).
+            self._emit_trace(
+                "tool_call", detail=tool_call.name, status="error",
+                error=f"loop detected ({loop_verdict})",
+            )
             return result_str, result
 
         _trace_t0 = time.time()

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -518,15 +518,61 @@ class AgentLoop:
         # inner loop with a live FastAPI thread.
         self._last_iteration_ts: float | None = None
         self._iterations_since_boot: int = 0
+        # Strong refs to in-flight fire-and-forget trace POSTs so the event
+        # loop doesn't garbage-collect them mid-flight (Phase 4 observability).
+        self._trace_tasks: set = set()
+
+    def _emit_trace(
+        self, event_type: str, *, detail: str = "", status: str = "ok",
+        error: str = "", duration_ms: int = 0, meta: dict | None = None,
+    ) -> None:
+        """Fire-and-forget an agent-side trace event to the mesh (Phase 4).
+
+        Non-blocking by design: schedules ``mesh_client.record_trace`` as a
+        background task (which itself swallows all errors and no-ops without an
+        active trace context) so the loop never waits on or fails from tracing.
+        ``asyncio.create_task`` copies the current context, so the spawned task
+        sees the same ``current_trace_id`` set on this turn.
+        """
+        # Nothing to correlate without an active trace — skip scheduling a
+        # task at all (heartbeat/free-chat iterations have no trace context).
+        from src.shared.trace import current_trace_id
+        if current_trace_id.get() is None:
+            return
+        client = getattr(self, "mesh_client", None)
+        record = getattr(client, "record_trace", None)
+        # Only schedule a real coroutine. Guards the common test setup where
+        # mesh_client is a plain MagicMock (record_trace is then a non-async
+        # attribute and create_task would TypeError). AsyncMock passes.
+        if record is None or not asyncio.iscoroutinefunction(record):
+            return
+        try:
+            task = asyncio.create_task(
+                record(
+                    event_type, detail=detail, status=status,
+                    error=error, duration_ms=duration_ms, meta=meta,
+                )
+            )
+            self._trace_tasks.add(task)
+            task.add_done_callback(self._trace_tasks.discard)
+        except Exception:
+            # Best-effort: tracing must never break the loop (no running loop,
+            # scheduling failure, etc.).
+            return
 
     def _bump_liveness(self) -> None:
         """Stamp the last-iteration timestamp + bump the boot-relative counter.
 
         Called at the head of every iteration in execute_task and per-round
-        in the chat loops. Cheap on purpose — no I/O, no lock.
+        in the chat loops. Cheap on purpose — no I/O, no lock. The trace emit
+        is fire-and-forget (a scheduled task, not an awaited call), so this
+        stays non-blocking.
         """
         self._last_iteration_ts = time.time()
         self._iterations_since_boot += 1
+        self._emit_trace(
+            "iteration", detail=f"iteration {self._iterations_since_boot}",
+        )
 
     @property
     def _tool_filter_kw(self) -> dict:
@@ -3537,6 +3583,7 @@ class AgentLoop:
             self._loop_detector.record(tool_call.name, tool_call.arguments, result_str)
             return result_str, result
 
+        _trace_t0 = time.time()
         try:
             result = await asyncio.wait_for(
                 self.tools.execute(
@@ -3600,6 +3647,20 @@ class AgentLoop:
                         "soft-error learnings write failed: %s", learn_err,
                     )
 
+            # Phase 4 trace: one tool_call event per executed tool. Status
+            # reflects the soft-error envelope ({"error": ...}) that most
+            # builtins return without raising. Fire-and-forget — never blocks.
+            _tool_err = (
+                str(result["error"])[:500]
+                if isinstance(result, dict) and result.get("error")
+                else ""
+            )
+            self._emit_trace(
+                "tool_call", detail=tool_call.name,
+                status="error" if _tool_err else "ok", error=_tool_err,
+                duration_ms=int((time.time() - _trace_t0) * 1000),
+            )
+
             # Build multimodal content when an image is present
             if image_block and isinstance(image_block, dict) and image_block.get("data"):
                 media_type = image_block.get("media_type", "image/png")
@@ -3617,6 +3678,11 @@ class AgentLoop:
             self._loop_detector.record(tool_call.name, tool_call.arguments, result_str)
             result = {"error": f"Timed out after {_TOOL_TIMEOUT}s"}
             logger.error(f"Tool {tool_call.name} timed out after {_TOOL_TIMEOUT}s")
+            self._emit_trace(
+                "tool_call", detail=tool_call.name, status="error",
+                error=f"Timed out after {_TOOL_TIMEOUT}s",
+                duration_ms=int((time.time() - _trace_t0) * 1000),
+            )
             await self._record_failure(
                 tool_call.name, f"Timed out after {_TOOL_TIMEOUT}s",
                 truncate(str(tool_call.arguments), 200),
@@ -3629,6 +3695,11 @@ class AgentLoop:
             self._loop_detector.record(tool_call.name, tool_call.arguments, result_str)
             result = {"error": str(e)}
             logger.error(f"Tool {tool_call.name} failed: {e}")
+            self._emit_trace(
+                "tool_call", detail=tool_call.name, status="error",
+                error=str(e)[:500],
+                duration_ms=int((time.time() - _trace_t0) * 1000),
+            )
             await self._record_failure(
                 tool_call.name, str(e),
                 truncate(str(tool_call.arguments), 200),

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -386,7 +386,7 @@ class MeshClient:
             return
         try:
             client = await self._get_client()
-            await client.post(
+            resp = await client.post(
                 f"{self.mesh_url}/mesh/traces",
                 json={
                     "agent_id": self.agent_id,
@@ -400,6 +400,19 @@ class MeshClient:
                 headers=headers,
                 timeout=5,
             )
+            # Surface a silently-dropped trace (auth/rate-limit/no-store) at
+            # debug so a broken tracer is diagnosable without spamming logs or
+            # ever raising — the response is otherwise discarded.
+            if resp.status_code >= 400:
+                logger.debug(
+                    "record_trace(%s) rejected: HTTP %s", event_type, resp.status_code,
+                )
+            else:
+                try:
+                    if resp.json().get("recorded") is False:
+                        logger.debug("record_trace(%s) not recorded by mesh", event_type)
+                except Exception:
+                    pass
         except Exception as e:
             logger.debug("record_trace(%s) failed (non-fatal): %s", event_type, e)
 

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
-from src.shared.trace import origin_header
+from src.shared.trace import TRACE_HEADER, origin_header
 from src.shared.types import MeshEvent
 from src.shared.utils import setup_logging
 
@@ -360,6 +360,48 @@ class MeshClient:
         )
         _raise_with_body(response)
         return response.json()
+
+    async def record_trace(
+        self,
+        event_type: str,
+        *,
+        detail: str = "",
+        status: str = "ok",
+        error: str = "",
+        duration_ms: int = 0,
+        meta: dict | None = None,
+    ) -> None:
+        """Record an agent-side trace event on the mesh (Phase 4).
+
+        The agent never writes ``traces.db`` directly — container isolation is
+        the whole reason traces are host-only — so it POSTs to ``/mesh/traces``
+        and the mesh records on its behalf under the inbound ``x-trace-id``
+        (mirroring how ``llm_call`` traces already reach the store from the API
+        proxy). Best-effort and non-blocking: callers fire-and-forget this, and
+        it swallows every error so tracing can never stall or break the loop. If
+        no trace context is active there is nothing to correlate, so it no-ops.
+        """
+        headers = self._trace_headers()
+        if TRACE_HEADER not in headers:
+            return
+        try:
+            client = await self._get_client()
+            await client.post(
+                f"{self.mesh_url}/mesh/traces",
+                json={
+                    "agent_id": self.agent_id,
+                    "event_type": event_type,
+                    "detail": detail,
+                    "status": status,
+                    "error": error,
+                    "duration_ms": duration_ms,
+                    "meta": meta or {},
+                },
+                headers=headers,
+                timeout=5,
+            )
+        except Exception as e:
+            logger.debug("record_trace(%s) failed (non-fatal): %s", event_type, e)
 
     async def publish_event(self, topic: str, payload: dict | None = None) -> dict:
         """Publish an event to the mesh pub/sub."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1078,6 +1078,12 @@ def create_mesh_app(
         # cap notification-store writes when a runaway agent retries on a
         # broken credential before its lane gate latches.
         "auth_failure": (60, 60),
+        # Agent-side trace ingest (Phase 4 observability). One write per tool
+        # call / handoff / loop iteration — paced by the agent loop itself, so
+        # this ceiling only catches a genuinely runaway loop. Generous like the
+        # other forensic write paths; dropped traces only degrade observability,
+        # never correctness.
+        "trace_ingest": (12000, 60),
     }
 
     async def _check_rate_limit(endpoint: str, agent_id: str) -> None:
@@ -2732,6 +2738,43 @@ def create_mesh_app(
         except Exception as e:
             logger.debug("user_notification_log.record failed: %s", e)
         return {"sent": True}
+
+    @app.post("/mesh/traces")
+    async def record_agent_trace(data: dict, request: Request) -> dict:
+        """Ingest an agent-side trace event (Phase 4 observability).
+
+        Agents cannot write ``traces.db`` directly — host-only by container
+        isolation — so they POST tool_call / handoff / iteration events here
+        and the mesh records them under the inbound ``x-trace-id``, the same
+        indirection the API proxy uses for ``llm_call`` traces. Gated by
+        standard agent auth (``_resolve_agent_id`` derives the unforgeable id
+        from the Bearer token; the body ``agent_id`` is never trusted when auth
+        is active). Best-effort: no trace context or no store → accepted no-op;
+        a record failure never propagates back to the agent. Redaction happens
+        inside ``TraceStore.record`` (H16), so detail/error/meta pass through.
+        """
+        agent_id = _resolve_agent_id(str(data.get("agent_id", "")), request)
+        await _check_rate_limit("trace_ingest", agent_id)
+        req_trace_id = request.headers.get("x-trace-id")
+        if not req_trace_id or trace_store is None:
+            return {"recorded": False}
+        try:
+            meta = data.get("meta")
+            trace_store.record(
+                trace_id=req_trace_id,
+                source="agent",
+                agent=agent_id,
+                event_type=str(data.get("event_type", ""))[:64],
+                detail=str(data.get("detail", "")),
+                duration_ms=int(data.get("duration_ms", 0) or 0),
+                status=str(data.get("status", "ok")),
+                error=str(data.get("error", "")),
+                meta=meta if isinstance(meta, dict) else None,
+            )
+        except Exception:
+            logger.debug("trace ingest failed for agent=%s", agent_id, exc_info=True)
+            return {"recorded": False}
+        return {"recorded": True}
 
     @app.post("/mesh/credential-request")
     async def credential_request(data: dict, request: Request) -> dict:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2758,6 +2758,13 @@ def create_mesh_app(
         req_trace_id = request.headers.get("x-trace-id")
         if not req_trace_id or trace_store is None:
             return {"recorded": False}
+        # Coerce duration defensively: a malformed value must not drop the
+        # whole trace, and a negative one must not be stored. Clamp to a sane
+        # ceiling (24h in ms) so a bogus huge value can't pollute rollups.
+        try:
+            duration_ms = max(0, min(int(data.get("duration_ms", 0) or 0), 86_400_000))
+        except (TypeError, ValueError):
+            duration_ms = 0
         try:
             meta = data.get("meta")
             trace_store.record(
@@ -2766,7 +2773,7 @@ def create_mesh_app(
                 agent=agent_id,
                 event_type=str(data.get("event_type", ""))[:64],
                 detail=str(data.get("detail", "")),
-                duration_ms=int(data.get("duration_ms", 0) or 0),
+                duration_ms=duration_ms,
                 status=str(data.get("status", "ok")),
                 error=str(data.get("error", "")),
                 meta=meta if isinstance(meta, dict) else None,

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -48,6 +48,18 @@ current_task_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "current_task_id", default=None,
 )
 
+# Identity of the process/agent emitting work. Set once at agent boot
+# (``src/agent/__main__.py``) so every log line in an agent container can
+# be attributed without threading the id through. The mesh host process
+# leaves it ``None`` (host log lines carry the agent in ``extra_data``
+# instead). Phase 4 log correlation reads this alongside the trace/task
+# ids; the structured formatter additionally falls back to the ``AGENT_ID``
+# env var so per-request contexts that never inherited the boot ``set()``
+# are still attributed.
+current_agent_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_agent_id", default=None,
+)
+
 
 def new_trace_id() -> str:
     """Generate a fresh trace ID: ``tr_<12-hex-chars>``."""
@@ -95,6 +107,7 @@ __all__ = [
     "current_trace_id",
     "current_origin",
     "current_task_id",
+    "current_agent_id",
     "new_trace_id",
     "trace_headers",
     "origin_header",

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -178,6 +178,35 @@ def friendly_streaming_error(exc: Exception) -> str:
     return raw
 
 
+def _log_trace_context() -> dict:
+    """Return active correlation IDs (trace/task/agent) for a log line.
+
+    Lazy-imports ``src.shared.trace`` to avoid the import cycle (trace.py
+    imports ``setup_logging`` from this module). Repeated imports are a cheap
+    ``sys.modules`` lookup. Never raises — a logging path must never break.
+    ``current_agent_id`` falls back to the ``AGENT_ID`` env var so agent
+    containers attribute every line even when a per-request context never
+    inherited the boot-time ``set()``; the mesh host has no ``AGENT_ID`` so it
+    stays absent there.
+    """
+    try:
+        from src.shared.trace import current_agent_id, current_task_id, current_trace_id
+
+        ctx: dict = {}
+        tid = current_trace_id.get()
+        if tid:
+            ctx["trace_id"] = tid
+        task = current_task_id.get()
+        if task:
+            ctx["task_id"] = task
+        aid = current_agent_id.get() or os.environ.get("AGENT_ID")
+        if aid:
+            ctx["agent_id"] = aid
+        return ctx
+    except Exception:
+        return {}
+
+
 class StructuredFormatter(logging.Formatter):
     """JSON log formatter for structured logging."""
 
@@ -190,6 +219,8 @@ class StructuredFormatter(logging.Formatter):
         }
         if record.exc_info:
             log_entry["exception"] = self.formatException(record.exc_info)
+        # Correlation IDs first so an explicit ``extra_data`` key still wins.
+        log_entry.update(_log_trace_context())
         if hasattr(record, "extra_data"):
             log_entry.update(record.extra_data)
         return json.dumps(log_entry)
@@ -202,6 +233,9 @@ class TextFormatter(logging.Formatter):
         ts = datetime.now(UTC).strftime("%H:%M:%S")
         msg = record.getMessage()
         line = f"{ts} [{record.levelname:<5}] {record.name}: {msg}"
+        ctx = _log_trace_context()
+        if ctx:
+            line += " [" + " ".join(f"{k}={v}" for k, v in ctx.items()) + "]"
         if record.exc_info:
             line += "\n" + self.formatException(record.exc_info)
         return line

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -46,6 +46,31 @@ def _make_mesh_client(agent_id="scout", standalone=False):
 
 class TestHandOff:
     @pytest.mark.asyncio
+    async def test_hand_off_emits_handoff_trace(self):
+        """Phase 4: a successful handoff records a ``handoff`` trace edge
+        (creator → assignee) carrying the new task_id. Best-effort and awaited
+        inline; a non-async record_trace (the default MagicMock) is skipped."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.record_trace = AsyncMock()
+
+        result = await hand_off(
+            to="analyst",
+            summary="dig into the logs",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        mc.record_trace.assert_awaited_once()
+        args, kwargs = mc.record_trace.call_args
+        assert args[0] == "handoff"
+        assert "scout" in kwargs["detail"] and "analyst" in kwargs["detail"]
+        assert kwargs["meta"]["task_id"] == "task_abc123def456"
+        assert kwargs["meta"]["to"] == "analyst"
+
+    @pytest.mark.asyncio
     async def test_hand_off_invalid_target(self):
         from src.agent.builtins.coordination_tool import hand_off
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -147,6 +147,75 @@ async def test_task_nudge_fires_when_tools_available():
 
 
 @pytest.mark.asyncio
+async def test_run_tool_emits_tool_call_trace():
+    """Phase 4: ``_run_tool`` fire-and-forgets a ``tool_call`` trace under the
+    active trace context. The emit is non-blocking (a scheduled task), so we
+    let the loop tick once to flush it before asserting."""
+    from src.shared.trace import current_trace_id
+
+    loop = _make_loop()
+    loop.tools.execute = AsyncMock(return_value={"results": ["r1"]})
+    loop.mesh_client.record_trace = AsyncMock()
+
+    tok = current_trace_id.set("tr_tool0000001")
+    try:
+        await loop._run_tool(ToolCallInfo(name="web_search", arguments={"q": "x"}))
+        # Flush the fire-and-forget create_task scheduled by _emit_trace.
+        for _ in range(3):
+            await asyncio.sleep(0)
+    finally:
+        current_trace_id.reset(tok)
+
+    loop.mesh_client.record_trace.assert_awaited()
+    args, kwargs = loop.mesh_client.record_trace.call_args
+    assert args[0] == "tool_call"
+    assert kwargs["detail"] == "web_search"
+    assert kwargs["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_tool_emits_error_status_on_soft_error():
+    """A builtin's ``{"error": ...}`` envelope (no raise) is traced with
+    ``status='error'`` and the error text."""
+    from src.shared.trace import current_trace_id
+
+    loop = _make_loop()
+    loop.tools.execute = AsyncMock(return_value={"error": "bad input"})
+    loop.mesh_client.record_trace = AsyncMock()
+
+    tok = current_trace_id.set("tr_tool0000002")
+    try:
+        await loop._run_tool(ToolCallInfo(name="file_read", arguments={}))
+        for _ in range(3):
+            await asyncio.sleep(0)
+    finally:
+        current_trace_id.reset(tok)
+
+    loop.mesh_client.record_trace.assert_awaited()
+    _, kwargs = loop.mesh_client.record_trace.call_args
+    assert kwargs["status"] == "error"
+    assert "bad input" in kwargs["error"]
+
+
+@pytest.mark.asyncio
+async def test_emit_trace_noops_with_non_async_record_trace():
+    """The common MagicMock mesh_client (record_trace is a non-coroutine
+    attribute) must not schedule a broken task or raise — the
+    ``iscoroutinefunction`` guard skips it even WITH an active trace context."""
+    from src.shared.trace import current_trace_id
+
+    loop = _make_loop()  # mesh_client is a MagicMock → record_trace is MagicMock
+    tok = current_trace_id.set("tr_guard0000001")
+    try:
+        # Must not raise despite a non-async record_trace.
+        loop._emit_trace("iteration", detail="x")
+        await asyncio.sleep(0)
+    finally:
+        current_trace_id.reset(tok)
+    assert loop._trace_tasks == set()
+
+
+@pytest.mark.asyncio
 async def test_lazy_completion_guard_fails_text_only_after_nudge():
     """Bug F: LLM responds with text-only acknowledgment ("I'll do it now")
     on iteration 0, gets nudged, then responds with text-only again on

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -198,6 +198,34 @@ async def test_run_tool_emits_error_status_on_soft_error():
 
 
 @pytest.mark.asyncio
+async def test_emit_trace_child_inherits_trace_after_parent_reset():
+    """The fire-and-forget trace is load-bearing only if the spawned task sees
+    the trace_id from creation time, not from whatever the parent context holds
+    when the task later runs. Reset the parent context IMMEDIATELY after
+    scheduling and prove the child still observed the original trace."""
+    from src.shared.trace import current_trace_id
+
+    seen: list = []
+
+    async def _capture(*_a, **_k):
+        # Yields control first so the parent's reset (below) has already run by
+        # the time we read the contextvar — proving inheritance, not timing.
+        await asyncio.sleep(0)
+        seen.append(current_trace_id.get())
+
+    loop = _make_loop()
+    loop.mesh_client.record_trace = _capture
+
+    tok = current_trace_id.set("tr_inherit00001")
+    loop._emit_trace("iteration", detail="x")
+    current_trace_id.reset(tok)  # parent context cleared before the child runs
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    assert seen == ["tr_inherit00001"]
+
+
+@pytest.mark.asyncio
 async def test_emit_trace_noops_with_non_async_record_trace():
     """The common MagicMock mesh_client (record_trace is a non-coroutine
     attribute) must not schedule a broken task or raise — the

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1597,6 +1597,36 @@ async def test_traces_ingest_without_header_noops(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_traces_ingest_coerces_bad_duration(tmp_path, monkeypatch):
+    """A malformed/negative ``duration_ms`` must not drop the whole trace —
+    it is coerced (bad → 0) and clamped (negative → 0) rather than raising
+    into the no-op path."""
+    server_module = _reload_server(monkeypatch, tasks_db=str(tmp_path / "tasks.db"))
+    app, bb, traces = _build_traces_app(tmp_path, server_module)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r_bad = await c.post(
+                "/mesh/traces",
+                json={"agent_id": "a", "event_type": "iteration", "duration_ms": "oops"},
+                headers={"X-Agent-ID": "a", "X-Trace-Id": "tr_dur00000001"},
+            )
+            r_neg = await c.post(
+                "/mesh/traces",
+                json={"agent_id": "a", "event_type": "iteration", "duration_ms": -5},
+                headers={"X-Agent-ID": "a", "X-Trace-Id": "tr_dur00000002"},
+            )
+        assert r_bad.json()["recorded"] is True
+        assert r_neg.json()["recorded"] is True
+        assert traces.get_trace("tr_dur00000001")[0]["duration_ms"] == 0
+        assert traces.get_trace("tr_dur00000002")[0]["duration_ms"] == 0
+    finally:
+        bb.close()
+        traces.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
 async def test_traces_ingest_agent_id_from_token_not_body(tmp_path, monkeypatch):
     """Under auth the recorded ``agent`` is the verified token identity — a
     spoofed body ``agent_id`` is ignored (``_resolve_agent_id`` derives it

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1501,3 +1501,128 @@ async def test_retry_clone_inherits_original_trace_id(v2_app):
         clone = r.json()["clone"]
         assert clone["id"] != tid
         assert clone["trace_id"] == "tr_retry0000001"
+
+
+# ── Session observability (Phase 4): agent-side trace ingest endpoint ──
+#
+# Agents cannot write traces.db (host-only by container isolation), so they
+# POST tool_call/handoff/iteration events to ``/mesh/traces`` and the mesh
+# records them under the inbound ``X-Trace-Id`` — mirroring the llm_call
+# ingest in the API proxy. These tests pin: (1) a record lands with
+# source="agent" under the header trace; (2) no header → accepted no-op,
+# nothing stored (no orphan rows with a NULL/empty trace); (3) under auth the
+# recorded ``agent`` comes from the verified token, not the spoofable body.
+
+
+def _build_traces_app(tmp_path, server_module, *, auth_tokens=None):
+    """Mesh app wired with a TraceStore, for ``/mesh/traces`` ingest tests."""
+    from src.host.traces import TraceStore
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    permissions = PermissionMatrix()
+    router = MessageRouter(permissions, {"analyst": "http://analyst:8400"})
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=PubSub(),
+        router=router,
+        permissions=permissions,
+        trace_store=traces,
+        auth_tokens=auth_tokens,
+    )
+    return app, blackboard, traces
+
+
+@pytest.mark.asyncio
+async def test_traces_ingest_records_under_header_trace_id(tmp_path, monkeypatch):
+    """``POST /mesh/traces`` with ``X-Trace-Id`` records an agent-sourced
+    event the session reader can join by trace_id. Redaction happens inside
+    ``TraceStore.record`` — a URL with embedded credentials is stripped."""
+    server_module = _reload_server(monkeypatch, tasks_db=str(tmp_path / "tasks.db"))
+    app, bb, traces = _build_traces_app(tmp_path, server_module)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/traces",
+                json={
+                    "agent_id": "analyst",
+                    "event_type": "tool_call",
+                    "detail": "http_request via https://u:p4ss@api.example.com/x",
+                    "duration_ms": 42,
+                    "status": "ok",
+                    "meta": {"foo": "bar"},
+                },
+                headers={"X-Agent-ID": "analyst", "X-Trace-Id": "tr_agent0000001"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["recorded"] is True
+        rows = traces.get_trace("tr_agent0000001")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["source"] == "agent"
+        assert row["agent"] == "analyst"
+        assert row["event_type"] == "tool_call"
+        assert row["duration_ms"] == 42
+        # H16: embedded credentials redacted at storage.
+        assert "p4ss" not in row["detail"]
+        assert "api.example.com" in row["detail"]
+    finally:
+        bb.close()
+        traces.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_traces_ingest_without_header_noops(tmp_path, monkeypatch):
+    """No ``X-Trace-Id`` → accepted no-op: nothing is stored. There is no
+    trace to correlate, and we never want an orphan row with an empty trace."""
+    server_module = _reload_server(monkeypatch, tasks_db=str(tmp_path / "tasks.db"))
+    app, bb, traces = _build_traces_app(tmp_path, server_module)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/traces",
+                json={"agent_id": "analyst", "event_type": "iteration"},
+                headers={"X-Agent-ID": "analyst"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["recorded"] is False
+        assert traces.list_recent(limit=10) == []
+    finally:
+        bb.close()
+        traces.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_traces_ingest_agent_id_from_token_not_body(tmp_path, monkeypatch):
+    """Under auth the recorded ``agent`` is the verified token identity — a
+    spoofed body ``agent_id`` is ignored (``_resolve_agent_id`` derives it
+    from the Bearer token)."""
+    server_module = _reload_server(monkeypatch, tasks_db=str(tmp_path / "tasks.db"))
+    app, bb, traces = _build_traces_app(
+        tmp_path, server_module,
+        auth_tokens={"analyst": "tok_analyst", "scout": "tok_scout"},
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/traces",
+                json={"agent_id": "scout", "event_type": "tool_call", "detail": "x"},
+                headers={
+                    "X-Agent-ID": "scout",  # spoof attempt
+                    "Authorization": "Bearer tok_analyst",
+                    "X-Trace-Id": "tr_authagent001",
+                },
+            )
+        assert r.status_code == 200, r.text
+        rows = traces.get_trace("tr_authagent001")
+        assert len(rows) == 1
+        assert rows[0]["agent"] == "analyst"  # token wins over body/header
+    finally:
+        bb.close()
+        traces.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)

--- a/tests/test_session_trace_emit.py
+++ b/tests/test_session_trace_emit.py
@@ -1,0 +1,167 @@
+"""Phase 4 session-observability tests: agent-side trace emission +
+structured-log correlation.
+
+Covers the *agent* end of the trace pipeline (the mesh ingest endpoint is
+tested in ``test_orchestration_endpoints.py``):
+
+* ``MeshClient.record_trace`` — no-ops without an active trace context, POSTs
+  to ``/mesh/traces`` under it, and swallows transport errors (best-effort).
+* ``StructuredFormatter`` / ``TextFormatter`` — inject ``trace_id`` /
+  ``task_id`` / ``agent_id`` correlation IDs, with ``extra_data`` winning and
+  the ``AGENT_ID`` env var as the agent-id fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.agent.mesh_client import MeshClient
+from src.shared.trace import current_agent_id, current_task_id, current_trace_id
+from src.shared.utils import StructuredFormatter, TextFormatter
+
+
+def _mk_client_with_fake_post():
+    mc = MeshClient("http://mesh:8420", "worker")
+    fake = MagicMock()
+    fake.post = AsyncMock()
+    mc._get_client = AsyncMock(return_value=fake)
+    return mc, fake
+
+
+@pytest.mark.asyncio
+async def test_record_trace_noops_without_trace_context():
+    """No active trace → nothing to correlate → no POST is made."""
+    mc, fake = _mk_client_with_fake_post()
+    tok = current_trace_id.set(None)
+    try:
+        await mc.record_trace("tool_call", detail="x")
+    finally:
+        current_trace_id.reset(tok)
+    fake.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_trace_posts_under_trace_context():
+    """With an active trace, POST /mesh/traces carries the event + the
+    X-Trace-Id header so the mesh records under the originating trace."""
+    mc, fake = _mk_client_with_fake_post()
+    tok = current_trace_id.set("tr_emit0000001")
+    try:
+        await mc.record_trace(
+            "tool_call", detail="http_request", duration_ms=12,
+            status="ok", meta={"a": 1},
+        )
+    finally:
+        current_trace_id.reset(tok)
+    fake.post.assert_awaited_once()
+    args, kwargs = fake.post.call_args
+    assert args[0].endswith("/mesh/traces")
+    body = kwargs["json"]
+    assert body["event_type"] == "tool_call"
+    assert body["agent_id"] == "worker"
+    assert body["detail"] == "http_request"
+    assert body["duration_ms"] == 12
+    assert body["meta"] == {"a": 1}
+    assert kwargs["headers"].get("X-Trace-Id") == "tr_emit0000001"
+
+
+@pytest.mark.asyncio
+async def test_record_trace_swallows_post_errors():
+    """Transport failure must never propagate — tracing is best-effort."""
+    mc = MeshClient("http://mesh:8420", "worker")
+    fake = MagicMock()
+    fake.post = AsyncMock(side_effect=RuntimeError("boom"))
+    mc._get_client = AsyncMock(return_value=fake)
+    tok = current_trace_id.set("tr_emit0000002")
+    try:
+        await mc.record_trace("tool_call")  # must not raise
+    finally:
+        current_trace_id.reset(tok)
+
+
+def _rec(msg: str = "hello") -> logging.LogRecord:
+    return logging.LogRecord("mod", logging.INFO, "f.py", 1, msg, None, None)
+
+
+def _reset_ctx():
+    """Pin all correlation contextvars to None and return reset tokens."""
+    return (
+        current_trace_id.set(None),
+        current_task_id.set(None),
+        current_agent_id.set(None),
+    )
+
+
+def test_structured_formatter_omits_ids_without_context(monkeypatch):
+    monkeypatch.delenv("AGENT_ID", raising=False)
+    toks = _reset_ctx()
+    try:
+        out = json.loads(StructuredFormatter().format(_rec()))
+    finally:
+        current_trace_id.reset(toks[0])
+        current_task_id.reset(toks[1])
+        current_agent_id.reset(toks[2])
+    assert "trace_id" not in out
+    assert "task_id" not in out
+    assert "agent_id" not in out
+
+
+def test_structured_formatter_injects_correlation_ids(monkeypatch):
+    monkeypatch.delenv("AGENT_ID", raising=False)
+    t1 = current_trace_id.set("tr_log00000001")
+    t2 = current_task_id.set("task_log_1")
+    t3 = current_agent_id.set("worker7")
+    try:
+        out = json.loads(StructuredFormatter().format(_rec()))
+    finally:
+        current_trace_id.reset(t1)
+        current_task_id.reset(t2)
+        current_agent_id.reset(t3)
+    assert out["trace_id"] == "tr_log00000001"
+    assert out["task_id"] == "task_log_1"
+    assert out["agent_id"] == "worker7"
+
+
+def test_structured_formatter_extra_data_wins(monkeypatch):
+    monkeypatch.delenv("AGENT_ID", raising=False)
+    t1 = current_trace_id.set("tr_ambient")
+    try:
+        rec = _rec()
+        rec.extra_data = {"trace_id": "tr_explicit", "extra": 1}
+        out = json.loads(StructuredFormatter().format(rec))
+    finally:
+        current_trace_id.reset(t1)
+    assert out["trace_id"] == "tr_explicit"
+    assert out["extra"] == 1
+
+
+def test_structured_formatter_agent_id_falls_back_to_env(monkeypatch):
+    """Per-request contexts may never inherit the boot ``set()``; the env
+    var keeps every agent-container line attributed."""
+    monkeypatch.setenv("AGENT_ID", "env_worker")
+    toks = _reset_ctx()  # current_agent_id explicitly None
+    try:
+        out = json.loads(StructuredFormatter().format(_rec()))
+    finally:
+        current_trace_id.reset(toks[0])
+        current_task_id.reset(toks[1])
+        current_agent_id.reset(toks[2])
+    assert out["agent_id"] == "env_worker"
+
+
+def test_text_formatter_appends_correlation_suffix(monkeypatch):
+    monkeypatch.delenv("AGENT_ID", raising=False)
+    t1 = current_trace_id.set("tr_text00000001")
+    t3 = current_agent_id.set("worker9")
+    try:
+        line = TextFormatter().format(_rec("doing work"))
+    finally:
+        current_trace_id.reset(t1)
+        current_agent_id.reset(t3)
+    assert "doing work" in line
+    assert "trace_id=tr_text00000001" in line
+    assert "agent_id=worker9" in line


### PR DESCRIPTION
## Summary

Completes **Session Observability** (Phases 1–3 already on `main`: #1149, #1153, #1154). Until now `traces.db` was written only by the mesh (`llm_call` events from the API proxy); the agent's own actions never reached the timeline, and log lines carried no correlation key. Phase 4 closes both gaps.

### Agent-side trace emission
Agents can't write `traces.db` directly (host-only by container isolation), so a new **`POST /mesh/traces`** ingest endpoint records on the agent's behalf under the inbound `x-trace-id` — the same indirection the API proxy already uses for `llm_call` traces. New `MeshClient.record_trace()` POSTs there; `AgentLoop` emits:
- **`tool_call`** — `_run_tool` (success / soft-error / timeout / exception), with `duration_ms` + `status` reflecting the `{"error": ...}` envelope most builtins return without raising
- **`handoff`** — `coordination_tool.hand_off`, right after `create_task`
- **`iteration`** — `_bump_liveness`

Emission is **fire-and-forget and best-effort**: a trace-context guard skips it when there's nothing to correlate, an `iscoroutinefunction` guard skips the common MagicMock test fleet, and every error is swallowed so tracing can never stall or break the loop.

### Endpoint security posture
- Gated by **standard agent auth** (`_resolve_agent_id` derives the unforgeable id from the Bearer token; the body `agent_id` is never trusted when auth is active).
- Rate-limited via a generous `trace_ingest` bucket (12000/60 — paced by the loop; only catches a runaway).
- Degrades to an **accepted no-op** when there's no trace context or no store; a record failure never propagates to the agent.
- **Redaction stays centralized** in `TraceStore.record` (H16) — detail/error/meta pass through and are redacted at storage.
- Trust note: like the existing `llm_call` ingest, an agent supplies its own `x-trace-id`. The recorded `agent` is the verified token identity (unforgeable); trace_ids are random and observability-only (never drive enforcement). No new boundary crossed.

### Log correlation
`StructuredFormatter` / `TextFormatter` now inject `trace_id` / `task_id` / `agent_id` onto every line from the request contextvars, with an explicit `extra_data` key still winning. A new `current_agent_id` contextvar is set at agent boot; the formatter falls back to the `AGENT_ID` env var so every container line is attributed even for paths that never inherit the boot `set()`. The host has no `AGENT_ID`, so host lines omit it. A lazy import in the formatter avoids the `trace`↔`utils` cycle.

Agent traces inherit the originating turn's `trace_id` (the agent server already threads inbound `x-trace-id` into `execute_task`/`chat`), so they join the rest of the session in the `openlegion session` reader **with no reader change**.

Off-box log shipping is left as a deliberately deferred out-of-MVP hook.

## Docs
- `docs/internal/session-observability.md` — marked all phases shipped, added a **Correlated logs** section, updated store/availability tables.
- `docs/plans/2026-06-18-session-observability.md` — status → SHIPPED.

## Tests
- `record_trace`: no-op without trace context / POSTs under it / swallows transport errors
- formatter: id injection, `extra_data` wins, `AGENT_ID` env fallback, text suffix
- loop `tool_call` emission: ok / soft-error status / non-async guard
- `hand_off` emission
- `POST /mesh/traces` ingest: record / no-header no-op / agent-id-from-token-not-body

**Full fast suite: 2599 passed, 47 skipped, 0 failures.** `ruff check` clean.