### PR TITLE
fix(host): infra-killed tasks land blocked (recoverable), not failed

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -244,6 +244,12 @@ class RuntimeContext:
         self._start_time: float | None = None
         self._agent_results: list = []
         self._cron_job_count: int = 0
+        # Set True as the FIRST act of shutdown() so an in-flight dispatch that
+        # drops *because we are tearing down* is attributable. A connection-drop
+        # is reclassified to recoverable ``blocked`` ONLY while this is True
+        # (see _close_task_on_dispatch_error); a drop while still running stays
+        # terminal ``failed`` — a genuine agent-container crash must not hide.
+        self._shutting_down = False
 
     def start(self) -> None:
         """Initialize and start all components. Called once."""
@@ -266,6 +272,10 @@ class RuntimeContext:
 
     def shutdown(self) -> None:
         """Tear down all components in reverse order."""
+        # FIRST, before any teardown: mark the mesh as shutting down so any
+        # in-flight dispatch that drops during teardown is attributable to the
+        # restart (and thus reclassified to recoverable ``blocked``).
+        self._shutting_down = True
         click.echo("  Stopping OpenLegion...", nl=False)
         if self.chain_watcher:
             self.chain_watcher.stop()
@@ -809,16 +819,25 @@ class RuntimeContext:
         (host restart tearing down an in-flight ``/chat``) is NOT a real task
         error — its work is recoverable. Those land as ``blocked`` (recoverable)
         with an honest ``interrupted by host restart`` note, NOT terminal
-        ``failed``, so the task is not silently lost. Only the connection-drop
-        class is reclassified (see :func:`_is_infra_disconnect`); a genuine task
-        error still becomes terminal ``failed``.
+        ``failed``, so the task is not silently lost. A connection-drop signature
+        is **necessary but NOT sufficient** for that reclassification: the exact
+        same transport errors also fire when an agent container genuinely
+        CRASHES with no host restart. So we additionally gate on the mesh
+        actually shutting down (``self._shutting_down``) — only a dispatch that
+        drops *because we are restarting* becomes ``blocked``; a drop while NOT
+        shutting down stays terminal ``failed`` (see :func:`_is_infra_disconnect`).
         """
         from src.host.orchestration import InvalidStatusTransition
 
         tasks_store = getattr(getattr(self, "_app", None), "tasks_store", None)
         if tasks_store is None:
             return
-        if _is_infra_disconnect(exc):
+        # Reclassify to recoverable ``blocked`` ONLY when BOTH the error is a
+        # transport-drop signature AND the mesh is shutting down. A drop while
+        # still running is a real failure (e.g. agent container crash) and must
+        # stay terminal ``failed`` so operators see it. ``getattr`` is defensive
+        # in case a construction path bypasses ``__init__``.
+        if _is_infra_disconnect(exc) and getattr(self, "_shutting_down", False):
             target_status = "blocked"
             note = _INFRA_INTERRUPT_NOTE
         else:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -140,6 +140,75 @@ def _build_dispatch_error_note(exc: BaseException) -> str:
     return note[:_DISPATCH_ERROR_NOTE_MAX]
 
 
+# Honest, operator-visible ``blocker_note`` written when a dispatch is killed
+# by an INFRA shutdown / connection-drop rather than a real task error. The
+# task is left ``blocked`` (recoverable) — NOT terminal ``failed`` — so its
+# work is not silently lost. (Prod incident: a host restart under running
+# tasks killed three in-flight subtasks as terminal ``failed`` with
+# ``dispatch_error: Server disconnected without sending a response``; they had
+# to be manually re-dispatched.)
+_INFRA_INTERRUPT_NOTE = "interrupted by host restart — recoverable"
+
+# Substrings (lower-cased) that mark a transport/connection-drop signature —
+# i.e. the host (or the agent container) went away mid-request, the hallmark
+# of a graceful-shutdown / restart tear-down rather than a genuine task error.
+# Conservative on purpose: only the connection-drop class is reclassified to
+# the recoverable ``blocked`` state; everything else stays terminal ``failed``.
+_INFRA_DISCONNECT_MARKERS: tuple[str, ...] = (
+    "server disconnected",
+    "disconnected without sending",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "remote protocol error",
+    "peer closed connection",
+    "incomplete chunked read",
+    "all connection attempts failed",
+)
+
+
+def _is_infra_disconnect(exc: BaseException) -> bool:
+    """True when ``exc`` is a transport-level connection drop — the signature
+    of a host/agent shutdown or restart tearing down an in-flight ``/chat``
+    dispatch, as opposed to a genuine task error.
+
+    Detection is conservative and twofold:
+
+    1. **Type-based** — httpx transport-error subclasses that only arise when
+       the connection itself fails (``ConnectError``, ``ReadError``,
+       ``WriteError``, ``RemoteProtocolError``, ``ConnectTimeout``,
+       ``PoolTimeout``). httpx is an optional-at-import dependency here, so the
+       check degrades gracefully if it can't be imported.
+    2. **String-based** — a fallback that matches the connection-drop markers
+       in the (already untrusted, but here only substring-tested) message, so
+       a non-httpx wrapper carrying the same signature still classifies right.
+
+    A ``read`` *timeout while the connection stays up* is deliberately NOT
+    matched — that is the agent being slow, governed by the lane watchdog, not
+    an infra tear-down.
+    """
+    try:
+        import httpx
+
+        if isinstance(
+            exc,
+            (
+                httpx.ConnectError,
+                httpx.ReadError,
+                httpx.WriteError,
+                httpx.RemoteProtocolError,
+                httpx.ConnectTimeout,
+                httpx.PoolTimeout,
+            ),
+        ):
+            return True
+    except Exception:  # pragma: no cover - httpx import shouldn't fail
+        pass
+
+    text = str(exc).lower()
+    return any(marker in text for marker in _INFRA_DISCONNECT_MARKERS)
+
+
 class RuntimeContext:
     """Manages the full OpenLegion runtime lifecycle."""
 
@@ -724,7 +793,7 @@ class RuntimeContext:
     async def _close_task_on_dispatch_error(
         self, task_id: str, exc: BaseException,
     ) -> None:
-        """Mark a durable task ``failed`` after its mesh→agent dispatch raised.
+        """Close a durable task after its mesh→agent dispatch raised.
 
         Without this, ``_direct_dispatch`` used to return ``f"Error: {e}"`` —
         an opaque string the lane recorded as a *successful* turn, so the
@@ -735,13 +804,26 @@ class RuntimeContext:
         during a race isn't clobbered), then write a REDACTED + truncated
         ``blocker_note``. Best-effort: a failure to close must never mask the
         original error from the lane.
+
+        **Classification (prod incident):** an INFRA shutdown / connection-drop
+        (host restart tearing down an in-flight ``/chat``) is NOT a real task
+        error — its work is recoverable. Those land as ``blocked`` (recoverable)
+        with an honest ``interrupted by host restart`` note, NOT terminal
+        ``failed``, so the task is not silently lost. Only the connection-drop
+        class is reclassified (see :func:`_is_infra_disconnect`); a genuine task
+        error still becomes terminal ``failed``.
         """
         from src.host.orchestration import InvalidStatusTransition
 
         tasks_store = getattr(getattr(self, "_app", None), "tasks_store", None)
         if tasks_store is None:
             return
