### PR TITLE
feat(observability): interleave external infra-event markers into `openlegion session`

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -765,24 +765,63 @@ def tasks_cmd(agent, team, status, port, as_json):
 
 
 @cli.command("session")
-@click.argument("trace_id")
+@click.argument("trace_id", required=False, default=None)
+@click.option(
+    "--recent", "recent", is_flag=True, default=False,
+    help="List recent sessions instead of one trace (optionally pass a count, default 20)",
+)
 @click.option(
     "--data-dir", "data_dir", default=None,
     help="Path to the on-box data dir holding the SQLite stores (default: ./data)",
 )
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
-def session_cmd(trace_id: str, data_dir: str | None, as_json: bool):
+def session_cmd(trace_id: str | None, recent: bool, data_dir: str | None, as_json: bool):
     """Reconstruct one session's full timeline by trace_id (read-only).
 
     Assembles intent + actions + task transitions + cost from the host SQLite
-    stores. Works even when the mesh is down. NOTE: per-turn chat transcript
-    text is container-local, so this host-side timeline does not include the
-    full conversation — only intent, traces, tasks, and costs.
-    """
-    from src.cli.session_reader import assemble_session, render_session
+    stores — and interleaves external infra-event markers (host restart /
+    deploy) by wall-clock so an unexplained gap gets attributed to its cause.
+    Works even when the mesh is down. NOTE: per-turn chat transcript text is
+    container-local, so this host-side timeline does not include the full
+    conversation — only intent, traces, tasks, and costs.
 
