### PR TITLE
feat(browser): fail-closed proxy option, egress-IP binding, no-proxy TZ warning

### DIFF
--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -89,6 +89,31 @@ KNOWN_FLAGS: dict[str, str] = {
         "arrivals as bot signal. Operators who run high-volume tests "
         "against these platforms (or have measured no benefit) can "
         "disable globally or per-agent.",
+    # ── Proxy hardening ───────────────────────────────────────────────────
+    "BROWSER_REQUIRE_PROXY":
+        "true | false (DEFAULT FALSE) — fail closed when no proxy is "
+        "resolved for an agent. When true and the effective proxy config "
+        "is None, the browser REFUSES to launch for that agent rather "
+        "than egressing from the datacenter IP (a strong bot signal + a "
+        "deanonymization risk). Recoverable: the mesh re-pushes the proxy "
+        "config + resets, and the next launch succeeds. When false "
+        "(default) the historical fail-open behavior is preserved — launch "
+        "without a proxy and log a warning.",
+    "BROWSER_PROXY_EGRESS_IP_CHECK":
+        "true | false (DEFAULT FALSE) — when a proxy IS set, best-effort "
+        "probe the real egress IP through the proxy at launch and fold it "
+        "into the per-agent binding signature. Rotating residential pools "
+        "share ONE proxy URL across a changing egress IP, so a URL-only "
+        "signature never invalidates anti-bot bound cookies "
+        "(cf_clearance / datadome / _abck …) when the IP rotates — they "
+        "get replayed under a new IP for a guaranteed 403 + trust hit. "
+        "Probe failure / timeout falls back to the UA+URL signature "
+        "(never raises). Probed once per browser instance lifetime.",
+    "BROWSER_PROXY_EGRESS_IP_ECHO_URL":
+        "URL of an echo endpoint returning the caller's public IP as "
+        "plain text (default https://api.ipify.org). Fetched THROUGH the "
+        "agent's proxy with a 5s timeout when "
+        "BROWSER_PROXY_EGRESS_IP_CHECK is enabled.",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from src.browser.service import BrowserManager, BrowserPoolExhausted
+from src.browser.service import BrowserManager, BrowserPoolExhausted, ProxyRequiredError
 from src.shared.paths import resolve_under_root
 from src.shared.trace import TRACE_HEADER, current_trace_id
 from src.shared.types import AGENT_ID_RE_PATTERN
@@ -156,6 +156,27 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
                 "error": "browser_pool_full",
                 "message": str(exc),
                 "cap": exc.cap,
+                "retry_after_s": exc.retry_after_s,
+            },
+        )
+
+    # Fail-closed proxy handler — converts the typed exception raised by
+    # ``_start_browser`` when ``BROWSER_REQUIRE_PROXY`` is on and no proxy
+    # resolved into a structured, RECOVERABLE 503. The agent's model sees
+    # ``error="proxy_required"`` + a retry hint (the mesh pushes a proxy +
+    # resets shortly) instead of egressing from the datacenter IP or
+    # getting an opaque 500.
+    @app.exception_handler(ProxyRequiredError)
+    async def _proxy_required_handler(
+        request: Request, exc: ProxyRequiredError,
+    ):
+        return JSONResponse(
+            status_code=503,
+            headers={"Retry-After": str(exc.retry_after_s)},
+            content={
+                "error": "proxy_required",
+                "message": str(exc),
+                "agent_id": exc.agent_id,
                 "retry_after_s": exc.retry_after_s,
             },
         )

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -110,6 +110,37 @@ class BrowserPoolExhausted(RuntimeError):
         )
 
 
