### PR TITLE
fix(browser): enforce identity coherence on the always-on profile channel

### DIFF
--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -250,6 +250,18 @@ def main() -> None:
             await _cost_counter.restore()
         except Exception as exc:
             logger.warning("captcha_cost_counter.restore failed: %s", exc)
+        # Durable fingerprint burn + per-agent binding-signature state.
+        # Without this restore, a fingerprint flagged "burned" reads clean
+        # after a restart while its poisoned cookies persist on disk, and
+        # the binding-coherence check has no prior signature to compare
+        # against. Non-fatal — a missing / corrupt sidecar restores empty.
+        from src.browser.service import (
+            load_fingerprint_state as _load_fp_state,
+        )
+        try:
+            await _load_fp_state()
+        except Exception as exc:
+            logger.warning("load_fingerprint_state failed: %s", exc)
         await manager.start_cleanup_loop()
         logger.info("Browser service ready (max=%d, idle_timeout=%dm)", _MAX_BROWSERS, _IDLE_TIMEOUT)
         yield
@@ -257,6 +269,13 @@ def main() -> None:
             await _cost_counter.snapshot()
         except Exception as exc:
             logger.warning("captcha_cost_counter.snapshot failed: %s", exc)
+        from src.browser.service import (
+            persist_fingerprint_state as _persist_fp_state,
+        )
+        try:
+            await _persist_fp_state()
+        except Exception as exc:
+            logger.warning("persist_fingerprint_state failed: %s", exc)
         # ``stop_all`` tears down every per-agent X stack via
         # ``_teardown_per_agent_x_stack``; no global processes to reap.
         await manager.stop_all()

