### PR TITLE
feat(agent/streaming): classify transport errors as retryable + mid-stream interrupt notice

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -378,42 +378,51 @@ class LLMClient:
             timeout=self.timeout_seconds,
         ) as response:
             response.raise_for_status()
-            async for line in response.aiter_lines():
-                if not line.startswith("data: "):
-                    continue
-                payload = line[6:]
-                try:
-                    data = json.loads(payload)
-                except json.JSONDecodeError:
-                    continue
+            _TRANSPORT_ERRORS = (
+                httpx.RemoteProtocolError,
+                httpx.ReadTimeout,
+                httpx.ConnectError,
+                httpx.ReadError,
+            )
+            try:
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    payload = line[6:]
+                    try:
+                        data = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
 
-                if "error" in data:
-                    # Distinguished error types ride the SSE payload so the
-                    # agent loop can route to the auth-failure / config-error
-                    # branches. Shared helper also adds the ``transient`` +
-                    # substring-backstop retry handling that ``chat`` has —
-                    # closing the streaming-path asymmetry (a mid-stream
-                    # transient is now retried rather than raised as a bare
-                    # RuntimeError).
-                    self._raise_classified_error(
-                        data["error"],
-                        data.get("error_type"),
-                        data.get("error_meta") or {},
-                        prefix="LLM stream error",
-                    )
+                    if "error" in data:
+                        # Distinguished error types ride the SSE payload so the
+                        # agent loop can route to the auth-failure / config-error
+                        # branches. Shared helper also adds the ``transient`` +
+                        # substring-backstop retry handling that ``chat`` has —
+                        # closing the streaming-path asymmetry (a mid-stream
+                        # transient is now retried rather than raised as a bare
+                        # RuntimeError).
+                        self._raise_classified_error(
+                            data["error"],
+                            data.get("error_type"),
+                            data.get("error_meta") or {},
+                            prefix="LLM stream error",
+                        )
 
-                if data.get("type") == "text_delta":
-                    yield {"type": "text_delta", "content": data.get("content", "")}
+                    if data.get("type") == "text_delta":
+                        yield {"type": "text_delta", "content": data.get("content", "")}
 
-                elif data.get("type") == "done":
-                    llm_resp = LLMResponse(
-                        content=data.get("content", ""),
-                        thinking_content=data.get("thinking_content"),
-                        tool_calls=self._parse_tool_calls(data.get("tool_calls", [])),
-                        tokens_used=data.get("tokens_used", 0),
-                        model=data.get("model", ""),
-                    )
-                    yield {"type": "done", "response": llm_resp}
+                    elif data.get("type") == "done":
+                        llm_resp = LLMResponse(
+                            content=data.get("content", ""),
+                            thinking_content=data.get("thinking_content"),
+                            tool_calls=self._parse_tool_calls(data.get("tool_calls", [])),
+                            tokens_used=data.get("tokens_used", 0),
+                            model=data.get("model", ""),
+                        )
+                        yield {"type": "done", "response": llm_resp}
+            except _TRANSPORT_ERRORS as transport_exc:
+                raise LLMRetryableError(str(transport_exc)) from transport_exc
 
     async def chat_collect(
         self,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -5176,6 +5176,13 @@ class AgentLoop:
                     )
                 except Exception as e:
                     logger.warning(f"LLM streaming failed ({e}), falling back to non-streaming")
+                    if any_text_streamed:
+                        # Mid-stream failure: notify the user so partial output is
+                        # clearly separated from the fallback response.
+                        yield {
+                            "type": "text_delta",
+                            "content": "\n\n*(Stream interrupted — retrying…)*\n\n",
+                        }
 
                 streamed = llm_response is not None
                 if llm_response is None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -481,3 +481,91 @@ def test_thinking_override_on_openai_reasoning_models():
     )
     llm.thinking_override = "high"
     assert llm._get_thinking_params() == {"reasoning_effort": "high"}
