### PR TITLE
feat(dashboard): agent deliverables as one-click downloads in chat

### DIFF
--- a/docs/plans/2026-06-24-chat-deliverable-files.md
+++ b/docs/plans/2026-06-24-chat-deliverable-files.md
@@ -1,0 +1,95 @@
+# Chat-native deliverable files — "your agent's files live in chat"
+
+**Date:** 2026-06-24
+**Status:** Phase 1 in progress
+**Origin:** Live diagnosis on cake. The `map` agent ran a lead-gen job and
+produced real deliverables (`leads_master.csv`, `leads.db`, a sync script,
+an 11.6 MB `map.db`). The user asked, verbatim, *"where is that
+sheet_sync_appscript.gs"*. The agent **invented** a "files/attachments panel
+of this session" that does not exist, then pasted the file contents inline.
+That degrades for a 2 KB script and is impossible for the 97 KB CSV / 950 KB
+DB / 11.6 MB DB.
+
+## Problem
+
+The egress *backend* already shipped (PR #1037): the agent `/files/{path}`
+endpoint is rooted at the whole `/data` volume, and the dashboard
+`GET /api/agents/{id}/file-download/{path}` streams any file up to 64 MB as a
+`Content-Disposition` attachment. What is missing is any bridge from **chat**
+(where the user lives) to it:
+
+1. The file browser is buried — the **Files** sub-tab of a per-agent detail
+   view under the **Teams** tab. From chat the user must leave Chat → Teams →
+   pick the agent → open detail → switch Config→Files → navigate `/data`.
+   Nothing in chat links there.
+2. Chat renders agent messages as plain markdown (`renderMarkdown`,
+   `app.js`) — no file chip, no download affordance.
+3. The agent has no truthful way to hand a file over, so it improvises:
+   hallucinates a panel, or inlines bytes. `/chat/note` is plain text;
+   `task_artifact_added` routes to the task drawer, not chat.
+
+## CPO framing — what's best for the user
+
+The user's mental model is set by every consumer chat product: **a file made
+for you shows up as a thing you click, in the conversation.** They never ask
+"where is it." The worst failure here was a *trust* failure — the agent lied
+about how to retrieve the work.
+
+So the design has one hard constraint: **whatever surfaces a file must be
+backed by a real file, so it can never lie.** That rules out heuristic
+prose-parsing as the foundation and points at ground-truth: the agent's
+actual `workspace/artifacts/` directory.
+
+This is not a new paradigm — it completes the chat-native-delivery direction
+already shipped (#1139 chain outcomes → chat, #1143 watch chip). A file is
+just the richest outcome.
+
+## Phases
+
+### Phase 1 — Deliverables affordance in chat (this PR)
+
+Frontend + a prompt change. No schema change, no agent image rebuild for the
+dashboard half.
+
+- **Chat-panel "Files" affordance** in BOTH chat surfaces (operator chat,
+  keyed `'operator'`; side-chat, keyed `activeChatId`). A button shows the
+  deliverable count and toggles an inline panel listing the agent's
+  `workspace/artifacts/` entries (name + size) each with a one-click
+  **Download** wired to the existing `downloadAgentFile(agentId, path)`.
+  Ground-truth backed (lists real files) → never lies. Covers exactly the
+  files the map agent produced, works with or without a task context.
+- **Truth-telling prompt change** (`workspace.py` system-prompt body): save
+  user-facing deliverables to `artifacts/`; the user retrieves them as
+  files/cards in the chat; never paste large files inline; never describe a
+  retrieval location/UI that isn't real. Ships in the same PR so the agent
+  stops describing a panel that doesn't exist. (Agent-side → needs an image
+  rebuild to take effect on a box; the dashboard affordance does not.)
+
+### Phase 2 — Auto-cards (deferred)
+
+Deliverables appear as download cards **automatically** the moment they're
+produced, without the user opening the panel. Route an artifact event into
+`chatHistories[agentId]` (the `operator_action_receipt` handler at
+`app.js:4646` is the precedent pattern). Open question first: the existing
+`task_artifact_added` event carries an opaque task `ref` (`orchestration.py`
+:1828) and requires a task context — confirm/establish a path from `ref` to a
+downloadable file path before wiring it, or emit a new file-scoped event when
+an agent writes to `artifacts/`.
+
+### Horizon — send to a destination
+
+For many users the file is a means, not the end (the map user was trying to
+get leads into a Google Sheet). A one-click **"Send to Google Sheets / Drive /
+email"** on the deliverable card is the deepest UX win; it rides the
+in-progress OAuth integrations connect flow. Download is the universal
+fallback that always works; "send to destination" is the evolution. Phase 1
+cards are built with room for a "Send to…" action to drop in later.
+
+## Non-goals / deliberately deferred
+
+- An explicit `share_file` agent tool — auto-surfacing all of `artifacts/`
+  lets the *user* pick, which is safer for "I don't know what I'm looking
+  for" than trusting the model to hand over the right one file. Add only if
+  auto-surface proves noisy.
+- Prose-detection chips (linkify filenames the agent types) — heuristic, so
+  "magic that fails silently." Optional polish, never load-bearing.

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -1301,6 +1301,14 @@ when the window compacts. Append findings to a working-notes file
 your notes and save it with save_artifact. Notes and artifacts live on
 disk — they survive compaction; conversation history does not.
 
+**Delivering a file to the user** — When a deliverable is a file the user
+needs to download (a CSV, dataset, document, archive, database), save it to
+your `artifacts/` folder. The user sees their agent's artifacts as
+downloadable files directly in the chat, so just name the file you saved
+(e.g. "saved as leads.csv"). Do NOT paste large file contents into the chat,
+and do NOT describe any other place or panel to retrieve it from — artifacts
+in the chat is the one true path.
+
 **Tool calls** — Each tool round costs a full LLM call (system prompt +
 entire history re-sent). Batching multiple actions in one response is
 cheaper than one action per turn. The system detects repeated identical
@@ -1417,6 +1425,14 @@ when the window compacts. Append findings to a working-notes file
 (write_file) as you gather them, then write the final deliverable from
 your notes and save it with save_artifact. Notes and artifacts live on
 disk — they survive compaction; conversation history does not.
+
+**Delivering a file to the user** — When a deliverable is a file the user
+needs to download (a CSV, dataset, document, archive, database), save it to
+your `artifacts/` folder. The user sees their agent's artifacts as
+downloadable files directly in the chat, so just name the file you saved
+(e.g. "saved as leads.csv"). Do NOT paste large file contents into the chat,
+and do NOT describe any other place or panel to retrieve it from — artifacts
+in the chat is the one true path.
 
 **Tool calls** — Each tool round costs a full LLM call (system prompt +
 entire history re-sent). Batching multiple actions in one response is

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1627,6 +1627,108 @@ body {
 
 /* ── Chat input composite (textarea + send button) ── */
 
+/* ── Chat deliverables (an agent's artifacts as inline downloads) ── */
+
+.chat-deliverables {
+  width: 100%;
+  margin-bottom: 6px;
+}
+
+.chat-deliverables-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid rgba(42, 42, 58, 0.8);
+  border-radius: 0.625rem;
+  background: rgba(17, 17, 24, 0.6);
+  color: #9ca3af;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+}
+
+.chat-deliverables-toggle:hover {
+  color: #e5e7eb;
+  border-color: rgba(99, 102, 241, 0.4);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.chat-deliverables-toggle span {
+  flex: 1;
+}
+
+.chat-deliverables-caret {
+  flex-shrink: 0;
+  transition: transform 0.15s;
+}
+
+.chat-deliverables-caret.rotate-90 {
+  transform: rotate(90deg);
+}
+
+.chat-deliverables-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.chat-deliverable-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 10px;
+  border-radius: 0.5rem;
+  background: rgba(17, 17, 24, 0.5);
+}
+
+.chat-deliverable-row:hover {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.chat-deliverable-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: #e5e7eb;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-deliverable-size {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-deliverable-dl {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: #818cf8;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.chat-deliverable-dl:hover {
+  color: #fff;
+  background: rgba(99, 102, 241, 0.85);
+}
+
 .chat-input-wrap {
   display: flex;
   align-items: flex-end;  /* keep send/attach pinned to the last line as the textarea grows */

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -406,6 +406,15 @@ function dashboard() {
     agentFilePreview: null,   // { path, content, mime_type, encoding, size }
     agentFilePreviewLoading: false,
 
+    // Chat deliverables — an agent's workspace/artifacts/ surfaced as
+    // one-click downloads right where the user is reading (keyed by agent id,
+    // 'operator' for the operator chat). Ground-truth backed: lists the real
+    // files on disk, so a download card can never point at a file that isn't
+    // there. See docs/plans/2026-06-24-chat-deliverable-files.md.
+    chatDeliverables: {},        // { agentId: [{ path, name, size }] }
+    chatDeliverablesOpen: {},    // { agentId: bool } — panel expanded
+    chatDeliverablesLoading: {}, // { agentId: bool }
+
     // Uploads panel (System tab)
     uploadsList: [],
     uploadsLoading: false,
@@ -4637,6 +4646,11 @@ function dashboard() {
             this._workplaceTasksDebounce = setTimeout(() => this.loadWorkplaceTasks(), 250);
           }
         }
+        // Keep the in-chat deliverables list fresh for whichever agent just
+        // produced an artifact, so the Files count updates without a manual
+        // refresh. Best-effort.
+        const actor = evt.data?.actor || evt.agent;
+        if (actor) this.loadChatDeliverables(actor);
       }
 
       // PR 1 — operator_action_receipt: append a receipt card to the
@@ -5979,6 +5993,43 @@ function dashboard() {
       document.body.appendChild(a);
       a.click();
       a.remove();
+    },
+
+    // ── Chat deliverables ─────────────────────────────────────────
+    // The agent's workspace/artifacts/ folder is the designed deliverable
+    // channel; surface it as download cards inside the chat so the user
+    // never has to hunt the buried Files sub-tab. Best-effort + silent: a
+    // chat with no artifacts simply shows nothing.
+    async loadChatDeliverables(agentId) {
+      if (!agentId) return;
+      this.chatDeliverablesLoading[agentId] = true;
+      try {
+        const resp = await fetch(
+          `${window.__config.apiBase}/agents/${agentId}/files?path=${encodeURIComponent('workspace/artifacts')}`
+        );
+        if (resp.ok) {
+          const data = await resp.json();
+          this.chatDeliverables[agentId] = (data.entries || [])
+            .filter((e) => e.type === 'file')
+            .map((e) => ({ path: e.path, name: e.path.split('/').pop(), size: e.size }));
+        } else {
+          // 400/404 = no artifacts dir yet; treat as empty, not an error.
+          this.chatDeliverables[agentId] = [];
+        }
+      } catch (e) {
+        console.warn('loadChatDeliverables failed:', e);
+      }
+      this.chatDeliverablesLoading[agentId] = false;
+    },
+
+    chatDeliverableCount(agentId) {
+      return (this.chatDeliverables[agentId] || []).length;
+    },
+
+    toggleChatDeliverables(agentId) {
+      const open = !this.chatDeliverablesOpen[agentId];
+      this.chatDeliverablesOpen[agentId] = open;
+      if (open) this.loadChatDeliverables(agentId); // always refresh on expand
     },
 
     agentFilesParentPath(path) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1461,6 +1461,30 @@
                   <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
                 </button>
               </div>
+              <!-- Deliverables: the operator's workspace/artifacts/ surfaced
+                   as one-click downloads, inline in chat. Loads on mount;
+                   hidden until there's at least one file to deliver. -->
+              <div class="chat-deliverables" x-init="loadChatDeliverables('operator')"
+                x-show="chatDeliverableCount('operator') > 0" x-cloak>
+                <button type="button" class="chat-deliverables-toggle"
+                  @click="toggleChatDeliverables('operator')"
+                  :aria-expanded="chatDeliverablesOpen['operator'] ? 'true' : 'false'">
+                  <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+                  <span x-text="chatDeliverableCount('operator') + (chatDeliverableCount('operator') === 1 ? ' file from this agent' : ' files from this agent')"></span>
+                  <svg class="chat-deliverables-caret" :class="chatDeliverablesOpen['operator'] ? 'rotate-90' : ''" width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+                </button>
+                <div x-show="chatDeliverablesOpen['operator']" class="chat-deliverables-list">
+                  <template x-for="f in (chatDeliverables['operator'] || [])" :key="f.path">
+                    <div class="chat-deliverable-row">
+                      <span class="chat-deliverable-name" x-text="f.name" :title="f.name"></span>
+                      <span class="chat-deliverable-size" x-text="formatFileSize(f.size)"></span>
+                      <button type="button" class="chat-deliverable-dl" @click="downloadAgentFile('operator', f.path)" :title="'Download ' + f.name" aria-label="Download">
+                        <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                      </button>
+                    </div>
+                  </template>
+                </div>
+              </div>
               <!-- Input row -->
               <div class="chat-input-wrap">
                 <!-- Attach file button -->
@@ -9152,6 +9176,30 @@
               Steering
             </span>
             <span class="text-[11px] text-gray-500">Agent is working &mdash; your message will redirect it</span>
+          </div>
+          <!-- Deliverables for the active side-chat agent. x-effect reloads
+               whenever activeChatId changes (the panel stays in the DOM and
+               just re-keys), mirroring the operator-chat affordance above. -->
+          <div class="chat-deliverables" x-effect="activeChatId && loadChatDeliverables(activeChatId)"
+            x-show="chatDeliverableCount(activeChatId) > 0" x-cloak>
+            <button type="button" class="chat-deliverables-toggle"
+              @click="toggleChatDeliverables(activeChatId)"
+              :aria-expanded="chatDeliverablesOpen[activeChatId] ? 'true' : 'false'">
+              <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+              <span x-text="chatDeliverableCount(activeChatId) + (chatDeliverableCount(activeChatId) === 1 ? ' file from this agent' : ' files from this agent')"></span>
+              <svg class="chat-deliverables-caret" :class="chatDeliverablesOpen[activeChatId] ? 'rotate-90' : ''" width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+            </button>
+            <div x-show="chatDeliverablesOpen[activeChatId]" class="chat-deliverables-list">
+              <template x-for="f in (chatDeliverables[activeChatId] || [])" :key="f.path">
+                <div class="chat-deliverable-row">
+                  <span class="chat-deliverable-name" x-text="f.name" :title="f.name"></span>
+                  <span class="chat-deliverable-size" x-text="formatFileSize(f.size)"></span>
+                  <button type="button" class="chat-deliverable-dl" @click="downloadAgentFile(activeChatId, f.path)" :title="'Download ' + f.name" aria-label="Download">
+                    <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                  </button>
+                </div>
+              </template>
+            </div>
           </div>
           <!-- Input row -->
           <div class="chat-input-wrap">

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2594,3 +2594,52 @@ class TestChatWatchChips:
     def test_pipelines_seeded_on_mount_and_chat_entry(self):
         js = _read(_APP_JS)
         assert js.count("this.loadWorkplacePipelines()") >= 3  # mount + chat entry + WS debounce
+
+
+class TestChatDeliverables:
+    """Chat-native deliverable files: an agent's workspace/artifacts/ surfaced
+    as one-click downloads inside both chat surfaces.
+    docs/plans/2026-06-24-chat-deliverable-files.md."""
+
+    def test_deliverables_state_declared(self):
+        for marker in (
+            "chatDeliverables:", "chatDeliverablesOpen:", "chatDeliverablesLoading:",
+        ):
+            assert marker in _APP_JS_TEXT, marker
+
+    def test_deliverables_methods_present(self):
+        for marker in (
+            "loadChatDeliverables(agentId)",
+            "chatDeliverableCount(agentId)",
+            "toggleChatDeliverables(agentId)",
+        ):
+            assert marker in _APP_JS_TEXT, marker
+
+    def test_deliverables_lists_artifacts_dir_ground_truth(self):
+        """Must read the agent's real workspace/artifacts/ listing — the
+        ground-truth backing that keeps a download card from ever pointing
+        at a file that isn't there."""
+        idx = _APP_JS_TEXT.index("async loadChatDeliverables(")
+        block = _APP_JS_TEXT[idx:idx + 900]
+        assert "workspace/artifacts" in block
+        assert "/files?path=" in block
+
+    def test_deliverables_refresh_on_artifact_event(self):
+        """task_artifact_added keeps the in-chat list live without a manual
+        refresh."""
+        idx = _APP_JS_TEXT.index("task_artifact_added'")
+        block = _APP_JS_TEXT[idx:idx + 1200]
+        assert "loadChatDeliverables(" in block
+
+    def test_deliverables_markup_in_both_chat_surfaces(self):
+        # Operator chat keys on the literal 'operator'; the side-chat keys on
+        # the reactive activeChatId. Both must render the affordance.
+        assert "toggleChatDeliverables('operator')" in _INDEX_HTML
+        assert "toggleChatDeliverables(activeChatId)" in _INDEX_HTML
+        assert _INDEX_HTML.count('class="chat-deliverables"') == 2
+
+    def test_deliverables_download_wired_to_existing_endpoint(self):
+        # The chip reuses the shipped downloadAgentFile() egress path
+        # (PR #1037) rather than inventing a new download route.
+        assert "downloadAgentFile('operator', f.path)" in _INDEX_HTML
+        assert "downloadAgentFile(activeChatId, f.path)" in _INDEX_HTML


### PR DESCRIPTION
## Problem (diagnosed live on cake)

The `map` agent ran a lead-gen job and produced real deliverables in `workspace/artifacts/` (`leads_master.csv`, a sync script, etc.). The user — in chat — asked verbatim **"where is that sheet_sync_appscript.gs"**. The agent **invented** a *"files/attachments panel of this session"* that does not exist, then pasted the file contents inline. Fine for a 2 KB script; impossible for a 97 KB CSV / 950 KB DB / 11.6 MB DB.

The egress *backend* already shipped (PR #1037: `/api/agents/{id}/file-download/{path}` + `downloadAgentFile`). The gap is pure discoverability: the file browser is buried under Teams → agent → detail → Files sub-tab, nothing in chat links there, chat does no file linkification, and the agent has no truthful way to hand a file over.

## What this does (Phase 1)

A **deliverables affordance in both chat surfaces** (operator chat, keyed `'operator'`; per-agent side-chat, keyed `activeChatId`): a *"N files from this agent"* toggle above the composer that lists the agent's `workspace/artifacts/` entries (name + size) with a one-click **Download** wired to the existing `downloadAgentFile()`.

- **Ground-truth backed** — lists the real files on disk, so a download chip can never point at a file that isn't there. That's the trust property the hallucinated panel broke.
- Hidden until there's ≥1 file; refreshes live on `task_artifact_added`.
- **Truth-telling prompt change** (`workspace.py`): save deliverables to `artifacts/`, name the file, never paste large files inline, never describe a retrieval location that isn't real — so the agent stops inventing panels. *(Agent-side → needs an image rebuild to take effect on a box; the dashboard half does not.)*

## Deferred (in the plan, not this PR)

- **Auto-cards** — deliverables appearing as cards without opening the panel (needs a file-scoped event; `task_artifact_added` carries an opaque task `ref`).
- **Send to Google Sheets / Drive / email** — rides the OAuth integrations work; download is the universal fallback.
- An explicit `share_file` agent tool and prose-detection chips — both deliberately not load-bearing.

Plan: `docs/plans/2026-06-24-chat-deliverable-files.md`.

## Tests

- New `TestChatDeliverables` (6 tests) — state, methods, ground-truth artifacts listing, live refresh, markup in both surfaces, download wired to the existing endpoint.
- `tests/test_dashboard_ui.py` — 206 passed, 3 skipped. `ruff check` clean.

🤖 Diagnosed and implemented via Claude Code.