--- a/src/browser/fingerprint_state.py
+++ b/src/browser/fingerprint_state.py
@@ -1,0 +1,253 @@
+"""Durable per-agent fingerprint-burn + binding-signature state.
+
+Two pieces of always-on browser identity state used to live only in
+``src/browser/service.py`` module globals, so they evaporated on a
+browser-service restart:
+
+  1. **Fingerprint-burn state** — the rolling accept/reject window, the
+     hard-burn set, and its reasons. When these were in-memory-only, a
+     fingerprint flagged "burned" (poisoned) read *clean* after a restart
+     even though the cookies that got it burned still sat on disk in the
+     Camoufox persistent profile. The operator would see a healthy agent
+     that instantly re-tripped every anti-bot vendor.
+
+  2. **Per-agent binding signatures** — a short opaque hash of the
+     ``(UA, proxy)`` identity the agent last launched with. The
+     always-on profile channel (``user_data_dir``) restores ALL cookies
+     on launch, including anti-bot trust tokens (``cf_clearance``,
+     ``datadome``, ``_abck`` …) that vendors bind to the original
+     ``(UA, IP)`` tuple. Replaying one of those under a rotated UA or a
+     different proxy egress is an instant 403 AND lowers the trust score
+     for the session lifetime. ``service._enforce_binding_cookie_coherence``
+     compares the persisted signature against the current one on each
+     launch and drops bound cookies on a mismatch — which requires the
+     signature to survive restarts.
+
+Both are identity state that must be durable, so they share one sidecar.
+
+The in-memory globals in ``service.py`` stay the source of truth
+in-process; this module is pure serialization. It deliberately does NOT
+import ``service`` (no cycle): callers pass the state in on
+:func:`snapshot` and receive a :class:`FingerprintState` back from
+:func:`restore`, then repopulate their own globals.
+
+Atomic-write + non-fatal-restore protocol mirrors
+:mod:`src.browser.captcha_cost_counter` (open ``0o600`` → ``fchmod`` →
+``json.dump`` → ``fsync`` → ``os.replace`` → ``chmod``). A missing or
+corrupt file restores empty rather than raising — a bad sidecar must
+never block browser-service startup.
+
+On-disk schema::
+
+    {
+      "version": 1,
+      "saved_at": <epoch seconds>,
+      "window": {"<agent_id>": [true, false, ...], ...},
+      "last_signal": {"<agent_id>": <epoch float>, ...},
+      "hard_burned": ["<agent_id>", ...],
+      "hard_burn_reason": {"<agent_id>": ["<vendor>", "<signal>"], ...},
+      "binding_signatures": {"<agent_id>": "<16-hex>", ...}
+    }
+
+Default path ``data/fingerprint_state.json``; env override
+``FINGERPRINT_STATE_PATH`` (consistent with ``CAPTCHA_COST_COUNTER_PATH``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.fingerprint_state")
+
+
+# Persistence path. Lives under ``data/`` alongside the captcha-cost
+# counter sidecar so all browser-service persistence stays under one
+# parent. Override-able via env for tests + custom deployments.
+_DEFAULT_PATH = "data/fingerprint_state.json"
+_SCHEMA_VERSION = 1
+# Default rolling-window bound. Mirrors ``service._FINGERPRINT_WINDOW_SIZE``
+# but kept as a local default so this module has NO import cycle back into
+# service.py. The live caller passes its own constant to :func:`restore`
+# (``window_maxlen=_FINGERPRINT_WINDOW_SIZE``) so the two can never drift
+# silently; the default only matters for standalone / test use.
+_DEFAULT_WINDOW_MAXLEN = 10
+
+
+def _state_path() -> Path:
+    """Return the fingerprint-state sidecar path (env-overridable)."""
+    return Path(os.environ.get("FINGERPRINT_STATE_PATH", _DEFAULT_PATH))
+
+
+@dataclass
+class FingerprintState:
+    """In-memory view of the persisted fingerprint state.
+
+    Field shapes match the ``service.py`` globals they seed so a caller
+    can ``.update()`` each straight in. ``window`` values are bounded
+    ``deque`` rebuilt with the caller-supplied ``maxlen`` on restore.
+    """
+
+    window: dict[str, deque] = field(default_factory=dict)
+    last_signal: dict[str, float] = field(default_factory=dict)
+    hard_burned: set[str] = field(default_factory=set)
+    hard_burn_reason: dict[str, tuple[str, str]] = field(default_factory=dict)
+    binding_signatures: dict[str, str] = field(default_factory=dict)
+
+
+def snapshot(
+    *,
+    window: Mapping[str, Iterable[bool]],
+    last_signal: Mapping[str, float],
+    hard_burned: Iterable[str],
+    hard_burn_reason: Mapping[str, Iterable[str]],
+    binding_signatures: Mapping[str, str],
+    path: Path | str | None = None,
+) -> bool:
+    """Atomically write the supplied state to ``path`` as JSON.
+
+    Synchronous by design: the ``service.py`` caller already holds the
+    fingerprint lock across its mutation, so there is no internal state
+    to guard here. Returns ``True`` on success; failures log + return
+    ``False`` rather than raise — the mutation / shutdown paths must not
+    abort because persistence failed (same posture as the captcha-cost
+    counter snapshot).
+
+    Atomic-write protocol: ``os.open`` the tmp sibling with mode 0o600
+    (no world-readable window), ``fchmod``, write + ``fsync``,
+    ``os.replace`` over the destination, then re-``chmod`` 0o600.
+    """
+    target = Path(path) if path else _state_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning("fingerprint_state snapshot: cannot create parent dir: %s", e)
+        return False
+
+    payload = {
+        "version": _SCHEMA_VERSION,
+        "saved_at": int(time.time()),
+        "window": {str(a): [bool(v) for v in w] for a, w in window.items()},
+        "last_signal": {str(a): float(t) for a, t in last_signal.items()},
+        "hard_burned": sorted(str(a) for a in hard_burned),
+        "hard_burn_reason": {str(a): [str(x) for x in r] for a, r in hard_burn_reason.items()},
+        "binding_signatures": {str(a): str(s) for a, s in binding_signatures.items()},
+    }
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        # Open with 0o600 from the start (umask-aware) so there is no
+        # world-readable window before the explicit chmod below.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        # We own ``fd`` until ``os.fdopen`` returns; ``fchmod`` / ``fdopen``
+        # can raise (OSError / MemoryError) which would leak the descriptor
+        # unless we close it in that narrow window. After fdopen returns the
+        # file object owns ``fd`` and the ``with`` block handles cleanup.
+        try:
+            os.fchmod(fd, 0o600)
+            fh = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        with fh:
+            json.dump(payload, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+        # ``os.replace`` preserves the destination's mode on most
+        # filesystems but Python's docs are not load-bearing on this;
+        # explicit chmod after replace ensures 0o600 regardless of
+        # whether the target pre-existed.
+        os.chmod(target, 0o600)
+    except OSError as e:
+        logger.warning("fingerprint_state snapshot failed: %s", e)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def restore(
+    path: Path | str | None = None,
+    *,
+    window_maxlen: int = _DEFAULT_WINDOW_MAXLEN,
+) -> FingerprintState:
+    """Load state from ``path`` if it exists, returning a :class:`FingerprintState`.
+
+    Missing / unreadable / malformed files are non-fatal — log + return an
+    empty state. Every field is parsed defensively; a malformed individual
+    entry is skipped rather than aborting the whole restore. ``window``
+    deques are rebuilt with ``maxlen=window_maxlen`` so the bound survives
+    the round-trip (the live caller passes ``_FINGERPRINT_WINDOW_SIZE``).
+    """
+    target = Path(path) if path else _state_path()
+    state = FingerprintState()
+    if not target.exists():
+        return state
+    try:
+        with open(target, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("fingerprint_state restore: %s — starting empty", e)
+        return state
+    if not isinstance(payload, dict):
+        logger.warning(
+            "fingerprint_state restore: unexpected payload type — starting empty",
+        )
+        return state
+    version = payload.get("version")
+    if version != _SCHEMA_VERSION:
+        logger.warning(
+            "fingerprint_state restore: unexpected version %r (expected %d) — starting empty",
+            version,
+            _SCHEMA_VERSION,
+        )
+        return state
+
+    window = payload.get("window")
+    if isinstance(window, dict):
+        for agent_id, values in window.items():
+            if not isinstance(agent_id, str) or not isinstance(values, list):
+                continue
+            state.window[agent_id] = deque(
+                (bool(v) for v in values),
+                maxlen=window_maxlen,
+            )
+
+    last_signal = payload.get("last_signal")
+    if isinstance(last_signal, dict):
+        for agent_id, ts in last_signal.items():
+            if isinstance(agent_id, str) and isinstance(ts, (int, float)):
+                state.last_signal[agent_id] = float(ts)
+
+    hard_burned = payload.get("hard_burned")
+    if isinstance(hard_burned, list):
+        state.hard_burned = {a for a in hard_burned if isinstance(a, str)}
+
+    reasons = payload.get("hard_burn_reason")
+    if isinstance(reasons, dict):
+        for agent_id, pair in reasons.items():
+            if not isinstance(agent_id, str):
+                continue
+            if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                state.hard_burn_reason[agent_id] = (str(pair[0]), str(pair[1]))
+
+    sigs = payload.get("binding_signatures")
+    if isinstance(sigs, dict):
+        for agent_id, sig in sigs.items():
+            if isinstance(agent_id, str) and isinstance(sig, str):
+                state.binding_signatures[agent_id] = sig
+
+    return state

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -888,6 +888,15 @@ _fingerprint_hard_burned: set[str] = set()
 # {agent_id: (vendor, header_or_status)} — last hard-block reason captured
 # for operator visibility on the dashboard. Operator-only; never logged.
 _fingerprint_hard_burn_reason: dict[str, tuple[str, str]] = {}
+# {agent_id: signature} — short opaque hash of the (UA, proxy) identity the
+# agent last launched with, written by ``_enforce_binding_cookie_coherence``.
+# The always-on Camoufox persistent profile restores ALL cookies on launch,
+# so a changed identity must drop anti-bot bound cookies (cf_clearance et al.)
+# BEFORE they replay under the new fingerprint. Persisted alongside the burn
+# state so the signature survives a browser-service restart (Constraint #8:
+# a new module-level global, but lock-protected identity state consistent
+# with the surrounding fingerprint globals). Guarded by ``_fingerprint_lock``.
+_binding_signatures: dict[str, str] = {}
 
 
 def _get_fingerprint_lock() -> asyncio.Lock:
@@ -917,7 +926,11 @@ async def _record_fingerprint_outcome(
             _fingerprint_window[agent_id] = bucket
         bucket.append(bool(rejected))
         _fingerprint_last_signal[agent_id] = time.time()
-        return _is_burned_locked(bucket)
+        burned = _is_burned_locked(bucket)
+        # Persist across restarts so a poisoned window can't read clean
+        # after a browser-service bounce while its cookies survive on disk.
+        _snapshot_fingerprint_state_locked()
+        return burned
 
 
 def _is_burned_locked(bucket: deque[bool]) -> bool:
@@ -1027,6 +1040,8 @@ async def _force_fingerprint_burn(
         _fingerprint_hard_burned.add(agent_id)
         _fingerprint_hard_burn_reason[agent_id] = (vendor, reason)
         _fingerprint_last_signal[agent_id] = time.time()
+        # Persist so a vendor-confirmed hard block survives a restart.
+        _snapshot_fingerprint_state_locked()
     return not already
 
 
@@ -1100,7 +1115,61 @@ async def _reset_fingerprint_window(agent_id: str) -> bool:
         _fingerprint_last_signal.pop(agent_id, None)
         _fingerprint_hard_burned.discard(agent_id)
         _fingerprint_hard_burn_reason.pop(agent_id, None)
+        # Persist so the cleared slate survives a restart. Binding
+        # signatures are intentionally left intact — a manual reset is a
+        # burn-state concern; identity coherence is handled on next launch.
+        _snapshot_fingerprint_state_locked()
     return had_state
+
+
+def _snapshot_fingerprint_state_locked() -> bool:
+    """Durably persist the fingerprint burn + binding-signature state.
+
+    Caller MUST hold :func:`_get_fingerprint_lock`. Best-effort —
+    :func:`fingerprint_state.snapshot` logs + returns ``False`` on any I/O
+    failure and never raises, so a persistence hiccup can't break the
+    low-frequency mutation path that calls this (post-solve outcome,
+    hard-burn, operator reset, identity-signature update). Synchronous
+    file I/O under the async lock is acceptable at this call frequency
+    and mirrors the captcha-cost counter's snapshot posture.
+    """
+    from src.browser import fingerprint_state as _fp_state
+    return _fp_state.snapshot(
+        window=_fingerprint_window,
+        last_signal=_fingerprint_last_signal,
+        hard_burned=_fingerprint_hard_burned,
+        hard_burn_reason=_fingerprint_hard_burn_reason,
+        binding_signatures=_binding_signatures,
+    )
+
+
+async def persist_fingerprint_state() -> bool:
+    """Snapshot the fingerprint burn + binding-signature state (shutdown hook)."""
+    async with _get_fingerprint_lock():
+        return _snapshot_fingerprint_state_locked()
+
+
+async def load_fingerprint_state() -> None:
+    """Restore the fingerprint burn + binding-signature state (startup hook).
+
+    Non-fatal: a missing / corrupt sidecar restores empty. Repopulates
+    the in-process globals in place so existing references stay valid.
+    Without this, a fingerprint flagged "burned" would read clean after a
+    browser-service restart while its poisoned cookies persisted on disk.
+    """
+    from src.browser import fingerprint_state as _fp_state
+    loaded = _fp_state.restore(window_maxlen=_FINGERPRINT_WINDOW_SIZE)
+    async with _get_fingerprint_lock():
+        _fingerprint_window.clear()
+        _fingerprint_window.update(loaded.window)
+        _fingerprint_last_signal.clear()
+        _fingerprint_last_signal.update(loaded.last_signal)
+        _fingerprint_hard_burned.clear()
+        _fingerprint_hard_burned.update(loaded.hard_burned)
+        _fingerprint_hard_burn_reason.clear()
+        _fingerprint_hard_burn_reason.update(loaded.hard_burn_reason)
+        _binding_signatures.clear()
+        _binding_signatures.update(loaded.binding_signatures)
 
 
 # ── §22 — fingerprint audit aggregator (per-minute, no URL leak) ──────────
@@ -4262,6 +4331,17 @@ class BrowserManager:
             # through to Firefox (it owns the profile dir directly). The end
             # state is the same: cookies merged into the cookie jar; localStorage
             # seeded on each origin's first navigation via the init script.
+            #
+            # ALWAYS-ON identity coherence — runs on the persistent-profile
+            # channel regardless of BROWSER_SESSION_PERSISTENCE_ENABLED. The
+            # Camoufox profile dir restored every cookie above, including
+            # anti-bot trust tokens bound to the previous (UA, proxy). If the
+            # identity signature changed, drop those bound cookies here BEFORE
+            # any navigation so a rotated fingerprint can't replay a stale
+            # token into an instant 403 + trust-score hit. Must run before the
+            # opt-in sidecar restore so a re-added-then-invalidated ordering
+            # can't leak a bound cookie.
+            await self._enforce_binding_cookie_coherence(inst)
             await self._maybe_restore_session(inst)
 
             # §9.1 wire request listeners at the BrowserContext level so new
@@ -4333,6 +4413,135 @@ class BrowserManager:
             with contextlib.suppress(Exception):
                 await self._teardown_per_agent_x_stack(teardown_target)
             raise
+
+    async def _enforce_binding_cookie_coherence(
+        self, inst: CamoufoxInstance,
+    ) -> None:
+        """Drop anti-bot bound cookies from the profile when identity changed.
+
+        Camoufox's ``persistent_context=True`` profile dir (the always-on
+        channel) restores EVERY cookie on launch — including anti-bot trust
+        tokens (``cf_clearance``, ``datadome``, ``_abck`` …) that Cloudflare /
+        DataDome / PerimeterX bind to the original ``(UA, egress-IP)`` tuple.
+        Replaying one under a rotated UA or a different proxy is a guaranteed
+        403 AND lowers the trust score for the session lifetime. The opt-in
+        ``session_persistence`` sidecar already drops these on a signature
+        change; this mirrors that safety onto the always-on profile channel
+        so it runs regardless of ``BROWSER_SESSION_PERSISTENCE_ENABLED``.
+
+        Flow: compute the current ``(UA, proxy)`` signature; compare against
+        the per-agent signature persisted last launch. On a mismatch, drop
+        only the bound vendor cookies (never generic session cookies). Then
+        persist the current signature as the new baseline — including on the
+        first launch, when nothing is dropped. Best-effort throughout: any
+        failure is logged and the browser starts anyway.
+        """
+        from src.browser import session_persistence as _sp
+
+        agent_id = inst.agent_id
+        context = inst.context
+        try:
+            current_sig = _sp._hash_signature(
+                self._build_session_binding_signature(agent_id),
+            )
+        except Exception as e:
+            logger.debug(
+                "binding-coherence: signature build failed for '%s': %s",
+                agent_id, e,
+            )
+            return
+
+        async with _get_fingerprint_lock():
+            persisted_sig = _binding_signatures.get(agent_id)
+
+        # Only drop when we have a prior signature AND it changed. First
+        # launch (no prior signature) drops nothing but still records the
+        # baseline below.
+        if persisted_sig is not None and persisted_sig != current_sig:
+            try:
+                cookies = await context.cookies()
+            except Exception as e:
+                logger.warning(
+                    "binding-coherence: context.cookies() failed for '%s': %s",
+                    agent_id, e,
+                )
+                cookies = None
+            if cookies:
+                bound_names: list[str] = []
+                vendors: list[str] = []
+                for cookie in cookies:
+                    if not isinstance(cookie, dict):
+                        continue
+                    name = cookie.get("name")
+                    family = _sp.cookie_binding_vendor(name)
+                    if family is not None:
+                        bound_names.append(name)
+                        if family not in vendors:
+                            vendors.append(family)
+                if bound_names:
+                    dropped = await self._clear_bound_cookies(
+                        context, bound_names, cookies,
+                    )
+                    if dropped:
+                        logger.info(
+                            "binding-coherence for '%s': identity signature "
+                            "changed (persisted=%s current=%s); dropped %d "
+                            "cookie(s) bound to vendors: %s",
+                            agent_id, persisted_sig, current_sig, dropped,
+                            ",".join(vendors) or "(none)",
+                        )
+
+        # Record the current signature as the new baseline (first-run
+        # included) and durably persist it next to the burn state.
+        async with _get_fingerprint_lock():
+            _binding_signatures[agent_id] = current_sig
+            try:
+                _snapshot_fingerprint_state_locked()
+            except Exception as e:
+                logger.debug(
+                    "binding-coherence: state snapshot failed for '%s': %s",
+                    agent_id, e,
+                )
+
+    async def _clear_bound_cookies(
+        self, context, bound_names: list[str], all_cookies: list,
+    ) -> int:
+        """Delete the named cookies from ``context``; return the count removed.
+
+        Prefers Playwright's targeted ``clear_cookies(name=...)`` (>=1.43;
+        our pin is ~1.51). If that filtered form is unavailable (older
+        Playwright raising ``TypeError`` on the kwarg), falls back to
+        clearing ALL cookies then re-adding the non-bound subset — the same
+        end state (only bound cookies gone) via a coarser path.
+        """
+        bound_set = set(bound_names)
+        try:
+            for name in bound_names:
+                await context.clear_cookies(name=name)
+            return len(bound_names)
+        except TypeError:
+            # Older Playwright: no ``name`` kwarg. Fall through to the
+            # clear-all + re-add-non-bound path below.
+            pass
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: targeted clear_cookies failed (%s); "
+                "falling back to clear-all + re-add", e,
+            )
+        try:
+            await context.clear_cookies()
+            keep = [
+                c for c in all_cookies
+                if isinstance(c, dict) and c.get("name") not in bound_set
+            ]
+            if keep:
+                await context.add_cookies(keep)
+            return len(bound_names)
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: fallback clear/re-add failed: %s", e,
+            )
+            return 0
 
     async def _maybe_restore_session(self, inst: CamoufoxInstance) -> None:
         """§20 — restore cookies + localStorage from the per-agent sidecar.

