### PR TITLE
fix(host): port allocator must never hand out the mesh host port (prod outage)

### DIFF
--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -308,6 +308,15 @@ class DockerBackend(RuntimeBackend):
         self.use_host_network = use_host_network
         self._next_port = 8401
         self._port_lock = threading.Lock()
+        # Host ports the loopback allocator must never hand out to a
+        # container. The mesh host (a non-container host process) binds
+        # ``mesh_host_port``; if a published agent/browser port collided with
+        # it, the mesh would fail to bind ([Errno 98] address already in use),
+        # never come up, and the whole instance would 404 — self-perpetuating
+        # on every restart. The allocator range (8401+) reaches 8420 once
+        # enough agents exist, so the mesh port MUST be excluded. A set so
+        # other host-published ports can be reserved later.
+        self._reserved_ports: set[int] = {self.mesh_host_port}
         self.browser_service_url: str | None = None
         self.browser_auth_token: str = ""
         self._browser_container = None
@@ -371,6 +380,18 @@ class DockerBackend(RuntimeBackend):
             options={"com.docker.network.bridge.enable_icc": "false"},
         )
 
+    def _allocate_port(self) -> int:
+        """Return the next free loopback host port, skipping any reserved
+        port (at minimum the mesh host port). ``_next_port`` stays monotonic;
+        we just jump over reserved ports so a published agent/browser port can
+        never collide with the mesh host process. Caller must hold
+        ``self._port_lock``."""
+        while self._next_port in self._reserved_ports:
+            self._next_port += 1
+        port = self._next_port
+        self._next_port += 1
+        return port
+
     @staticmethod
     def backend_name() -> str:
         return "docker"
@@ -397,8 +418,7 @@ class DockerBackend(RuntimeBackend):
         env_overrides: dict[str, str] | None = None,
     ) -> str:
         with self._port_lock:
-            port = self._next_port
-            self._next_port += 1
+            port = self._allocate_port()
 
         # Generate per-agent auth token for mesh request verification.
         # Task 4 invariant: every agent (including the operator) gets a
@@ -767,8 +787,7 @@ class DockerBackend(RuntimeBackend):
                 environment[var] = env_val
 
         with self._port_lock:
-            api_port = self._next_port
-            self._next_port += 1
+            api_port = self._allocate_port()
 
         uploads_path = str(self.uploads_dir.as_posix() if platform.system() == "Windows" else self.uploads_dir)
         run_kwargs: dict[str, Any] = {

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -381,13 +381,18 @@ class DockerBackend(RuntimeBackend):
         )
 
     def _allocate_port(self) -> int:
-        """Return the next free loopback host port, skipping any reserved
+        """Return the next unreserved loopback host port, skipping any reserved
         port (at minimum the mesh host port). ``_next_port`` stays monotonic;
         we just jump over reserved ports so a published agent/browser port can
