### PR TITLE
fix(agent): calibrate token estimate from real overflow counts (context-wedge no-op prune)

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -39,6 +39,13 @@ _TOOL_RESULT_SUMMARY_CHARS = 2_000   # per tool-result slice fed to the compacti
 
 _CONSOLIDATION_MIN_INTERVAL_S = 6 * 3600   # at most every 6 hours
 _CONSOLIDATION_MIN_LOG_CHARS = 1_500       # skip if little new material accrued
+
+# Upper bound on the learned estimate-correction multiplier (see
+# ContextManager.calibrate_from_overflow). The chars/token heuristic can
+# undershoot dense content (CSV/JSON/code ~1.75 chars/tok vs the assumed 3.5),
+# but a runaway ratio from a degenerate estimate must not prune the context to
+# nothing — 6x covers the worst realistic case (single-char-token data).
+_MAX_ESTIMATE_CORRECTION = 6.0
 _CONSOLIDATION_FAIL_BACKOFF_S = 30 * 60    # after a failed run, wait before retrying
 _DECAY_MIN_INTERVAL_S = 6 * 3600           # salience-decay cadence for the maintenance pass
 
@@ -210,6 +217,12 @@ class ContextManager:
         # Backoff clock for the maintenance pass: set to a future time after a
         # failed consolidation so a frequent tick doesn't hammer the LLM.
         self._consolidation_retry_after = 0.0
+        # Learned multiplier that corrects estimate_request_tokens toward the
+        # provider's real tokenizer. Starts at 1.0 (no change) and only ratchets
+        # UP when an actual overflow tells us the true count
+        # (calibrate_from_overflow). Healthy agents that never 400 keep 1.0, so
+        # this is a no-op for them.
+        self._estimate_correction = 1.0
 
     def reset(self) -> None:
         """Reset per-session state for a new conversation."""
@@ -261,6 +274,28 @@ class ContextManager:
         (``len(json.dumps(tools)) // 3``, a tighter divisor than the 4-chars/tok
         message default) — overshooting the budget is safe; undershooting
         re-wedges.
+
+        The chars/token heuristic is still content-dependent (dense CSV/JSON/
+        code tokenizes ~2x denser than the assumed 3.5 chars/tok), so the raw
+        base is scaled by ``self._estimate_correction`` — a multiplier learned
+        from real overflow counts (:meth:`calibrate_from_overflow`). It is 1.0
+        until an actual 400 proves the estimate low, so this is a no-op for
+        agents that never overflow.
+        """
+        raw = self._raw_request_tokens(messages, system_prompt, tools)
+        return int(raw * self._estimate_correction)
+
+    def _raw_request_tokens(
+        self,
+        messages: list[dict],
+        system_prompt: str = "",
+        tools: list[dict] | None = None,
+    ) -> int:
+        """Uncorrected full-request estimate (messages + system + tools).
+
+        Kept separate from :meth:`estimate_request_tokens` so calibration can
+        compare the provider's real count against the RAW heuristic, rather than
+        against an already-corrected number (which would make the ratio drift).
         """
         total = estimate_tokens(messages, self.model)
         if system_prompt:
@@ -278,6 +313,36 @@ class ContextManager:
                 total += len(str(tools)) // 4
         return total
 
+    def calibrate_from_overflow(
+        self,
+        actual_tokens: int,
+        messages: list[dict],
+        system_prompt: str = "",
+        tools: list[dict] | None = None,
+    ) -> float:
+        """Teach the estimator the real chars/token density from an overflow.
+
+        ``actual_tokens`` is the provider-reported size of the request we just
+        sent (parsed from "… 1000961 tokens > 1000000 maximum"). Comparing it to
+        our RAW estimate of the same request yields the correction ratio. We
+        ratchet ``self._estimate_correction`` UP only (a single observation can
+        be noisy; the worst case is what re-wedges us) and clamp it so a
+        degenerate estimate can't prune the context to nothing. Returns the new
+        multiplier.
+        """
+        raw = self._raw_request_tokens(messages, system_prompt, tools)
+        if raw <= 0 or actual_tokens <= 0:
+            return self._estimate_correction
+        ratio = actual_tokens / raw
+        if ratio > self._estimate_correction:
+            self._estimate_correction = min(ratio, _MAX_ESTIMATE_CORRECTION)
+            logger.warning(
+                "estimate calibrated from overflow: actual=%s raw_est=%s "
+                "correction=%.2f",
+                f"{actual_tokens:,}", f"{raw:,}", self._estimate_correction,
+            )
+        return self._estimate_correction
+
     def prune_to_fit(
         self,
         messages: list[dict],
@@ -285,10 +350,18 @@ class ContextManager:
         tools: list[dict] | None = None,
         *,
         ceiling_frac: float = 0.90,
+        target_tokens: int | None = None,
     ) -> list[dict]:
         """Emergency hard safety net: drop oldest tool-call groups until the
         FULL request (messages + system + tools) fits under a fraction of the
         model window.