--- a/src/browser/session_persistence.py
+++ b/src/browser/session_persistence.py
@@ -179,6 +179,30 @@ def _hash_signature(parts: dict[str, str | None]) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
 
+def cookie_binding_vendor(name: str) -> str | None:
+    """Return the vendor family if ``name`` is a binding-sensitive cookie, else ``None``.
+
+    THE single source of truth for "is this an anti-bot bound cookie" —
+    shared by the opt-in sidecar restore path
+    (:func:`_drop_binding_sensitive_cookies`) and the always-on profile
+    coherence check in ``service._enforce_binding_cookie_coherence``.
+
+    Match rule (unchanged from the original inline matcher): case-
+    insensitive; a cookie matches a prefix when its lowercased name
+    equals the prefix OR starts with it. The returned family is the
+    prefix's leading ``_``-delimited segment (or the whole prefix when
+    that segment is empty, e.g. ``_abck`` → ``_abck``) so operators see
+    "we dropped Cloudflare tokens" without leaking specific cookie names.
+    """
+    if not isinstance(name, str):
+        return None
+    lowered = name.lower()
+    for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
+        if lowered == prefix or lowered.startswith(prefix):
+            return prefix.split("_", 1)[0] or prefix
+    return None
+
+
 def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int:
     """Strip cookies whose names match the binding-sensitive prefix list.
 
@@ -195,20 +219,12 @@ def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int
         if not isinstance(cookie, dict):
             kept.append(cookie)
             continue
-        name = (cookie.get("name") or "").lower()
-        bound = False
-        for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
-            if name == prefix or name.startswith(prefix):
-                bound = True
-                # Track which vendor families we dropped (de-dupe by
-                # caller). Helps operators see "we dropped Cloudflare
-                # tokens" without leaking specific cookie names.
-                family = prefix.split("_", 1)[0] or prefix
-                if family not in vendors_seen:
-                    vendors_seen.append(family)
-                break
-        if bound:
+        family = cookie_binding_vendor(cookie.get("name") or "")
+        if family is not None:
             dropped += 1
+            # Track which vendor families we dropped (de-dupe by caller).
+            if family not in vendors_seen:
+                vendors_seen.append(family)
         else:
             kept.append(cookie)
     state["cookies"] = kept

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,23 @@ os.environ["OPENLEGION_SKIP_TRUST_TIER_BOOT_GATE"] = "1"
 # e2e runs with real keys keep working.
 os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
 
+# Redirect the durable fingerprint-state sidecar off the real ``data/``
+# path for the whole session. The browser service now snapshots fingerprint
+# burn + binding-signature state on every low-frequency mutation
+# (``_record_fingerprint_outcome`` / ``_force_fingerprint_burn`` /
+# ``_reset_fingerprint_window`` and the launch-time binding-coherence check),
+# so any test that drives those would otherwise write ``data/fingerprint_state.json``
+# in the repo root. A per-pid temp path keeps each xdist/shard worker isolated;
+# ``setdefault`` so a test that needs a specific path can still override.
+import tempfile as _tempfile  # noqa: E402
+
+os.environ.setdefault(
+    "FINGERPRINT_STATE_PATH",
+    os.path.join(
+        _tempfile.gettempdir(), f"ol_test_fingerprint_state_{os.getpid()}.json",
+    ),
+)
+
 # Time-returning helpers consumed by ``src.browser.service`` via
 # ``from src.browser.timing import X``. ``scroll_increment`` and
 # ``scroll_ramp`` are intentionally excluded — they return pixel counts

--- a/tests/test_binding_cookie_coherence.py
+++ b/tests/test_binding_cookie_coherence.py
@@ -1,0 +1,203 @@
+"""Tests for the always-on bound-cookie identity-coherence check.
+
+``BrowserManager._enforce_binding_cookie_coherence`` mirrors the opt-in
+session-persistence sidecar's binding-drop onto the always-on Camoufox
+persistent-profile channel. When the agent's ``(UA, proxy)`` signature
+changed since last launch, anti-bot bound cookies (cf_clearance, datadome,
+_abck, …) must be dropped BEFORE they replay under the new fingerprint —
+otherwise an instant 403 + trust-score hit. Runs regardless of
+``BROWSER_SESSION_PERSISTENCE_ENABLED``.
+
+Covers:
+  * mismatched persisted signature → matching bound cookies removed,
+    non-bound (generic session) cookies retained; new signature persisted.
+  * matching persisted signature → nothing dropped (cookies never read).
+  * first run (no persisted signature) → nothing dropped, signature
+    persisted so the NEXT identity change is detectable.
+  * legacy Playwright without ``clear_cookies(name=...)`` → clear-all +
+    re-add of the non-bound subset (same end state).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import types
+
+import pytest
+
+from src.browser import session_persistence as sp
+from src.browser.service import BrowserManager
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Clean binding-signature global + a private state sidecar per test."""
+    from src.browser.service import _binding_signatures
+
+    monkeypatch.setenv(
+        "FINGERPRINT_STATE_PATH",
+        str(tmp_path / "fp_state.json"),
+    )
+    _binding_signatures.clear()
+    yield
+    _binding_signatures.clear()
+
+
+def _cookie(name: str) -> dict:
+    return {
+        "name": name,
+        "value": "v-" + name,
+        "domain": ".example.com",
+        "path": "/",
+    }
+
+
+# A realistic mix: three vendor-bound cookies + two generic session cookies.
+_BOUND = ["cf_clearance", "datadome", "_abck"]
+_GENERIC = ["session", "csrftoken"]
+
+
+class _FakeContext:
+    """Playwright BrowserContext duck-type supporting name-filtered clear."""
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cookies_calls = 0
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        self.cookies_calls += 1
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)
+
+
+class _LegacyContext:
+    """Older Playwright: ``clear_cookies`` has NO ``name`` kwarg.
+
+    Calling ``clear_cookies(name=...)`` therefore raises ``TypeError`` —
+    the exact signal the coherence helper falls back on.
+    """
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+    async def clear_cookies(self) -> None:  # no ``name`` param on purpose
+        self.cleared_all += 1
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_bcc_")
+    return BrowserManager(profiles_dir=root)
+
+
+def _inst(agent_id: str, context) -> types.SimpleNamespace:
+    return types.SimpleNamespace(agent_id=agent_id, context=context)
+
+
+def _current_sig(mgr: BrowserManager, agent_id: str) -> str:
+    return sp._hash_signature(mgr._build_session_binding_signature(agent_id))
+
+
+class TestSignatureMismatch:
+    @pytest.mark.asyncio
+    async def test_mismatch_drops_bound_keeps_generic(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-mismatch"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-new:8080"})
+        # Seed a DIFFERENT prior signature → forces the drop branch.
+        _binding_signatures[agent] = "deadbeefdeadbeef"
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Every bound cookie was cleared by name; no generic cookie was.
+        assert set(ctx.cleared_names) == set(_BOUND)
+        assert all(g not in ctx.cleared_names for g in _GENERIC)
+        assert ctx.cleared_all == 0  # targeted path, not clear-all
+        # The current signature is now the persisted baseline.
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestSignatureMatch:
+    @pytest.mark.asyncio
+    async def test_match_drops_nothing_and_skips_cookie_read(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-match"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-stable:8080"})
+        # Seed the SAME signature the agent will compute now.
+        _binding_signatures[agent] = _current_sig(mgr, agent)
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        # Unchanged identity ⇒ we don't even enumerate cookies.
+        assert ctx.cookies_calls == 0
+        # Signature is re-persisted (unchanged).
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestFirstRun:
+    @pytest.mark.asyncio
+    async def test_first_run_drops_nothing_but_persists_signature(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-first"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-first:8080"})
+        assert agent not in _binding_signatures  # no prior baseline
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        assert ctx.cookies_calls == 0  # nothing to invalidate on first run
+        # But the baseline IS recorded so the next change is detectable.
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestLegacyPlaywrightFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_clears_all_then_readds_non_bound(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-legacy"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-legacy:8080"})
+        _binding_signatures[agent] = "0000000000000000"  # force mismatch
+
+        ctx = _LegacyContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Fell back to clear-all …
+        assert ctx.cleared_all == 1
+        # … then re-added ONLY the non-bound cookies.
+        assert ctx.readded is not None
+        readded_names = {c["name"] for c in ctx.readded}
+        assert readded_names == set(_GENERIC)
+        assert all(b not in readded_names for b in _BOUND)
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -52,6 +52,7 @@ atexit.register(shutil.rmtree, _PROFILES_ROOT, ignore_errors=True)
 def _reset_fingerprint_state():
     """Each test starts with empty module-level fingerprint state."""
     from src.browser.service import (
+        _binding_signatures,
         _fingerprint_audit_buckets,
         _fingerprint_hard_burn_reason,
         _fingerprint_hard_burned,
@@ -63,12 +64,14 @@ def _reset_fingerprint_state():
     _fingerprint_audit_buckets.clear()
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
+    _binding_signatures.clear()
     yield
     _fingerprint_window.clear()
     _fingerprint_last_signal.clear()
     _fingerprint_audit_buckets.clear()
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
+    _binding_signatures.clear()
 
 
 class TestRollingWindow:

--- a/tests/test_fingerprint_state.py
+++ b/tests/test_fingerprint_state.py
@@ -1,0 +1,225 @@
+"""Tests for the durable fingerprint-state sidecar (burn + binding signatures).
+
+Covers:
+  * snapshot → restore round-trip preserves the rolling window (values AND
+    the ``maxlen`` bound), the hard-burned set, and the hard-burn reasons.
+  * binding-signature map round-trips.
+  * a ``deque`` longer than ``maxlen`` restores keeping only the last N.
+  * missing file restores an empty state (no raise).
+  * corrupt JSON / wrong-shape / wrong-version restores empty (no raise).
+  * the sidecar is written 0o600 (opaque state, but matches the codebase's
+    atomic-write posture).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections import deque
+
+from src.browser import fingerprint_state as fp
+
+
+def _snapshot(path, **overrides):
+    """Snapshot with sensible empty defaults; overrides fill in fields."""
+    kwargs = dict(
+        window={},
+        last_signal={},
+        hard_burned=set(),
+        hard_burn_reason={},
+        binding_signatures={},
+        path=path,
+    )
+    kwargs.update(overrides)
+    return fp.snapshot(**kwargs)
+
+
+class TestRoundTrip:
+    def test_window_values_and_maxlen_survive(self, tmp_path):
+        target = tmp_path / "fp.json"
+        window = {
+            "agent-a": deque([True, False, True], maxlen=10),
+            "agent-b": deque([False], maxlen=10),
+        }
+        assert _snapshot(target, window=window) is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True, False, True]
+        assert list(loaded.window["agent-b"]) == [False]
+        # Rebuilt as a bounded deque with the same maxlen — appending an
+        # 11th element evicts the oldest rather than growing unbounded.
+        restored = loaded.window["agent-a"]
+        assert isinstance(restored, deque)
+        assert restored.maxlen == 10
+        for _ in range(12):
+            restored.append(True)
+        assert len(restored) == 10
+
+    def test_full_window_at_maxlen_keeps_last_n(self, tmp_path):
+        target = tmp_path / "fp.json"
+        # 10 entries = a full window: 6 rejects then 4 accepts.
+        full = deque([True] * 6 + [False] * 4, maxlen=10)
+        assert _snapshot(target, window={"agent-a": full}) is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True] * 6 + [False] * 4
+        assert loaded.window["agent-a"].maxlen == 10
+
+    def test_oversized_list_truncates_to_maxlen_last_n(self, tmp_path):
+        # A hand-tampered / legacy file could hold more entries than maxlen;
+        # deque(iterable, maxlen=N) keeps the LAST N, so restore is safe.
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "saved_at": 0,
+                    "window": {"agent-a": [True, False, True, True, False]},
+                    "last_signal": {},
+                    "hard_burned": [],
+                    "hard_burn_reason": {},
+                    "binding_signatures": {},
+                }
+            )
+        )
+        loaded = fp.restore(target, window_maxlen=3)
+        assert list(loaded.window["agent-a"]) == [True, True, False]
+        assert loaded.window["agent-a"].maxlen == 3
+
+    def test_hard_burned_and_reasons_survive(self, tmp_path):
+        target = tmp_path / "fp.json"
+        ok = _snapshot(
+            target,
+            hard_burned={"agent-a", "agent-b"},
+            hard_burn_reason={
+                "agent-a": ("cloudflare", "cf-mitigated=block"),
+                "agent-b": ("perimeterx", "x-px-block-type=1"),
+            },
+            last_signal={"agent-a": 1234.5},
+        )
+        assert ok is True
+
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == {"agent-a", "agent-b"}
+        assert loaded.hard_burn_reason["agent-a"] == ("cloudflare", "cf-mitigated=block")
+        assert loaded.hard_burn_reason["agent-b"] == ("perimeterx", "x-px-block-type=1")
+        # Reasons restore as a 2-tuple (list-in-JSON → tuple in memory).
+        assert isinstance(loaded.hard_burn_reason["agent-a"], tuple)
+        assert loaded.last_signal["agent-a"] == 1234.5
+
+    def test_binding_signatures_round_trip(self, tmp_path):
+        target = tmp_path / "fp.json"
+        sigs = {"agent-a": "0011223344556677", "agent-b": "aabbccddeeff0011"}
+        assert _snapshot(target, binding_signatures=sigs) is True
+
+        loaded = fp.restore(target)
+        assert loaded.binding_signatures == sigs
+
+    def test_combined_round_trip(self, tmp_path):
+        target = tmp_path / "fp.json"
+        ok = _snapshot(
+            target,
+            window={"agent-a": deque([True, True], maxlen=10)},
+            last_signal={"agent-a": 42.0},
+            hard_burned={"agent-a"},
+            hard_burn_reason={"agent-a": ("datadome", "x-datadome=protected")},
+            binding_signatures={"agent-a": "cafebabecafebabe"},
+        )
+        assert ok is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True, True]
+        assert loaded.last_signal["agent-a"] == 42.0
+        assert loaded.hard_burned == {"agent-a"}
+        assert loaded.hard_burn_reason["agent-a"] == ("datadome", "x-datadome=protected")
+        assert loaded.binding_signatures["agent-a"] == "cafebabecafebabe"
+
+
+class TestNonFatalRestore:
+    def test_missing_file_restores_empty(self, tmp_path):
+        loaded = fp.restore(tmp_path / "does-not-exist.json")
+        assert loaded.window == {}
+        assert loaded.last_signal == {}
+        assert loaded.hard_burned == set()
+        assert loaded.hard_burn_reason == {}
+        assert loaded.binding_signatures == {}
+
+    def test_corrupt_json_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text("{not valid json at all")
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == set()
+        assert loaded.binding_signatures == {}
+
+    def test_wrong_shape_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text(json.dumps(["not", "a", "dict"]))
+        loaded = fp.restore(target)
+        assert loaded.window == {}
+
+    def test_wrong_version_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "hard_burned": ["agent-a"],
+                    "binding_signatures": {"agent-a": "sig"},
+                }
+            )
+        )
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == set()
+        assert loaded.binding_signatures == {}
+
+    def test_malformed_entries_skipped_not_fatal(self, tmp_path):
+        # Individual bad rows are dropped; the well-formed ones survive.
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "window": {"agent-a": [True], "bad": "not-a-list"},
+                    "last_signal": {"agent-a": 1.0, "bad": "nan-string"},
+                    "hard_burned": ["agent-a", 123],
+                    "hard_burn_reason": {"agent-a": ["cf", "block"], "bad": ["only-one"]},
+                    "binding_signatures": {"agent-a": "sig", "bad": 12345},
+                }
+            )
+        )
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True]
+        assert "bad" not in loaded.window
+        assert loaded.last_signal == {"agent-a": 1.0}
+        assert loaded.hard_burned == {"agent-a"}
+        assert loaded.hard_burn_reason == {"agent-a": ("cf", "block")}
+        assert loaded.binding_signatures == {"agent-a": "sig"}
+
+
+class TestFilePermissions:
+    def test_sidecar_is_owner_only(self, tmp_path):
+        target = tmp_path / "fp.json"
+        assert _snapshot(target, hard_burned={"agent-a"}) is True
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode == 0o600
+
+
+class TestEnvOverride:
+    def test_default_path_env_override(self, tmp_path, monkeypatch):
+        target = tmp_path / "custom_fp.json"
+        monkeypatch.setenv("FINGERPRINT_STATE_PATH", str(target))
+        # No explicit path → falls back to the env-configured location.
+        assert (
+            fp.snapshot(
+                window={},
+                last_signal={},
+                hard_burned={"agent-z"},
+                hard_burn_reason={},
+                binding_signatures={},
+            )
+            is True
+        )
+        assert target.exists()
+        loaded = fp.restore()
+        assert loaded.hard_burned == {"agent-z"}


