### PR TITLE
fix(channels): deterministic bot-command routing bypasses LLM

### DIFF
--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -281,6 +281,15 @@ class Channel(abc.ABC):
         "/addkey", "/steer", "/broadcast", "/reset", "/debug",
     })
 
+    #: Deterministic command → agent routing. When a command matches a key
+    #: in this map, it is dispatched directly to the target agent without
+    #: consuming an LLM round-trip. Value is ``(target_agent, task_template)``
+    #: where ``task_template`` may contain ``{args}`` for the command tail.
+    #:
+    #: Empty by default — deployments populate it with their own routes.
+    #: Routes are skipped silently if the target agent is not running.
+    _BOT_COMMAND_ROUTES: dict[str, tuple[str, str]] = {}
+
     async def _handle_command(
         self, user_id: str, message: str, current: str, agents: list[str],
         is_owner: bool = False,
@@ -294,6 +303,26 @@ class Channel(abc.ABC):
         # state, or expose traces — restrict them to the owner.
         if cmd in self._OWNER_ONLY_COMMANDS and not is_owner:
             return f"'{cmd}' is owner only."
+
+        # Deterministic bot-command routing — bypasses LLM for reliability.
+        if cmd in self._BOT_COMMAND_ROUTES:
+            target_agent, task_tmpl = self._BOT_COMMAND_ROUTES[cmd]
+            if target_agent in agents:
+                args = parts[1].strip() if len(parts) > 1 else ""
+                task = task_tmpl.format(args=args) if "{args}" in task_tmpl else task_tmpl
+                from src.shared.types import MessageOrigin
+
+                origin: MessageOrigin | None = None
+                if self.CHANNEL_TYPE and user_id:
+                    origin = MessageOrigin(
+                        kind="human",
+                        channel=self.CHANNEL_TYPE,
+                        user=str(user_id),
+                    )
+                response = await self.dispatch(target_agent, task, origin=origin)
+                if not response or not response.strip():
+                    return ""
+                return f"[{target_agent}] {response}"
 
         if cmd == "/use":
             if len(parts) < 2:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -250,6 +250,71 @@ class TestCommands:
         assert "Unknown command" in result
 
 
+# ── deterministic bot-command routing ─────────────────────────
+
+class TestBotCommandRoutes:
+    @pytest.mark.asyncio
+    async def test_route_dispatches_to_target_agent(self):
+        ch = _make_channel(agents=["alpha", "beta"])
+        ch._BOT_COMMAND_ROUTES = {"/brief": ("beta", "Summarize the latest activity.")}
+        result = await ch.handle_message("u1", "/brief")
+        assert "[beta]" in result
+        assert "reply from beta" in result
+
+    @pytest.mark.asyncio
+    async def test_route_with_args_substitutes_placeholder(self):
+        dispatched: list[tuple[str, str]] = []
+
+        async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
+            dispatched.append((agent, message))
+            return "ok"
+
+        ch = _make_channel(agents=["alpha", "researcher"], dispatch_fn=dispatch_fn)
+        ch._BOT_COMMAND_ROUTES = {"/research": ("researcher", "Research: {args}")}
+        result = await ch.handle_message("u1", "/research quantum computing")
+        assert "[researcher]" in result
+        assert dispatched == [("researcher", "Research: quantum computing")]
+
+    @pytest.mark.asyncio
+    async def test_route_without_args_strips_placeholder(self):
+        dispatched: list[tuple[str, str]] = []
+
+        async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
+            dispatched.append((agent, message))
+            return "ok"
+
+        ch = _make_channel(agents=["alpha", "monitor"], dispatch_fn=dispatch_fn)
+        ch._BOT_COMMAND_ROUTES = {"/brief": ("monitor", "Prepare the morning briefing.")}
+        result = await ch.handle_message("u1", "/brief")
+        assert "[monitor]" in result
+        assert dispatched == [("monitor", "Prepare the morning briefing.")]
+
+    @pytest.mark.asyncio
+    async def test_route_skipped_when_target_agent_not_running(self):
+        ch = _make_channel(agents=["alpha"])
+        ch._BOT_COMMAND_ROUTES = {"/brief": ("monitor", "Prepare the briefing.")}
+        result = await ch.handle_message("u1", "/brief")
+        # Target agent not in agents list → falls through to normal command handling
+        assert "Unknown command" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_routes_dict_does_nothing(self):
+        ch = _make_channel()
+        assert ch._BOT_COMMAND_ROUTES == {}
+        result = await ch.handle_message("u1", "/use beta")
+        assert "Now chatting with" in result
+
+    @pytest.mark.asyncio
+    async def test_route_silent_on_empty_response(self):
+        async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
+            return ""
+
+        ch = _make_channel(agents=["alpha", "beta"], dispatch_fn=dispatch_fn)
+        ch._BOT_COMMAND_ROUTES = {"/brief": ("beta", "Briefing.")}
+        result = await ch.handle_message("u1", "/brief")
+        assert result == ""
+
+
 # ── per-user active agent ─────────────────────────────────────
 
 class TestPerUserAgent:


### PR DESCRIPTION
## Summary

- Add `_BOT_COMMAND_ROUTES` class attribute to `Channel` — a dict mapping command strings to `(target_agent, task_template)` tuples
- When a command matches a key in this map, it is dispatched directly to the target agent **without consuming an LLM round-trip**, improving latency and reliability for well-known commands
- The map is **empty by default**; deployments populate it with their own routes
- `task_template` may contain `{args}` for the command tail (e.g. `/research quantum computing` → `Research: quantum computing`)
- Routes are **skipped silently** if the target agent is not running, falling through to normal command handling

## Why

For commands with a fixed target agent (e.g. `/brief` → monitor, `/research` → researcher), routing through the LLM is wasteful and unreliable — the assistant model may misroute or add unnecessary latency. Deterministic dispatch eliminates this class of failure.

## Test plan

- [x] `test_route_dispatches_to_target_agent` — basic dispatch to target
- [x] `test_route_with_args_substitutes_placeholder` — `{args}` substitution
- [x] `test_route_without_args_strips_placeholder` — no-args case
- [x] `test_route_skipped_when_target_agent_not_running` — graceful fallthrough
- [x] `test_empty_routes_dict_does_nothing` — backward compatible
- [x] `test_route_silent_on_empty_response` — suppresses empty replies
- [x] Full `tests/test_channels.py` suite: 62 passed, 15 skipped, 0 failed