+class ProxyRequiredError(RuntimeError):
+    """Raised when ``BROWSER_REQUIRE_PROXY`` is on but no proxy resolved.
+
+    Fail-closed egress control. Without a proxy the container egresses
+    from the datacenter IP — a strong bot-cluster signal AND a
+    deanonymization risk (the real host IP leaks to every site the agent
+    visits). When the operator sets ``BROWSER_REQUIRE_PROXY=true`` and the
+    effective proxy config for an agent is ``None``, ``_start_browser``
+    refuses to launch and raises this instead of silently leaking.
+
+    Recoverable by design: the mesh pushes the per-agent proxy config
+    shortly after boot (which triggers a reset), so a later
+    ``get_or_start`` finds a proxy and launches normally. The browser
+    service FastAPI app maps this to HTTP 503 with ``Retry-After`` and a
+    structured ``error="proxy_required"`` envelope — the agent's model
+    sees a recoverable failure and can retry rather than an opaque 500.
+
+    The default is ``false`` (historical fail-open behavior); this only
+    fires when an operator opts in.
+    """
+
+    def __init__(self, *, agent_id: str, retry_after_s: int = 30):
+        self.agent_id = agent_id
+        self.retry_after_s = retry_after_s
+        super().__init__(
+            f"Browser start refused for '{agent_id}': BROWSER_REQUIRE_PROXY "
+            f"is on but no proxy is configured yet. The mesh should push a "
+            f"proxy + reset shortly; retry in ~{retry_after_s}s.",
+        )
+
+
 # ── §11.13 structured CAPTCHA detection envelope ──────────────────────────
 # Both helpers below produce literal-string enums (see plan §11.13). We do
 # NOT use Python ``enum.Enum``: the wire format is JSON strings, and a real
@@ -3129,6 +3160,14 @@ class BrowserManager:
         self._playwright = None
         self.redactor = CredentialRedactor()
         self._proxy_configs: dict[str, dict | None] = {}
+        # Per-agent probed egress IP (BROWSER_PROXY_EGRESS_IP_CHECK). Cached
+        # for the browser instance's lifetime so we probe once at launch,
+        # never per navigation. Cleared on proxy re-push and on stop so the
+        # next launch re-probes against the (possibly rotated) egress.
+        self._egress_ips: dict[str, str] = {}
+        # Agents already warned about a no-proxy locale/TZ mismatch, so the
+        # coarse coherence warning fires at most once per agent.
+        self._tz_mismatch_warned: set[str] = set()
         self.boot_id: str = str(uuid.uuid4())
         self._captcha_solver = get_solver()
         self._metrics_sink = metrics_sink
@@ -4141,6 +4180,27 @@ class BrowserManager:
         else:
             logger.info("Starting Camoufox for '%s' (profile=%s, no proxy)", agent_id, profile_dir)
 
+        # Fail-closed egress control. When the operator has opted into
+        # BROWSER_REQUIRE_PROXY, refuse to launch without a proxy rather
+        # than egressing from the datacenter IP. Raises BEFORE allocating a
+        # display slot / spawning the X stack so nothing leaks on refusal.
+        # Recoverable: the mesh pushes the proxy + resets, and the next
+        # get_or_start finds a proxy and launches normally.
+        self._enforce_require_proxy(agent_id, _proxy_opt)
+
+        if _proxy_opt is None:
+            # Fail-open (default): launching without a proxy means GeoIP is
+            # off and the timezone falls back to the container TZ. Warn once
+            # per agent on a coarse locale/TZ mismatch (no behavior change).
+            self._warn_locale_tz_mismatch(agent_id)
+        else:
+            # Best-effort real-egress-IP probe (BROWSER_PROXY_EGRESS_IP_CHECK,
+            # default off). Only meaningful when a proxy IS set; folds the
+            # returned IP into the binding signature so a rotated residential
+            # egress invalidates bound anti-bot cookies. Never raises — a
+            # probe failure falls back to the UA+URL-only signature.
+            await self._probe_egress_ip(agent_id, _proxy_opt)
+
         # ── Per-agent X stack ─────────────────────────────────────────────
         # Allocate a (display, port) slot and bring up Xvnc + Openbox +
         # unclutter sized to the picked window resolution.  Camoufox is
@@ -4973,6 +5033,9 @@ class BrowserManager:
                 agent_id, e,
             )
         self._session_snapshot_elapsed_s.pop(agent_id, None)
+        # Drop the probed egress IP — its lifetime is one browser instance.
+        # The next launch re-probes (proxy may have rotated meanwhile).
+        self._egress_ips.pop(agent_id, None)
         # ``context.close()`` can wedge indefinitely when the underlying
         # Camoufox child has hung (X11 stuck, deadlocked on its own
         # mutex, or refusing SIGTERM). A 10s ceiling lets one bad
@@ -5084,15 +5147,159 @@ class BrowserManager:
             self._proxy_configs.pop(agent_id, None)
         else:
             self._proxy_configs[agent_id] = config
