### PR TITLE
fix(browser): pin Camoufox version to prevent Playwright/Juggler drift

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -132,9 +132,20 @@ RUN mkdir -p /opt/openlegion/extensions \
 # also used by ``vnc_ws`` to connect upstream to the per-agent
 # KasmVNC.
 COPY pyproject.toml .
+# ``camoufox`` is version-pinned on purpose. Camoufox itself pins
+# ``playwright="*"``, so an unpinned rebuild can silently drift onto a
+# Playwright release that breaks the Camoufox<->Firefox Juggler bridge
+# (camoufox#617), and it also drags in a different fingerprint DB. Both
+# are invisible to CI (CI never builds this image) and only surface as a
+# live antibot/session regression. 0.4.11 is the current latest release,
+# i.e. exactly what an unpinned build resolves to today — pinning it locks
+# in current, known-good behavior with zero drift. Refresh this pin
+# DELIBERATELY and re-run the browser canary (``src/browser/canary.py``)
+# at staging after any bump. The ``python -m camoufox fetch`` below
+# resolves the matching Firefox build from whatever version is pinned here.
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
-    "camoufox[geoip]" fastapi "uvicorn[standard]" pydantic httpx \
+    "camoufox[geoip]==0.4.11" fastapi "uvicorn[standard]" pydantic httpx \
     "Pillow>=10.0"
 
 # Application code

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -135,14 +135,20 @@ COPY pyproject.toml .
 # ``camoufox`` is version-pinned on purpose. Camoufox itself pins
 # ``playwright="*"``, so an unpinned rebuild can silently drift onto a
 # Playwright release that breaks the Camoufox<->Firefox Juggler bridge
-# (camoufox#617), and it also drags in a different fingerprint DB. Both
-# are invisible to CI (CI never builds this image) and only surface as a
-# live antibot/session regression. 0.4.11 is the current latest release,
+# (camoufox#617), and it also drags in a different fingerprint DB. CI's
+# ``build-and-smoke`` job (.github/workflows/browser-image.yml) builds
+# this exact image whenever Dockerfile.browser/pyproject.toml change, so
+# it WILL catch an un-installable or absent pin — it already caught an
+# earlier bad pin (a non-existent version). What CI does NOT do is run
+# the browser canary (``src/browser/canary.py``) or any live
+# Camoufox-launch / Juggler-bridge / fingerprint check, so the *runtime*
+# behavior of a future version BUMP still surfaces only as a live
+# antibot/session regression. 0.4.11 is the current latest release,
 # i.e. exactly what an unpinned build resolves to today — pinning it locks
 # in current, known-good behavior with zero drift. Refresh this pin
-# DELIBERATELY and re-run the browser canary (``src/browser/canary.py``)
-# at staging after any bump. The ``python -m camoufox fetch`` below
-# resolves the matching Firefox build from whatever version is pinned here.
+# DELIBERATELY and re-run the browser canary at staging after any bump.
+# The ``python -m camoufox fetch`` below resolves the matching Firefox
+# build from whatever version is pinned here.
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
     "camoufox[geoip]==0.4.11" fastapi "uvicorn[standard]" pydantic httpx \


### PR DESCRIPTION
## What

Pin the browser image's Camoufox install from `"camoufox[geoip]"` (unpinned) to `"camoufox[geoip]==0.4.11"` in `Dockerfile.browser`, with an explanatory comment.

## Why

Camoufox itself pins `playwright="*"`. With Camoufox unpinned, any rebuild of the browser image can silently drift onto:

- a **newer Playwright** that breaks the Camoufox<->Firefox Juggler bridge (see [camoufox#617](https://github.com/daijro/camoufox/issues/617)), and
- a **different bundled fingerprint DB**, changing stealth behavior.

Both are invisible to source review and only surface at runtime as an antibot / browser-session regression on a live box after a deploy-time rebuild. Pinning makes the browser image reproducible: the same source builds the same Camoufox / Playwright / Firefox stack every time.

`0.4.11` is the current **latest** release on PyPI — i.e. exactly what an unpinned build resolves to today — so this pin locks in current, known-good behavior with **zero** drift. The existing `python -m camoufox fetch` step resolves the matching patched-Firefox build from the pinned pip version, so no separate Firefox pin is needed.

## What CI validates — and what it does NOT

The `Browser image smoke` workflow (`.github/workflows/browser-image.yml`, job `build-and-smoke`) is path-filtered to run on `Dockerfile.browser` / `pyproject.toml` changes, so it **does run on this PR**. It builds the browser image end-to-end and verifies the runtime deps resolve, install, and import. That build step is exactly what caught an earlier attempt to pin a non-existent `camoufox==0.5.2` — so CI *does* protect against a bad/absent pin.

What CI does **not** do: run the browser canary (`src/browser/canary.py`) or any real Camoufox-launch / Juggler-bridge / fingerprint validation. So the *runtime behavior* of a version bump is not exercised by CI. Before/at deploy, a human should validate a bump at staging by:

1. Confirming the browser-image smoke is green (image builds, deps import), and
2. Running the browser canary (`src/browser/canary.py`) against the fresh image to confirm the Camoufox launch + Juggler bridge + fingerprint stack still works at runtime.

For this specific PR the runtime risk is nil (0.4.11 == today's unpinned resolution), but future bumps should be refreshed **deliberately** (never a floating range) and followed by a staging canary run. The comment added above the install line documents this.

## Risk

Low. Single-line dependency pin plus a comment; no application code touched. The static dep test (`test_dockerfile_browser_deps.py`) still matches (`camoufox` substring is unchanged), and the `build-and-smoke` workflow builds the image on this PR.
