### PR TITLE
fix(heartbeat): keep routine ok states silent

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2420,7 +2420,7 @@ class AgentLoop:
                     f"{inbox_line}"
                     f"- If nothing in HEARTBEAT.md, {nothing_clause} needs attention, reply HEARTBEAT_OK immediately.\n"
                     f"- You have max {max_iters} iterations.\n"
-                    f"- Use notify_user to report results to the user.\n"
+                    f"- Use notify_user only for actionable updates, alerts, or scheduled digest outputs. If nothing meaningful changed, reply HEARTBEAT_OK without notifying the user.\n"
                 )
 
                 # 4. Learnings — avoid repeating past mistakes (half of chat cap)

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -577,8 +577,8 @@ class CronScheduler:
                             "Only call tools if there is actual work to do.\n"
                             "2. If nothing needs attention, respond HEARTBEAT_OK "
                             "immediately. Do NOT make unnecessary tool calls.\n"
-                            "3. Report what you worked on to the USER via "
-                            "notify_user.\n"
+                            "3. Use notify_user ONLY for actionable updates, alerts, or scheduled digest outputs. "
+                            "If everything is normal, stay silent and return HEARTBEAT_OK.\n"
                         )
                         if not agent_standalone:
                             hb_rules += (

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -794,6 +794,39 @@ class TestHeartbeatDispatchFn:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_heartbeat_prompt_uses_silent_ok_rule(self):
+        """Heartbeat prompt should not force user notifications for routine OK states."""
+        dispatch = AsyncMock(return_value="should not be called")
+        hb_dispatch = AsyncMock(return_value={
+            "response": "HEARTBEAT_OK",
+            "summary": "Nothing to do",
+            "tools_used": [],
+            "duration_ms": 100,
+            "tokens_used": 10,
+            "outcome": "ok",
+            "skipped": False,
+        })
+        context_fn = AsyncMock(return_value={
+            "heartbeat_rules": "# Rules\nStay quiet on no-op heartbeats",
+            "is_default_heartbeat": False,
+            "has_recent_activity": True,
+        })
+        sched = CronScheduler(
+            config_path=self.config_path,
+            dispatch_fn=dispatch,
+            heartbeat_dispatch_fn=hb_dispatch,
+            context_fn=context_fn,
+        )
+        job = sched.add_job(
+            agent="test", schedule="every 15m", message="heartbeat", heartbeat=True,
+        )
+        await sched._execute_job(job)
+
+        msg = hb_dispatch.call_args.args[1]
+        assert "stay silent and return HEARTBEAT_OK" in msg
+        assert "Report what you worked on to the USER via notify_user" not in msg
+
+    @pytest.mark.asyncio
     async def test_heartbeat_emits_event(self):
         """heartbeat_complete event is emitted with structured data."""
         hb_dispatch = AsyncMock(return_value={


### PR DESCRIPTION
## Summary

- Update heartbeat prompts in `loop.py` and `cron.py` to instruct agents to use `notify_user` **only for actionable updates, alerts, or scheduled digest outputs**
- When everything is normal, agents should stay silent and return `HEARTBEAT_OK` without notifying the user

## Why

The previous prompts always instructed agents to "report results to the user via notify_user", producing unnecessary notifications on every routine heartbeat cycle where nothing meaningful happened. This creates notification fatigue and wastes API credits on redundant `notify_user` tool calls.

## Test plan

- [x] `test_heartbeat_prompt_uses_silent_ok_rule` — verifies new prompt text is present and old phrasing is gone
- [x] Full `TestHeartbeatDispatchFn` suite: 5 passed, 0 failed