### PR TITLE
fix(cli): fail fast when the mesh cannot bind its primary port

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import socket
 import subprocess
 import sys
 import threading
@@ -138,6 +139,42 @@ def _build_dispatch_error_note(exc: BaseException) -> str:
     safe = redact_text_with_urls(raw)
     note = f"dispatch_error: {safe}"
     return note[:_DISPATCH_ERROR_NOTE_MAX]
+
+
+def _bind_mesh_socket(host: str, port: int) -> socket.socket:
+    """Bind and return the mesh's primary listening socket — FATAL on failure.
+
+    Production incident (70-min silent outage): a ``systemctl restart`` raced
+    the old mesh's teardown, so the new process found port 8420 still held.
+    uvicorn's own ``startup()`` catches the bind ``OSError``, logs the
+    ``[Errno 98] address already in use`` line, and calls ``sys.exit(1)`` — but
+    it runs the server in a daemon thread, so that ``SystemExit`` only kills the
+    *thread*. The main process kept running bound to NO port while systemd
+    reported ``active (running)`` and the provisioner health check (which hit
+    the *stale* listener still answering on 8420) believed the mesh was up. The
+    mesh served 404s for ~70 minutes.
+
+    We bind the socket ourselves on the MAIN thread *before* launching uvicorn
+    and hand it the open socket. A bind failure now raises here, on the caller's
+    thread, where it tears the whole process down (caller exits non-zero) — so
+    systemd restarts it and the health check sees the truth. The success banner
+    is never printed when the bind fails.
+
+    ``SO_REUSEADDR`` matches uvicorn's default and lets a genuinely-released
+    port be re-bound through TIME_WAIT; it does NOT mask a live listener
+    (a second ``bind()`` to an actively-LISTENing socket still raises
+    ``EADDRINUSE``), which is exactly the failure we must surface.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        sock.listen(2048)
+        sock.set_inheritable(True)
+    except OSError:
+        sock.close()
+        raise
+    return sock
 
 
 class RuntimeContext:
@@ -1394,6 +1431,29 @@ class RuntimeContext:
 
         mesh_port = self.cfg["mesh"]["port"]
 
+        # Bind the primary port on THIS (main) thread BEFORE building the app
+        # or launching uvicorn. A bind failure must be fatal to the whole
+        # process — see _bind_mesh_socket for the outage this prevents. uvicorn
+        # would otherwise swallow the OSError inside its daemon thread, leaving
+        # the process "running" but bound to nothing while the health check
+        # answered off a stale listener. Binding first also avoids wiring the
+        # whole app only to throw it away.
+        try:
+            mesh_socket = _bind_mesh_socket("0.0.0.0", mesh_port)
+        except OSError as exc:
+            echo_fail(
+                f"Mesh server could not bind port {mesh_port}: {exc}. "
+                f"Another process may already own it. Try: openlegion stop"
+            )
+            logger.error("FATAL: mesh failed to bind port %d: %s", mesh_port, exc)
+            # Tear down any agent containers we started so a failed-to-bind
+            # boot doesn't leave orphans behind for systemd to restart over.
+            try:
+                self.runtime.stop_all()
+            except Exception as cleanup_err:
+                logger.debug("Cleanup after bind failure errored: %s", cleanup_err)
+            sys.exit(1)
+
         webhook_manager = WebhookManager(dispatch_fn=self.async_dispatch)
 
         # Wallet signing service (only if master seed is configured).
@@ -1535,7 +1595,13 @@ class RuntimeContext:
 
         server_config = uvicorn.Config(app, host="0.0.0.0", port=mesh_port, log_level="warning")
         self._server = uvicorn.Server(server_config)
-        mesh_thread = threading.Thread(target=self._server.run, daemon=True)
+        # Hand uvicorn the already-bound socket so it never re-binds (and so
+        # the bind result was already asserted, fatally, above).
+        mesh_thread = threading.Thread(
+            target=self._server.run,
+            kwargs={"sockets": [mesh_socket]},
+            daemon=True,
+        )
         mesh_thread.start()
 
     def _wait_for_readiness(self) -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2707,3 +2707,80 @@ class TestSystemSignalReroute:
             stub, "x", attempts=3, backoff_s=0,
         )
         assert stub.transport.calls == 3
+
+
+# ── Mesh primary-port bind: fail fast (prod outage regression) ────
+
+
+class TestMeshBindFailFast:
+    """A mesh that cannot bind its primary port MUST crash the process.
+
+    Regression for the 70-min silent outage: a restart raced the old mesh's
+    teardown, uvicorn swallowed the bind OSError in its daemon thread, and the
+    process kept "running" bound to nothing while the health check hit the
+    stale listener.
+    """
+
+    def test_bind_helper_raises_when_port_in_use(self):
+        import socket as _socket
+
+        from src.cli.runtime import _bind_mesh_socket
+
+        # Occupy a port with a throwaway listener.
+        occupied = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        occupied.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+        occupied.bind(("127.0.0.1", 0))
+        occupied.listen(1)
+        port = occupied.getsockname()[1]
+        try:
+            with pytest.raises(OSError):
+                _bind_mesh_socket("127.0.0.1", port)
+        finally:
+            occupied.close()
+
+    def test_bind_helper_succeeds_on_free_port_and_listens(self):
+        import socket as _socket
+
+        from src.cli.runtime import _bind_mesh_socket
+
+        sock = _bind_mesh_socket("127.0.0.1", 0)
+        try:
+            assert sock.fileno() != -1
+            # A bound + listening socket answers connect attempts.
+            port = sock.getsockname()[1]
+            client = _socket.create_connection(("127.0.0.1", port), timeout=2)
+            client.close()
+        finally:
+            sock.close()
+
+    def test_start_mesh_server_fatal_when_bind_fails(self):
+        """The fatal path: bind fails → stop_all() + SystemExit(1), and uvicorn
+        is NEVER constructed (the app is never built / banner never reached).
+
+        The bind is the FIRST thing _start_mesh_server does, so patching the
+        helper to raise OSError is sufficient to exercise the whole escalation
+        without standing up the real app graph.
+        """
+        from src.cli.runtime import RuntimeContext
+
+        ctx = RuntimeContext.__new__(RuntimeContext)
+        ctx.cfg = {"mesh": {"port": 8420}}
+        ctx.runtime = MagicMock()
+        # A sentinel that would be reached only if the function continued past
+        # the bind — it must not, so async_dispatch (used to build the
+        # WebhookManager right after the bind) is never touched.
+        ctx.async_dispatch = MagicMock(side_effect=AssertionError("reached app build"))
+
+        with patch(
+            "src.cli.runtime._bind_mesh_socket",
+            side_effect=OSError("[Errno 98] address already in use"),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                ctx._start_mesh_server()
+
+        assert excinfo.value.code == 1
+        # Orphan cleanup ran so systemd doesn't restart over a leaked container.
+        ctx.runtime.stop_all.assert_called_once()
+        # We bailed before any app construction — so the "Started" banner can
+        # never be printed on a failed bind.
+        ctx.async_dispatch.assert_not_called()


### PR DESCRIPTION
## The outage

A real 70-minute production outage. A provisioner `systemctl restart openlegion` raced the old mesh's teardown, so the new process found port 8420 still held:

```
07:41:17 openlegion[...]: ERROR:    [Errno 98] error while attempting to bind on address ('0.0.0.0', 8420): address already in use
07:41:42 openlegion[...]:   Started in 38.7s      <- CLI printed its success banner anyway
```

`systemctl show openlegion` then reported `ActiveState=active SubState=running`, but `ss -ltnp` showed the mesh process bound to **no TCP port at all**. The mesh served 404s for ~70 min while systemd and the provisioner health check believed it was up.

## Root cause

uvicorn runs in a **daemon thread** (`src/cli/runtime.py:_start_mesh_server` → `threading.Thread(target=self._server.run)`). On a bind failure, uvicorn's own `Server.startup()` catches the `OSError`, logs the `[Errno 98]` line, and calls `sys.exit(1)` — but that `SystemExit` only kills the **thread**, not the process.

The CLI's `_wait_for_readiness` probe then *passed* because the **stale old listener** was still answering on 8420, so the poll saw `200 OK` and `_print_ready` printed "Started in 38.7s". The new process kept running, bound to nothing.

## The fix

Bind the primary listening socket ourselves on the **main thread**, at the very top of `_start_mesh_server`, before building the app or launching uvicorn:

- A bind failure now raises on the caller's thread, where we escalate to a loud fatal `sys.exit(1)` (after `runtime.stop_all()` so we don't leave orphaned agent containers). systemd restarts the unit and the health check sees the truth.
- The already-bound socket is handed to uvicorn via `Server.run(sockets=[sock])`, so it never re-binds.
- The success banner can **never** print on a failed bind — we exit before any app construction.
- `SO_REUSEADDR` matches uvicorn's own default; it lets a genuinely-released port be re-bound through TIME_WAIT but does **not** mask a live listener (a second `bind()` to an actively-LISTENing socket still raises `EADDRINUSE`), which is exactly the failure we must surface.

Normal startup is unchanged. Cleanup on bind failure mirrors the existing `_wait_for_readiness` failure path (`stop_all()` then `sys.exit(1)`).

## Tests

New `TestMeshBindFailFast` in `tests/test_runtime.py`:
- `test_bind_helper_raises_when_port_in_use` — occupy the port, assert `_bind_mesh_socket` raises `OSError`.
- `test_bind_helper_succeeds_on_free_port_and_listens` — binds + actually accepts a connection on a free port.
- `test_start_mesh_server_fatal_when_bind_fails` — bind fails ⇒ `SystemExit(1)` + `stop_all()` called once, and no app construction / banner reached.

## Verification

- `ruff check` clean on changed files.
- New tests: `3 passed`.
- Full fast suite (`make test`): `7691 passed, 48 skipped`.

## Files changed

- `src/cli/runtime.py` — new module-level `_bind_mesh_socket()` helper; `_start_mesh_server` pre-binds + fatal-exits on failure + hands the socket to uvicorn.
- `tests/test_runtime.py` — `TestMeshBindFailFast`.