### PR DESCRIPTION
## The defect (P0 correctness)

The agent browser keeps a durable identity two ways, and the safety machinery was on the wrong one.

- **Always-on channel** — Camoufox's persistent profile dir (`user_data_dir`) restores **all** cookies on launch, including anti-bot trust tokens (`cf_clearance`, `datadome`, `_abck`, `incap_ses_*`, `pxhd`, …) that Cloudflare / DataDome / PerimeterX / Imperva / Akamai bind to the original `(UA, egress-IP)` tuple. Nothing checked identity coherence here.
- **Opt-in channel** — the `session_persistence.py` sidecar was the *only* path that dropped those bound cookies when the identity (UA/proxy) changed, and it is **default-OFF** (`BROWSER_SESSION_PERSISTENCE_ENABLED`).

Replaying a bound token under a changed IP/UA is a guaranteed **403** *and* lowers the vendor trust score for the session lifetime. So the default configuration did the dangerous thing on every UA/proxy rotation.

Separately, **fingerprint-burn state** (rolling accept/reject window + hard-burn set + reasons) lived only in `service.py` module globals, so a fingerprint flagged "burned" read **clean** after a browser-service restart while its poisoned cookies persisted on disk — the operator saw a healthy agent that instantly re-tripped every vendor.

## The fix