+
+        ``target_tokens`` overrides the ``ceiling_frac * max_tokens`` ceiling
+        with an absolute target. The self-heal uses it to FORCE real reduction
+        when the API has told us we overflowed but our estimate (possibly
+        uncalibrated, e.g. on the masked proxy path) still thinks the context
+        fits — without it the prune would no-op and the retry would 400
+        identically.
 
         This is NOT a threshold change — the 0.60/0.70/0.80 compaction
         thresholds are untouched. This is a separate last-resort guard for the
@@ -308,7 +381,10 @@ class ContextManager:
         if not messages:
             return messages
 
-        ceiling = int(self.max_tokens * ceiling_frac)
+        ceiling = (
+            target_tokens if target_tokens is not None
+            else int(self.max_tokens * ceiling_frac)
+        )
         before = self.estimate_request_tokens(messages, system_prompt, tools)
         if before <= ceiling:
             return messages

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -227,6 +227,13 @@ class ContextManager:
     def reset(self) -> None:
         """Reset per-session state for a new conversation."""
         self._flush_triggered = False
+        # NOTE: ``_estimate_correction`` is deliberately NOT reset. It reflects
+        # the model+content tokenization density, which is stable for an agent
+        # and survives a conversation reset. Clearing it would force the next
+        # conversation to RE-overflow once before re-learning — reintroducing
+        # the wedge this calibration prevents. Over-pruning a lower-density
+        # conversation that follows is the safe direction (the module's rule:
+        # overshooting the budget is safe; undershooting re-wedges).
 
     def usage(self, messages: list[dict]) -> float:
         """Return context usage as a fraction (0.0 to 1.0)."""

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3792,7 +3792,9 @@ class AgentLoop:
                 "output": result,
             })
 
-    def _emergency_prune(self, system: str, tools) -> bool:
+    def _emergency_prune(
+        self, system: str, tools, *, overflow_message: str | None = None,
+    ) -> bool:
         """Emergency-prune ``self._chat_messages`` to ~0.75 of the window after
         a context-overflow 400, and report whether it made progress.
 
@@ -3803,17 +3805,50 @@ class AgentLoop:
         while the role-alternation bridge inserts 1 leaves the count unchanged
         though tokens fell, so a count check would bail prematurely on
         text-heavy (no-tool) operator chats. Callers guard ``context_manager``.
+
+        Two reinforcing mechanisms keep this from no-op'ing when the local
+        estimate is low (dense CSV/JSON/code can read ~2x under the real
+        tokenizer, so the 0.75 ceiling on a 1M window saw 504K and dropped
+        nothing while the real request was 1.0M+):
+
+        1. ``overflow_message`` — when the API reported real counts (the
+           streaming path forwards them un-masked), calibrate the estimator so
+           every subsequent estimate, here and on later turns, reflects reality.
+        2. Forced progress — if the (possibly still-uncalibrated, e.g. masked
+           proxy path) estimate claims we already fit, shed a fixed fraction of
+           the CURRENT size anyway. The API already told us we overflowed, so
+           trusting the estimate over the 400 is the bug we're fixing.
         """
         cm = self.context_manager