+        # A new (or cleared) proxy means the previously-probed egress IP
+        # is stale. Drop it so the next launch re-probes against the new
+        # egress — this is the automatic-recovery path after a rotation
+        # or a proxy re-push.
+        self._egress_ips.pop(agent_id, None)
 
     def get_proxy_config(self, agent_id: str) -> dict | None:
         """Get stored proxy config for an agent, or None."""
         return self._proxy_configs.get(agent_id)
 
+    def _enforce_require_proxy(self, agent_id: str, proxy_opt: dict | None) -> None:
+        """Refuse to launch without a proxy when ``BROWSER_REQUIRE_PROXY`` is on.
+
+        Fail-closed egress control. ``proxy_opt`` is the resolved
+        Playwright-style proxy dict (``None`` when no proxy will be used).
+        When it is ``None`` AND the operator opted into
+        ``BROWSER_REQUIRE_PROXY`` (default off), raise
+        :class:`ProxyRequiredError` so the browser never egresses from the
+        datacenter IP. Otherwise return quietly — a configured proxy or the
+        default fail-open posture both proceed to launch.
+
+        Split out from ``_start_browser`` so the gate is unit-testable
+        without driving a full (camoufox-dependent) launch.
+        """
+        if proxy_opt is not None:
+            return
+        from src.browser.flags import get_bool
+        if not get_bool("BROWSER_REQUIRE_PROXY", False, agent_id=agent_id):
+            return
+        logger.error(
+            "Refusing to start browser for '%s': BROWSER_REQUIRE_PROXY is on "
+            "but no proxy is configured — would egress from the datacenter "
+            "IP. Waiting for the mesh to push a proxy.",
+            agent_id,
+        )
+        raise ProxyRequiredError(agent_id=agent_id)
+
+    async def _probe_egress_ip(self, agent_id: str, proxy_arg: dict) -> None:
+        """Best-effort probe of the real egress IP through ``proxy_arg``.
+
+        Gated on ``BROWSER_PROXY_EGRESS_IP_CHECK`` (default off). When on
+        AND a proxy is set, fetch the echo URL
+        (``BROWSER_PROXY_EGRESS_IP_ECHO_URL``, default
+        ``https://api.ipify.org``) THROUGH the proxy with a 5s timeout and
+        cache the returned IP in ``self._egress_ips[agent_id]``. The cached
+        IP is folded into :meth:`_build_session_binding_signature`, so a
+        rotating residential pool (one proxy URL, changing egress IP) now
+        invalidates bound anti-bot cookies instead of replaying them under
+        a new IP for a guaranteed 403 + trust hit.
+
+        NEVER raises: any failure / timeout / flag-off leaves the cache
+        untouched, and the signature transparently falls back to UA+URL
+        only. Probes once per instance lifetime — a cached entry short-
+        circuits, so this is never per-navigation. Proxy credentials are
+        redacted from every log via :func:`redact_url`.
+        """
+        from src.browser.flags import get_bool, get_str
+        if not get_bool("BROWSER_PROXY_EGRESS_IP_CHECK", False, agent_id=agent_id):
+            return
+        if agent_id in self._egress_ips:
+            return  # already probed for this instance lifetime
+        server = (proxy_arg or {}).get("server")
+        if not server:
+            return
+        # Build an httpx proxy URL, re-injecting credentials from the
+        # playwright-style proxy dict (they live in separate keys there).
+        import ipaddress  # noqa: PLC0415 — local import keeps startup cheap
+        from urllib.parse import quote, urlsplit, urlunsplit
+        try:
+            parsed = urlsplit(server)
+        except ValueError:
+            return
+        scheme = (parsed.scheme or "").lower()
+        # Only HTTP(S) proxies are probeable here. SOCKS was removed
+        # deliberately (unreliable through the browser service); a SOCKS
+        # URL would also need httpx's socks extra. Skip → UA+URL fallback.
+        if scheme not in ("http", "https"):
+            return
+        netloc = parsed.netloc
+        if "@" in netloc:
+            netloc = netloc.rsplit("@", 1)[-1]  # drop any embedded userinfo
+        username = proxy_arg.get("username")
+        password = proxy_arg.get("password")
+        if username:
+            userinfo = quote(str(username), safe="")
+            if password:
+                userinfo += ":" + quote(str(password), safe="")
+            netloc = f"{userinfo}@{netloc}"
+        proxy_url = urlunsplit((parsed.scheme, netloc, parsed.path or "", "", ""))
+        echo_url = get_str(
+            "BROWSER_PROXY_EGRESS_IP_ECHO_URL",
+            "https://api.ipify.org",
+            agent_id=agent_id,
+        )
+        import httpx  # noqa: PLC0415 — local import (see _is_httpx_timeout)
+        try:
+            async with httpx.AsyncClient(proxy=proxy_url, timeout=5.0) as client:
+                resp = await client.get(echo_url)
+                resp.raise_for_status()
+                text = (resp.text or "").strip()
+            ip = ipaddress.ip_address(text)  # validates shape; raises on junk
+        except Exception as e:
+            logger.debug(
+                "egress-ip probe for '%s' via %s failed: %s",
+                agent_id, redact_url(proxy_url), e,
+            )
+            return
+        self._egress_ips[agent_id] = str(ip)
+        logger.info(
+            "egress-ip probe for '%s' succeeded via %s; folded into "
+            "binding signature", agent_id, redact_url(proxy_url),
+        )
+        logger.debug("egress-ip for '%s': %s", agent_id, str(ip))
+
+    def _warn_locale_tz_mismatch(self, agent_id: str) -> None:
+        """Warn once per agent on a coarse no-proxy locale/TZ mismatch.
+
+        With no proxy configured, GeoIP is off (Camoufox only enables it
+        when a proxy is set), so ``Intl`` timezone falls back to the
+        container ``TZ`` (default ``America/New_York``). If the agent
+        advertises a non-US ``BROWSER_LOCALE`` (e.g. ``en-GB``) while the
+        container TZ is ``America/*``, anti-bot vendors see a locale/
+        timezone mismatch — a real coherence signal.
+
+        Coarse heuristic only (no exhaustive locale→TZ table): a non-US
+        BCP-47 region subtag paired with an ``America/*`` TZ. No behavior
+        change — this is a diagnostic WARNING recommending a per-agent
+        proxy (for GeoIP TZ coherence) or a matching container TZ.
+        """
+        if agent_id in self._tz_mismatch_warned:
+            return
+        locale = os.environ.get("BROWSER_LOCALE", "en-US")
+        tz = os.environ.get("TZ", "America/New_York")
+        # BCP-47 region subtag = the token after the first '-' (upper-cased).
+        region = ""
+        if "-" in locale:
+            region = locale.split("-", 1)[1].split("-", 1)[0].upper()
+        if region and region != "US" and tz.startswith("America/"):
+            self._tz_mismatch_warned.add(agent_id)
+            logger.warning(
+                "Agent '%s': no proxy set, so GeoIP is off and the browser "
+                "timezone falls back to the container TZ (%s), which does "
+                "not match BROWSER_LOCALE (%s, region=%s). Anti-bot vendors "
+                "flag a locale/timezone mismatch. Recommend a per-agent "
+                "proxy (for GeoIP timezone coherence) or a container TZ "
+                "matching the locale region.",
+                agent_id, tz, locale, region,
+            )
+
     def _build_session_binding_signature(
         self, agent_id: str,
     ) -> dict[str, str | None]:
-        """Build a (UA, proxy) signature for cookie-binding invalidation.
+        """Build a (UA, proxy[, egress-IP]) signature for cookie-binding invalidation.
 
         Cloudflare / DataDome / PerimeterX bind tokens like ``cf_clearance``
         to the original (UA, IP) tuple. Replaying them under a rotated
@@ -5101,13 +5308,17 @@ class BrowserManager:
         detect the change and drop bound cookies before seeding the
         context.
 
-        We hash UA + proxy server URL (not the egress IP itself, which is
-        often unknown to us). For most operators a proxy URL change is a
-        proxy provider change, which usually means a different egress IP
-        — close enough to gate cookie reuse on.
+        We always hash UA + proxy server URL. When
+        ``BROWSER_PROXY_EGRESS_IP_CHECK`` is enabled and a launch-time
+        probe resolved the real egress IP (cached in ``self._egress_ips``),
+        we ALSO include it under ``egress_ip`` — this is what makes a
+        rotating residential pool (one URL, changing egress IP) invalidate
+        bound cookies. When the probe is off or failed, the key is omitted
+        and the hash is identical to the historical UA+URL signature.
 
-        Returns ``{"ua": ..., "proxy": ...}`` with ``None`` for fields we
-        don't know. ``None`` keys are dropped before hashing so an
+        Returns ``{"ua": ..., "proxy": ...}`` (plus ``egress_ip`` when
+        known) with ``None`` for fields we don't know. Falsy / ``None``
+        keys are dropped before hashing (see ``_hash_signature``) so an
         operator who never configures a proxy gets stable hashes across
         snapshots.
         """
@@ -5120,7 +5331,11 @@ class BrowserManager:
                 or proxy_cfg.get("url")
                 or None
             )
-        return {"ua": ua, "proxy": proxy_url}
+        sig: dict[str, str | None] = {"ua": ua, "proxy": proxy_url}
+        egress_ip = self._egress_ips.get(agent_id)
+        if egress_ip:
+            sig["egress_ip"] = egress_ip
+        return sig
 
     async def get_status(self, agent_id: str) -> dict:
         """Get status for a specific agent's browser.