**1. Bound-cookie coherence on the always-on profile channel.** New `BrowserManager._enforce_binding_cookie_coherence` runs in `_start_browser` once the live Playwright context exists and **before** the opt-in sidecar restore — **regardless** of `BROWSER_SESSION_PERSISTENCE_ENABLED`. It compares the current `(UA, proxy)` signature against the per-agent signature persisted last launch; on a mismatch it enumerates `context.cookies()`, drops **only** the vendor-bound cookies (never generic session cookies) via `context.clear_cookies(name=...)` — with a `clear_cookies()` + re-add-non-bound fallback for older Playwright — then records the current signature as the new baseline (first launch included, dropping nothing). The "is this an anti-bot bound cookie" match rule is now a single shared helper, `session_persistence.cookie_binding_vendor`, reused by both channels (behavior-preserving refactor of `_drop_binding_sensitive_cookies`).

**2. Durable fingerprint-burn state.** New `src/browser/fingerprint_state.py` mirrors `captcha_cost_counter.py`'s atomic-`0o600`-snapshot / non-fatal-restore pattern and persists, keyed by `agent_id`: the rolling window (`deque(maxlen=10)` serialized as a list, rebuilt with `maxlen` on restore), `hard_burned`, `hard_burn_reason`, `last_signal`. Default path `data/fingerprint_state.json`, env override `FINGERPRINT_STATE_PATH`. Loaded on browser-service startup and snapshotted on shutdown in the `__main__.py` lifespan (next to the cost-counter hooks); the in-memory globals stay the in-process source of truth, with a best-effort atomic snapshot at each low-frequency mutation site (`_record_fingerprint_outcome` / `_force_fingerprint_burn` / `_reset_fingerprint_window`).