+        sent = self._messages_with_volatile(self._chat_messages)
+        if overflow_message:
+            from src.shared.errors import parse_overflow_tokens
+            counts = parse_overflow_tokens(overflow_message)
+            if counts:
+                cm.calibrate_from_overflow(counts[0], sent, system, tools)
+
         before_msgs = len(self._chat_messages)
         before_tokens = cm.estimate_request_tokens(self._chat_messages, system, tools)
         self._chat_messages = cm.prune_to_fit(
             self._chat_messages, system_prompt=system, tools=tools, ceiling_frac=0.75,
         )
         after_tokens = cm.estimate_request_tokens(self._chat_messages, system, tools)
+
+        # Forced progress: the API said we overflowed, so a no-op prune means
+        # the estimate is lying — drop ~30% of the current size outright. Guard
+        # on >1 message so prune_to_fit always retains the first+last group.
+        if after_tokens >= before_tokens and before_msgs > 1:
+            self._chat_messages = cm.prune_to_fit(
+                self._chat_messages, system_prompt=system, tools=tools,
+                target_tokens=int(after_tokens * 0.7),
+            )
+            after_tokens = cm.estimate_request_tokens(self._chat_messages, system, tools)
+
         logger.warning(
-            "context overflow: emergency-pruned %d->%d messages (%d->%d est tokens)",
+            "context overflow: emergency-pruned %d->%d messages (%d->%d est tokens, "
+            "correction=%.2f)",
             before_msgs, len(self._chat_messages), before_tokens, after_tokens,
+            cm._estimate_correction,
         )
         return after_tokens < before_tokens
 
@@ -3844,15 +3879,17 @@ class AgentLoop:
                     tools=tools,
                     **kwargs,
                 )
-            except LLMContextOverflowError:
+            except LLMContextOverflowError as e:
                 # Last attempt, no context manager, or the prune can't shrink it
                 # any further → surface the failure instead of looping on the
                 # same 400. (``or`` short-circuits, so we don't prune on the
-                # final attempt.)
+                # final attempt.) ``str(e)`` carries the real token counts when
+                # the provider detail survived (streaming path) so the prune can
+                # calibrate; harmless when it's the masked text.
                 if (
                     attempt >= 2
                     or not self.context_manager
-                    or not self._emergency_prune(system, tools)
+                    or not self._emergency_prune(system, tools, overflow_message=str(e))
                 ):
                     raise
 
@@ -5114,6 +5151,7 @@ class AgentLoop:
                 tools = self.tools.get_tool_definitions(**self._tool_filter_kw) or None
                 _msgs = self._messages_with_volatile(self._chat_messages)
                 _overflowed = False
+                _overflow_msg: str | None = None
                 try:
                     async for event in self.llm.chat_stream(
                         system=system, messages=_msgs, tools=tools,
@@ -5126,11 +5164,14 @@ class AgentLoop:
                         elif etype == "done":
                             llm_response = event["response"]
                     used_streaming = True
-                except LLMContextOverflowError:
+                except LLMContextOverflowError as _overflow_exc:
                     # Context-overflow self-heal: emergency-prune and retry
                     # rather than re-wedge. Only meaningful when nothing was
-                    # streamed yet (overflow 400s before the first token).
+                    # streamed yet (overflow 400s before the first token). The
+                    # streaming SSE path forwards the raw provider detail, so
+                    # this message carries the real token counts for calibration.
                     _overflowed = True
+                    _overflow_msg = str(_overflow_exc)
                     logger.warning(
                         "LLM stream overflowed context window; emergency-pruning",
                     )
@@ -5143,7 +5184,9 @@ class AgentLoop:
                         # First prune before falling back to non-streaming; the
                         # fallback loop below self-heals further if it overflows
                         # again. (Progress bool ignored — this is the 1st pass.)
-                        self._emergency_prune(system, tools)
+                        # Pass the streamed overflow detail so the estimator
+                        # calibrates from the real token count.
+                        self._emergency_prune(system, tools, overflow_message=_overflow_msg)
                         _msgs = self._messages_with_volatile(self._chat_messages)
                     elif used_streaming:
                         logger.warning("LLM stream ended without done event, falling back")
@@ -5157,11 +5200,13 @@ class AgentLoop:
                                 messages=_msgs, tools=tools,
                             )
                             break