+    Usage:
+
+    \b
+      openlegion session <trace_id>     reconstruct one session's timeline
+      openlegion session --recent [N]   list the N most recent sessions (default 20)
+
+    See also the ``sessions`` command for richer filters (``--since`` /
+    ``--user`` / ``--agent``).
+    """
     as_json = as_json or _json_mode
     base = Path(data_dir) if data_dir else cli_config.DATA_DIR
+
+    # --recent: list recent sessions instead of reconstructing one trace. The
+    # optional ``[N]`` rides in on the positional ``trace_id`` slot (so the
+    # documented ``session --recent 50`` syntax works); default 20.
+    if recent:
+        from src.cli.session_reader import list_sessions, render_sessions
+
+        limit = 20
+        if trace_id:
+            try:
+                limit = max(1, int(trace_id))
+            except ValueError:
+                _fail(f"--recent expects a count, got {trace_id!r}")
+        # Unbounded window — "recent" is a count, not a time floor.
+        summaries = list_sessions(base, since=0.0, limit=limit)
+        if as_json:
+            click.echo(dumps_safe({"sessions": summaries}))
+        else:
+            click.echo(render_sessions(summaries))
+        return
+
+    if not trace_id:
+        _fail("Provide a trace_id, or use --recent [N] to list recent sessions.")
+
+    from src.cli.session_reader import assemble_session, render_session
+
     session = assemble_session(base, trace_id)
     if as_json:
         click.echo(dumps_safe(session))

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -163,6 +163,7 @@ class RuntimeContext:
         self.event_bus = None
         self.trace_store = None
         self.intent_store = None
+        self.lifecycle_store = None
         self.agent_urls: dict[str, str] = {}
         self._dispatch_loop = None
         # Post-completion verification wakes (success path) — sliding
@@ -216,6 +217,8 @@ class RuntimeContext:
             self.trace_store.close()
         if self.intent_store:
             self.intent_store.close()
+        if self.lifecycle_store:
+            self.lifecycle_store.close()
         if self.pubsub:
             self.pubsub.close()
         if self.blackboard:
@@ -404,6 +407,15 @@ class RuntimeContext:
         from src.host.intent import IntentStore
         self.intent_store = IntentStore(
             db_path=os.environ.get("OPENLEGION_INTENT_DB", "data/intent.db")
+        )
+        # External infra-event markers (host restart / deploy / OOM). Emitted
+        # out-of-band by the provisioner or an operator runbook via the
+        # internal-only POST /mesh/system/lifecycle_event endpoint and
+        # interleaved by wall-clock into the session-reader timeline. Append-
+        # only with a 90-day time-based GC (mirrors the intent store).
+        from src.host.lifecycle import LifecycleStore
+        self.lifecycle_store = LifecycleStore(
+            db_path=os.environ.get("OPENLEGION_LIFECYCLE_DB", "data/lifecycle.db")
         )
         self.blackboard = Blackboard(event_bus=self.event_bus)
         self.pubsub = PubSub(db_path="pubsub.db")
@@ -1429,6 +1441,7 @@ class RuntimeContext:
             auth_tokens=self.runtime.auth_tokens,
             trace_store=self.trace_store,
             intent_store=self.intent_store,
+            lifecycle_store=self.lifecycle_store,
             event_bus=self.event_bus,
             health_monitor=self.health_monitor,
             cost_tracker=self.cost_tracker,
@@ -1528,6 +1541,7 @@ class RuntimeContext:
             connector_store=self.connector_store,
             mcp_gateway=self.mcp_gateway,
             intent_store=self.intent_store,
+            lifecycle_store=self.lifecycle_store,
         )
         app.include_router(dashboard_router)
         app.include_router(create_spa_catchall_router())  # Must be last — SPA deep linking

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1541,7 +1541,6 @@ class RuntimeContext:
             connector_store=self.connector_store,
             mcp_gateway=self.mcp_gateway,
             intent_store=self.intent_store,
-            lifecycle_store=self.lifecycle_store,
         )
         app.include_router(dashboard_router)
         app.include_router(create_spa_catchall_router())  # Must be last — SPA deep linking

--- a/src/cli/session_reader.py
+++ b/src/cli/session_reader.py
@@ -211,6 +211,38 @@ def _fetch_tasks(data_dir: Path, trace_id: str) -> list[dict]:
         conn.close()
 
 
+def _fetch_lifecycle(data_dir: Path, start: float, end: float) -> list[dict]:
+    """Return external infra-event markers overlapping ``[start, end]``.
+
+    Lifecycle markers (host restart / deploy / OOM) are NOT trace-keyed — a host
+    restart hits every in-flight trace at once — so they're correlated to a
+    session by wall-clock overlap, not by a ``trace_id`` join. The window is
+    padded slightly on both ends so a restart that lands just outside the first/
+    last recorded event (the gap it likely *caused*) still surfaces.
+    """
+    conn = _connect_ro(data_dir / "lifecycle.db")
+    if conn is None:
+        return []
+    try:
+        cols = _columns(conn, "lifecycle_events")
+        if not cols:
+            return []
+        pad = 60.0  # seconds of slack on each edge
+        rows = conn.execute(
+            "SELECT timestamp, kind, detail FROM lifecycle_events "
+            "WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp",
+            (start - pad, end + pad),
+        ).fetchall()
+        return [
+            {"timestamp": r["timestamp"], "kind": r["kind"], "detail": r["detail"]}
+            for r in rows
+        ]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
 def _fetch_cost(data_dir: Path, trace_id: str) -> dict:
     """Return a cost rollup for a trace_id: totals + per-model breakdown."""
     empty = {"total_tokens": 0, "total_cost_usd": 0.0, "by_model": []}
@@ -258,6 +290,25 @@ def assemble_session(data_dir: str | Path, trace_id: str) -> dict:
     actions = _fetch_actions(data_dir, trace_id)
     tasks = _fetch_tasks(data_dir, trace_id)
     cost = _fetch_cost(data_dir, trace_id)
+
+    # Lifecycle markers are correlated by wall-clock, so derive the session's
+    # time window from every timestamped row we found and pull markers that
+    # overlap it. Only query when the window is non-empty (a found session).
+    timestamps: list[float] = []
+    for it in intent:
+        if it.get("timestamp"):
+            timestamps.append(float(it["timestamp"]))
+    for a in actions:
+        if a.get("timestamp"):
+            timestamps.append(float(a["timestamp"]))
+    for t in tasks:
+        for key in ("created_at", "updated_at", "completed_at"):
+            if t.get(key):
+                timestamps.append(float(t[key]))
+    lifecycle: list[dict] = []
+    if timestamps:
+        lifecycle = _fetch_lifecycle(data_dir, min(timestamps), max(timestamps))
+
     found = bool(intent or actions or tasks or cost["by_model"])
     return {
         "trace_id": trace_id,
@@ -266,6 +317,7 @@ def assemble_session(data_dir: str | Path, trace_id: str) -> dict:
         "actions": actions,
         "tasks": tasks,
         "cost": cost,
+        "lifecycle": lifecycle,
     }
 
 
@@ -420,6 +472,14 @@ def render_session(session: dict) -> str:
             f"(assignee={t.get('assignee') or '?'})"
         )
         events.append((ts, line))
+    # External infra-event markers (host restart / deploy / OOM), interleaved by
+    # wall-clock. Flagged with ``**`` so a restart that explains a timeline gap
+    # jumps out of the normal action stream.
+    for ev in session.get("lifecycle", []):
+        ts = ev.get("timestamp") or 0
+        detail = ev.get("detail") or ""
+        suffix = f" — {detail[:120]}" if detail else ""
+        events.append((ts, f"  [{_fmt_ts(ts)}] ** infra:{ev.get('kind') or 'event'}{suffix}"))
     if events:
         for _ts, line in sorted(events, key=lambda e: e[0]):
             lines.append(line)

--- a/src/host/lifecycle.py
+++ b/src/host/lifecycle.py
@@ -1,0 +1,156 @@
+"""LifecycleStore — SQLite append-only store for external infra-event markers.
+
+Records out-of-band lifecycle events that the engine itself cannot observe but
+which are essential context when reconstructing what happened during a session:
+the provisioner restarting the host, a deploy/`systemctl restart openlegion`, a
+Docker daemon bounce, an OOM kill, etc. These markers are emitted by EXTERNAL
+actors (the provisioner over SSH, an operator runbook) via the internal-only
+``POST /mesh/system/lifecycle_event`` endpoint and interleaved by wall-clock into
+the ``openlegion session`` timeline.
+
+Motivation (real incident): an in-flight multi-agent workflow died because the
+provisioner restarted the host mid-run. Nothing in ``intent.db`` / ``traces.db``
+/ ``tasks.db`` recorded the restart, so the timeline showed an unexplained gap.
+This store gives the reader a place to surface that external cause.
+
+Unlike ``trace_id``-keyed stores, lifecycle markers are NOT tied to a single
+session — a host restart affects every in-flight trace at once. They are keyed
+only by wall-clock ``timestamp`` and interleaved into a session timeline by time
+overlap, not by ``trace_id`` join.
+
+Follows the same SQLite-WAL + throttled time-based-GC pattern as ``IntentStore``
+(``src/host/intent.py``). Append-only, default 90-day retention.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from src.shared.redaction import deep_redact, redact_text_with_urls
+from src.shared.sqlite_helpers import open_db
+from src.shared.utils import dumps_safe, setup_logging
+
+logger = setup_logging("host.lifecycle")
+
+# Cap the free-form fields so a hostile/buggy emitter can't bloat the DB.
+_MAX_KIND_LEN = 64
+_MAX_DETAIL_LEN = 2000
+
+
+class LifecycleStore:
+    """SQLite-backed append-only store for external infra-event markers."""
+
+    def __init__(self, db_path: str = "data/lifecycle.db", max_age_hours: int | None = 24 * 90):
+        self.max_age_hours = max_age_hours
+        # ensure first GC runs regardless of monotonic() epoch
+        self._last_age_gc: float = -300.0
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = open_db(db_path, busy_timeout_ms=5000)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS lifecycle_events (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp  REAL NOT NULL,
+                kind       TEXT NOT NULL DEFAULT '',
+                detail     TEXT NOT NULL DEFAULT '',
+                meta_json  TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_lifecycle_timestamp ON lifecycle_events (timestamp)")
+        self._conn.commit()
+
+    def record(
+        self,
+        *,
+        kind: str,
+        detail: str = "",
+        timestamp: float | None = None,
+        meta: dict | None = None,
+    ) -> dict:
+        """Insert a lifecycle-event marker. Returns the stored row as a dict.
+
+        ``timestamp`` defaults to now but may be supplied by the emitter (an
+        external actor often records the marker slightly after the event it
+        describes — e.g. the provisioner logging a restart once SSH reconnects).
+
+        ``detail`` and every string inside ``meta`` are redacted at storage so a
+        stray credential in an emitter's free-form text is never persisted in
+        plaintext (matches the IntentStore / TraceStore H16 posture).
+        """
+        kind = (kind or "").strip()[:_MAX_KIND_LEN]
+        detail = redact_text_with_urls((detail or "")[:_MAX_DETAIL_LEN])
+        ts = float(timestamp) if timestamp is not None else time.time()
+        meta_json = dumps_safe(deep_redact(meta)) if meta else ""
+        cur = self._conn.execute(
+            "INSERT INTO lifecycle_events (timestamp, kind, detail, meta_json) VALUES (?, ?, ?, ?)",
+            (ts, kind, detail, meta_json),
+        )
+        self._conn.commit()
+        self._maybe_gc_old()
+        return {
+            "id": cur.lastrowid,
+            "timestamp": ts,
+            "kind": kind,
+            "detail": detail,
+            "meta": json.loads(meta_json) if meta_json else {},
+        }
+
+    def _maybe_gc_old(self) -> None:
+        """Remove rows older than max_age_hours, throttled to once per 5 minutes.
+
+        Time-based GC (mirrors ``IntentStore._maybe_gc_old``): lifecycle markers
+        are append-only with no terminal lifecycle status to anchor a per-row
+        retention deadline against.
+        """
+        if self.max_age_hours is None:
+            return
+        now = time.monotonic()
+        if now - self._last_age_gc < 300:
+            return
+        self._last_age_gc = now
+        cutoff = time.time() - (self.max_age_hours * 3600)
+        self._conn.execute("DELETE FROM lifecycle_events WHERE timestamp < ?", (cutoff,))
+        self._conn.commit()
+
+    def _row_to_dict(self, row: tuple) -> dict:
+        """Convert a query row to a lifecycle-event dict."""
+        meta_json = row[3] if len(row) > 3 else ""
+        meta = json.loads(meta_json) if meta_json else {}
+        return {
+            "timestamp": row[0],
+            "kind": row[1],
+            "detail": row[2],
+            "meta": meta,
+        }
+
+    _COLS = "timestamp, kind, detail, meta_json"
+
+    def list_between(self, start: float, end: float, limit: int = 1000) -> list[dict]:
+        """Return markers with ``start <= timestamp <= end``, ordered by time."""
+        cur = self._conn.execute(
+            f"SELECT {self._COLS} FROM lifecycle_events "
+            "WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp LIMIT ?",
+            (start, end, max(1, min(limit, 10000))),
+        )
+        return [self._row_to_dict(row) for row in cur.fetchall()]
+
+    def list_recent(self, *, since: float | None = None, limit: int = 100) -> list[dict]:
+        """Return recent markers (newest first), optionally floored at ``since``."""
+        conditions = []
+        params: list = []
+        if since is not None:
+            conditions.append("timestamp >= ?")
+            params.append(since)
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        params.append(max(1, min(limit, 1000)))
+        cur = self._conn.execute(
+            f"SELECT {self._COLS} FROM lifecycle_events{where} ORDER BY id DESC LIMIT ?",
+            params,
+        )
+        return [self._row_to_dict(row) for row in cur.fetchall()]
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -285,6 +285,7 @@ if TYPE_CHECKING:
     from src.host.health import HealthMonitor
     from src.host.intent import IntentStore
     from src.host.lanes import LaneManager
+    from src.host.lifecycle import LifecycleStore
     from src.host.mcp_gateway import MCPGateway
     from src.host.mesh import Blackboard, MessageRouter, PubSub
     from src.host.permissions import PermissionMatrix
@@ -766,6 +767,7 @@ def create_mesh_app(
     auth_tokens: dict[str, str] | None = None,
     trace_store: TraceStore | None = None,
     intent_store: "IntentStore | None" = None,
+    lifecycle_store: "LifecycleStore | None" = None,
     event_bus: EventBus | None = None,
     health_monitor: HealthMonitor | None = None,
     cost_tracker: CostTracker | None = None,
@@ -899,6 +901,13 @@ def create_mesh_app(
     # Instantiated in cli/runtime and passed in; attached here so the
     # Phase 3 read endpoints / reader can reach it off the app.
     app.intent_store = intent_store  # exposed for tests/Phase 3 reader
+
+    # External infra-event markers (host restart / deploy / OOM). Populated
+    # out-of-band by the provisioner or an operator runbook via the
+    # internal-only ``POST /mesh/system/lifecycle_event`` endpoint; the
+    # session reader interleaves them by wall-clock so an unexplained
+    # workflow gap can be attributed to its external cause.
+    app.lifecycle_store = lifecycle_store  # exposed for tests/Phase 3 reader
 
     # Observation log of agent→user notifications. NOT a message channel:
     # agents call ``notify_user`` (intent: tell the human) and the mesh
@@ -5108,6 +5117,54 @@ def create_mesh_app(
             # means no LLM keys at all (deployment broken).
             "available_providers": available_providers,
         }
+
+    @app.post("/mesh/system/lifecycle_event")
+    async def record_lifecycle_event(body: dict, request: Request) -> dict:
+        """Record an EXTERNAL infra-event marker (host restart / deploy / OOM).
+
+        Internal-only (loopback + ``x-mesh-internal``): the emitter is the
+        provisioner over SSH or an operator runbook — never an agent. These
+        markers describe events the engine itself cannot observe but which
+        explain otherwise-unexplained gaps in a session timeline (the real
+        incident: the provisioner restarted the host mid-workflow). The
+        ``openlegion session`` reader interleaves them by wall-clock.
+
+        Body: ``{kind: str (required), detail?: str, timestamp?: float,
+        meta?: dict}``. ``kind`` and ``detail`` are length-capped and
+        redacted at storage (matches the intent/trace H16 posture).
+        """
+        if not _is_internal_caller(request):
+            _record_denial(
+                "role", caller="?", target="lifecycle_event",
+                gate="lifecycle_event:internal_only",
+            )
+            raise HTTPException(403, "lifecycle_event is internal-only")
+        if lifecycle_store is None:
+            return {"recorded": False, "reason": "no lifecycle_store"}
+        if not isinstance(body, dict):
+            raise HTTPException(400, "body must be a JSON object")
+        kind = str(body.get("kind", "")).strip()
+        if not kind:
+            raise HTTPException(400, "kind is required")
+        ts_raw = body.get("timestamp")
+        timestamp: float | None
+        if ts_raw is None:
+            timestamp = None
+        else:
+            try:
+                timestamp = float(ts_raw)
+            except (TypeError, ValueError):
+                raise HTTPException(400, "timestamp must be a number (epoch seconds)")
+        meta = body.get("meta")
+        if meta is not None and not isinstance(meta, dict):
+            raise HTTPException(400, "meta must be a JSON object")
+        row = lifecycle_store.record(
+            kind=kind,
+            detail=str(body.get("detail", "")),
+            timestamp=timestamp,
+            meta=meta,
+        )
+        return {"recorded": True, "event": row}
 
     @app.get("/mesh/agents/{agent_id}/metrics")
     async def agent_metrics(agent_id: str, request: Request) -> dict:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,347 @@
+"""Tests for LifecycleStore + the internal lifecycle_event endpoint + the
+session reader's wall-clock interleaving of external infra-event markers.
+
+Stretch goal of the session-observability work: the root cause of the real
+incident was an EXTERNAL event (the provisioner restarting the host) that the
+engine could not observe. These markers are emitted out-of-band via the
+internal-only ``POST /mesh/system/lifecycle_event`` endpoint and interleaved by
+wall-clock into the ``openlegion session`` timeline.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+
+import pytest
+from click.testing import CliRunner
+from httpx import ASGITransport, AsyncClient
+
+from src.cli import cli
+from src.cli.session_reader import _fetch_lifecycle, assemble_session, render_session
+from src.host.intent import IntentStore
+from src.host.lifecycle import LifecycleStore
+from src.host.traces import TraceStore
+
+TRACE = "tr_lifecyclexx"
+
+
+# ── LifecycleStore unit ──────────────────────────────────────
+
+
+class TestLifecycleStore:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "lifecycle.db")
+        self.store = LifecycleStore(db_path=self.db_path)
+
+    def teardown_method(self):
+        self.store.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_record_returns_row_and_persists(self):
+        row = self.store.record(kind="host_restart", detail="provisioner update")
+        assert row["kind"] == "host_restart"
+        assert row["detail"] == "provisioner update"
+        assert row["timestamp"] > 0
+        recent = self.store.list_recent()
+        assert len(recent) == 1
+        assert recent[0]["kind"] == "host_restart"
+
+    def test_explicit_timestamp_honoured(self):
+        when = time.time() - 3600
+        self.store.record(kind="deploy", timestamp=when)
+        rows = self.store.list_recent()
+        assert rows[0]["timestamp"] == when
+
+    def test_list_between_window(self):
+        # Synthetic small timestamps fall below the 90-day retention cutoff, so
+        # the first-insert GC (mirrors IntentStore) would reap them. Disable GC
+        # for this pure range test — retention is covered by its own test below.
+        store = LifecycleStore(
+            db_path=os.path.join(self._tmpdir, "between.db"),
+            max_age_hours=None,
+        )
+        try:
+            store.record(kind="a", timestamp=100.0)
+            store.record(kind="b", timestamp=200.0)
+            store.record(kind="c", timestamp=300.0)
+            rows = store.list_between(150.0, 250.0)
+            assert [r["kind"] for r in rows] == ["b"]
+        finally:
+            store.close()
+
+    def test_list_recent_newest_first(self):
+        # GC disabled — synthetic timestamps below the retention cutoff would
+        # otherwise be reaped on the first insert. Ordering is the unit here.
+        store = LifecycleStore(
+            db_path=os.path.join(self._tmpdir, "order.db"),
+            max_age_hours=None,
+        )
+        try:
+            store.record(kind="first", timestamp=10.0)
+            store.record(kind="second", timestamp=20.0)
+            rows = store.list_recent()
+            assert [r["kind"] for r in rows] == ["second", "first"]
+        finally:
+            store.close()
+
+    def test_kind_and_detail_length_capped(self):
+        self.store.record(kind="x" * 200, detail="d" * 5000)
+        row = self.store.list_recent()[0]
+        assert len(row["kind"]) == 64
+        assert len(row["detail"]) <= 2000
+
+    def test_detail_redacted_at_storage(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(kind="deploy", detail=f"key {secret}")
+        raw = self.store._conn.execute("SELECT detail FROM lifecycle_events").fetchone()[0]
+        assert secret not in raw
+        assert "[REDACTED]" in raw
+
+    def test_meta_redacted_at_storage(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(kind="deploy", meta={"note": f"creds {secret}"})
+        raw = self.store._conn.execute("SELECT meta_json FROM lifecycle_events").fetchone()[0]
+        assert secret not in raw
+
+    def test_time_based_gc_drops_old_rows(self):
+        store = LifecycleStore(
+            db_path=os.path.join(self._tmpdir, "gc.db"),
+            max_age_hours=1,
+        )
+        try:
+            store._conn.execute(
+                "INSERT INTO lifecycle_events (timestamp, kind, detail) VALUES (?, ?, ?)",
+                (time.time() - 7200, "ancient", ""),
+            )
+            store._conn.commit()
+            assert store.list_recent()
+            store._last_age_gc = -300.0
+            store.record(kind="fresh")
+            kinds = [r["kind"] for r in store.list_recent()]
+            assert "ancient" not in kinds
+            assert "fresh" in kinds
+        finally:
+            store.close()
+
+    def test_idempotent_schema_init(self):
+        self.store.record(kind="x")
+        self.store.close()
+        store2 = LifecycleStore(db_path=self.db_path)
+        try:
+            assert store2.list_recent()
+            store2.record(kind="y")
+        finally:
+            self.store = store2  # teardown closes it
+
+
+# ── reader: wall-clock interleaving ──────────────────────────
+
+
+def _seed_session_with_restart(data_dir: str) -> float:
+    """Seed one trace whose actions straddle a host-restart marker.
+
+    Returns the restart timestamp so the test can assert ordering.
+    """
+    intent = IntentStore(db_path=os.path.join(data_dir, "intent.db"))
+    traces = TraceStore(db_path=os.path.join(data_dir, "traces.db"))
+    lifecycle = LifecycleStore(db_path=os.path.join(data_dir, "lifecycle.db"))
+
+    t0 = time.time()
+    intent.record(
+        trace_id=TRACE,
+        origin_kind="human",
+        origin_channel="dashboard",
+        origin_user="alice",
+        agent="alpha",
+        message="long running workflow",
+    )
+    # Two actions bracketing the restart. Write timestamps directly so the
+    # window is deterministic.
+    traces._conn.execute(
+        "INSERT INTO traces (trace_id, timestamp, source, agent, event_type, detail) VALUES (?, ?, ?, ?, ?, ?)",
+        (TRACE, t0, "mesh", "alpha", "chat", "dispatch"),
+    )
+    traces._conn.execute(
+        "INSERT INTO traces (trace_id, timestamp, source, agent, event_type, detail) VALUES (?, ?, ?, ?, ?, ?)",
+        (TRACE, t0 + 100, "mesh", "alpha", "llm_call", "resumed"),
+    )
+    traces._conn.commit()
+
+    restart_ts = t0 + 50
+    lifecycle.record(kind="host_restart", detail="provisioner update", timestamp=restart_ts)
+    # A marker WAY outside the window must NOT be pulled in.
+    lifecycle.record(kind="deploy", detail="unrelated", timestamp=t0 - 100000)
+
+    intent.close()
+    traces.close()
+    lifecycle.close()
+    return restart_ts
+
+
+def test_reader_interleaves_lifecycle_by_wallclock(tmp_path):
+    restart_ts = _seed_session_with_restart(str(tmp_path))
+    session = assemble_session(str(tmp_path), TRACE)
+    assert session["found"]
+    # Only the in-window marker is pulled in.
+    assert len(session["lifecycle"]) == 1
+    assert session["lifecycle"][0]["kind"] == "host_restart"
+    assert session["lifecycle"][0]["timestamp"] == restart_ts
+
+    rendered = render_session(session)
+    assert "infra:host_restart" in rendered
+    # The restart line must land BETWEEN the two action lines (chat → restart
+    # → llm_call), proving wall-clock interleaving rather than appending.
+    lines = rendered.splitlines()
+    idx_chat = next(i for i, ln in enumerate(lines) if "chat" in ln)
+    idx_restart = next(i for i, ln in enumerate(lines) if "infra:host_restart" in ln)
+    idx_resumed = next(i for i, ln in enumerate(lines) if "llm_call" in ln)
+    assert idx_chat < idx_restart < idx_resumed
+
+
+def test_reader_no_lifecycle_db_degrades(tmp_path):
+    # No lifecycle.db at all — reader must not crash and yields no markers.
+    intent = IntentStore(db_path=os.path.join(str(tmp_path), "intent.db"))
+    intent.record(trace_id=TRACE, agent="alpha", message="hi")
+    intent.close()
+    session = assemble_session(str(tmp_path), TRACE)
+    assert session["lifecycle"] == []
+    assert "infra:" not in render_session(session)
+
+
+def test_fetch_lifecycle_missing_db_returns_empty(tmp_path):
+    assert _fetch_lifecycle(tmp_path, 0.0, time.time()) == []
+
+
+# ── CLI: session --recent ────────────────────────────────────
+
+
+def test_session_recent_lists_sessions(tmp_path):
+    intent = IntentStore(db_path=os.path.join(str(tmp_path), "intent.db"))
+    for i in range(3):
+        intent.record(
+            trace_id=f"tr_recent{i}",
+            origin_kind="human",
+            origin_user="alice",
+            agent="alpha",
+            message=f"request {i}",
+        )
+    intent.close()
+
+    res = CliRunner().invoke(cli, ["session", "--recent", "2", "--data-dir", str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    # Newest first, capped at 2.
+    assert "tr_recent2" in res.output
+    assert "tr_recent1" in res.output
+    assert "tr_recent0" not in res.output
+
+
+def test_session_recent_default_count_and_json(tmp_path):
+    intent = IntentStore(db_path=os.path.join(str(tmp_path), "intent.db"))
+    intent.record(trace_id="tr_only", origin_user="bob", agent="beta", message="hello")
+    intent.close()
+
+    res = CliRunner().invoke(cli, ["session", "--recent", "--json", "--data-dir", str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    import json as _json
+
+    payload = _json.loads(res.output)
+    assert payload["sessions"][0]["trace_id"] == "tr_only"
+
+
+def test_session_without_trace_or_recent_errors(tmp_path):
+    res = CliRunner().invoke(cli, ["session", "--data-dir", str(tmp_path)])
+    assert res.exit_code == 1
+    assert "trace_id" in res.output
+
+
+# ── endpoint: internal-only + happy path ─────────────────────
+
+
+def _build_min_mesh(tmp_path):
+    import src.host.server as server_module
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    lifecycle = LifecycleStore(db_path=str(tmp_path / "lifecycle.db"))
+    app = server_module.create_mesh_app(
+        blackboard=bb,
+        pubsub=pubsub,
+        router=router,
+        permissions=perms,
+        lifecycle_store=lifecycle,
+    )
+    app.state._test_bb = bb
+    app.state._test_lifecycle = lifecycle
+    return app
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoint_records_internal(tmp_path):
+    app = _build_min_mesh(tmp_path)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/system/lifecycle_event",
+                headers={"x-mesh-internal": "1"},
+                json={"kind": "host_restart", "detail": "systemctl restart openlegion"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["recorded"] is True
+        assert body["event"]["kind"] == "host_restart"
+        # Persisted to the store.
+        rows = app.state._test_lifecycle.list_recent()
+        assert rows and rows[0]["kind"] == "host_restart"
+    finally:
+        app.state._test_bb.close()
+        app.state._test_lifecycle.close()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoint_rejects_non_internal(tmp_path):
+    app = _build_min_mesh(tmp_path)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            # No x-mesh-internal header → not an internal caller → 403.
+            resp = await client.post(
+                "/mesh/system/lifecycle_event",
+                json={"kind": "host_restart"},
+            )
+        assert resp.status_code == 403
+        assert app.state._test_lifecycle.list_recent() == []
+    finally:
+        app.state._test_bb.close()
+        app.state._test_lifecycle.close()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoint_requires_kind(tmp_path):
+    app = _build_min_mesh(tmp_path)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/system/lifecycle_event",
+                headers={"x-mesh-internal": "1"},
+                json={"detail": "no kind"},
+            )
+        assert resp.status_code == 400
+    finally:
+        app.state._test_bb.close()
+        app.state._test_lifecycle.close()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -345,3 +345,74 @@ async def test_lifecycle_endpoint_requires_kind(tmp_path):
     finally:
         app.state._test_bb.close()
         app.state._test_lifecycle.close()
+
+
+# ── App-construction smoke: lifecycle_store wiring ───────────────
+#
+# Regression for the ship-blocker where ``_start_mesh_server`` passed
+# ``lifecycle_store=`` to BOTH ``create_mesh_app`` (which accepts it) and
+# ``create_dashboard_router`` (which does NOT) → ``TypeError`` at mesh
+# startup. The dashboard never consumes lifecycle markers — the
+# ``openlegion session`` reader reads ``lifecycle.db`` directly — so the
+# kwarg belongs to the mesh factory only. These two asserts pin that
+# split so the spurious kwarg can't be reintroduced.
+
+
+def test_create_mesh_app_accepts_lifecycle_store(tmp_path):
+    import src.host.server as server_module
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    lifecycle = LifecycleStore(db_path=str(tmp_path / "lifecycle.db"))
+    try:
+        # Must construct without TypeError.
+        app = server_module.create_mesh_app(
+            blackboard=bb,
+            pubsub=pubsub,
+            router=router,
+            permissions=perms,
+            lifecycle_store=lifecycle,
+        )
+        assert app is not None
+    finally:
+        bb.close()
+        lifecycle.close()
+
+
+def test_create_dashboard_router_does_not_accept_lifecycle_store(tmp_path):
+    """The dashboard factory must NOT take ``lifecycle_store``.
+
+    The runtime wires it only into ``create_mesh_app``; passing it to the
+    dashboard router was the original ``TypeError`` ship-blocker. This
+    asserts the signature stays free of it so the bug can't regress.
+    """
+    from unittest.mock import MagicMock
+
+    from src.dashboard.server import create_dashboard_router
+
+    registry: dict[str, str] = {}
+    common = dict(
+        blackboard=MagicMock(),
+        health_monitor=None,
+        cost_tracker=MagicMock(),
+        trace_store=None,
+        event_bus=None,
+        agent_registry=registry,
+        mesh_port=8420,
+    )
+
+    # The legitimate call (no lifecycle_store) constructs fine.
+    router = create_dashboard_router(**common)
+    assert router is not None
+
+    # Passing lifecycle_store would raise the original TypeError.
+    lifecycle = LifecycleStore(db_path=str(tmp_path / "lifecycle.db"))
+    try:
+        with pytest.raises(TypeError):
+            create_dashboard_router(**common, lifecycle_store=lifecycle)
+    finally:
+        lifecycle.close()


### PR DESCRIPTION
## Why

The `openlegion session` reader already stitches a session's narrative from the
host-side SQLite spine (`intent.db` + `traces.db` + `tasks.db` + `costs.db`), so
an engineer can answer "what happened in this session?" over SSH after the fact.

But the **root cause of the cake outage was an EXTERNAL event the engine never
recorded**: the provisioner restarted the host mid-workflow. The reconstructed
timeline showed an unexplained gap — every in-engine store was silent because
nothing *in* the engine caused the death. Diagnosing it meant hand-correlating
two hosts' systemd journals against raw SQLite queries on the box. This PR gives
the reader a place to surface that external cause.

## What

**`LifecycleStore`** (`src/host/lifecycle.py`) — append-only SQLite store for
external infra-event markers `{timestamp, kind, detail, meta}` (host restart,
deploy/`systemctl restart openlegion`, Docker bounce, OOM kill). Mirrors
`IntentStore`: WAL, redaction-at-storage (H16), throttled 90-day time-based GC,
length caps on `kind`/`detail`.

**Internal-only endpoint** `POST /mesh/system/lifecycle_event` — loopback +
`x-mesh-internal`, matching the existing internal-endpoint auth posture
(`_is_internal_caller`). The emitter is the provisioner over SSH or an operator
runbook — **never an agent** (non-internal callers get 403; `kind` required →
400). Body: `{kind, detail?, timestamp?, meta?}`.

**Reader interleaving** — `session <trace_id>` now pulls lifecycle markers that
overlap the session's wall-clock window and interleaves them into the `TIMELINE`,
flagged `** infra:<kind>` so the external cause jumps out of the action stream.
Markers are correlated by **wall-clock, not `trace_id`** (a host restart hits
every in-flight trace at once). Read-only; degrades gracefully when
`lifecycle.db` is absent.

## Commands

- `openlegion session <trace_id>` — chronological narrative: intent → ordered
  trace events (time/agent/event_type/status/duration/error) → interleaved infra
  markers → task outcomes (status + blocker_note) → cost rollup.
- `openlegion session --recent [N]` — list the N most recent sessions (default
  20) to find a `trace_id`. Complements the richer `sessions --since/--user/--agent`.
- Both support `--json` and `--data-dir`.

## Emission (follow-up, intentionally out of scope)

This PR adds the *sink* (store + endpoint + reader). Cross-repo *emission* is
deliberately not built here. The concrete follow-up: have
`provisioner/app/services/ssh.py:run_update()` POST a `{kind: "deploy"}` /
`{kind: "host_restart"}` marker (localhost + `x-mesh-internal`) immediately
before/after a `systemctl restart openlegion`, so the timeline self-annotates
the exact gap a restart causes. The endpoint is ready for it today.

## Tests

`tests/test_lifecycle.py` (all green): `LifecycleStore` unit coverage
(record/list/window/redaction/GC/idempotent init), endpoint auth (internal-only
403 + happy path + kind-required 400), reader wall-clock interleaving (restart
lands *between* bracketing actions; out-of-window marker excluded; missing-db
degradation), and the `--recent` CLI variants. Full fast suite: **7727 passed,
27 skipped**; `ruff check` clean.

NOTE: per-turn chat transcript text remains container-local; this host-side
timeline = intent + traces + tasks + costs + infra markers (not the full
conversation). Surfaced in `--help` and the rendered footer.