### PR TITLE
fix(observability): final-review fixes — chain trace continuity + dashboard intent + parse_since

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1527,6 +1527,7 @@ class RuntimeContext:
             summaries_store=getattr(app, "summaries_store", None),
             connector_store=self.connector_store,
             mcp_gateway=self.mcp_gateway,
+            intent_store=self.intent_store,
         )
         app.include_router(dashboard_router)
         app.include_router(create_spa_catchall_router())  # Must be last — SPA deep linking

--- a/src/cli/session_reader.py
+++ b/src/cli/session_reader.py
@@ -269,6 +269,23 @@ def assemble_session(data_dir: str | Path, trace_id: str) -> dict:
     }
 
 
+def _terminal_task(tasks: list[dict]) -> dict | None:
+    """Pick the task that best represents how a session ended.
+
+    ``_fetch_tasks`` orders by ``created_at``, so ``tasks[-1]`` is the newest
+    *created* task — which is wrong for the one-line outcome: a session whose
+    root task is ``done`` but which spawned a still-``pending`` child would
+    summarize as ``pending``. Prefer the most recently completed task; if none
+    has completed, fall back to the most recently updated/created one.
+    """
+    if not tasks:
+        return None
+    completed = [t for t in tasks if t.get("completed_at")]
+    if completed:
+        return max(completed, key=lambda t: t.get("completed_at") or 0)
+    return max(tasks, key=lambda t: t.get("updated_at") or t.get("created_at") or 0)
+
+
 def list_sessions(
     data_dir: str | Path,
     *,
@@ -320,8 +337,8 @@ def list_sessions(
         cost = _fetch_cost(data_dir, trace_id)
         # The terminal task's status/outcome is the most useful one-line signal.
         outcome = ""
-        if tasks:
-            last = tasks[-1]
+        last = _terminal_task(tasks)
+        if last:
             outcome = last.get("status") or ""
             if last.get("outcome"):
                 outcome = f"{outcome}/{last['outcome']}"
@@ -393,7 +410,11 @@ def render_session(session: dict) -> str:
         suffix = f" ({', '.join(tail)})" if tail else ""
         events.append((ts, f"  [{_fmt_ts(ts)}] {' '.join(bits)}{suffix}"))
     for t in session["tasks"]:
-        ts = t.get("created_at") or 0
+        # The line renders the task's CURRENT status, so timestamp it at the
+        # transition that produced that status — completed_at for a terminal
+        # task, else the last update, else creation. Using created_at would
+        # pin a "→ done" 30 minutes early and scramble the merged timeline.
+        ts = t.get("completed_at") or t.get("updated_at") or t.get("created_at") or 0
         line = (
             f"  [{_fmt_ts(ts)}] task {t.get('id') or '?'} → {t.get('status') or '?'} "
             f"(assignee={t.get('assignee') or '?'})"

--- a/src/cli/session_reader.py
+++ b/src/cli/session_reader.py
@@ -65,21 +65,26 @@ def parse_since(since: str | None) -> float:
     default = time.time() - (7 * 24 * 60 * 60)
     if not since:
         return default
-    s = since.strip().lower()
-    if not s:
+    raw = since.strip()
+    low = raw.lower()
+    if not low:
         return default
-    if s == "today":
+    if low == "today":
         now = datetime.now()
         midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
         return midnight.timestamp()
     # Duration form: Ns / Nm / Nh / Nd
-    if s[-1] in {"s", "m", "h", "d"} and s[:-1].isdigit():
-        n = int(s[:-1])
-        mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}[s[-1]]
+    if low[-1] in {"s", "m", "h", "d"} and low[:-1].isdigit():
+        n = int(low[:-1])
+        mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}[low[-1]]
         return time.time() - (n * mult)
-    # ISO date / timestamp
+    # ISO date / timestamp. Parse the ORIGINAL-case string: on Python 3.10
+    # (a supported interpreter) ``datetime.fromisoformat`` rejects a lowercase
+    # ``t`` separator, so lowercasing first made a full ``2026-06-18T12:00:00``
+    # silently fall back to the 7-day default. Only the ``Z``/``z`` UTC suffix
+    # is normalized (3.10 doesn't accept it either).
     try:
-        dt = datetime.fromisoformat(s.replace("z", "+00:00"))
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00").replace("z", "+00:00"))
         return dt.timestamp()
     except (ValueError, TypeError):
         return default

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -653,6 +653,12 @@ def create_dashboard_router(
     # Optional so existing dashboard tests that don't construct one keep
     # working; the endpoints return ``{enabled: False}`` when absent.
     summaries_store: Any = None,
+    # Session observability (Phase 2) — verbatim-intent store. The dashboard
+    # chat endpoints call the agent DIRECTLY (not via the lane's
+    # ``_direct_dispatch``, the only other capture point), so this is the sole
+    # intent-capture surface for the primary human UI. Optional so existing
+    # tests keep working; capture is skipped when absent.
+    intent_store: Any = None,
     # Phase -1 onboarding wizard — tracks first-visit activation. Optional
     # so existing tests that don't pass it keep working; we lazy-init a
     # default :class:`DashboardTelemetry` against ``data/telemetry.db``
@@ -3622,14 +3628,33 @@ def create_dashboard_router(
         # from an unrelated chat. The finally runs after transport.request,
         # so the outbound trace_headers() still carries X-Trace-Id.
         _trace_tok = current_trace_id.set(new_trace_id())
-        origin = MessageOrigin(
-            kind="human",
-            channel="dashboard",
-            user=_operator_session_id(request),
-        )
-        hdrs = trace_headers()
-        hdrs.update(origin_header(origin))
         try:
+            origin = MessageOrigin(
+                kind="human",
+                channel="dashboard",
+                user=_operator_session_id(request),
+            )
+            hdrs = trace_headers()
+            hdrs.update(origin_header(origin))
+            # Session observability (Phase 2): capture the verbatim dashboard
+            # turn. This path calls the agent directly (not via
+            # ``_direct_dispatch``), so it is the ONLY intent-capture point for
+            # the primary human surface — without it ``sessions``/``session``
+            # never see dashboard turns. Best-effort: a store failure must
+            # never break chat. Redaction happens at storage (H16).
+            if intent_store is not None:
+                try:
+                    intent_store.record(
+                        trace_id=current_trace_id.get(),
+                        origin_kind="human",
+                        origin_channel="dashboard",
+                        origin_user=origin.user,
+                        agent=agent_id,
+                        message=message,
+                        meta={"surface": "dashboard"},
+                    )
+                except Exception as _intent_err:
+                    logger.debug("dashboard intent capture failed: %s", _intent_err)
             result = await transport.request(
                 agent_id, "POST", "/chat", json={"message": message}, timeout=120,
                 headers=hdrs,
@@ -3686,6 +3711,22 @@ def create_dashboard_router(
             )
             _hdrs = trace_headers()
             _hdrs.update(origin_header(_origin))
+            # Session observability (Phase 2): capture the verbatim dashboard
+            # turn here (the streaming path also bypasses ``_direct_dispatch``).
+            # Best-effort; redaction at storage (H16). See api_chat above.
+            if intent_store is not None:
+                try:
+                    intent_store.record(
+                        trace_id=current_trace_id.get(),
+                        origin_kind="human",
+                        origin_channel="dashboard",
+                        origin_user=_origin.user,
+                        agent=agent_id,
+                        message=message,
+                        meta={"surface": "dashboard"},
+                    )
+                except Exception as _intent_err:
+                    logger.debug("dashboard intent capture failed: %s", _intent_err)
         finally:
             current_trace_id.reset(_trace_tok)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5769,6 +5769,11 @@ def create_mesh_app(
             _try_wake_agent(
                 "operator", wake_msg, wake_origin,
                 auto_notify=False,
+                # Continue the failed task's session so the operator's
+                # recovery work joins the same trace (this path runs from
+                # update_task_status, which does not seed the contextvar, so
+                # pass the task's stored trace explicitly — like retry does).
+                trace_id=task_record.get("trace_id"),
                 on_fail=lambda e: logger.warning(
                     "Operator wake for task %s failed: %s", task_id, e,
                 ),
@@ -5919,6 +5924,11 @@ def create_mesh_app(
                 _try_wake_agent(
                     origin_user, wake_msg, wake_origin,
                     task_id=task_id, auto_notify=False,
+                    # Continue the originating task's session: this back-edge
+                    # fires from update_task_status (no seeded contextvar), so
+                    # pass the task's stored trace so the notified originator's
+                    # follow-up work stays on the same trace instead of forking.
+                    trace_id=task_record.get("trace_id"),
                     on_fail=lambda e: logger.warning(
                         "Back-edge wake for %s on task %s failed: %s",
                         origin_user, task_id, e,
@@ -6641,6 +6651,9 @@ def create_mesh_app(
             f"Operator rerouted task to you: {title!r}{reason_suffix}. "
             "Call check_inbox() to pick it up.",
             origin,
+            # Continue the rerouted task's session (consistent with retry);
+            # this endpoint doesn't seed the contextvar.
+            trace_id=updated.get("trace_id"),
         )
         return updated
 
@@ -7674,6 +7687,9 @@ def create_mesh_app(
                 f"{reason_suffix}. Stop work on it and call check_inbox() "
                 "for next steps.",
                 origin,
+                # Continue the cancelled task's session so the stop-work wake
+                # joins the same trace (consistent with retry/reroute).
+                trace_id=updated.get("trace_id"),
             )
         return updated
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1697,6 +1697,10 @@ def create_mesh_app(
             ok, err = _try_wake_agent(
                 target, wake_msg, origin,
                 task_id=task_id, auto_notify=had_origin,
+                # Propagate the handoff's originating trace so the recipient's
+                # work joins the same session (keystone for multi-agent chain
+                # reconstruction).
+                trace_id=request.headers.get("x-trace-id"),
                 on_fail=lambda e: logger.warning(
                     "Wake enqueue for %s failed: %s", target, e,
                 ),
@@ -2767,15 +2771,28 @@ def create_mesh_app(
             duration_ms = 0
         try:
             meta = data.get("meta")
+            # Bound the meta payload: a runaway/compromised agent could otherwise
+            # inflate a single row up to the 8 MiB body cap. Drop an oversized
+            # meta to a marker rather than persist it (the row itself still
+            # records, so the timeline isn't lost).
+            if isinstance(meta, dict):
+                try:
+                    if len(dumps_safe(meta)) > 8192:
+                        meta = {"_truncated": True}
+                except Exception:
+                    meta = {"_truncated": True}
             trace_store.record(
                 trace_id=req_trace_id,
                 source="agent",
                 agent=agent_id,
                 event_type=str(data.get("event_type", ""))[:64],
-                detail=str(data.get("detail", "")),
+                # Cap free-text fields server-side so a misbehaving agent can't
+                # store oversized rows — symmetric with the event_type cap and
+                # independent of the agent's own client-side truncation.
+                detail=str(data.get("detail", ""))[:2000],
                 duration_ms=duration_ms,
-                status=str(data.get("status", "ok")),
-                error=str(data.get("error", "")),
+                status=str(data.get("status", "ok"))[:32],
+                error=str(data.get("error", ""))[:2000],
                 meta=meta if isinstance(meta, dict) else None,
             )
         except Exception:
@@ -6502,6 +6519,7 @@ def create_mesh_app(
         target: str, message: str, origin: "MessageOrigin | None",
         *,
         task_id: str | None = None,
+        trace_id: str | None = None,
         auto_notify: bool | None = None,
         on_fail=None,
     ) -> tuple[bool, str | None]:
@@ -6536,11 +6554,23 @@ def create_mesh_app(
         eff_origin = origin if origin is not None else MessageOrigin(
             kind="agent", channel="", user="",
         )
+        # Session observability: propagate the originating turn's trace_id into
+        # the lane so the woken agent's work (LLM calls, tool_call/handoff
+        # traces) records under the SAME trace as the human turn that triggered
+        # it — otherwise every handoff starts a fresh, disconnected trace and a
+        # multi-agent chain cannot be reconstructed. Read the active contextvar
+        # here in the request thread (the enqueue coroutine runs on a different
+        # loop, so the contextvar must be captured at bind time). Callers that
+        # already know the trace (e.g. retry of a stored task) pass it
+        # explicitly; ``None`` downstream falls back to a fresh id.
+        from src.shared.trace import current_trace_id
+        eff_trace_id = trace_id if trace_id is not None else current_trace_id.get()
         # Build the coroutine first so we can close it explicitly if the
         # dispatch loop is unhealthy — otherwise an orphaned coroutine
         # would emit a "coroutine was never awaited" warning.
         coro = lane_manager.enqueue(
             target, sanitize_for_prompt(message), mode="followup",
+            trace_id=eff_trace_id,
             origin=eff_origin,
             auto_notify=had_origin if auto_notify is None else auto_notify,
             task_id=task_id, system_note=True,
@@ -6722,6 +6752,9 @@ def create_mesh_app(
             f"Operator retried failed task as {clone['id']!r}: {title!r}. "
             "Call check_inbox() to pick it up.",
             origin,
+            # Continue the original task's session on the retry clone (the
+            # contextvar was already reset above, so pass it explicitly).
+            trace_id=_retry_trace_id,
         )
         return {"clone": clone, "original_id": original["id"]}
 
@@ -7073,17 +7106,20 @@ def create_mesh_app(
         import time as _time
         if not since:
             return _time.time() - (7 * 24 * 60 * 60)
-        s = since.strip().lower()
+        raw = since.strip()
+        low = raw.lower()
         # Duration form: ``Nh`` / ``Nd`` / ``Nm``
-        if s and s[-1] in {"s", "m", "h", "d"} and s[:-1].isdigit():
-            n = int(s[:-1])
-            unit = s[-1]
+        if low and low[-1] in {"s", "m", "h", "d"} and low[:-1].isdigit():
+            n = int(low[:-1])
+            unit = low[-1]
             mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
             return _time.time() - (n * mult)
-        # ISO timestamp
+        # ISO timestamp. Parse the ORIGINAL-case string — Python 3.10's
+        # ``fromisoformat`` rejects a lowercase ``t`` separator, so lowercasing
+        # first made a full ``...T...`` timestamp silently fall back to 7d.
         try:
             from datetime import datetime as _dt
-            dt = _dt.fromisoformat(s.replace("z", "+00:00"))
+            dt = _dt.fromisoformat(raw.replace("Z", "+00:00").replace("z", "+00:00"))
             return dt.timestamp()
         except (ValueError, TypeError):
             return _time.time() - (7 * 24 * 60 * 60)

--- a/tests/test_back_edge_helper.py
+++ b/tests/test_back_edge_helper.py
@@ -356,6 +356,56 @@ class TestBackEdgeHelperEligibility:
         assert len(lane.calls) == 1
 
 
+class TestBackEdgeTracePropagation:
+    """Session observability: a back-edge / operator-recovery wake must
+    continue the failed task's trace so ``openlegion session <trace>`` shows
+    the recovery branch. ``update_task_status`` does not seed the trace
+    contextvar, so the helper must pass the task's stored ``trace_id``
+    explicitly — otherwise ``_direct_dispatch`` mints a fresh, disconnected
+    trace and the recovery work falls out of the session."""
+
+    def test_agent_origin_back_edge_wake_carries_task_trace(
+        self, mesh_app_with_back_edge,
+    ):
+        app, _blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "task_trace_1",
+            creator="scout",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+            trace_id="tr_aaaaaaaaaaaa",
+        )
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        assert len(lane.calls) == 1
+        assert lane.calls[0]["args"][0] == "scout"
+        assert lane.calls[0]["kwargs"].get("trace_id") == "tr_aaaaaaaaaaaa"
+
+    def test_human_origin_recovery_wake_carries_task_trace(
+        self, mesh_app_with_back_edge,
+    ):
+        app, _blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "task_trace_2",
+            origin={"kind": "human", "channel": "telegram", "user": "9999"},
+            trace_id="tr_bbbbbbbbbbbb",
+        )
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        op_wakes = [c for c in lane.calls if c["args"][0] == "operator"]
+        assert len(op_wakes) == 1
+        assert op_wakes[0]["kwargs"].get("trace_id") == "tr_bbbbbbbbbbbb"
+
+
 class TestBackEdgeTTLSplit:
     """Actionable events keep the 7-day TTL; informational events get a
     much shorter 24h TTL so they don't pile up for a week and flood the

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6101,3 +6101,68 @@ class TestDashboardChatMintsTraceId:
                     or self._captured["headers"].get("x-trace-id"))
         assert bc_trace != chat_trace
         assert not bc_trace, f"broadcast leaked a stale trace_id: {bc_trace!r}"
+
+
+class TestDashboardIntentCapture:
+    """Session observability (Phase 2): the dashboard chat endpoints call the
+    agent directly (not via the lane's ``_direct_dispatch``), so they are the
+    ONLY intent-capture point for the primary human surface. Without capture
+    here, ``openlegion sessions``/``session`` never see dashboard turns — the
+    feature's headline use case. These pin that wiring end-to-end."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        from src.host.intent import IntentStore
+
+        self.intent_store = IntentStore(db_path=os.path.join(self._tmpdir, "intent.db"))
+        self.components["intent_store"] = self.intent_store
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.intent_store.close()
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_dashboard_chat_captures_intent(self):
+        self.components["transport"].request = AsyncMock(return_value={"response": "ok"})
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat",
+            json={"message": "pull last week signups"},
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.intent_store.list_recent(since=0)
+        assert len(rows) == 1, rows
+        row = rows[0]
+        assert row["origin_kind"] == "human"
+        assert row["origin_channel"] == "dashboard"
+        assert row["agent"] == "alpha"
+        assert "signups" in row["message"]
+        assert (row["trace_id"] or "").startswith("tr_")
+
+    def test_dashboard_chat_stream_captures_intent(self):
+        async def _mock_stream(agent_id, method, path, **kwargs):
+            yield {"type": "done", "response": "done"}
+
+        self.components["transport"].stream_request = _mock_stream
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat/stream",
+            json={"message": "stream intent here"},
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.intent_store.list_recent(since=0)
+        assert len(rows) == 1, rows
+        assert rows[0]["origin_channel"] == "dashboard"
+        assert "stream intent" in rows[0]["message"]
+
+    def test_dashboard_chat_capture_failure_never_breaks_chat(self):
+        """Intent capture is best-effort — a store failure must not 5xx the
+        chat response."""
+        self.components["transport"].request = AsyncMock(return_value={"response": "ok"})
+        self.intent_store.record = MagicMock(side_effect=RuntimeError("boom"))
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat",
+            json={"message": "still works"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["response"] == "ok"

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -420,6 +420,32 @@ async def test_origin_passed_to_dispatch_fn():
     assert received_kwargs.get("origin") == origin
 
 
+@pytest.mark.asyncio
+async def test_trace_id_propagated_to_dispatch_context():
+    """Session observability keystone: a followup enqueued with a trace_id
+    runs its dispatch_fn under that trace in ``current_trace_id`` — so a
+    handoff-woken agent's outbound /chat carries the ORIGINATING session's
+    X-Trace-Id and a multi-agent chain reconstructs as one session. Before the
+    fix the lane enqueued with no trace_id, so every handoff minted a fresh,
+    disconnected trace downstream."""
+    from src.shared.trace import current_trace_id
+
+    seen: dict = {}
+
+    async def recording_dispatch(agent, message, **kwargs):
+        seen["trace"] = current_trace_id.get()
+        return "ok"
+
+    lm = LaneManager(dispatch_fn=recording_dispatch)
+    await lm.enqueue("agent1", "handoff work", trace_id="tr_chain0000001")
+    for _ in range(50):
+        if "trace" in seen:
+            break
+        await asyncio.sleep(0.01)
+
+    assert seen.get("trace") == "tr_chain0000001"
+
+
 # ── Per-task lane watchdog (Bug 4) ─────────────────────────────
 
 

--- a/tests/test_session_reader.py
+++ b/tests/test_session_reader.py
@@ -18,7 +18,7 @@ import tempfile
 from click.testing import CliRunner
 
 from src.cli import cli
-from src.cli.session_reader import assemble_session, parse_since
+from src.cli.session_reader import _fmt_ts, _terminal_task, assemble_session, parse_since, render_session
 from src.host.costs import CostTracker
 from src.host.intent import IntentStore
 from src.host.orchestration import Tasks
@@ -117,6 +117,76 @@ class TestParseSince:
         # UTC 'Z' suffix also parses (folded to +00:00).
         z = "2026-01-02T03:04:05Z"
         assert parse_since(z) == _dt.fromisoformat("2026-01-02T03:04:05+00:00").timestamp()
+
+
+class TestTerminalTaskSelection:
+    """The one-line ``sessions`` outcome must reflect how the session ENDED,
+    not the newest-created task. ``_fetch_tasks`` orders by created_at, so a
+    naive ``tasks[-1]`` picks a still-pending child over a completed root."""
+
+    def test_empty(self):
+        assert _terminal_task([]) is None
+
+    def test_prefers_completed_over_newer_pending(self):
+        tasks = [
+            {"id": "root", "status": "done", "outcome": "approved",
+             "completed_at": 100.0, "created_at": 10.0, "updated_at": 100.0},
+            {"id": "child", "status": "pending",
+             "completed_at": None, "created_at": 20.0, "updated_at": 20.0},
+        ]
+        # tasks[-1] is the pending child; terminal must be the completed root.
+        assert _terminal_task(tasks)["id"] == "root"
+
+    def test_falls_back_to_latest_updated_when_none_completed(self):
+        tasks = [
+            {"id": "a", "status": "working",
+             "completed_at": None, "created_at": 10.0, "updated_at": 50.0},
+            {"id": "b", "status": "pending",
+             "completed_at": None, "created_at": 20.0, "updated_at": 20.0},
+        ]
+        assert _terminal_task(tasks)["id"] == "a"
+
+    def test_picks_most_recently_completed(self):
+        tasks = [
+            {"id": "first", "status": "failed",
+             "completed_at": 100.0, "created_at": 10.0, "updated_at": 100.0},
+            {"id": "second", "status": "done",
+             "completed_at": 200.0, "created_at": 20.0, "updated_at": 200.0},
+        ]
+        assert _terminal_task(tasks)["id"] == "second"
+
+
+class TestTimelineTimestamp:
+    """A task's ``→ status`` line must be timestamped at the transition that
+    produced that status (completion), not at creation — otherwise a task
+    created at 10:00 and completed at 10:30 renders ``→ done`` at 10:00 and
+    scrambles the merged chronological timeline."""
+
+    def _session(self, task):
+        return {
+            "trace_id": "tr_timeline", "found": True,
+            "intent": [], "actions": [], "tasks": [task],
+            "cost": {"total_tokens": 0, "total_cost_usd": 0.0, "by_model": []},
+        }
+
+    def test_terminal_status_uses_completed_at_not_created_at(self):
+        task = {
+            "id": "t1", "status": "done", "assignee": "alpha",
+            "created_at": 1000.0, "updated_at": 5000.0, "completed_at": 5000.0,
+        }
+        out = render_session(self._session(task))
+        task_line = next(ln for ln in out.splitlines() if "task t1 → done" in ln)
+        assert _fmt_ts(5000.0) in task_line
+        assert _fmt_ts(1000.0) not in task_line
+
+    def test_pending_task_falls_back_to_created_at(self):
+        task = {
+            "id": "t2", "status": "pending", "assignee": "beta",
+            "created_at": 2000.0, "updated_at": None, "completed_at": None,
+        }
+        out = render_session(self._session(task))
+        task_line = next(ln for ln in out.splitlines() if "task t2 → pending" in ln)
+        assert _fmt_ts(2000.0) in task_line
 
 
 class TestAssemble:

--- a/tests/test_session_reader.py
+++ b/tests/test_session_reader.py
@@ -94,6 +94,30 @@ class TestParseSince:
         assert abs(parse_since("") - default) < 5
         assert abs(parse_since("nonsense") - default) < 5
 
+    def test_full_iso_timestamp_with_T_separator(self):
+        """Regression: a full ISO timestamp with the uppercase ``T`` separator
+        must parse, not silently fall back to the 7-day default. The parser
+        used to lowercase the whole string first, which Python 3.10's
+        ``fromisoformat`` rejects (the ``t`` separator) — a supported
+        interpreter per pyproject's ``requires-python = ">=3.10"``."""
+        import time as _t
+
+        now = _t.time()
+        seven_days_ago = now - (7 * 86400)
+        # An hour ago, expressed as a full local ISO timestamp with 'T'.
+        from datetime import datetime as _dt
+
+        ts = _dt.fromtimestamp(now - 3600)
+        iso = ts.isoformat(timespec="seconds")  # e.g. 2026-06-23T12:00:00
+        assert "T" in iso
+        parsed = parse_since(iso)
+        # Must be ~1h ago, NOT the 7-day default.
+        assert abs(parsed - (now - 3600)) < 5
+        assert abs(parsed - seven_days_ago) > 60
+        # UTC 'Z' suffix also parses (folded to +00:00).
+        z = "2026-01-02T03:04:05Z"
+        assert parse_since(z) == _dt.fromisoformat("2026-01-02T03:04:05+00:00").timestamp()
+
 
 class TestAssemble:
     def setup_method(self):


### PR DESCRIPTION
## What this is

Final principal-engineer review of the **integrated** Session Observability feature (Phases 1–4, all merged: #1149/#1153/#1154/#1155) — 3 parallel adversarial reviewers (one per phase slice) + an independent **Codex** full-diff pass + a full-suite run. The per-phase reviews were each clean when they landed; this pass targeted **cross-phase / whole-system** correctness, and found three real gaps the per-phase reviews structurally couldn't catch.

## Fixed here (must-fix)

### 1. Keystone: multi-agent chains were never reconstructable
`/mesh/wake` (the handoff path) called `_try_wake_agent` → `lane_manager.enqueue` **without a `trace_id`**, so `QueuedTask.trace_id` was `None` → the lane set `current_trace_id` to `None` → `_direct_dispatch` minted a **fresh** trace for the recipient. Every handoff started a disconnected session; `openlegion session <root>` showed only the first agent's work. This defeats the feature's headline ("reconstruct a multi-agent interaction").
**Fix:** thread the originating trace through `_try_wake_agent` (new `trace_id` param, falling back to the active contextvar) into `enqueue`; stamp the inbound `X-Trace-Id` at `/mesh/wake` and the original task's trace on retry. Recipient LLM calls + `tool_call`/`handoff` traces now record under the same trace as the human turn. (Per-turn `trace_id` is the design's atom — minting one per handoff violated it.)

### 2. Headline surface: dashboard turns captured no intent
`api_chat` / `api_chat_stream` call the agent **directly**, bypassing `_direct_dispatch` — the *only* `intent_store.record` callsite. So the primary human UI minted a `trace_id` but wrote no `intent.db` row, and `openlegion sessions` (driven entirely off `intent.db`) never listed dashboard turns.
**Fix:** thread `intent_store` into `create_dashboard_router`; capture verbatim intent (`origin` human/dashboard) best-effort in both endpoints. Also moved the `api_chat` trace-token `set` inside the `try` for reset-safety parity with the streaming variant.

### 3. `parse_since` drops full ISO timestamps on Python 3.10
Lowercasing before `datetime.fromisoformat` breaks the `T` separator, so `--since 2026-06-18T12:00:00` silently fell back to the 7-day default — on a **supported** interpreter (`requires-python = ">=3.10"`). Fixed in the reader **and** the pre-existing twin `server.py:_parse_since` (restores their documented parity).

### Hardening (Codex)
Cap `/mesh/traces` `detail`/`error`/`status`/`meta` server-side so an authenticated runaway agent can't bloat `traces.db` (symmetric with the existing `event_type` cap).

## Tests
- dashboard `/chat` + `/chat/stream` intent capture + best-effort-never-breaks-chat
- lane `trace_id` → dispatch-context propagation (pins the keystone)
- `parse_since` full-ISO-with-`T` regression

**846 affected tests pass; baseline full suite 7676 passed/27 skipped pre-change** (both run against this worktree's code).

## Verified clean (no action)
Migration/schema safety (idempotent ALTERs, no `_row_to_dict` drift), read-only reader (no mutation/create path; graceful on legacy schema), redaction completeness (no plaintext credential path into intent/traces), Phase-4 contextvar propagation + single-emit-per-exit, ingest auth (token-derived identity, no spoofing).

## Flagged for a scoped follow-up (NOT in this PR)
Each touches a separate subsystem and deserves its own tested change:
- **Channel streaming (Telegram/Discord)** — `runtime.py:stream_dispatch_to_agent` calls `stream_request` with no `X-Trace-Id` and no intent capture. Needs `origin` threaded through `stream_dispatch_fn` (`channels/base.py`, `telegram.py`, `discord.py`). *Primary prod surface — highest follow-up priority.*
- **Steer** — `lanes._handle_steer` / `runtime._direct_steer` don't thread `trace_id`.
- **REPL streaming** — mints a trace but bypasses `_direct_dispatch`, so no intent row (dev surface).
- **`sessions` listing** — post-keystone, handoff wakes (system_note) share the root trace, so `sessions --since` lists "New task from…" rows beside genuine human turns. A human-only/dedup-by-trace default is a behavior change worth deciding deliberately (likely needs `system_note` promoted to an intent column).
- **Minor (Codex nice):** lane quarantine/early-continue runs outside the trace context; intent-capture failures log at `debug` (consider `warning`/health counter).