-                        except LLMContextOverflowError:
+                        except LLMContextOverflowError as e:
                             if (
                                 _heal_attempt >= 2
                                 or not self.context_manager
-                                or not self._emergency_prune(system, tools)
+                                or not self._emergency_prune(
+                                    system, tools, overflow_message=str(e),
+                                )
                             ):
                                 raise
                             _msgs = self._messages_with_volatile(self._chat_messages)

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -27,7 +27,7 @@ from src.agent.tool_groups import (
 )
 from src.agent.workspace import INTROSPECT_PERM_KEYS
 from src.shared import limits
-from src.shared.errors import LLMAuthError, LLMConfigError
+from src.shared.errors import LLMAuthError, LLMConfigError, parse_overflow_tokens
 from src.shared.types import SILENT_REPLY_TOKEN, AgentStatus, LLMResponse, TaskAssignment, TaskResult
 from src.shared.utils import dumps_safe, format_dict, generate_id, sanitize_for_prompt, setup_logging, truncate
 
@@ -3820,11 +3820,10 @@ class AgentLoop:
            trusting the estimate over the 400 is the bug we're fixing.
         """
         cm = self.context_manager
-        sent = self._messages_with_volatile(self._chat_messages)
         if overflow_message:
-            from src.shared.errors import parse_overflow_tokens
             counts = parse_overflow_tokens(overflow_message)
             if counts:
+                sent = self._messages_with_volatile(self._chat_messages)
                 cm.calibrate_from_overflow(counts[0], sent, system, tools)
 
         before_msgs = len(self._chat_messages)

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -3963,6 +3963,12 @@ class CredentialVault:
                     error_data: dict = {'error': str(e)}
                     if getattr(e, 'status_code', 0) == 402:
                         error_data['credit_exhausted'] = True
+                    # Tag context-overflow so the agent self-heals on the TYPE,
+                    # not the raw text. The streaming frame forwards the detail
+                    # un-masked today (the agent's substring backstop fires), but
+                    # the tag is the durable signal if that text ever changes.
+                    if is_context_overflow(str(e)):
+                        error_data['error_type'] = 'context_overflow'
                     yield f"data: {json.dumps(error_data)}\n\n"
                     return
                 last_error = e
@@ -4030,6 +4036,8 @@ class CredentialVault:
                             error_data = {'error': str(e)}
                             if getattr(e, 'status_code', 0) == 402:
                                 error_data['credit_exhausted'] = True
+                            if is_context_overflow(str(e)):
+                                error_data['error_type'] = 'context_overflow'
                             yield f"data: {json.dumps(error_data)}\n\n"
                             return
                         last_error = e

--- a/src/shared/errors.py
+++ b/src/shared/errors.py
@@ -24,6 +24,8 @@ handlers keep working without modification.
 """
 from __future__ import annotations
 
+import re
+
 
 class LLMAuthError(RuntimeError):
     """Raised when LLM credentials are broken (401/403) — actionable by rotating creds."""
@@ -128,3 +130,34 @@ def is_context_overflow(text: str) -> bool:
     # `max_tokens` exceed context limit...", which would defeat the marker.
     t = (text or "").lower().replace("`", "")
     return any(marker in t for marker in CONTEXT_OVERFLOW_MARKERS)