+
+
+# ── chat_stream transport error classification ────────────────
+
+
+def _make_streaming_mock(lines: list[str] | None = None, exc: Exception | None = None):
+    """Build a mock that mimics client.stream() for chat_stream tests."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    async def _aiter_lines():
+        if lines:
+            for line in lines:
+                yield line
+        if exc:
+            raise exc
+
+    mock_response.aiter_lines = _aiter_lines
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_http = AsyncMock()
+    mock_http.stream = MagicMock(return_value=mock_cm)
+    return mock_http
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_transport_error_classified_retryable():
+    """httpx RemoteProtocolError during streaming should raise LLMRetryableError."""
+    import httpx
+
+    llm = _make_llm_client()
+    mock_http = _make_streaming_mock(exc=httpx.RemoteProtocolError("peer closed"))
+    llm._get_client = AsyncMock(return_value=mock_http)
+
+    with pytest.raises(LLMRetryableError):
+        async for _ in llm.chat_stream("system", [{"role": "user", "content": "hi"}]):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_readtimeout_classified_retryable():
+    """httpx ReadTimeout during streaming should raise LLMRetryableError."""
+    import httpx
+
+    llm = _make_llm_client()
+    mock_http = _make_streaming_mock(exc=httpx.ReadTimeout("read timed out"))
+    llm._get_client = AsyncMock(return_value=mock_http)
+
+    with pytest.raises(LLMRetryableError):
+        async for _ in llm.chat_stream("system", [{"role": "user", "content": "hi"}]):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_connecterror_classified_retryable():
+    """httpx ConnectError during streaming should raise LLMRetryableError."""
+    import httpx
+
+    llm = _make_llm_client()
+    mock_http = _make_streaming_mock(exc=httpx.ConnectError("connection refused"))
+    llm._get_client = AsyncMock(return_value=mock_http)
+
+    with pytest.raises(LLMRetryableError):
+        async for _ in llm.chat_stream("system", [{"role": "user", "content": "hi"}]):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_normal_completion_unaffected():
+    """Normal SSE stream should still yield text_delta + done without transport wrapping."""
+    llm = _make_llm_client()
+    lines = [
+        'data: {"type":"text_delta","content":"hello"}',
+        'data: {"type":"done","content":"hello","tokens_used":5,"model":"test"}',
+    ]
+    mock_http = _make_streaming_mock(lines=lines)
+    llm._get_client = AsyncMock(return_value=mock_http)
+
+    chunks = []
+    async for chunk in llm.chat_stream("system", [{"role": "user", "content": "hi"}]):
+        chunks.append(chunk)
+
+    assert chunks[0]["type"] == "text_delta"
+    assert chunks[0]["content"] == "hello"
+    assert chunks[1]["type"] == "done"


### PR DESCRIPTION
## Summary

- **Transport error classification**: `chat_stream()` now wraps the SSE iteration in a try/except for httpx transport errors (`RemoteProtocolError`, `ReadTimeout`, `ConnectError`, `ReadError`) and raises them as `LLMRetryableError` so the loop's backoff-retry logic triggers correctly
- **Mid-stream interrupt notice**: When a stream breaks after partial content has been streamed (`any_text_streamed=True`), the loop emits a visible "*(Stream interrupted — retrying…)*" notice before falling back to non-streaming, preventing silent duplicate content

## Why

Without transport error classification, a mid-stream `RemoteProtocolError` or `ReadTimeout` surfaced as a bare exception and **killed the task** instead of retrying. The non-streaming fallback path in `loop.py` was never reached because the exception type wasn't `LLMRetryableError`.

Without the mid-stream notice, when streaming partially succeeded and then failed, the non-streaming fallback would produce the full response — but the user had already seen partial streamed content, creating a **silent duplicate** with no visual separation.

## Test plan

- [x] `test_chat_stream_transport_error_classified_retryable` — `RemoteProtocolError` → `LLMRetryableError`
- [x] `test_chat_stream_readtimeout_classified_retryable` — `ReadTimeout` → `LLMRetryableError`
- [x] `test_chat_stream_connecterror_classified_retryable` — `ConnectError` → `LLMRetryableError`
- [x] `test_chat_stream_normal_completion_unaffected` — normal SSE stream still works
- [x] Full `tests/test_llm.py` suite: 34 passed, 0 failed