-        never collide with the mesh host process. Caller must hold
+        never collide with the mesh host process. (Skips reserved ports; it
+        does not OS-probe for a free one.) Caller must hold
         ``self._port_lock``."""
         while self._next_port in self._reserved_ports:
             self._next_port += 1
+        if self._next_port > 65535:
+            raise RuntimeError(
+                f"host port range exhausted (next={self._next_port}); too many containers"
+            )
         port = self._next_port
         self._next_port += 1
         return port

--- a/tests/test_agent_registration.py
+++ b/tests/test_agent_registration.py
@@ -351,6 +351,7 @@ def test_docker_backend_operator_gets_distinct_token(tmp_path, monkeypatch):
     backend = DockerBackend.__new__(DockerBackend)
     backend.auth_tokens = {}
     backend._next_port = 9000
+    backend._reserved_ports = {8420}
     import threading
     backend._port_lock = threading.Lock()
     backend.use_host_network = False

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -188,6 +188,15 @@ class TestDockerBackendPortAllocator:
         assert backend._allocate_port() == 8419
         assert backend._allocate_port() == 8422
 
+    def test_raises_on_port_exhaustion(self):
+        """At the top of the 16-bit range, the last valid port is handed out,
+        then the allocator raises rather than returning an invalid (>65535)
+        port and deferring the failure to Docker."""
+        backend = self._make_backend(next_port=65535)
+        assert backend._allocate_port() == 65535
+        with pytest.raises(RuntimeError, match="host port range exhausted"):
+            backend._allocate_port()
+
 
 # ── SandboxBackend ────────────────────────────────────────────
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -119,6 +119,7 @@ class TestDockerBackendLifecycle:
         backend.agents = {}
         backend._port_lock = __import__("threading").Lock()
         backend._next_port = 8400
+        backend._reserved_ports = {8420}
         backend.use_host_network = True
         backend.mesh_host_port = 8420
         backend.extra_env = {}
@@ -138,6 +139,54 @@ class TestDockerBackendLifecycle:
         # Token must have been popped on the failure path.
         assert "gamma" not in backend.auth_tokens
         assert "gamma" not in backend.agents
+
+
+# ── Host-port allocator: must never collide with the mesh host port ──
+#
+# Production outage: the loopback allocator (8401+) incremented blindly and
+# eventually handed an agent container 127.0.0.1:8420 — the exact port the
+# mesh host process must bind. The mesh then failed with
+# [Errno 98] address already in use, never bound, and the whole instance
+# served 404s, self-perpetuating on every restart.
+
+class TestDockerBackendPortAllocator:
+    def _make_backend(self, *, next_port: int = 8401, mesh_host_port: int = 8420) -> DockerBackend:
+        backend = DockerBackend.__new__(DockerBackend)
+        backend._port_lock = __import__("threading").Lock()
+        backend._next_port = next_port
+        backend.mesh_host_port = mesh_host_port
+        backend._reserved_ports = {mesh_host_port}
+        return backend
+
+    def test_skips_mesh_host_port(self):
+        """8419 → 8421: the mesh host port is jumped over, never returned."""
+        backend = self._make_backend(next_port=8419)
+        assert backend._allocate_port() == 8419
+        # 8420 (the mesh port) must be skipped entirely.
+        assert backend._allocate_port() == 8421
+        assert backend._allocate_port() == 8422
+
+    def test_mesh_port_never_assigned_across_full_range(self):
+        """Allocate well past the mesh port; it must appear in no assignment."""
+        backend = self._make_backend(next_port=8401)
+        assigned = [backend._allocate_port() for _ in range(30)]
+        assert backend.mesh_host_port not in assigned
+        # No duplicates and still monotonic.
+        assert assigned == sorted(assigned)
+        assert len(set(assigned)) == len(assigned)
+
+    def test_allocator_skips_mesh_port_when_next_lands_on_it(self):
+        """When _next_port lands exactly on the reserved mesh port, the next
+        allocation jumps over it rather than returning it."""
+        backend = self._make_backend(next_port=8420)
+        assert backend._allocate_port() == 8421
+
+    def test_multiple_reserved_ports_all_skipped(self):
+        """The reserved set is extensible — every member is jumped over."""
+        backend = self._make_backend(next_port=8419)
+        backend._reserved_ports = {8420, 8421}
+        assert backend._allocate_port() == 8419
+        assert backend._allocate_port() == 8422
 
 
 # ── SandboxBackend ────────────────────────────────────────────
@@ -549,6 +598,7 @@ def _make_docker_backend(**overrides):
     backend.mesh_host_port = 8420
     backend.use_host_network = False
     backend._next_port = 8401
+    backend._reserved_ports = {backend.mesh_host_port}
     backend._port_lock = threading.Lock()
     backend.project_root = __import__("pathlib").Path("/tmp")
     backend.browser_service_url = None


### PR DESCRIPTION
## The outage (verified in production — full instance down)

The DockerBackend loopback host-port allocator in `src/host/runtime.py` started at `self._next_port = 8401` and simply incremented, publishing each agent container's `:8400` as `127.0.0.1:<port>`. It **never excluded the mesh host port** (`self.mesh_host_port`, default **8420**).

On a production box with ~22 containers the allocator range (8401–8422) reached **8420**, so an agent container published `127.0.0.1:8420` — the exact port the mesh host (a non-container host process) must bind. On restart the agent grabbed 8420 first, the mesh got `[Errno 98] address already in use`, the mesh **never bound any port**, and the whole instance served 404s (Caddy proxies the site to 8420 → hit the agent container instead of the mesh). **Self-perpetuating**: every restart re-hit the collision and took the box down again.

## The fix

A skip-aware allocator:
- `self._reserved_ports: set[int] = {self.mesh_host_port}` — seeded with the mesh port, structured as a set so other host-published ports can be reserved later.
- `_allocate_port()` keeps `_next_port` **monotonic** but jumps over any reserved port before returning.

Applied to **both** DockerBackend allocation sites:
- the agent host port (`start_agent`)
- the browser-service API port (browser container start)

The allocator can now never return `self.mesh_host_port`. (SandboxBackend uses `docker sandbox exec` with no host-port publishing, so it has no allocator to fix.)

## Tests

`TestDockerBackendPortAllocator` proves: the mesh port is skipped (8419 → 8421), never appears across a 30-port sweep, is jumped over even when `_next_port` lands exactly on it, and that multiple reserved ports are all skipped. Three `__new__`-based DockerBackend test fixtures that exercise the start path were updated to seed `_reserved_ports`.

- `make test`: **1773 passed, 30 skipped** (full fast suite).
- `ruff check src/ tests/`: clean.

## Durability — MUST merge + deploy

A prod **hotpatch to `runtime.py` is discarded** by the deploy's `git checkout . && git pull`. This fix is only durable once it is **merged and deployed**; a local edit on a box will be wiped on the next update.