+
+
+# Anthropic phrases the overflow as "prompt is too long: 1000961 tokens >
+# 1000000 maximum". When that detail survives to the agent (the streaming SSE
+# path forwards it un-masked), the actual token count is ground truth we can
+# use to CALIBRATE our local estimate — which is content-dependent and can
+# undershoot the real tokenizer by ~2x on dense CSV/JSON/code, leaving the
+# emergency prune a no-op. See ContextManager.calibrate_from_overflow.
+_OVERFLOW_COUNT_RE = re.compile(r"(\d[\d,]*)\s*tokens?\s*>\s*(\d[\d,]*)")
+
+
+def parse_overflow_tokens(text: str) -> tuple[int, int] | None:
+    """Parse ``(actual_tokens, limit_tokens)`` from a context-overflow message.
+
+    Returns ``None`` when the message carries no counts (e.g. the non-streaming
+    proxy path masks the detail to "Upstream service call failed."). Callers
+    must handle ``None`` by forcing progress some other way.
+    """
+    if not text:
+        return None
+    m = _OVERFLOW_COUNT_RE.search(text)
+    if not m:
+        return None
+    try:
+        actual = int(m.group(1).replace(",", ""))
+        limit = int(m.group(2).replace(",", ""))
+    except (ValueError, AttributeError):
+        return None
+    if actual <= 0 or limit <= 0:
+        return None
+    return actual, limit

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1174,6 +1174,78 @@ class TestPruneToFit:
         assert len(aggressive) <= len(lenient)
         assert cm.estimate_request_tokens(aggressive) <= cm.max_tokens * 0.50
 
+    def test_target_tokens_overrides_frac_ceiling(self):
+        # An absolute target forces pruning below it even though the default
+        # frac-ceiling would no-op. This is the forced-progress lever the
+        # self-heal uses when the estimate (uncalibrated) thinks we fit.
+        cm = ContextManager(max_tokens=1_000_000, model="anthropic/claude")
+        msgs = _tool_group_messages(8, chars_each=4000)
+        # Well under 0.90 * 1M, so the default ceiling is a no-op...
+        assert cm.prune_to_fit(msgs) is msgs
+        before = cm.estimate_request_tokens(msgs)
+        # ...but an absolute target below `before` must shed real content.
+        pruned = cm.prune_to_fit(msgs, target_tokens=int(before * 0.5))
+        assert len(pruned) < len(msgs)
+        assert cm.estimate_request_tokens(pruned) <= before * 0.5
+
+
+class TestEstimateCalibration:
+    """Regression for the map-agent wedge (2026-06-24): the chars/token estimate
+    read ~2x under the real tokenizer on dense CSV/JSON content (504,884 est vs
+    1,001,150 actual), so the 0.75 emergency ceiling on a 1M window saw 504K,
+    pruned NOTHING, and every retry 400'd identically. Calibrating from the
+    provider-reported count fixes both the no-op prune and future turns."""
+
+    def test_correction_defaults_to_identity(self):
+        cm = ContextManager(max_tokens=1_000_000, model="anthropic/claude")
+        assert cm._estimate_correction == 1.0
+        msgs = _make_messages(4, chars_each=400)
+        assert cm.estimate_request_tokens(msgs) == cm._raw_request_tokens(msgs)
+
+    def test_calibrate_ratchets_correction_and_scales_estimate(self):
+        cm = ContextManager(max_tokens=1_000_000, model="anthropic/claude")
+        msgs = _make_messages(6, chars_each=4000)
+        raw = cm._raw_request_tokens(msgs)
+        # Provider says the request was actually ~2x our raw estimate.
+        cm.calibrate_from_overflow(actual_tokens=raw * 2, messages=msgs)
+        assert cm._estimate_correction == pytest.approx(2.0, abs=0.05)
+        assert cm.estimate_request_tokens(msgs) == pytest.approx(raw * 2, rel=0.05)
+
+    def test_correction_only_ratchets_up(self):
+        cm = ContextManager(max_tokens=1_000_000, model="anthropic/claude")
+        msgs = _make_messages(6, chars_each=4000)
+        raw = cm._raw_request_tokens(msgs)
+        cm.calibrate_from_overflow(actual_tokens=raw * 2, messages=msgs)
+        # A later, smaller ratio must NOT lower the learned correction.
+        cm.calibrate_from_overflow(actual_tokens=int(raw * 1.2), messages=msgs)
+        assert cm._estimate_correction == pytest.approx(2.0, abs=0.05)
+
+    def test_correction_is_clamped(self):
+        from src.agent.context import _MAX_ESTIMATE_CORRECTION
+        cm = ContextManager(max_tokens=1_000_000, model="anthropic/claude")
+        msgs = _make_messages(6, chars_each=4000)
+        raw = cm._raw_request_tokens(msgs)
+        cm.calibrate_from_overflow(actual_tokens=raw * 100, messages=msgs)
+        assert cm._estimate_correction == _MAX_ESTIMATE_CORRECTION
+
+    def test_calibration_turns_a_noop_prune_into_a_real_one(self):
+        # The exact cake shape: raw estimate sits UNDER the 0.75 ceiling so the
+        # emergency prune would no-op — until calibration scales it over.
+        cm = ContextManager(max_tokens=100_000, model="anthropic/claude")
+        # ~50K raw est: comfortably under the 0.75 ceiling (so the default prune
+        # no-ops) yet over 0.375*max, so doubling it via calibration clears the
+        # ceiling and forces a real prune.
+        msgs = _tool_group_messages(14, chars_each=4000)
+        raw = cm._raw_request_tokens(msgs)
+        assert raw <= cm.max_tokens * 0.75, "precondition: default prune would no-op"
+        assert cm.prune_to_fit(msgs, ceiling_frac=0.75) is msgs
+        # API reports the request was actually ~2x — calibrate, then re-prune.
+        cm.calibrate_from_overflow(actual_tokens=raw * 2, messages=msgs)
+        assert cm.estimate_request_tokens(msgs) > cm.max_tokens * 0.75
+        pruned = cm.prune_to_fit(msgs, ceiling_frac=0.75)
+        assert len(pruned) < len(msgs), "after calibration the prune must drop groups"
+        assert cm.estimate_request_tokens(pruned) <= cm.max_tokens * 0.75
+
 
 class TestSummarizeTailCap:
     @pytest.mark.asyncio

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -5428,3 +5428,55 @@ class TestSystemNoteTranscriptRole:
         out = AgentLoop._steer_interjection([("a", True), ("b", False)])
         assert "[System]: a" in out
         assert "[User interjection]: b" in out