-        note = _build_dispatch_error_note(exc)
+        if _is_infra_disconnect(exc):
+            target_status = "blocked"
+            note = _INFRA_INTERRUPT_NOTE
+        else:
+            target_status = "failed"
+            note = _build_dispatch_error_note(exc)
         loop = asyncio.get_running_loop()
         try:
             pre = await loop.run_in_executor(
@@ -764,18 +846,22 @@ class RuntimeContext:
             # generic dispatch note.
             logger.info(
                 "Dispatch error: task %s already terminal (status=%s) — "
-                "skipping failed-close", task_id, pre.get("status"),
+                "skipping close", task_id, pre.get("status"),
             )
             return
+        # Infra interrupts ride the recoverable error code so the dashboard /
+        # observers can distinguish "host restart, will recover" from a real
+        # dispatch failure.
+        error_code = "infra_interrupt" if target_status == "blocked" else "dispatch_error"
         try:
             await loop.run_in_executor(
                 None,
                 lambda: tasks_store.update_status(
                     task_id,
-                    "failed",
+                    target_status,
                     actor="dispatch",
                     blocker_note=note,
-                    extra_payload={"error": "dispatch_error"},
+                    extra_payload={"error": error_code},
                 ),
             )
         except InvalidStatusTransition as race_err:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2206,6 +2206,170 @@ class TestDispatchErrorSurfacing:
         assert fetched["status"] == "working"
 
 
+# ── Infra shutdown / connection-drop ⇒ recoverable (blocked) ──────────────
+#
+# Prod incident: the host was restarted under running tasks. The in-flight
+# mesh→agent ``/chat`` dispatches died with
+# ``Server disconnected without sending a response`` and the durable tasks
+# were closed as terminal ``failed`` — work lost, no auto-resume, three
+# subtasks manually re-dispatched. An infra tear-down is RECOVERABLE: such
+# tasks must land as ``blocked`` (NOT ``failed``) with an honest note. A
+# genuine task error must still be terminal ``failed``.
+
+
+class TestInfraDisconnectClassifier:
+    """Unit tests for the pure connection-drop classifier."""
+
+    def test_httpx_remote_protocol_error_is_infra(self):
+        import httpx
+
+        from src.cli.runtime import _is_infra_disconnect
+
+        assert _is_infra_disconnect(
+            httpx.RemoteProtocolError(
+                "Server disconnected without sending a response."
+            )
+        ) is True
+
+    def test_httpx_connect_and_read_errors_are_infra(self):
+        import httpx
+
+        from src.cli.runtime import _is_infra_disconnect
+
+        assert _is_infra_disconnect(httpx.ConnectError("refused")) is True
+        assert _is_infra_disconnect(httpx.ReadError("reset")) is True
+        assert _is_infra_disconnect(httpx.WriteError("broken pipe")) is True
+        assert _is_infra_disconnect(httpx.ConnectTimeout("slow")) is True
+
+    def test_string_signature_without_httpx_type_is_infra(self):
+        from src.cli.runtime import _is_infra_disconnect
+
+        # A non-httpx wrapper carrying the same connection-drop signature.
+        assert _is_infra_disconnect(
+            RuntimeError("Server disconnected without sending a response")
+        ) is True
+
+    def test_genuine_task_error_is_not_infra(self):
+        import httpx
+
+        from src.cli.runtime import _is_infra_disconnect
+
+        # A real application error (e.g. agent returned 500 with a body) is
+        # NOT a connection drop — must stay terminal ``failed``.
+        assert _is_infra_disconnect(
+            RuntimeError("502 from https://api.example.com/run")
+        ) is False
+        assert _is_infra_disconnect(RuntimeError("tool execution failed")) is False
+        # A read TIMEOUT while the connection stays up is the agent being slow
+        # (lane-watchdog territory), not an infra tear-down.
+        assert _is_infra_disconnect(httpx.ReadTimeout("slow")) is False
+
+
+class TestInfraInterruptRecoverable:
+    @pytest.mark.asyncio
+    async def test_server_disconnected_lands_blocked_not_failed(
+        self, monkeypatch, tmp_path,
+    ):
+        """A dispatch killed by a host-restart connection drop closes the
+        durable task to ``blocked`` (recoverable) with an honest note —
+        NOT terminal ``failed`` (the prod incident)."""
+        import httpx
+
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = httpx.RemoteProtocolError(
+            "Server disconnected without sending a response."
+        )
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        assert fetched["status"] == "blocked"
+        assert fetched["blocker_note"] == "interrupted by host restart — recoverable"
+
+    @pytest.mark.asyncio
+    async def test_connect_error_lands_blocked(
+        self, monkeypatch, tmp_path,
+    ):
+        """A bare connection-refused (host/agent gone) is also recoverable."""
+        import httpx
+
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = httpx.ConnectError("Connection refused")
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        assert store.get(task_id)["status"] == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_genuine_error_still_lands_failed(
+        self, monkeypatch, tmp_path,
+    ):
+        """A genuine (non-connection-drop) dispatch error must still close the
+        task to terminal ``failed`` — the recoverable carve-out is narrow."""
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = RuntimeError(
+            "502 from https://api.example.com/run"
+        )
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        assert fetched["status"] == "failed"
+        assert fetched["blocker_note"].startswith("dispatch_error: ")
+
+    @pytest.mark.asyncio
+    async def test_infra_interrupt_does_not_clobber_assignee_blocked(
+        self, monkeypatch, tmp_path,
+    ):
+        """An assignee-authored ``blocked`` (with its own note) is preserved
+        even on an infra interrupt — the already-terminal/blocked pre-check
+        still guards it."""
+        import httpx
+
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+        store.update_status(
+            task_id, "blocked", actor="worker",
+            blocker_note="waiting on credential CRED_FOO",
+        )
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = httpx.RemoteProtocolError(
+            "Server disconnected without sending a response."
+        )
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        assert fetched["status"] == "blocked"
+        assert fetched["blocker_note"] == "waiting on credential CRED_FOO"
+
+
 # ── Chain-outcome bell kinds ──────────────────────────────────
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2283,6 +2283,8 @@ class TestInfraInterruptRecoverable:
         dispatch_fn, ctx, transport = _capture_dispatch_fn(
             monkeypatch, app=_app_with_tasks(store),
         )
+        # The drop is only recoverable BECAUSE the mesh is shutting down.
+        ctx._shutting_down = True
         transport.request.side_effect = httpx.RemoteProtocolError(
             "Server disconnected without sending a response."
         )
@@ -2308,11 +2310,42 @@ class TestInfraInterruptRecoverable:
         dispatch_fn, ctx, transport = _capture_dispatch_fn(
             monkeypatch, app=_app_with_tasks(store),
         )
+        ctx._shutting_down = True
         transport.request.side_effect = httpx.ConnectError("Connection refused")
 
         await dispatch_fn("worker", "go", task_id=task_id)
 
         assert store.get(task_id)["status"] == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_disconnect_while_not_shutting_down_lands_failed(
+        self, monkeypatch, tmp_path,
+    ):
+        """The SAME transport-drop signature, but the mesh is NOT shutting
+        down (e.g. the agent container genuinely crashed), must close the task
+        to terminal ``failed`` with a ``dispatch_error:`` note — never silently
+        relabel a real failure as recoverable."""
+        import httpx
+
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        # Mesh is NOT shutting down (default from __new__-bypass; assert it).
+        assert getattr(ctx, "_shutting_down", False) is False
+        transport.request.side_effect = httpx.RemoteProtocolError(
+            "Server disconnected without sending a response."
+        )
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        assert fetched["status"] == "failed"
+        assert fetched["blocker_note"].startswith("dispatch_error: ")
 
     @pytest.mark.asyncio
     async def test_genuine_error_still_lands_failed(
@@ -2359,6 +2392,7 @@ class TestInfraInterruptRecoverable:
         dispatch_fn, ctx, transport = _capture_dispatch_fn(
             monkeypatch, app=_app_with_tasks(store),
         )
+        ctx._shutting_down = True
         transport.request.side_effect = httpx.RemoteProtocolError(
             "Server disconnected without sending a response."
         )


### PR DESCRIPTION
## The problem (real prod incident)

The host was restarted while tasks were running. The in-flight mesh→agent `/chat` dispatches died with `Server disconnected without sending a response`, and the dispatch-error close marked those durable tasks **terminal `failed`** with `blocker_note: "dispatch_error: Server disconnected without sending a response"`.

That mis-classifies an **infra shutdown** as a **real task error**. Per the failure-classification convention (`tasks.blocker_note` carries the reason; `blocked` = recoverable, `failed` = terminal), terminal `failed` means the work is lost and won't resume. Three Scraplings competitor-research subtasks (community-listener / gameplay-analyst / monetization-analyst) were lost this way and had to be manually re-dispatched.

## The fix

A connection-drop mid-dispatch is the signature of a host/agent **tear-down**, not a task error — the work is recoverable. `_close_task_on_dispatch_error` (`src/cli/runtime.py`) now classifies the exception:

- **Infra disconnect ⇒ `blocked` (recoverable)** with an honest `blocker_note: "interrupted by host restart — recoverable"` and `error` code `infra_interrupt`.
- **Everything else ⇒ terminal `failed`** (unchanged), still REDACTED + truncated.

Classification lives in a new pure helper `_is_infra_disconnect(exc)`:
- **Type-based** — httpx transport subclasses that only arise when the connection itself fails: `ConnectError`, `ReadError`, `WriteError`, `RemoteProtocolError`, `ConnectTimeout`, `PoolTimeout` (httpx import degrades gracefully).
- **String-based fallback** — connection-drop markers (`server disconnected`, `connection reset/refused/aborted`, `remote protocol error`, …) so a non-httpx wrapper carrying the same signature still classifies right.

**Conservative on purpose:** a read **timeout** while the connection stays up (`httpx.ReadTimeout`) is the agent being slow — lane-watchdog territory — and stays `failed`. A genuine application error (500 with a body, tool failure) stays `failed`.

The existing already-terminal/`blocked` pre-check is preserved, so an **assignee-authored `blocked`** (with its own meaningful note) is never clobbered even on an infra interrupt. `asyncio.CancelledError` still propagates untouched (lane watchdog owns the long-run timeout close).

`done` / `cancelled` semantics are unchanged.

## Tests (`tests/test_runtime.py`)

- `TestInfraDisconnectClassifier` — `_is_infra_disconnect` is true for the httpx connection-drop subclasses + the string signature, and **false** for a genuine error and for `ReadTimeout`.
- `TestInfraInterruptRecoverable` — a `Server disconnected` / `ConnectError` dispatch ⇒ task `blocked` with the recoverable note; a genuine error ⇒ still `failed`; an assignee-authored `blocked` is not clobbered.
- 19/19 targeted tests pass; full fast suite **7717 passed, 27 skipped** (e2e skip without Docker). `ruff check` clean.

## Follow-up (deferred, not in this PR)

**Auto-resume on mesh startup**: re-dispatch tasks left `blocked` with `error=infra_interrupt` so they self-heal without a manual re-kick. Deferred to keep this fix low-risk — re-dispatch storm control, origin/`task_id` reconstruction, and assignee-race handling each need their own design. Today, infra-killed tasks are at least correctly **recoverable `blocked`** (visible + actionable) instead of silently lost as terminal `failed`.