--- a/tests/test_browser_proxy_hardening.py
+++ b/tests/test_browser_proxy_hardening.py
@@ -1,0 +1,421 @@
+"""Tests for the browser proxy-hardening trio.
+
+Covers three independent knobs added on top of the always-on binding
+signature (see ``test_binding_cookie_coherence.py``):
+
+  1. ``BROWSER_REQUIRE_PROXY`` (default off) — fail-closed egress control.
+     ``BrowserManager._enforce_require_proxy`` raises ``ProxyRequiredError``
+     when the flag is on and no proxy resolved, so the browser never
+     egresses from the datacenter IP. Proxy present OR flag off → proceeds.
+
+  2. ``BROWSER_PROXY_EGRESS_IP_CHECK`` (default off) — fold the REAL egress
+     IP (probed through the proxy) into the binding signature so a rotating
+     residential pool (one URL, changing IP) invalidates bound anti-bot
+     cookies. Probe failure / timeout / flag-off falls back to the UA+URL
+     signature and never raises.
+
+  3. No-proxy locale/TZ coherence WARNING — a one-time-per-agent diagnostic
+     (no behavior change) when GeoIP is off and a coarse non-US-locale vs
+     ``America/*`` container-TZ mismatch is detected.
+
+``_start_browser`` itself imports camoufox (absent in the test env), so the
+gate + probe + warning are exercised through their extracted helpers,
+mirroring the helper-level style of ``test_binding_cookie_coherence.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+
+import httpx
+import pytest
+
+from src.browser import flags
+from src.browser import session_persistence as sp
+from src.browser.service import BrowserManager, ProxyRequiredError, _binding_signatures
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Clean flag layers + binding-signature state + the new flags' env."""
+    # Operator-settings layer: point at a nonexistent file so a real
+    # config/settings.json can't leak BROWSER_* flags into these tests.
+    monkeypatch.setenv("OPENLEGION_SETTINGS_PATH", str(tmp_path / "settings.json"))
+    saved_agents = dict(flags._agent_overrides)
+    flags._agent_overrides.clear()
+    flags.reload_operator_settings()
+    # Durable binding-signature sidecar → tmp; clear the in-memory global.
+    monkeypatch.setenv("FINGERPRINT_STATE_PATH", str(tmp_path / "fp_state.json"))
+    _binding_signatures.clear()
+    # Ensure the three new flags start unset (default posture).
+    for name in (
+        "BROWSER_REQUIRE_PROXY",
+        "BROWSER_PROXY_EGRESS_IP_CHECK",
+        "BROWSER_PROXY_EGRESS_IP_ECHO_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    flags._agent_overrides.clear()
+    flags._agent_overrides.update(saved_agents)
+    flags.reload_operator_settings()
+    _binding_signatures.clear()
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_proxyhard_")
+    return BrowserManager(profiles_dir=root)
+
+
+# ── httpx fakes ─────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAsyncClient:
+    """Records constructor kwargs + the GET url; returns a canned IP."""
+
+    last_proxy: str | None = None
+    last_timeout: object = None
+    last_url: str | None = None
+    ctor_calls: int = 0
+    get_calls: int = 0
+    reply_text: str = "203.0.113.7"
+
+    def __init__(self, *, proxy=None, timeout=None):
+        type(self).last_proxy = proxy
+        type(self).last_timeout = timeout
+        type(self).ctor_calls += 1
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        type(self).last_url = url
+        type(self).get_calls += 1
+        return _FakeResp(type(self).reply_text)
+
+
+def _install_client(monkeypatch, cls=_FakeAsyncClient):
+    cls.ctor_calls = 0
+    cls.get_calls = 0
+    monkeypatch.setattr("httpx.AsyncClient", cls)
+    return cls
+
+
+def _mismatch_warned(caplog) -> bool:
+    """True if the locale/timezone-mismatch WARNING was emitted.
+
+    Asserting on the specific message (not ``caplog.records`` emptiness)
+    keeps the no-warning tests robust to unrelated log noise — e.g. a
+    Playwright-less environment where ``BrowserManager`` construction logs
+    a CRITICAL about the artifact-stream API.
+    """
+    return any("locale/timezone mismatch" in r.getMessage() for r in caplog.records)
+
+
+# ── 1. BROWSER_REQUIRE_PROXY (fail-closed) ──────────────────────────────────
+
+
+class TestRequireProxy:
+    def test_flag_on_no_proxy_refuses(self, monkeypatch):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_REQUIRE_PROXY", "true")
+        with pytest.raises(ProxyRequiredError) as exc:
+            mgr._enforce_require_proxy("agent-refuse", None)
+        assert exc.value.agent_id == "agent-refuse"
+        assert exc.value.retry_after_s > 0
+        assert "agent-refuse" in str(exc.value)
+
+    def test_flag_on_proxy_present_allows(self, monkeypatch):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_REQUIRE_PROXY", "true")
+        # A resolved proxy → never refused, even with the flag on.
+        mgr._enforce_require_proxy("agent-ok", {"server": "http://proxy:8080"})
+
+    def test_flag_off_no_proxy_allows(self, monkeypatch):
+        mgr = _make_manager()
+        # Default off → historical fail-open behavior preserved.
+        mgr._enforce_require_proxy("agent-open", None)
+
+    def test_per_agent_override_gates_independently(self, monkeypatch):
+        mgr = _make_manager()
+        # Operator-wide off, but one agent opted in via the override layer.
+        flags.set_agent_override("agent-strict", "BROWSER_REQUIRE_PROXY", "true")
+        mgr._enforce_require_proxy("agent-loose", None)  # unaffected → no raise
+        with pytest.raises(ProxyRequiredError):
+            mgr._enforce_require_proxy("agent-strict", None)
+
+
+# ── 2. BROWSER_PROXY_EGRESS_IP_CHECK (fold egress IP into signature) ─────────
+
+
+class TestEgressIpProbe:
+    @pytest.mark.asyncio
+    async def test_probe_folds_egress_ip_into_signature(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-egress"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert mgr._egress_ips[agent] == "203.0.113.7"
+        assert client.get_calls == 1
+        assert client.last_timeout == 5.0
+        assert client.last_url == "https://api.ipify.org"  # default echo url
+
+        sig = mgr._build_session_binding_signature(agent)
+        assert sig.get("egress_ip") == "203.0.113.7"
+        with_ip = sp._hash_signature(sig)
+        assert with_ip != url_only  # egress IP changes the hash
+
+    @pytest.mark.asyncio
+    async def test_probe_injects_credentials_into_proxy_url(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-creds"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(
+            agent,
+            {"server": "http://proxy:8080", "username": "u", "password": "p@ss"},
+        )
+        # Creds live in separate keys of the playwright-style dict; the probe
+        # re-assembles a percent-encoded httpx proxy URL.
+        assert client.last_proxy == "http://u:p%40ss@proxy:8080"
+
+    @pytest.mark.asyncio
+    async def test_custom_echo_url_used(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-echo"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_ECHO_URL", "https://echo.example/ip")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert client.last_url == "https://echo.example/ip"
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_falls_back_no_exception(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-boom"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _BoomClient(_FakeAsyncClient):
+            async def get(self, url):
+                raise RuntimeError("proxy dead")
+
+        _install_client(monkeypatch, _BoomClient)
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+
+        # Must NOT raise.
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert agent not in mgr._egress_ips
+        sig = mgr._build_session_binding_signature(agent)
+        assert "egress_ip" not in sig
+        assert sp._hash_signature(sig) == url_only  # UA+URL fallback
+
+    @pytest.mark.asyncio
+    async def test_probe_timeout_falls_back(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-timeout"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _SlowClient(_FakeAsyncClient):
+            async def get(self, url):
+                raise httpx.ConnectTimeout("slow")
+
+        _install_client(monkeypatch, _SlowClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_junk_response_not_cached(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-junk"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _JunkClient(_FakeAsyncClient):
+            reply_text = "<html>not an ip</html>"
+
+        _install_client(monkeypatch, _JunkClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        # ipaddress.ip_address() rejects the body → nothing cached.
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_probe(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-off"
+        # Flag unset (default off).
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert client.ctor_calls == 0  # no httpx client constructed at all
+        assert agent not in mgr._egress_ips
+        sig = mgr._build_session_binding_signature(agent)
+        assert "egress_ip" not in sig
+        assert sp._hash_signature(sig) == url_only
+
+    @pytest.mark.asyncio
+    async def test_probe_cached_not_reprobed(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-cache"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert client.get_calls == 1  # second call short-circuits on cache
+
+    @pytest.mark.asyncio
+    async def test_socks_scheme_skipped(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-socks"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        client = _install_client(monkeypatch)
+        # SOCKS was removed deliberately; the probe skips non-HTTP schemes.
+        await mgr._probe_egress_ip(agent, {"server": "socks5://proxy:1080"})
+        assert client.ctor_calls == 0
+        assert agent not in mgr._egress_ips
+
+    def test_set_proxy_config_clears_cached_egress(self):
+        mgr = _make_manager()
+        agent = "agent-rotate"
+        mgr._egress_ips[agent] = "198.51.100.1"
+        mgr.set_proxy_config(agent, {"server": "http://new:8080"})
+        # A re-push means the old egress IP is stale → dropped for re-probe.
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_rotated_egress_ip_invalidates_bound_cookies(self, monkeypatch):
+        """Compose: a rotated egress IP flips the signature, so the always-on
+        coherence hook drops bound anti-bot cookies while keeping generics."""
+        mgr = _make_manager()
+        agent = "agent-compose"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://rot:8080"})
+
+        # Baseline persisted from a prior launch under an OLD egress IP.
+        mgr._egress_ips[agent] = "198.51.100.1"
+        old_sig = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        _binding_signatures[agent] = old_sig
+        # Simulate a stop clearing the cache, then a fresh launch probing a
+        # ROTATED egress IP behind the same proxy URL.
+        del mgr._egress_ips[agent]
+
+        class _RotClient(_FakeAsyncClient):
+            reply_text = "198.51.100.9"
+
+        _install_client(monkeypatch, _RotClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://rot:8080"})
+        assert mgr._egress_ips[agent] == "198.51.100.9"
+        assert sp._hash_signature(mgr._build_session_binding_signature(agent)) != old_sig
+
+        ctx = _FakeCookieContext([_cookie("cf_clearance"), _cookie("datadome"), _cookie("session")])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+        assert set(ctx.cleared_names) == {"cf_clearance", "datadome"}
+        assert "session" not in ctx.cleared_names
+
+
+# ── 3. No-proxy locale/TZ coherence warning ─────────────────────────────────
+
+
+class TestLocaleTzWarning:
+    def test_mismatch_warns_once(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-GB")
+        monkeypatch.setenv("TZ", "America/New_York")
+
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-tz")
+        assert any("locale/timezone mismatch" in r.getMessage() for r in caplog.records)
+
+        caplog.clear()
+        mgr._warn_locale_tz_mismatch("agent-tz")  # second call
+        assert not caplog.records  # one-time-per-agent
+
+    def test_us_locale_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-US")
+        monkeypatch.setenv("TZ", "America/New_York")
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-us")
+        # Assert the specific mismatch warning is absent (robust to unrelated
+        # log noise, e.g. a Playwright-less env's construction warning) and
+        # that no per-agent warned-marker was set.
+        assert not _mismatch_warned(caplog)
+        assert "agent-us" not in mgr._tz_mismatch_warned
+
+    def test_matching_region_tz_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-GB")
+        monkeypatch.setenv("TZ", "Europe/London")  # region-consistent → no warn
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-uk")
+        assert not _mismatch_warned(caplog)
+        assert "agent-uk" not in mgr._tz_mismatch_warned
+
+    def test_localeless_tag_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en")  # no region subtag
+        monkeypatch.setenv("TZ", "America/New_York")
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-noregion")
+        assert not _mismatch_warned(caplog)
+        assert "agent-noregion" not in mgr._tz_mismatch_warned
+
+
+# ── shared cookie-context fake (mirrors test_binding_cookie_coherence) ───────
+
+
+def _cookie(name: str) -> dict:
+    return {"name": name, "value": "v-" + name, "domain": ".example.com", "path": "/"}
+
+
+def _inst(agent_id: str, context):
+    import types
+
+    return types.SimpleNamespace(agent_id=agent_id, context=context)
+
+
+class _FakeCookieContext:
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)


### PR DESCRIPTION
Stacked on #1171 (`fix/browser-session-identity-coherence`) — **base this PR's diff against that branch**, not main. Extends the per-agent binding signature it introduced.

## What & why

Three proxy-hardening knobs, all default-off / behavior-preserving unless an operator opts in.

### 1. `BROWSER_REQUIRE_PROXY` (default `false`) — fail-closed egress
Today, a browser with no pushed proxy launches with `proxy=None` and only logs a warning, egressing from the datacenter IP — a strong bot signal and a deanonymization risk. When the flag is on and the resolved proxy is `None`, `_start_browser` now **refuses to launch** (new `ProxyRequiredError`, raised *before* any display slot / X stack is allocated so nothing leaks). The browser server maps it to a structured, **recoverable** HTTP 503 (`error="proxy_required"` + `Retry-After`), mirroring the `BrowserPoolExhausted` handler. Self-heals automatically: the mesh re-pushes the proxy + resets, and the next `get_or_start` launches normally. Fail-open behavior is unchanged when the flag is off.

### 2. `BROWSER_PROXY_EGRESS_IP_CHECK` (default `false`) + `BROWSER_PROXY_EGRESS_IP_ECHO_URL` (default `https://api.ipify.org`) — fold real egress IP into the binding signature
The signature hashed only UA + proxy URL, so a **rotating residential pool** (one URL, changing egress IP) never invalidated bound anti-bot cookies (`cf_clearance` / `datadome` / `_abck`) — they replayed under a new IP for a guaranteed 403 + trust hit. When enabled and a proxy is set, we now best-effort `GET` the echo URL **through the proxy** at launch (5s timeout, creds redacted via `redact_url`), cache the egress IP for the instance lifetime, and add it to the signature as `egress_ip`. #1171's coherence hook already diffs the signature, so a rotated IP now drops bound cookies automatically. Probe failure / timeout / flag-off **omits the key** — behavior-preserving fallback to the UA+URL signature; the probe never raises. Cache cleared on proxy re-push and on stop so a later launch re-probes.

### 3. No-proxy timezone-coherence warning (light)
Without a proxy, GeoIP is off and the timezone falls back to the container `TZ` (default `America/New_York`), which may not match `BROWSER_LOCALE`. On a coarse non-US-locale vs `America/*` TZ mismatch we log a one-time-per-agent WARNING recommending a per-agent proxy or a matching container TZ. **No behavior change.**

## Out of scope
SOCKS5 was **not** restored (removed deliberately in `c6c0ab6e` for reliability). The egress probe skips non-HTTP(S) proxy schemes.

## Tests
New `tests/test_browser_proxy_hardening.py` (19 tests): require-proxy refuse/allow/off + per-agent override; egress-IP fold/creds/custom-echo/failure/timeout/junk/flag-off/cache/SOCKS-skip/cache-clear + a compose test proving a rotated IP drives the coherence hook to drop bound cookies; TZ warning mismatch/US/matching/localeless. Helpers mock `httpx` + drive `set_proxy_config`, mirroring `test_binding_cookie_coherence.py` (helper-level, since `_start_browser` imports camoufox).

- `ruff check src/ tests/`: clean
- Full fast suite: **7782 passed, 27 skipped**

> Note: branch is `fix/browser-proxy-fail-closed-egress` — the plain `fix/browser-proxy-hardening` name already exists remotely as an unrelated stale branch (old PR #648), so I used a distinct name to avoid clobbering it.