+
+
+class TestEmergencyPruneCalibration:
+    """The map-agent wedge (2026-06-24): the local estimate read ~2x under the
+    real tokenizer, so _emergency_prune's 0.75 ceiling saw a sub-ceiling number
+    and dropped NOTHING, and the self-heal re-raised. Both the calibrated path
+    (provider gave counts) and the masked path (no counts) must now make real
+    downward progress."""
+
+    @staticmethod
+    def _wedged_loop(max_tokens: int = 100_000):
+        from src.agent.context import ContextManager
+        loop = _make_loop()
+        loop.context_manager = ContextManager(max_tokens=max_tokens, model="anthropic/claude")
+        # Tool-call groups dense enough that the RAW estimate sits UNDER the
+        # 0.75 emergency ceiling (so the old prune no-ops), but the real request
+        # is ~2x larger.
+        msgs = [{"role": "user", "content": "INITIAL " + "i" * 4000}]
+        for g in range(12):
+            msgs.append({
+                "role": "assistant", "content": "",
+                "tool_calls": [{"id": f"c{g}", "function": {"name": "do", "arguments": "{}"}}],
+            })
+            msgs.append({"role": "tool", "tool_call_id": f"c{g}", "content": "R" + "r" * 4000})
+            msgs.append({"role": "assistant", "content": "A" + "a" * 4000})
+            msgs.append({"role": "user", "content": "U" + "u" * 4000})
+        loop._chat_messages = msgs
+        return loop
+
+    def test_calibrates_and_prunes_when_provider_reports_counts(self):
+        loop = self._wedged_loop()
+        cm = loop.context_manager
+        tools = None
+        raw = cm._raw_request_tokens(loop._chat_messages)
+        assert raw <= cm.max_tokens * 0.75, "precondition: old prune would no-op"
+        before_n = len(loop._chat_messages)
+        # Streaming-style message carrying the real (≈2x) token count.
+        msg = f"LLM stream error: prompt is too long: {raw * 2} tokens > {cm.max_tokens} maximum"
+        progressed = loop._emergency_prune("system", tools, overflow_message=msg)
+        assert cm._estimate_correction > 1.5, "should have calibrated from the count"
+        assert progressed is True
+        assert len(loop._chat_messages) < before_n, "must drop real content"
+
+    def test_forces_progress_when_message_is_masked(self):
+        # Masked proxy path: no parseable counts, estimate still thinks we fit.
+        loop = self._wedged_loop()
+        before_n = len(loop._chat_messages)
+        progressed = loop._emergency_prune(
+            "system", None, overflow_message="Upstream service call failed (HTTP 400).",
+        )
+        assert progressed is True, "forced-progress backstop must shed content"
+        assert len(loop._chat_messages) < before_n