**3. Persistent per-agent binding signatures.** Stored as a `binding_signatures` section in the same always-on `fingerprint_state.py` store (both are always-on identity state), independent of the sidecar's opt-in flag.

Safety posture: only bound vendor cookies are ever dropped; a missing/corrupt sidecar restores empty and never blocks browser startup; the sidecar is written `0o600`.

## Tests
- **Part 1** (`tests/test_binding_cookie_coherence.py`): mismatched signature → bound cookies removed, generic retained + new signature persisted; matching signature → nothing dropped (cookies never read); first-run → nothing dropped + signature persisted; legacy-Playwright fallback → clear-all + re-add non-bound.
- **Part 2/3** (`tests/test_fingerprint_state.py`): snapshot→restore round-trip preserves the window (values + `maxlen` eviction behavior + last-N truncation), `hard_burned`, reasons, and `binding_signatures`; missing/corrupt/wrong-version/malformed-entry files restore empty without raising; `0o600` perms; env-override path.

`ruff check` clean. Full fast suite (matches CI, minus e2e): **7763 passed, 27 skipped**.

## Notes / decisions
- Adds one new lock-protected module global (`_binding_signatures`), consistent with the surrounding fingerprint-state globals cluster (CLAUDE.md Constraint #8 exception pattern — documented at the definition).
- Operator reset (`_reset_fingerprint_window`) intentionally does **not** clear a stored binding signature — reset is a burn-state concern; identity coherence is re-evaluated on the next launch.
- `tests/conftest.py` redirects `FINGERPRINT_STATE_PATH` to a per-pid temp path so the new mutation-site snapshots never touch the real `data/` file during test runs.
- Anchor drift: the burn mutation sites had drifted a few lines from the brief (`_record_fingerprint_outcome` ~903, `_force_fingerprint_burn` ~1021, `_reset_fingerprint_window` ~1085 vs. the cited 914/1026/1099); the `_start_browser` context/restore/signature anchors matched. Adapted by locating the functions by name.