### PR DESCRIPTION
## Symptom

An agent (`map` on cake, Opus 4.8, 1M window) wedged on the context limit — every chat call 400'd and never recovered:

```
LLM stream error: Anthropic API error (HTTP 400): prompt is too long: 1000961 tokens > 1000000 maximum
```

## Root cause (from cake logs)

The PR #1087 self-heal **is** present and fires, but the emergency prune was a **no-op**:

```
context overflow: emergency-pruned 124->124 messages (504884->504884 est tokens)
... prompt is too long: 1001150 tokens > 1000000 maximum
```

The `chars/3.5` token estimate read **~2× under** the real tokenizer (**504,884** est vs **1,001,150** actual). The content is dense ASCII CSV/JSON/code (lead-gen data), which tokenizes at ~1.75 chars/tok, not the assumed 3.5. So `_emergency_prune`'s `0.75 × 1M = 750K` ceiling saw 504K, **dropped nothing**, and every retry 400'd identically until the turn aborted. (The "961 over" was a red herring — just how far over the cap the request landed; the real gap is the 2× undercount.)

The #1087 fix code is deployed on cake (verified by symbol presence) — this is a real gap in it, matching its own deferred follow-ups.

## Fix — act on ground truth, not the lying estimate

1. **Calibration.** When the API reports the real count (the streaming SSE path forwards it un-masked), `parse_overflow_tokens` extracts it and `ContextManager.calibrate_from_overflow` learns a per-session `_estimate_correction` multiplier (ratchets **up** only, clamped ≤ 6×). `estimate_request_tokens` scales by it, so the prune — here and on every later turn — sees the true size. **Defaults to 1.0 → a no-op for agents that never overflow.**
2. **Forced progress.** On the masked proxy path (no parseable counts), `prune_to_fit(target_tokens=…)` drops to 70% of current size rather than trusting the estimate — the API already told us we overflowed, so a no-op prune means the estimate is wrong.
3. **Tag `error_type="context_overflow"` on the proxy STREAMING emit** too, so the streaming self-heal classifies on the type instead of depending on raw text surviving un-masked.

Both deferred #1087 follow-ups (calibrate-from-actual, tag-streaming-overflow) are now closed.

## Behaviour after fix

The wedged agent **self-heals**: on the next overflow the streaming path reports the real count → calibrate → the prune drops real content → the call succeeds. No manual `/chat/reset` needed.

## Tests

`TestEstimateCalibration` (ratchet/clamp/scale + no-op→real-prune regression), `TestEmergencyPruneCalibration` (calibrated path + masked forced-progress), and a `prune_to_fit` `target_tokens` test. Full `test_context.py`/`test_loop.py`/`test_llm.py` + errors/credentials sweep green; ruff clean.

## Deploy note

Agent-side change → needs an agent image rebuild + restart to take effect on a box. cake is a few PRs behind main regardless.

🤖 Diagnosed from live cake logs and fixed via Claude Code.