### PR TITLE
feat(browser): human-parity actions — JS dialogs, permission grants + geolocation, drag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 *.egg
 *.so
 .venv/
+.venv
 venv/
 env/
 .env

--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/Users/jeff/Desktop/projects/open/engine/.venv

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/Users/jeff/Desktop/projects/open/engine/.venv

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1275,6 +1275,205 @@ async def browser_inspect_requests(
 
 
 @tool(
+    name="browser_set_dialog_policy",
+    description=(
+        "Decide in advance how native JavaScript dialogs "
+        "(alert / confirm / prompt / the 'Leave site?' beforeunload prompt) "
+        "are answered. Without this, dialogs are auto-DISMISSED, so any flow "
+        "gated on a confirm() or prompt() fails silently. Call this BEFORE the "
+        "action that triggers the dialog (e.g. a delete button that pops a "
+        "confirm). action='accept' clicks OK/Leave, action='dismiss' clicks "
+        "Cancel/Stay (default), action='respond' answers a window.prompt() with "
+        "'text' and accepts it. The policy persists until you change it. "
+        "Returns the LAST dialog message seen so you can read what a dialog said."
+    ),
+    parameters={
+        "action": {
+            "type": "string",
+            "description": (
+                "How to resolve dialogs: 'accept' (OK/confirm), 'dismiss' "
+                "(Cancel — default), or 'respond' (type 'text' into a "
+                "prompt() and accept)."
+            ),
+            "default": "dismiss",
+        },
+        "text": {
+            "type": "string",
+            "description": (
+                "Answer supplied to a window.prompt() when action='respond'. "
+                "Ignored for alert/confirm."
+            ),
+            "default": "",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_set_dialog_policy(
+    action: str = "dismiss", text: str = "", *, mesh_client=None,
+) -> dict:
+    """Set how native JS dialogs resolve for the current browser."""
+    return await _browser_command(
+        mesh_client, "set_dialog_policy",
+        {"action": action, "text": text},
+    )
+
+
+@tool(
+    name="browser_drag",
+    description=(
+        "Drag from a source to a target using a real (trusted) pointer "
+        "press-move-release. Provide EITHER two element refs from "
+        "browser_get_elements (source_ref + target_ref) OR two viewport "
+        "coordinate pairs (source_x/source_y + target_x/target_y, CSS pixels). "
+        "Refs win when both are given. Use for sliders, canvas handles, and "
+        "reordering. LIMITATION: this is a pointer drag — it does NOT populate "
+        "the HTML5 DataTransfer object, so widgets that rely on dragstart/"
+        "dragover/drop events (many React / SortableJS lists) will not respond. "
+        "This is a universal browser-automation limitation, not a bug."
+    ),
+    parameters={
+        "source_ref": {
+            "type": "string",
+            "description": "Ref of the element to drag FROM (e.g. 'e5').",
+            "default": "",
+        },
+        "target_ref": {
+            "type": "string",
+            "description": "Ref of the element to drop ONTO (e.g. 'e9').",
+            "default": "",
+        },
+        "source_x": {
+            "type": "number",
+            "description": "Start x (viewport CSS px). Use with source_y when not using refs.",
+        },
+        "source_y": {
+            "type": "number",
+            "description": "Start y (viewport CSS px).",
+        },
+        "target_x": {
+            "type": "number",
+            "description": "End x (viewport CSS px).",
+        },
+        "target_y": {
+            "type": "number",
+            "description": "End y (viewport CSS px).",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_drag(
+    source_ref: str = "", target_ref: str = "",
+    source_x: float | None = None, source_y: float | None = None,
+    target_x: float | None = None, target_y: float | None = None,
+    *, mesh_client=None,
+) -> dict:
+    """Drag from a source point to a target point."""
+    params: dict = {}
+    if source_ref and target_ref:
+        params["source_ref"] = source_ref
+        params["target_ref"] = target_ref
+    else:
+        params["source_x"] = source_x
+        params["source_y"] = source_y
+        params["target_x"] = target_x
+        params["target_y"] = target_y
+    return await _browser_command(mesh_client, "drag", params)
+
+
+@tool(
+    name="browser_grant_permissions",
+    description=(
+        "Grant browser permissions for the current site so a page stops "
+        "prompting (or silently failing). This browser is Firefox — only these "
+        "permissions can be granted: geolocation, notifications, "
+        "persistent-storage, push, screen-wake-lock. Camera and microphone are "
+        "NOT possible on this engine (that would require a Chromium browser) — "
+        "requesting them returns a clear error rather than crashing. Optionally "
+        "scope the grant to a specific origin (e.g. 'https://example.com'); "
+        "omit to grant for the active page."
+    ),
+    parameters={
+        "permissions": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Permission strings to grant. Valid on Firefox: geolocation, "
+                "notifications, persistent-storage, push, screen-wake-lock."
+            ),
+        },
+        "origin": {
+            "type": "string",
+            "description": (
+                "Optional origin to scope the grant to (e.g. "
+                "'https://example.com'). Omit for the current page."
+            ),
+            "default": "",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_grant_permissions(
+    permissions: list[str] | None = None, origin: str = "",
+    *, mesh_client=None,
+) -> dict:
+    """Grant Firefox-scoped browser permissions."""
+    params: dict = {"permissions": permissions or []}
+    if origin:
+        params["origin"] = origin
+    return await _browser_command(mesh_client, "grant_permissions", params)
+
+
+@tool(
+    name="browser_set_geolocation",
+    description=(
+        "Override the geographic coordinates the browser reports to pages "
+        "(the Geolocation API). Also auto-grants the geolocation permission. "
+        "Use for location-gated sites or to test region-specific behavior. "
+        "NOTE: this fleet's stealth profile disables the geo API "
+        "(geo.enabled=False) to avoid leaking a server's real location, so "
+        "with the default profile pages will NOT receive these coordinates — "
+        "an operator must enable geo in the stealth prefs first. The override "
+        "is still applied (never a silent no-op)."
+    ),
+    parameters={
+        "latitude": {
+            "type": "number",
+            "description": "Latitude in decimal degrees, e.g. 37.7749.",
+        },
+        "longitude": {
+            "type": "number",
+            "description": "Longitude in decimal degrees, e.g. -122.4194.",
+        },
+        "accuracy": {
+            "type": "number",
+            "description": "Optional accuracy in meters (e.g. 50).",
+        },
+        "origin": {
+            "type": "string",
+            "description": (
+                "Optional origin to scope the geolocation permission to. "
+                "Omit for the current page."
+            ),
+            "default": "",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_set_geolocation(
+    latitude: float, longitude: float,
+    accuracy: float | None = None, origin: str = "",
+    *, mesh_client=None,
+) -> dict:
+    """Override the browser's reported geolocation (Firefox geo.enabled caveat)."""
+    params: dict = {"latitude": latitude, "longitude": longitude}
+    if accuracy is not None:
+        params["accuracy"] = accuracy
+    if origin:
+        params["origin"] = origin
+    return await _browser_command(mesh_client, "set_geolocation", params)
+
+
+@tool(
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile, etc.) "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1386,7 +1386,7 @@ async def browser_drag(
         "Grant browser permissions for the current site so a page stops "
         "prompting (or silently failing). This browser is Firefox — only these "
         "permissions can be granted: geolocation, notifications, "
-        "persistent-storage, push, screen-wake-lock. Camera and microphone are "
+        "persistent-storage, push. Camera and microphone are "
         "NOT possible on this engine (that would require a Chromium browser) — "
         "requesting them returns a clear error rather than crashing. Optionally "
         "scope the grant to a specific origin (e.g. 'https://example.com'); "
@@ -1398,7 +1398,7 @@ async def browser_drag(
             "items": {"type": "string"},
             "description": (
                 "Permission strings to grant. Valid on Firefox: geolocation, "
-                "notifications, persistent-storage, push, screen-wake-lock."
+                "notifications, persistent-storage, push."
             ),
         },
         "origin": {

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -166,6 +166,8 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
         "browser_fill_form", "browser_open_tab", "browser_inspect_requests",
         "browser_detect_captcha", "browser_upload_file",
         "browser_solve_captcha", "browser_download",
+        "browser_set_dialog_policy", "browser_drag",
+        "browser_grant_permissions", "browser_set_geolocation",
     }),
 }
 

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -119,6 +119,8 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
             "browser_find_text", "browser_fill_form", "browser_open_tab",
             "browser_inspect_requests", "browser_detect_captcha",
             "browser_upload_file", "browser_solve_captcha", "browser_download",
+            "browser_set_dialog_policy", "browser_drag",
+            "browser_grant_permissions", "browser_set_geolocation",
         ),
     ),
 )

--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -250,6 +250,18 @@ def main() -> None:
             await _cost_counter.restore()
         except Exception as exc:
             logger.warning("captcha_cost_counter.restore failed: %s", exc)
+        # Durable fingerprint burn + per-agent binding-signature state.
+        # Without this restore, a fingerprint flagged "burned" reads clean
+        # after a restart while its poisoned cookies persist on disk, and
+        # the binding-coherence check has no prior signature to compare
+        # against. Non-fatal — a missing / corrupt sidecar restores empty.
+        from src.browser.service import (
+            load_fingerprint_state as _load_fp_state,
+        )
+        try:
+            await _load_fp_state()
+        except Exception as exc:
+            logger.warning("load_fingerprint_state failed: %s", exc)
         await manager.start_cleanup_loop()
         logger.info("Browser service ready (max=%d, idle_timeout=%dm)", _MAX_BROWSERS, _IDLE_TIMEOUT)
         yield
@@ -257,6 +269,13 @@ def main() -> None:
             await _cost_counter.snapshot()
         except Exception as exc:
             logger.warning("captcha_cost_counter.snapshot failed: %s", exc)
+        from src.browser.service import (
+            persist_fingerprint_state as _persist_fp_state,
+        )
+        try:
+            await _persist_fp_state()
+        except Exception as exc:
+            logger.warning("persist_fingerprint_state failed: %s", exc)
         # ``stop_all`` tears down every per-agent X stack via
         # ``_teardown_per_agent_x_stack``; no global processes to reap.
         await manager.stop_all()

--- a/src/browser/fingerprint_state.py
+++ b/src/browser/fingerprint_state.py
@@ -1,0 +1,253 @@
+"""Durable per-agent fingerprint-burn + binding-signature state.
+
+Two pieces of always-on browser identity state used to live only in
+``src/browser/service.py`` module globals, so they evaporated on a
+browser-service restart:
+
+  1. **Fingerprint-burn state** — the rolling accept/reject window, the
+     hard-burn set, and its reasons. When these were in-memory-only, a
+     fingerprint flagged "burned" (poisoned) read *clean* after a restart
+     even though the cookies that got it burned still sat on disk in the
+     Camoufox persistent profile. The operator would see a healthy agent
+     that instantly re-tripped every anti-bot vendor.
+
+  2. **Per-agent binding signatures** — a short opaque hash of the
+     ``(UA, proxy)`` identity the agent last launched with. The
+     always-on profile channel (``user_data_dir``) restores ALL cookies
+     on launch, including anti-bot trust tokens (``cf_clearance``,
+     ``datadome``, ``_abck`` …) that vendors bind to the original
+     ``(UA, IP)`` tuple. Replaying one of those under a rotated UA or a
+     different proxy egress is an instant 403 AND lowers the trust score
+     for the session lifetime. ``service._enforce_binding_cookie_coherence``
+     compares the persisted signature against the current one on each
+     launch and drops bound cookies on a mismatch — which requires the
+     signature to survive restarts.
+
+Both are identity state that must be durable, so they share one sidecar.
+
+The in-memory globals in ``service.py`` stay the source of truth
+in-process; this module is pure serialization. It deliberately does NOT
+import ``service`` (no cycle): callers pass the state in on
+:func:`snapshot` and receive a :class:`FingerprintState` back from
+:func:`restore`, then repopulate their own globals.
+
+Atomic-write + non-fatal-restore protocol mirrors
+:mod:`src.browser.captcha_cost_counter` (open ``0o600`` → ``fchmod`` →
+``json.dump`` → ``fsync`` → ``os.replace`` → ``chmod``). A missing or
+corrupt file restores empty rather than raising — a bad sidecar must
+never block browser-service startup.
+
+On-disk schema::
+
+    {
+      "version": 1,
+      "saved_at": <epoch seconds>,
+      "window": {"<agent_id>": [true, false, ...], ...},
+      "last_signal": {"<agent_id>": <epoch float>, ...},
+      "hard_burned": ["<agent_id>", ...],
+      "hard_burn_reason": {"<agent_id>": ["<vendor>", "<signal>"], ...},
+      "binding_signatures": {"<agent_id>": "<16-hex>", ...}
+    }
+
+Default path ``data/fingerprint_state.json``; env override
+``FINGERPRINT_STATE_PATH`` (consistent with ``CAPTCHA_COST_COUNTER_PATH``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.fingerprint_state")
+
+
+# Persistence path. Lives under ``data/`` alongside the captcha-cost
+# counter sidecar so all browser-service persistence stays under one
+# parent. Override-able via env for tests + custom deployments.
+_DEFAULT_PATH = "data/fingerprint_state.json"
+_SCHEMA_VERSION = 1
+# Default rolling-window bound. Mirrors ``service._FINGERPRINT_WINDOW_SIZE``
+# but kept as a local default so this module has NO import cycle back into
+# service.py. The live caller passes its own constant to :func:`restore`
+# (``window_maxlen=_FINGERPRINT_WINDOW_SIZE``) so the two can never drift
+# silently; the default only matters for standalone / test use.
+_DEFAULT_WINDOW_MAXLEN = 10
+
+
+def _state_path() -> Path:
+    """Return the fingerprint-state sidecar path (env-overridable)."""
+    return Path(os.environ.get("FINGERPRINT_STATE_PATH", _DEFAULT_PATH))
+
+
+@dataclass
+class FingerprintState:
+    """In-memory view of the persisted fingerprint state.
+
+    Field shapes match the ``service.py`` globals they seed so a caller
+    can ``.update()`` each straight in. ``window`` values are bounded
+    ``deque`` rebuilt with the caller-supplied ``maxlen`` on restore.
+    """
+
+    window: dict[str, deque] = field(default_factory=dict)
+    last_signal: dict[str, float] = field(default_factory=dict)
+    hard_burned: set[str] = field(default_factory=set)
+    hard_burn_reason: dict[str, tuple[str, str]] = field(default_factory=dict)
+    binding_signatures: dict[str, str] = field(default_factory=dict)
+
+
+def snapshot(
+    *,
+    window: Mapping[str, Iterable[bool]],
+    last_signal: Mapping[str, float],
+    hard_burned: Iterable[str],
+    hard_burn_reason: Mapping[str, Iterable[str]],
+    binding_signatures: Mapping[str, str],
+    path: Path | str | None = None,
+) -> bool:
+    """Atomically write the supplied state to ``path`` as JSON.
+
+    Synchronous by design: the ``service.py`` caller already holds the
+    fingerprint lock across its mutation, so there is no internal state
+    to guard here. Returns ``True`` on success; failures log + return
+    ``False`` rather than raise — the mutation / shutdown paths must not
+    abort because persistence failed (same posture as the captcha-cost
+    counter snapshot).
+
+    Atomic-write protocol: ``os.open`` the tmp sibling with mode 0o600
+    (no world-readable window), ``fchmod``, write + ``fsync``,
+    ``os.replace`` over the destination, then re-``chmod`` 0o600.
+    """
+    target = Path(path) if path else _state_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning("fingerprint_state snapshot: cannot create parent dir: %s", e)
+        return False
+
+    payload = {
+        "version": _SCHEMA_VERSION,
+        "saved_at": int(time.time()),
+        "window": {str(a): [bool(v) for v in w] for a, w in window.items()},
+        "last_signal": {str(a): float(t) for a, t in last_signal.items()},
+        "hard_burned": sorted(str(a) for a in hard_burned),
+        "hard_burn_reason": {str(a): [str(x) for x in r] for a, r in hard_burn_reason.items()},
+        "binding_signatures": {str(a): str(s) for a, s in binding_signatures.items()},
+    }
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        # Open with 0o600 from the start (umask-aware) so there is no
+        # world-readable window before the explicit chmod below.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        # We own ``fd`` until ``os.fdopen`` returns; ``fchmod`` / ``fdopen``
+        # can raise (OSError / MemoryError) which would leak the descriptor
+        # unless we close it in that narrow window. After fdopen returns the
+        # file object owns ``fd`` and the ``with`` block handles cleanup.
+        try:
+            os.fchmod(fd, 0o600)
+            fh = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        with fh:
+            json.dump(payload, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+        # ``os.replace`` preserves the destination's mode on most
+        # filesystems but Python's docs are not load-bearing on this;
+        # explicit chmod after replace ensures 0o600 regardless of
+        # whether the target pre-existed.
+        os.chmod(target, 0o600)
+    except OSError as e:
+        logger.warning("fingerprint_state snapshot failed: %s", e)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def restore(
+    path: Path | str | None = None,
+    *,
+    window_maxlen: int = _DEFAULT_WINDOW_MAXLEN,
+) -> FingerprintState:
+    """Load state from ``path`` if it exists, returning a :class:`FingerprintState`.
+
+    Missing / unreadable / malformed files are non-fatal — log + return an
+    empty state. Every field is parsed defensively; a malformed individual
+    entry is skipped rather than aborting the whole restore. ``window``
+    deques are rebuilt with ``maxlen=window_maxlen`` so the bound survives
+    the round-trip (the live caller passes ``_FINGERPRINT_WINDOW_SIZE``).
+    """
+    target = Path(path) if path else _state_path()
+    state = FingerprintState()
+    if not target.exists():
+        return state
+    try:
+        with open(target, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("fingerprint_state restore: %s — starting empty", e)
+        return state
+    if not isinstance(payload, dict):
+        logger.warning(
+            "fingerprint_state restore: unexpected payload type — starting empty",
+        )
+        return state
+    version = payload.get("version")
+    if version != _SCHEMA_VERSION:
+        logger.warning(
+            "fingerprint_state restore: unexpected version %r (expected %d) — starting empty",
+            version,
+            _SCHEMA_VERSION,
+        )
+        return state
+
+    window = payload.get("window")
+    if isinstance(window, dict):
+        for agent_id, values in window.items():
+            if not isinstance(agent_id, str) or not isinstance(values, list):
+                continue
+            state.window[agent_id] = deque(
+                (bool(v) for v in values),
+                maxlen=window_maxlen,
+            )
+
+    last_signal = payload.get("last_signal")
+    if isinstance(last_signal, dict):
+        for agent_id, ts in last_signal.items():
+            if isinstance(agent_id, str) and isinstance(ts, (int, float)):
+                state.last_signal[agent_id] = float(ts)
+
+    hard_burned = payload.get("hard_burned")
+    if isinstance(hard_burned, list):
+        state.hard_burned = {a for a in hard_burned if isinstance(a, str)}
+
+    reasons = payload.get("hard_burn_reason")
+    if isinstance(reasons, dict):
+        for agent_id, pair in reasons.items():
+            if not isinstance(agent_id, str):
+                continue
+            if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                state.hard_burn_reason[agent_id] = (str(pair[0]), str(pair[1]))
+
+    sigs = payload.get("binding_signatures")
+    if isinstance(sigs, dict):
+        for agent_id, sig in sigs.items():
+            if isinstance(agent_id, str) and isinstance(sig, str):
+                state.binding_signatures[agent_id] = sig
+
+    return state

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -89,6 +89,31 @@ KNOWN_FLAGS: dict[str, str] = {
         "arrivals as bot signal. Operators who run high-volume tests "
         "against these platforms (or have measured no benefit) can "
         "disable globally or per-agent.",
+    # ── Proxy hardening ───────────────────────────────────────────────────
+    "BROWSER_REQUIRE_PROXY":
+        "true | false (DEFAULT FALSE) — fail closed when no proxy is "
+        "resolved for an agent. When true and the effective proxy config "
+        "is None, the browser REFUSES to launch for that agent rather "
+        "than egressing from the datacenter IP (a strong bot signal + a "
+        "deanonymization risk). Recoverable: the mesh re-pushes the proxy "
+        "config + resets, and the next launch succeeds. When false "
+        "(default) the historical fail-open behavior is preserved — launch "
+        "without a proxy and log a warning.",
+    "BROWSER_PROXY_EGRESS_IP_CHECK":
+        "true | false (DEFAULT FALSE) — when a proxy IS set, best-effort "
+        "probe the real egress IP through the proxy at launch and fold it "
+        "into the per-agent binding signature. Rotating residential pools "
+        "share ONE proxy URL across a changing egress IP, so a URL-only "
+        "signature never invalidates anti-bot bound cookies "
+        "(cf_clearance / datadome / _abck …) when the IP rotates — they "
+        "get replayed under a new IP for a guaranteed 403 + trust hit. "
+        "Probe failure / timeout falls back to the UA+URL signature "
+        "(never raises). Probed once per browser instance lifetime.",
+    "BROWSER_PROXY_EGRESS_IP_ECHO_URL":
+        "URL of an echo endpoint returning the caller's public IP as "
+        "plain text (default https://api.ipify.org). Fetched THROUGH the "
+        "agent's proxy with a 5s timeout when "
+        "BROWSER_PROXY_EGRESS_IP_CHECK is enabled.",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from src.browser.service import BrowserManager, BrowserPoolExhausted
+from src.browser.service import BrowserManager, BrowserPoolExhausted, ProxyRequiredError
 from src.shared.paths import resolve_under_root
 from src.shared.trace import TRACE_HEADER, current_trace_id
 from src.shared.types import AGENT_ID_RE_PATTERN
@@ -156,6 +156,27 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
                 "error": "browser_pool_full",
                 "message": str(exc),
                 "cap": exc.cap,
+                "retry_after_s": exc.retry_after_s,
+            },
+        )
+
+    # Fail-closed proxy handler — converts the typed exception raised by
+    # ``_start_browser`` when ``BROWSER_REQUIRE_PROXY`` is on and no proxy
+    # resolved into a structured, RECOVERABLE 503. The agent's model sees
+    # ``error="proxy_required"`` + a retry hint (the mesh pushes a proxy +
+    # resets shortly) instead of egressing from the datacenter IP or
+    # getting an opaque 500.
+    @app.exception_handler(ProxyRequiredError)
+    async def _proxy_required_handler(
+        request: Request, exc: ProxyRequiredError,
+    ):
+        return JSONResponse(
+            status_code=503,
+            headers={"Retry-After": str(exc.retry_after_s)},
+            content={
+                "error": "proxy_required",
+                "message": str(exc),
+                "agent_id": exc.agent_id,
                 "retry_after_s": exc.retry_after_s,
             },
         )

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -904,18 +904,18 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
 
     @app.post("/browser/{agent_id}/set_geolocation")
     async def set_geolocation(agent_id: str, request: Request):
-        """Override the reported geolocation for the context."""
+        """Override the reported geolocation for the context.
+
+        Manager-side validates ``latitude`` / ``longitude`` and returns a
+        §2.3 envelope on bad input rather than raising HTTP 400, matching the
+        other human-parity browser actions (drag / set_dialog_policy).
+        """
         _verify_auth(request)
         body = await request.json()
-        lat = body.get("latitude")
-        lon = body.get("longitude")
-        if not isinstance(lat, (int, float)) or isinstance(lat, bool) \
-                or not isinstance(lon, (int, float)) or isinstance(lon, bool):
-            raise HTTPException(400, "latitude and longitude are required numbers")
         result = await manager.set_geolocation(
             agent_id,
-            latitude=float(lat),
-            longitude=float(lon),
+            latitude=body.get("latitude"),
+            longitude=body.get("longitude"),
             accuracy=body.get("accuracy"),
             origin=body.get("origin"),
         )

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -852,6 +852,76 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    # ── Human-parity actions ──────────────────────────────────────────────
+
+    @app.post("/browser/{agent_id}/set_dialog_policy")
+    async def set_dialog_policy(agent_id: str, request: Request):
+        """Set how native JS dialogs (alert/confirm/prompt) resolve.
+
+        Manager-side validates ``action`` and returns a §2.3 envelope on
+        bad input rather than raising HTTP 400, matching the other
+        default-allow browser actions.
+        """
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.set_dialog_policy(
+            agent_id,
+            action=body.get("action", "dismiss"),
+            text=body.get("text", "") or "",
+        )
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/drag")
+    async def drag(agent_id: str, request: Request):
+        """Drag from a source point to a target point (refs or coords)."""
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.drag(
+            agent_id,
+            source_ref=body.get("source_ref"),
+            target_ref=body.get("target_ref"),
+            source_x=body.get("source_x"),
+            source_y=body.get("source_y"),
+            target_x=body.get("target_x"),
+            target_y=body.get("target_y"),
+        )
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/grant_permissions")
+    async def grant_permissions(agent_id: str, request: Request):
+        """Grant Firefox-scoped browser permissions for the context."""
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.grant_permissions(
+            agent_id,
+            permissions=body.get("permissions") or [],
+            origin=body.get("origin"),
+        )
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/set_geolocation")
+    async def set_geolocation(agent_id: str, request: Request):
+        """Override the reported geolocation for the context."""
+        _verify_auth(request)
+        body = await request.json()
+        lat = body.get("latitude")
+        lon = body.get("longitude")
+        if not isinstance(lat, (int, float)) or isinstance(lat, bool) \
+                or not isinstance(lon, (int, float)) or isinstance(lon, bool):
+            raise HTTPException(400, "latitude and longitude are required numbers")
+        result = await manager.set_geolocation(
+            agent_id,
+            latitude=float(lat),
+            longitude=float(lon),
+            accuracy=body.get("accuracy"),
+            origin=body.get("origin"),
+        )
+        await _apply_delay()
+        return result
+
     # ── Session persistence (Phase 10 §20) ────────────────────────────────
     #
     # Read-only summary + operator clear endpoint. Mounted on the browser

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -8380,8 +8380,15 @@ class BrowserManager:
                     )
                 # Resolve source + target to (x, y) viewport points.
                 if source_ref and target_ref:
-                    src_loc = await self._locator_from_ref(inst, source_ref)
-                    tgt_loc = await self._locator_from_ref(inst, target_ref)
+                    # ``_locator_from_ref`` raises RefStale when the DOM has
+                    # shifted since snapshot; surface the ref_stale recovery
+                    # path (re-snapshot) rather than a misleading
+                    # ``service_unavailable`` from the outer handler.
+                    try:
+                        src_loc = await self._locator_from_ref(inst, source_ref)
+                        tgt_loc = await self._locator_from_ref(inst, target_ref)
+                    except RefStale as rs:
+                        return _err("ref_stale", str(rs))
                     if not src_loc:
                         return _err("ref_stale", f"Ref '{source_ref}' not found")
                     if not tgt_loc:
@@ -11788,13 +11795,19 @@ class BrowserManager:
                 await dialog.dismiss()
 
     def _attach_dialog_listeners(self, inst: CamoufoxInstance) -> None:
-        """Wire a native-dialog handler on the initial page + every new page.
+        """Wire a native-dialog handler on EVERY existing page + every new page.
 
         Playwright Python event callbacks are SYNC, but ``dialog.accept()`` /
         ``dialog.dismiss()`` are coroutines — so schedule ``_on_dialog`` via
-        ``asyncio.create_task``. The context-level ``page`` event covers
-        popups / ``window.open()`` / OAuth windows (mirrors
-        ``_attach_network_listeners``'s context-level wiring). Idempotent
+        ``asyncio.create_task``. Unlike ``request`` / ``response``, Playwright
+        has NO context-level ``dialog`` event, so the handler must be attached
+        per page. A persistent Camoufox profile can RESTORE multiple pages at
+        launch; wiring only ``inst.page`` (as this did before) left every other
+        restored tab with no handler, so a ``switch_tab`` to one of them meant
+        confirm/prompt dialogs were silently auto-dismissed. We therefore wire
+        the handler on all pages currently in ``inst.context.pages`` plus the
+        initial ``inst.page``, then use the context-level ``page`` event for
+        FUTURE pages (popups / ``window.open()`` / OAuth windows). Idempotent
         via ``_dialog_attached``; re-runs after RESET (fresh instance).
 
         Best-effort: a Camoufox build that doesn't surface the events must
@@ -11804,10 +11817,17 @@ class BrowserManager:
         if getattr(inst, "_dialog_attached", False):
             return
         try:
-            inst.page.on(
-                "dialog",
-                lambda d: asyncio.create_task(self._on_dialog(inst, d)),
-            )
+            # De-dupe by object identity so a page reached via both
+            # ``context.pages`` and ``inst.page`` is not wired twice (which
+            # would fire ``_on_dialog`` twice for one dialog).
+            existing = list(inst.context.pages)
+            if inst.page is not None and inst.page not in existing:
+                existing.append(inst.page)
+            for page in existing:
+                page.on(
+                    "dialog",
+                    lambda d: asyncio.create_task(self._on_dialog(inst, d)),
+                )
             inst.context.on(
                 "page",
                 lambda p: p.on(

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1480,15 +1480,17 @@ def _err(
 
 # Permission strings Playwright's FIREFOX engine can actually grant.
 # Chromium additionally supports camera / microphone / clipboard-read /
-# clipboard-write / etc., but Camoufox is Firefox — passing any of those
-# to ``context.grant_permissions`` raises ``Unknown permission``. We
-# allowlist to these five and reject the rest with a structured error so
+# clipboard-write / wake-lock / etc., but Camoufox is Firefox —
+# passing any of those to ``context.grant_permissions`` raises ``Unknown
+# permission``. Playwright's Firefox permission map (ffBrowser.js
+# ``webPermissionToProtocol``) covers exactly these four: geolocation,
+# notifications (→ desktop-notification), persistent-storage, and push. We
+# allowlist to those four and reject the rest with a structured error so
 # the agent gets a clear "not grantable on Firefox" message rather than a
 # raw Playwright exception. Camera / microphone are NOT possible on this
 # engine — that would require a Chromium stack (known limitation, not a bug).
 _FIREFOX_GRANTABLE_PERMISSIONS: frozenset[str] = frozenset({
-    "geolocation", "notifications", "persistent-storage",
-    "push", "screen-wake-lock",
+    "geolocation", "notifications", "persistent-storage", "push",
 })
 
 _MAX_SNAPSHOT_ELEMENTS = 200
@@ -7368,18 +7370,26 @@ class BrowserManager:
                 capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
-        await asyncio.sleep(click_dwell())
-        # 3. Move to the target with the button held — this is the drag.
-        await self._x11_move_to(inst, int(bx), int(by))
-        await asyncio.sleep(pre_click_settle())
-        # 4. Release.
-        await loop.run_in_executor(
-            None,
-            lambda: subprocess.run(
-                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3, env=inst.subprocess_env(),
-            ),
-        )
+        # Once button 1 is physically DOWN the release MUST always fire. The
+        # target move (``_x11_move_to``) genuinely raises — RuntimeError on an
+        # xdotool non-zero exit, ``subprocess.TimeoutExpired``, and
+        # ``asyncio.CancelledError`` passes through — so without a finally the
+        # button stays held for the rest of the session and the CDP fallback
+        # (a different input channel) cannot release it.
+        try:
+            await asyncio.sleep(click_dwell())
+            # 3. Move to the target with the button held — this is the drag.
+            await self._x11_move_to(inst, int(bx), int(by))
+            await asyncio.sleep(pre_click_settle())
+        finally:
+            # 4. Release.
+            await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
+                ),
+            )
 
     async def _x11_ensure_in_viewport(
         self, inst: CamoufoxInstance, locator, *,
@@ -8406,6 +8416,10 @@ class BrowserManager:
                     )
 
                 _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
+                # Track the path actually taken: an X11 drag that raises falls
+                # back to CDP, so ``_use_x11`` alone would mislabel a
+                # CDP-injected drag as "x11".
+                method = "x11" if _use_x11 else "cdp"
                 if _use_x11:
                     try:
                         await self._x11_drag(inst, ax, ay, bx, by)
@@ -8414,22 +8428,29 @@ class BrowserManager:
                             "X11 drag failed for '%s', falling back to CDP: %s",
                             agent_id, e,
                         )
+                        method = "cdp"
                         await inst.page.mouse.move(ax, ay)
                         await inst.page.mouse.down()
-                        await inst.page.mouse.move(bx, by)
-                        await inst.page.mouse.up()
+                        # A raised move must not leave the CDP button down.
+                        try:
+                            await inst.page.mouse.move(bx, by)
+                        finally:
+                            await inst.page.mouse.up()
                 else:
                     await inst.page.mouse.move(ax, ay)
                     await inst.page.mouse.down()
-                    await inst.page.mouse.move(bx, by)
-                    await inst.page.mouse.up()
+                    # A raised move must not leave the CDP button down.
+                    try:
+                        await inst.page.mouse.move(bx, by)
+                    finally:
+                        await inst.page.mouse.up()
                 await asyncio.sleep(action_delay())
                 return {
                     "success": True,
                     "data": {
                         "from": [ax, ay],
                         "to": [bx, by],
-                        "method": "x11" if _use_x11 else "cdp",
+                        "method": method,
                     },
                 }
             except Exception as e:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1478,6 +1478,19 @@ def _err(
     }
 
 
+# Permission strings Playwright's FIREFOX engine can actually grant.
+# Chromium additionally supports camera / microphone / clipboard-read /
+# clipboard-write / etc., but Camoufox is Firefox — passing any of those
+# to ``context.grant_permissions`` raises ``Unknown permission``. We
+# allowlist to these five and reject the rest with a structured error so
+# the agent gets a clear "not grantable on Firefox" message rather than a
+# raw Playwright exception. Camera / microphone are NOT possible on this
+# engine — that would require a Chromium stack (known limitation, not a bug).
+_FIREFOX_GRANTABLE_PERMISSIONS: frozenset[str] = frozenset({
+    "geolocation", "notifications", "persistent-storage",
+    "push", "screen-wake-lock",
+})
+
 _MAX_SNAPSHOT_ELEMENTS = 200
 _MAX_WALK_DEPTH = 50
 
@@ -2956,6 +2969,23 @@ class CamoufoxInstance:
         # SDK. ``secrets.token_hex`` is stdlib, no extra dependency.
         import secrets
         self._captcha_probe_var: str = f"__telemetry_{secrets.token_hex(4)}"
+        # Native JS dialog (alert / confirm / prompt / beforeunload) policy.
+        # Playwright auto-DISMISSES any dialog when no ``page.on("dialog")``
+        # handler is registered, so dialog-gated flows (a "Save changes?"
+        # beforeunload, a JS confirm() before delete, a window.prompt()) fail
+        # silently. ``_on_dialog`` (wired in ``_start_browser`` at the page
+        # AND context level so popups/OAuth windows are covered) resolves
+        # every dialog per this policy and records the last message so the
+        # agent can read what a dialog said. Default stays dismiss to match
+        # the pre-handler behavior — an agent must opt in to accept/respond.
+        self.dialog_policy: dict = {"action": "dismiss", "text": ""}
+        # Idempotency flag for ``BrowserManager._attach_dialog_listeners``.
+        self._dialog_attached: bool = False
+        # Most-recent native dialog message + type, e.g.
+        # ``{"message": "Delete this?", "type": "confirm"}``. None until the
+        # first dialog fires. Surfaced by ``set_dialog_policy`` so the agent
+        # can read a dialog it just triggered.
+        self.last_dialog_message: dict | None = None
 
     @property
     def lock(self) -> asyncio.Lock:
@@ -4410,6 +4440,15 @@ class BrowserManager:
             # because RESET drops the whole instance and the next get_or_start
             # creates a fresh one with ``_network_attached=False``.
             self._attach_network_listeners(inst)
+
+            # Native JS dialog handling. Without a ``page.on("dialog")``
+            # handler Playwright silently auto-dismisses every alert /
+            # confirm / prompt / beforeunload — dialog-gated flows then
+            # fail with no signal. Wire at the initial page AND the context
+            # ``page`` event (mirrors ``_attach_network_listeners``) so
+            # popups / OAuth windows are covered too. Idempotent; re-runs
+            # after RESET with a fresh instance.
+            self._attach_dialog_listeners(inst)
 
             # Discover the new X11 window for targeted focus.  ``wids_before``
             # is empty by construction — the agent's display was just spawned,
@@ -7293,6 +7332,55 @@ class BrowserManager:
             )
             await asyncio.sleep(x11_step_delay())
 
+    async def _x11_drag(
+        self, inst: CamoufoxInstance,
+        ax: int, ay: int, bx: int, by: int,
+    ) -> None:
+        """Drag from (ax, ay) to (bx, by) via xdotool — trusted-event path.
+
+        Move to the source, press button 1 DOWN, move to the target with
+        the button held (the held button + ``mousemove --window`` produces
+        real ``dragover`` / pointer-move events the browser marks
+        ``isTrusted=true``), then release. Mirrors the settle / dwell +
+        subprocess-env shape of ``_x11_click``.
+
+        Known limitation (documented on the ``drag`` action / tool): a
+        pointer-driven drag does NOT populate the HTML5 ``DataTransfer``
+        object, so widgets that key off ``dragstart`` / ``dragover`` /
+        ``drop`` (many React / SortableJS lists) won't respond. Works for
+        pointer-driven sliders and reordering.
+        """
+        wid = inst.x11_wid
+        if not wid:
+            raise RuntimeError("No X11 window ID — cannot use xdotool drag")
+        wid_s = str(wid)
+        loop = asyncio.get_running_loop()
+
+        # 1. Move to the source point with the natural Bezier trajectory.
+        await self._x11_move_to(inst, int(ax), int(ay))
+        # 2. Press and hold the primary button (dwell before + after so the
+        #    grab registers, matching a human press-then-drag).
+        await asyncio.sleep(pre_click_settle())
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
+            ),
+        )
+        await asyncio.sleep(click_dwell())
+        # 3. Move to the target with the button held — this is the drag.
+        await self._x11_move_to(inst, int(bx), int(by))
+        await asyncio.sleep(pre_click_settle())
+        # 4. Release.
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
+            ),
+        )
+
     async def _x11_ensure_in_viewport(
         self, inst: CamoufoxInstance, locator, *,
         timeout: int = _CLICK_TIMEOUT_MS,
@@ -8248,6 +8336,204 @@ class BrowserManager:
                 return {"success": True, "data": {"hovered": ref or selector}}
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+    async def drag(
+        self, agent_id: str,
+        source_ref: str | None = None, target_ref: str | None = None,
+        source_x: float | None = None, source_y: float | None = None,
+        target_x: float | None = None, target_y: float | None = None,
+    ) -> dict:
+        """Drag from a source point to a target point.
+
+        Accepts EITHER two refs (``source_ref`` / ``target_ref``, resolved
+        to Fitts'-Law-sampled points inside each element's bbox) OR two
+        coordinate pairs (``source_x/y`` → ``target_x/y``, viewport CSS
+        pixels). Refs take precedence when both are supplied.
+
+        Uses the trusted X11 path (``_x11_drag``) when the agent has an X11
+        window; falls back to CDP ``page.mouse.move/down/move/up``.
+
+        Known limitation: a pointer-based drag does NOT populate the HTML5
+        ``DataTransfer`` object, so ``dragstart`` / ``dragover`` / ``drop``
+        widgets (many React / SortableJS lists) won't respond — a universal
+        Playwright limitation. Works for pointer-driven sliders / reordering.
+        """
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if inst._user_control:
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until "
+                        "control is released.",
+                    )
+                # Resolve source + target to (x, y) viewport points.
+                if source_ref and target_ref:
+                    src_loc = await self._locator_from_ref(inst, source_ref)
+                    tgt_loc = await self._locator_from_ref(inst, target_ref)
+                    if not src_loc:
+                        return _err("ref_stale", f"Ref '{source_ref}' not found")
+                    if not tgt_loc:
+                        return _err("ref_stale", f"Ref '{target_ref}' not found")
+                    src_box = await src_loc.bounding_box()
+                    tgt_box = await tgt_loc.bounding_box()
+                    if not src_box or not tgt_box:
+                        return _err(
+                            "invalid_input",
+                            "source or target element has no bounding box "
+                            "(not visible)",
+                        )
+                    ax, ay = self._pick_click_target(src_box)
+                    bx, by = self._pick_click_target(tgt_box)
+                elif (
+                    source_x is not None and source_y is not None
+                    and target_x is not None and target_y is not None
+                ):
+                    for v in (source_x, source_y, target_x, target_y):
+                        if isinstance(v, bool) or not isinstance(v, (int, float)):
+                            return _err(
+                                "invalid_input",
+                                "drag coordinates must be numbers",
+                            )
+                    ax, ay = int(source_x), int(source_y)
+                    bx, by = int(target_x), int(target_y)
+                else:
+                    return _err(
+                        "invalid_input",
+                        "provide either (source_ref, target_ref) or "
+                        "(source_x, source_y, target_x, target_y)",
+                    )
+
+                _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
+                if _use_x11:
+                    try:
+                        await self._x11_drag(inst, ax, ay, bx, by)
+                    except Exception as e:
+                        logger.warning(
+                            "X11 drag failed for '%s', falling back to CDP: %s",
+                            agent_id, e,
+                        )
+                        await inst.page.mouse.move(ax, ay)
+                        await inst.page.mouse.down()
+                        await inst.page.mouse.move(bx, by)
+                        await inst.page.mouse.up()
+                else:
+                    await inst.page.mouse.move(ax, ay)
+                    await inst.page.mouse.down()
+                    await inst.page.mouse.move(bx, by)
+                    await inst.page.mouse.up()
+                await asyncio.sleep(action_delay())
+                return {
+                    "success": True,
+                    "data": {
+                        "from": [ax, ay],
+                        "to": [bx, by],
+                        "method": "x11" if _use_x11 else "cdp",
+                    },
+                }
+            except Exception as e:
+                return _err("service_unavailable", str(e))
+
+    async def grant_permissions(
+        self, agent_id: str, permissions: list[str] | None = None,
+        origin: str | None = None,
+    ) -> dict:
+        """Grant browser permissions for the context (Firefox-scoped).
+
+        Only Firefox-grantable strings are accepted (see
+        :data:`_FIREFOX_GRANTABLE_PERMISSIONS`); anything else — notably
+        camera / microphone / clipboard — is rejected with a structured
+        error BEFORE Playwright can raise a raw ``Unknown permission``.
+        """
+        perms = permissions or []
+        if not isinstance(perms, list) or not perms:
+            return _err(
+                "invalid_input",
+                "permissions must be a non-empty list of strings",
+            )
+        invalid = [
+            p for p in perms
+            if not isinstance(p, str) or p not in _FIREFOX_GRANTABLE_PERMISSIONS
+        ]
+        if invalid:
+            return _err(
+                "invalid_input",
+                f"permission {invalid[0]!r} is not grantable on the Firefox "
+                f"engine (camera / microphone are not possible here); "
+                f"grantable: {sorted(_FIREFOX_GRANTABLE_PERMISSIONS)}",
+            )
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if origin:
+                    await inst.context.grant_permissions(perms, origin=origin)
+                else:
+                    await inst.context.grant_permissions(perms)
+                return {
+                    "success": True,
+                    "data": {"granted": perms, "origin": origin},
+                }
+            except Exception as e:
+                return _err("service_unavailable", str(e))
+
+    async def set_geolocation(
+        self, agent_id: str, latitude: float, longitude: float,
+        accuracy: float | None = None, origin: str | None = None,
+    ) -> dict:
+        """Override the browser's reported geolocation.
+
+        Sets the context geolocation AND grants the ``geolocation``
+        permission (Firefox requires BOTH to deliver coords). Note: the
+        stealth profile sets ``geo.enabled=False`` (``stealth.py``), which
+        disables the Firefox geo API entirely — with that pref on, pages
+        will NOT receive these coordinates. This action still wires the
+        override (never silently no-ops); an operator who needs live geo
+        must flip ``geo.enabled`` in the stealth prefs.
+        """
+        for v in (latitude, longitude):
+            if isinstance(v, bool) or not isinstance(v, (int, float)):
+                return _err(
+                    "invalid_input", "latitude and longitude must be numbers",
+                )
+        if accuracy is not None and (
+            isinstance(accuracy, bool) or not isinstance(accuracy, (int, float))
+        ):
+            return _err("invalid_input", "accuracy must be a number")
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                geo: dict = {
+                    "latitude": float(latitude),
+                    "longitude": float(longitude),
+                }
+                if accuracy is not None:
+                    geo["accuracy"] = float(accuracy)
+                await inst.context.set_geolocation(geo)
+                # Firefox only delivers coords when the origin has the
+                # geolocation permission too.
+                if origin:
+                    await inst.context.grant_permissions(
+                        ["geolocation"], origin=origin,
+                    )
+                else:
+                    await inst.context.grant_permissions(["geolocation"])
+                return {
+                    "success": True,
+                    "data": {
+                        "geolocation": geo,
+                        # Truth-in-advertising: warn the agent that the
+                        # stealth pref may swallow the override.
+                        "note": (
+                            "geo.enabled=False in the stealth profile may "
+                            "block delivery of these coordinates to pages"
+                        ),
+                    },
+                }
+            except Exception as e:
+                return _err("service_unavailable", str(e))
 
     async def type_text(self, agent_id: str, ref: str | None = None, selector: str | None = None,
                         text: str = "", clear: bool = True,
@@ -11442,6 +11728,105 @@ class BrowserManager:
                     pass
                 inst.page = previous_page
                 return _err("service_unavailable", "open_tab failed")
+
+    # ── Native JS dialog handling ───────────────────────────────
+
+    async def _on_dialog(self, inst: CamoufoxInstance, dialog) -> None:
+        """Resolve a native JS dialog per ``inst.dialog_policy``.
+
+        MUST always resolve the dialog (accept or dismiss) — a pending
+        dialog blocks the page's JS event loop indefinitely, so a handler
+        that returns without resolving hangs the tab. Records the message
+        + type first so the agent can read what the dialog said via
+        ``set_dialog_policy`` even when the policy dismisses it.
+
+        Best-effort: any exception is swallowed after a final dismiss
+        attempt so a listener error can't wedge the page.
+        """
+        try:
+            inst.last_dialog_message = {
+                "message": getattr(dialog, "message", "") or "",
+                "type": getattr(dialog, "type", "") or "",
+            }
+        except Exception:
+            inst.last_dialog_message = None
+        policy = inst.dialog_policy or {}
+        action = policy.get("action", "dismiss")
+        try:
+            if action in ("accept", "respond"):
+                # ``respond`` supplies prompt() text; accept() ignores text
+                # for alert/confirm. Empty string → None so Firefox uses the
+                # prompt's defaultValue rather than blanking it.
+                await dialog.accept(policy.get("text") or None)
+            else:
+                await dialog.dismiss()
+        except Exception as e:
+            logger.debug("dialog handler failed for '%s': %s", inst.agent_id, e)
+            # Last-ditch: never leave the dialog pending or the page hangs.
+            with contextlib.suppress(Exception):
+                await dialog.dismiss()
+
+    def _attach_dialog_listeners(self, inst: CamoufoxInstance) -> None:
+        """Wire a native-dialog handler on the initial page + every new page.
+
+        Playwright Python event callbacks are SYNC, but ``dialog.accept()`` /
+        ``dialog.dismiss()`` are coroutines — so schedule ``_on_dialog`` via
+        ``asyncio.create_task``. The context-level ``page`` event covers
+        popups / ``window.open()`` / OAuth windows (mirrors
+        ``_attach_network_listeners``'s context-level wiring). Idempotent
+        via ``_dialog_attached``; re-runs after RESET (fresh instance).
+
+        Best-effort: a Camoufox build that doesn't surface the events must
+        not take the browser down — the default auto-dismiss behavior
+        simply persists.
+        """
+        if getattr(inst, "_dialog_attached", False):
+            return
+        try:
+            inst.page.on(
+                "dialog",
+                lambda d: asyncio.create_task(self._on_dialog(inst, d)),
+            )
+            inst.context.on(
+                "page",
+                lambda p: p.on(
+                    "dialog",
+                    lambda d: asyncio.create_task(self._on_dialog(inst, d)),
+                ),
+            )
+        except Exception as e:
+            logger.debug(
+                "Dialog listener wiring failed for '%s': %s", inst.agent_id, e,
+            )
+            return
+        inst._dialog_attached = True
+
+    async def set_dialog_policy(
+        self, agent_id: str, action: str = "dismiss", text: str = "",
+    ) -> dict:
+        """Set how native JS dialogs (alert/confirm/prompt/beforeunload) resolve.
+
+        ``action`` ∈ {accept, dismiss, respond}. ``respond`` supplies
+        ``text`` as the ``window.prompt()`` answer. Returns the last dialog
+        message observed so the agent can read what a dialog said after
+        triggering it.
+        """
+        if action not in ("accept", "dismiss", "respond"):
+            return _err(
+                "invalid_input",
+                f"action must be one of accept/dismiss/respond, got {action!r}",
+            )
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            inst.dialog_policy = {"action": action, "text": text or ""}
+            return {
+                "success": True,
+                "data": {
+                    "policy": {"action": action, "text": text or ""},
+                    "last_dialog": inst.last_dialog_message,
+                },
+            }
 
     # ── §9.1 Network inspection ─────────────────────────────────
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -888,6 +888,15 @@ _fingerprint_hard_burned: set[str] = set()
 # {agent_id: (vendor, header_or_status)} — last hard-block reason captured
 # for operator visibility on the dashboard. Operator-only; never logged.
 _fingerprint_hard_burn_reason: dict[str, tuple[str, str]] = {}
+# {agent_id: signature} — short opaque hash of the (UA, proxy) identity the
+# agent last launched with, written by ``_enforce_binding_cookie_coherence``.
+# The always-on Camoufox persistent profile restores ALL cookies on launch,
+# so a changed identity must drop anti-bot bound cookies (cf_clearance et al.)
+# BEFORE they replay under the new fingerprint. Persisted alongside the burn
+# state so the signature survives a browser-service restart (Constraint #8:
+# a new module-level global, but lock-protected identity state consistent
+# with the surrounding fingerprint globals). Guarded by ``_fingerprint_lock``.
+_binding_signatures: dict[str, str] = {}
 
 
 def _get_fingerprint_lock() -> asyncio.Lock:
@@ -917,7 +926,11 @@ async def _record_fingerprint_outcome(
             _fingerprint_window[agent_id] = bucket
         bucket.append(bool(rejected))
         _fingerprint_last_signal[agent_id] = time.time()
-        return _is_burned_locked(bucket)
+        burned = _is_burned_locked(bucket)
+        # Persist across restarts so a poisoned window can't read clean
+        # after a browser-service bounce while its cookies survive on disk.
+        _snapshot_fingerprint_state_locked()
+        return burned
 
 
 def _is_burned_locked(bucket: deque[bool]) -> bool:
@@ -1027,6 +1040,8 @@ async def _force_fingerprint_burn(
         _fingerprint_hard_burned.add(agent_id)
         _fingerprint_hard_burn_reason[agent_id] = (vendor, reason)
         _fingerprint_last_signal[agent_id] = time.time()
+        # Persist so a vendor-confirmed hard block survives a restart.
+        _snapshot_fingerprint_state_locked()
     return not already
 
 
@@ -1100,7 +1115,61 @@ async def _reset_fingerprint_window(agent_id: str) -> bool:
         _fingerprint_last_signal.pop(agent_id, None)
         _fingerprint_hard_burned.discard(agent_id)
         _fingerprint_hard_burn_reason.pop(agent_id, None)
+        # Persist so the cleared slate survives a restart. Binding
+        # signatures are intentionally left intact — a manual reset is a
+        # burn-state concern; identity coherence is handled on next launch.
+        _snapshot_fingerprint_state_locked()
     return had_state
+
+
+def _snapshot_fingerprint_state_locked() -> bool:
+    """Durably persist the fingerprint burn + binding-signature state.
+
+    Caller MUST hold :func:`_get_fingerprint_lock`. Best-effort —
+    :func:`fingerprint_state.snapshot` logs + returns ``False`` on any I/O
+    failure and never raises, so a persistence hiccup can't break the
+    low-frequency mutation path that calls this (post-solve outcome,
+    hard-burn, operator reset, identity-signature update). Synchronous
+    file I/O under the async lock is acceptable at this call frequency
+    and mirrors the captcha-cost counter's snapshot posture.
+    """
+    from src.browser import fingerprint_state as _fp_state
+    return _fp_state.snapshot(
+        window=_fingerprint_window,
+        last_signal=_fingerprint_last_signal,
+        hard_burned=_fingerprint_hard_burned,
+        hard_burn_reason=_fingerprint_hard_burn_reason,
+        binding_signatures=_binding_signatures,
+    )
+
+
+async def persist_fingerprint_state() -> bool:
+    """Snapshot the fingerprint burn + binding-signature state (shutdown hook)."""
+    async with _get_fingerprint_lock():
+        return _snapshot_fingerprint_state_locked()
+
+
+async def load_fingerprint_state() -> None:
+    """Restore the fingerprint burn + binding-signature state (startup hook).
+
+    Non-fatal: a missing / corrupt sidecar restores empty. Repopulates
+    the in-process globals in place so existing references stay valid.
+    Without this, a fingerprint flagged "burned" would read clean after a
+    browser-service restart while its poisoned cookies persisted on disk.
+    """
+    from src.browser import fingerprint_state as _fp_state
+    loaded = _fp_state.restore(window_maxlen=_FINGERPRINT_WINDOW_SIZE)
+    async with _get_fingerprint_lock():
+        _fingerprint_window.clear()
+        _fingerprint_window.update(loaded.window)
+        _fingerprint_last_signal.clear()
+        _fingerprint_last_signal.update(loaded.last_signal)
+        _fingerprint_hard_burned.clear()
+        _fingerprint_hard_burned.update(loaded.hard_burned)
+        _fingerprint_hard_burn_reason.clear()
+        _fingerprint_hard_burn_reason.update(loaded.hard_burn_reason)
+        _binding_signatures.clear()
+        _binding_signatures.update(loaded.binding_signatures)
 
 
 # ── §22 — fingerprint audit aggregator (per-minute, no URL leak) ──────────
@@ -4262,6 +4331,17 @@ class BrowserManager:
             # through to Firefox (it owns the profile dir directly). The end
             # state is the same: cookies merged into the cookie jar; localStorage
             # seeded on each origin's first navigation via the init script.
+            #
+            # ALWAYS-ON identity coherence — runs on the persistent-profile
+            # channel regardless of BROWSER_SESSION_PERSISTENCE_ENABLED. The
+            # Camoufox profile dir restored every cookie above, including
+            # anti-bot trust tokens bound to the previous (UA, proxy). If the
+            # identity signature changed, drop those bound cookies here BEFORE
+            # any navigation so a rotated fingerprint can't replay a stale
+            # token into an instant 403 + trust-score hit. Must run before the
+            # opt-in sidecar restore so a re-added-then-invalidated ordering
+            # can't leak a bound cookie.
+            await self._enforce_binding_cookie_coherence(inst)
             await self._maybe_restore_session(inst)
 
             # §9.1 wire request listeners at the BrowserContext level so new
@@ -4333,6 +4413,135 @@ class BrowserManager:
             with contextlib.suppress(Exception):
                 await self._teardown_per_agent_x_stack(teardown_target)
             raise
+
+    async def _enforce_binding_cookie_coherence(
+        self, inst: CamoufoxInstance,
+    ) -> None:
+        """Drop anti-bot bound cookies from the profile when identity changed.
+
+        Camoufox's ``persistent_context=True`` profile dir (the always-on
+        channel) restores EVERY cookie on launch — including anti-bot trust
+        tokens (``cf_clearance``, ``datadome``, ``_abck`` …) that Cloudflare /
+        DataDome / PerimeterX bind to the original ``(UA, egress-IP)`` tuple.
+        Replaying one under a rotated UA or a different proxy is a guaranteed
+        403 AND lowers the trust score for the session lifetime. The opt-in
+        ``session_persistence`` sidecar already drops these on a signature
+        change; this mirrors that safety onto the always-on profile channel
+        so it runs regardless of ``BROWSER_SESSION_PERSISTENCE_ENABLED``.
+
+        Flow: compute the current ``(UA, proxy)`` signature; compare against
+        the per-agent signature persisted last launch. On a mismatch, drop
+        only the bound vendor cookies (never generic session cookies). Then
+        persist the current signature as the new baseline — including on the
+        first launch, when nothing is dropped. Best-effort throughout: any
+        failure is logged and the browser starts anyway.
+        """
+        from src.browser import session_persistence as _sp
+
+        agent_id = inst.agent_id
+        context = inst.context
+        try:
+            current_sig = _sp._hash_signature(
+                self._build_session_binding_signature(agent_id),
+            )
+        except Exception as e:
+            logger.debug(
+                "binding-coherence: signature build failed for '%s': %s",
+                agent_id, e,
+            )
+            return
+
+        async with _get_fingerprint_lock():
+            persisted_sig = _binding_signatures.get(agent_id)
+
+        # Only drop when we have a prior signature AND it changed. First
+        # launch (no prior signature) drops nothing but still records the
+        # baseline below.
+        if persisted_sig is not None and persisted_sig != current_sig:
+            try:
+                cookies = await context.cookies()
+            except Exception as e:
+                logger.warning(
+                    "binding-coherence: context.cookies() failed for '%s': %s",
+                    agent_id, e,
+                )
+                cookies = None
+            if cookies:
+                bound_names: list[str] = []
+                vendors: list[str] = []
+                for cookie in cookies:
+                    if not isinstance(cookie, dict):
+                        continue
+                    name = cookie.get("name")
+                    family = _sp.cookie_binding_vendor(name)
+                    if family is not None:
+                        bound_names.append(name)
+                        if family not in vendors:
+                            vendors.append(family)
+                if bound_names:
+                    dropped = await self._clear_bound_cookies(
+                        context, bound_names, cookies,
+                    )
+                    if dropped:
+                        logger.info(
+                            "binding-coherence for '%s': identity signature "
+                            "changed (persisted=%s current=%s); dropped %d "
+                            "cookie(s) bound to vendors: %s",
+                            agent_id, persisted_sig, current_sig, dropped,
+                            ",".join(vendors) or "(none)",
+                        )
+
+        # Record the current signature as the new baseline (first-run
+        # included) and durably persist it next to the burn state.
+        async with _get_fingerprint_lock():
+            _binding_signatures[agent_id] = current_sig
+            try:
+                _snapshot_fingerprint_state_locked()
+            except Exception as e:
+                logger.debug(
+                    "binding-coherence: state snapshot failed for '%s': %s",
+                    agent_id, e,
+                )
+
+    async def _clear_bound_cookies(
+        self, context, bound_names: list[str], all_cookies: list,
+    ) -> int:
+        """Delete the named cookies from ``context``; return the count removed.
+
+        Prefers Playwright's targeted ``clear_cookies(name=...)`` (>=1.43;
+        our pin is ~1.51). If that filtered form is unavailable (older
+        Playwright raising ``TypeError`` on the kwarg), falls back to
+        clearing ALL cookies then re-adding the non-bound subset — the same
+        end state (only bound cookies gone) via a coarser path.
+        """
+        bound_set = set(bound_names)
+        try:
+            for name in bound_names:
+                await context.clear_cookies(name=name)
+            return len(bound_names)
+        except TypeError:
+            # Older Playwright: no ``name`` kwarg. Fall through to the
+            # clear-all + re-add-non-bound path below.
+            pass
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: targeted clear_cookies failed (%s); "
+                "falling back to clear-all + re-add", e,
+            )
+        try:
+            await context.clear_cookies()
+            keep = [
+                c for c in all_cookies
+                if isinstance(c, dict) and c.get("name") not in bound_set
+            ]
+            if keep:
+                await context.add_cookies(keep)
+            return len(bound_names)
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: fallback clear/re-add failed: %s", e,
+            )
+            return 0
 
     async def _maybe_restore_session(self, inst: CamoufoxInstance) -> None:
         """§20 — restore cookies + localStorage from the per-agent sidecar.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -110,6 +110,37 @@ class BrowserPoolExhausted(RuntimeError):
         )
 
 
+class ProxyRequiredError(RuntimeError):
+    """Raised when ``BROWSER_REQUIRE_PROXY`` is on but no proxy resolved.
+
+    Fail-closed egress control. Without a proxy the container egresses
+    from the datacenter IP — a strong bot-cluster signal AND a
+    deanonymization risk (the real host IP leaks to every site the agent
+    visits). When the operator sets ``BROWSER_REQUIRE_PROXY=true`` and the
+    effective proxy config for an agent is ``None``, ``_start_browser``
+    refuses to launch and raises this instead of silently leaking.
+
+    Recoverable by design: the mesh pushes the per-agent proxy config
+    shortly after boot (which triggers a reset), so a later
+    ``get_or_start`` finds a proxy and launches normally. The browser
+    service FastAPI app maps this to HTTP 503 with ``Retry-After`` and a
+    structured ``error="proxy_required"`` envelope — the agent's model
+    sees a recoverable failure and can retry rather than an opaque 500.
+
+    The default is ``false`` (historical fail-open behavior); this only
+    fires when an operator opts in.
+    """
+
+    def __init__(self, *, agent_id: str, retry_after_s: int = 30):
+        self.agent_id = agent_id
+        self.retry_after_s = retry_after_s
+        super().__init__(
+            f"Browser start refused for '{agent_id}': BROWSER_REQUIRE_PROXY "
+            f"is on but no proxy is configured yet. The mesh should push a "
+            f"proxy + reset shortly; retry in ~{retry_after_s}s.",
+        )
+
+
 # ── §11.13 structured CAPTCHA detection envelope ──────────────────────────
 # Both helpers below produce literal-string enums (see plan §11.13). We do
 # NOT use Python ``enum.Enum``: the wire format is JSON strings, and a real
@@ -3129,6 +3160,14 @@ class BrowserManager:
         self._playwright = None
         self.redactor = CredentialRedactor()
         self._proxy_configs: dict[str, dict | None] = {}
+        # Per-agent probed egress IP (BROWSER_PROXY_EGRESS_IP_CHECK). Cached
+        # for the browser instance's lifetime so we probe once at launch,
+        # never per navigation. Cleared on proxy re-push and on stop so the
+        # next launch re-probes against the (possibly rotated) egress.
+        self._egress_ips: dict[str, str] = {}
+        # Agents already warned about a no-proxy locale/TZ mismatch, so the
+        # coarse coherence warning fires at most once per agent.
+        self._tz_mismatch_warned: set[str] = set()
         self.boot_id: str = str(uuid.uuid4())
         self._captcha_solver = get_solver()
         self._metrics_sink = metrics_sink
@@ -4141,6 +4180,27 @@ class BrowserManager:
         else:
             logger.info("Starting Camoufox for '%s' (profile=%s, no proxy)", agent_id, profile_dir)
 
+        # Fail-closed egress control. When the operator has opted into
+        # BROWSER_REQUIRE_PROXY, refuse to launch without a proxy rather
+        # than egressing from the datacenter IP. Raises BEFORE allocating a
+        # display slot / spawning the X stack so nothing leaks on refusal.
+        # Recoverable: the mesh pushes the proxy + resets, and the next
+        # get_or_start finds a proxy and launches normally.
+        self._enforce_require_proxy(agent_id, _proxy_opt)
+
+        if _proxy_opt is None:
+            # Fail-open (default): launching without a proxy means GeoIP is
+            # off and the timezone falls back to the container TZ. Warn once
+            # per agent on a coarse locale/TZ mismatch (no behavior change).
+            self._warn_locale_tz_mismatch(agent_id)
+        else:
+            # Best-effort real-egress-IP probe (BROWSER_PROXY_EGRESS_IP_CHECK,
+            # default off). Only meaningful when a proxy IS set; folds the
+            # returned IP into the binding signature so a rotated residential
+            # egress invalidates bound anti-bot cookies. Never raises — a
+            # probe failure falls back to the UA+URL-only signature.
+            await self._probe_egress_ip(agent_id, _proxy_opt)
+
         # ── Per-agent X stack ─────────────────────────────────────────────
         # Allocate a (display, port) slot and bring up Xvnc + Openbox +
         # unclutter sized to the picked window resolution.  Camoufox is
@@ -4973,6 +5033,9 @@ class BrowserManager:
                 agent_id, e,
             )
         self._session_snapshot_elapsed_s.pop(agent_id, None)
+        # Drop the probed egress IP — its lifetime is one browser instance.
+        # The next launch re-probes (proxy may have rotated meanwhile).
+        self._egress_ips.pop(agent_id, None)
         # ``context.close()`` can wedge indefinitely when the underlying
         # Camoufox child has hung (X11 stuck, deadlocked on its own
         # mutex, or refusing SIGTERM). A 10s ceiling lets one bad
@@ -5084,15 +5147,159 @@ class BrowserManager:
             self._proxy_configs.pop(agent_id, None)
         else:
             self._proxy_configs[agent_id] = config
+        # A new (or cleared) proxy means the previously-probed egress IP
+        # is stale. Drop it so the next launch re-probes against the new
+        # egress — this is the automatic-recovery path after a rotation
+        # or a proxy re-push.
+        self._egress_ips.pop(agent_id, None)
 
     def get_proxy_config(self, agent_id: str) -> dict | None:
         """Get stored proxy config for an agent, or None."""
         return self._proxy_configs.get(agent_id)
 
+    def _enforce_require_proxy(self, agent_id: str, proxy_opt: dict | None) -> None:
+        """Refuse to launch without a proxy when ``BROWSER_REQUIRE_PROXY`` is on.
+
+        Fail-closed egress control. ``proxy_opt`` is the resolved
+        Playwright-style proxy dict (``None`` when no proxy will be used).
+        When it is ``None`` AND the operator opted into
+        ``BROWSER_REQUIRE_PROXY`` (default off), raise
+        :class:`ProxyRequiredError` so the browser never egresses from the
+        datacenter IP. Otherwise return quietly — a configured proxy or the
+        default fail-open posture both proceed to launch.
+
+        Split out from ``_start_browser`` so the gate is unit-testable
+        without driving a full (camoufox-dependent) launch.
+        """
+        if proxy_opt is not None:
+            return
+        from src.browser.flags import get_bool
+        if not get_bool("BROWSER_REQUIRE_PROXY", False, agent_id=agent_id):
+            return
+        logger.error(
+            "Refusing to start browser for '%s': BROWSER_REQUIRE_PROXY is on "
+            "but no proxy is configured — would egress from the datacenter "
+            "IP. Waiting for the mesh to push a proxy.",
+            agent_id,
+        )
+        raise ProxyRequiredError(agent_id=agent_id)
+
+    async def _probe_egress_ip(self, agent_id: str, proxy_arg: dict) -> None:
+        """Best-effort probe of the real egress IP through ``proxy_arg``.
+
+        Gated on ``BROWSER_PROXY_EGRESS_IP_CHECK`` (default off). When on
+        AND a proxy is set, fetch the echo URL
+        (``BROWSER_PROXY_EGRESS_IP_ECHO_URL``, default
+        ``https://api.ipify.org``) THROUGH the proxy with a 5s timeout and
+        cache the returned IP in ``self._egress_ips[agent_id]``. The cached
+        IP is folded into :meth:`_build_session_binding_signature`, so a
+        rotating residential pool (one proxy URL, changing egress IP) now
+        invalidates bound anti-bot cookies instead of replaying them under
+        a new IP for a guaranteed 403 + trust hit.
+
+        NEVER raises: any failure / timeout / flag-off leaves the cache
+        untouched, and the signature transparently falls back to UA+URL
+        only. Probes once per instance lifetime — a cached entry short-
+        circuits, so this is never per-navigation. Proxy credentials are
+        redacted from every log via :func:`redact_url`.
+        """
+        from src.browser.flags import get_bool, get_str
+        if not get_bool("BROWSER_PROXY_EGRESS_IP_CHECK", False, agent_id=agent_id):
+            return
+        if agent_id in self._egress_ips:
+            return  # already probed for this instance lifetime
+        server = (proxy_arg or {}).get("server")
+        if not server:
+            return
+        # Build an httpx proxy URL, re-injecting credentials from the
+        # playwright-style proxy dict (they live in separate keys there).
+        import ipaddress  # noqa: PLC0415 — local import keeps startup cheap
+        from urllib.parse import quote, urlsplit, urlunsplit
+        try:
+            parsed = urlsplit(server)
+        except ValueError:
+            return
+        scheme = (parsed.scheme or "").lower()
+        # Only HTTP(S) proxies are probeable here. SOCKS was removed
+        # deliberately (unreliable through the browser service); a SOCKS
+        # URL would also need httpx's socks extra. Skip → UA+URL fallback.
+        if scheme not in ("http", "https"):
+            return
+        netloc = parsed.netloc
+        if "@" in netloc:
+            netloc = netloc.rsplit("@", 1)[-1]  # drop any embedded userinfo
+        username = proxy_arg.get("username")
+        password = proxy_arg.get("password")
+        if username:
+            userinfo = quote(str(username), safe="")
+            if password:
+                userinfo += ":" + quote(str(password), safe="")
+            netloc = f"{userinfo}@{netloc}"
+        proxy_url = urlunsplit((parsed.scheme, netloc, parsed.path or "", "", ""))
+        echo_url = get_str(
+            "BROWSER_PROXY_EGRESS_IP_ECHO_URL",
+            "https://api.ipify.org",
+            agent_id=agent_id,
+        )
+        import httpx  # noqa: PLC0415 — local import (see _is_httpx_timeout)
+        try:
+            async with httpx.AsyncClient(proxy=proxy_url, timeout=5.0) as client:
+                resp = await client.get(echo_url)
+                resp.raise_for_status()
+                text = (resp.text or "").strip()
+            ip = ipaddress.ip_address(text)  # validates shape; raises on junk
+        except Exception as e:
+            logger.debug(
+                "egress-ip probe for '%s' via %s failed: %s",
+                agent_id, redact_url(proxy_url), e,
+            )
+            return
+        self._egress_ips[agent_id] = str(ip)
+        logger.info(
+            "egress-ip probe for '%s' succeeded via %s; folded into "
+            "binding signature", agent_id, redact_url(proxy_url),
+        )
+        logger.debug("egress-ip for '%s': %s", agent_id, str(ip))
+
+    def _warn_locale_tz_mismatch(self, agent_id: str) -> None:
+        """Warn once per agent on a coarse no-proxy locale/TZ mismatch.
+
+        With no proxy configured, GeoIP is off (Camoufox only enables it
+        when a proxy is set), so ``Intl`` timezone falls back to the
+        container ``TZ`` (default ``America/New_York``). If the agent
+        advertises a non-US ``BROWSER_LOCALE`` (e.g. ``en-GB``) while the
+        container TZ is ``America/*``, anti-bot vendors see a locale/
+        timezone mismatch — a real coherence signal.
+
+        Coarse heuristic only (no exhaustive locale→TZ table): a non-US
+        BCP-47 region subtag paired with an ``America/*`` TZ. No behavior
+        change — this is a diagnostic WARNING recommending a per-agent
+        proxy (for GeoIP TZ coherence) or a matching container TZ.
+        """
+        if agent_id in self._tz_mismatch_warned:
+            return
+        locale = os.environ.get("BROWSER_LOCALE", "en-US")
+        tz = os.environ.get("TZ", "America/New_York")
+        # BCP-47 region subtag = the token after the first '-' (upper-cased).
+        region = ""
+        if "-" in locale:
+            region = locale.split("-", 1)[1].split("-", 1)[0].upper()
+        if region and region != "US" and tz.startswith("America/"):
+            self._tz_mismatch_warned.add(agent_id)
+            logger.warning(
+                "Agent '%s': no proxy set, so GeoIP is off and the browser "
+                "timezone falls back to the container TZ (%s), which does "
+                "not match BROWSER_LOCALE (%s, region=%s). Anti-bot vendors "
+                "flag a locale/timezone mismatch. Recommend a per-agent "
+                "proxy (for GeoIP timezone coherence) or a container TZ "
+                "matching the locale region.",
+                agent_id, tz, locale, region,
+            )
+
     def _build_session_binding_signature(
         self, agent_id: str,
     ) -> dict[str, str | None]:
-        """Build a (UA, proxy) signature for cookie-binding invalidation.
+        """Build a (UA, proxy[, egress-IP]) signature for cookie-binding invalidation.
 
         Cloudflare / DataDome / PerimeterX bind tokens like ``cf_clearance``
         to the original (UA, IP) tuple. Replaying them under a rotated
@@ -5101,13 +5308,17 @@ class BrowserManager:
         detect the change and drop bound cookies before seeding the
         context.
 
-        We hash UA + proxy server URL (not the egress IP itself, which is
-        often unknown to us). For most operators a proxy URL change is a
-        proxy provider change, which usually means a different egress IP
-        — close enough to gate cookie reuse on.
+        We always hash UA + proxy server URL. When
+        ``BROWSER_PROXY_EGRESS_IP_CHECK`` is enabled and a launch-time
+        probe resolved the real egress IP (cached in ``self._egress_ips``),
+        we ALSO include it under ``egress_ip`` — this is what makes a
+        rotating residential pool (one URL, changing egress IP) invalidate
+        bound cookies. When the probe is off or failed, the key is omitted
+        and the hash is identical to the historical UA+URL signature.
 
-        Returns ``{"ua": ..., "proxy": ...}`` with ``None`` for fields we
-        don't know. ``None`` keys are dropped before hashing so an
+        Returns ``{"ua": ..., "proxy": ...}`` (plus ``egress_ip`` when
+        known) with ``None`` for fields we don't know. Falsy / ``None``
+        keys are dropped before hashing (see ``_hash_signature``) so an
         operator who never configures a proxy gets stable hashes across
         snapshots.
         """
@@ -5120,7 +5331,11 @@ class BrowserManager:
                 or proxy_cfg.get("url")
                 or None
             )
-        return {"ua": ua, "proxy": proxy_url}
+        sig: dict[str, str | None] = {"ua": ua, "proxy": proxy_url}
+        egress_ip = self._egress_ips.get(agent_id)
+        if egress_ip:
+            sig["egress_ip"] = egress_ip
+        return sig
 
     async def get_status(self, agent_id: str) -> dict:
         """Get status for a specific agent's browser.

--- a/src/browser/session_persistence.py
+++ b/src/browser/session_persistence.py
@@ -179,6 +179,30 @@ def _hash_signature(parts: dict[str, str | None]) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
 
+def cookie_binding_vendor(name: str) -> str | None:
+    """Return the vendor family if ``name`` is a binding-sensitive cookie, else ``None``.
+
+    THE single source of truth for "is this an anti-bot bound cookie" —
+    shared by the opt-in sidecar restore path
+    (:func:`_drop_binding_sensitive_cookies`) and the always-on profile
+    coherence check in ``service._enforce_binding_cookie_coherence``.
+
+    Match rule (unchanged from the original inline matcher): case-
+    insensitive; a cookie matches a prefix when its lowercased name
+    equals the prefix OR starts with it. The returned family is the
+    prefix's leading ``_``-delimited segment (or the whole prefix when
+    that segment is empty, e.g. ``_abck`` → ``_abck``) so operators see
+    "we dropped Cloudflare tokens" without leaking specific cookie names.
+    """
+    if not isinstance(name, str):
+        return None
+    lowered = name.lower()
+    for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
+        if lowered == prefix or lowered.startswith(prefix):
+            return prefix.split("_", 1)[0] or prefix
+    return None
+
+
 def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int:
     """Strip cookies whose names match the binding-sensitive prefix list.
 
@@ -195,20 +219,12 @@ def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int
         if not isinstance(cookie, dict):
             kept.append(cookie)
             continue
-        name = (cookie.get("name") or "").lower()
-        bound = False
-        for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
-            if name == prefix or name.startswith(prefix):
-                bound = True
-                # Track which vendor families we dropped (de-dupe by
-                # caller). Helps operators see "we dropped Cloudflare
-                # tokens" without leaking specific cookie names.
-                family = prefix.split("_", 1)[0] or prefix
-                if family not in vendors_seen:
-                    vendors_seen.append(family)
-                break
-        if bound:
+        family = cookie_binding_vendor(cookie.get("name") or "")
+        if family is not None:
             dropped += 1
+            # Track which vendor families we dropped (de-dupe by caller).
+            if family not in vendors_seen:
+                vendors_seen.append(family)
         else:
             kept.append(cookie)
     state["cookies"] = kept

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1761,6 +1761,8 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_fill_form", "browser_open_tab", "browser_inspect_requests",
     "browser_detect_captcha", "browser_upload_file", "browser_solve_captcha",
     "browser_download",
+    "browser_set_dialog_policy", "browser_drag",
+    "browser_grant_permissions", "browser_set_geolocation",
 ]
 
 # Grouped Tool Search bridge — pulls a deferred capability group's full schemas

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -74,6 +74,11 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     # exclude the handoff would still see the second-call-to-dedicated-
     # endpoint succeed, defeating permission narrowing.
     "request_browser_login",
+    # Human-parity actions: native JS dialog policy (alert/confirm/prompt/
+    # beforeunload), Firefox-scoped permission grants + geolocation, and
+    # trusted-X11 drag-and-drop. Default-allow like every other known
+    # action; operators narrow via ``AgentPermissions.browser_actions``.
+    "set_dialog_policy", "grant_permissions", "set_geolocation", "drag",
 })
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,23 @@ os.environ["OPENLEGION_SKIP_TRUST_TIER_BOOT_GATE"] = "1"
 # e2e runs with real keys keep working.
 os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
 
+# Redirect the durable fingerprint-state sidecar off the real ``data/``
+# path for the whole session. The browser service now snapshots fingerprint
+# burn + binding-signature state on every low-frequency mutation
+# (``_record_fingerprint_outcome`` / ``_force_fingerprint_burn`` /
+# ``_reset_fingerprint_window`` and the launch-time binding-coherence check),
+# so any test that drives those would otherwise write ``data/fingerprint_state.json``
+# in the repo root. A per-pid temp path keeps each xdist/shard worker isolated;
+# ``setdefault`` so a test that needs a specific path can still override.
+import tempfile as _tempfile  # noqa: E402
+
+os.environ.setdefault(
+    "FINGERPRINT_STATE_PATH",
+    os.path.join(
+        _tempfile.gettempdir(), f"ol_test_fingerprint_state_{os.getpid()}.json",
+    ),
+)
+
 # Time-returning helpers consumed by ``src.browser.service`` via
 # ``from src.browser.timing import X``. ``scroll_increment`` and
 # ``scroll_ramp`` are intentionally excluded — they return pixel counts

--- a/tests/test_binding_cookie_coherence.py
+++ b/tests/test_binding_cookie_coherence.py
@@ -1,0 +1,203 @@
+"""Tests for the always-on bound-cookie identity-coherence check.
+
+``BrowserManager._enforce_binding_cookie_coherence`` mirrors the opt-in
+session-persistence sidecar's binding-drop onto the always-on Camoufox
+persistent-profile channel. When the agent's ``(UA, proxy)`` signature
+changed since last launch, anti-bot bound cookies (cf_clearance, datadome,
+_abck, …) must be dropped BEFORE they replay under the new fingerprint —
+otherwise an instant 403 + trust-score hit. Runs regardless of
+``BROWSER_SESSION_PERSISTENCE_ENABLED``.
+
+Covers:
+  * mismatched persisted signature → matching bound cookies removed,
+    non-bound (generic session) cookies retained; new signature persisted.
+  * matching persisted signature → nothing dropped (cookies never read).
+  * first run (no persisted signature) → nothing dropped, signature
+    persisted so the NEXT identity change is detectable.
+  * legacy Playwright without ``clear_cookies(name=...)`` → clear-all +
+    re-add of the non-bound subset (same end state).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import types
+
+import pytest
+
+from src.browser import session_persistence as sp
+from src.browser.service import BrowserManager
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Clean binding-signature global + a private state sidecar per test."""
+    from src.browser.service import _binding_signatures
+
+    monkeypatch.setenv(
+        "FINGERPRINT_STATE_PATH",
+        str(tmp_path / "fp_state.json"),
+    )
+    _binding_signatures.clear()
+    yield
+    _binding_signatures.clear()
+
+
+def _cookie(name: str) -> dict:
+    return {
+        "name": name,
+        "value": "v-" + name,
+        "domain": ".example.com",
+        "path": "/",
+    }
+
+
+# A realistic mix: three vendor-bound cookies + two generic session cookies.
+_BOUND = ["cf_clearance", "datadome", "_abck"]
+_GENERIC = ["session", "csrftoken"]
+
+
+class _FakeContext:
+    """Playwright BrowserContext duck-type supporting name-filtered clear."""
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cookies_calls = 0
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        self.cookies_calls += 1
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)
+
+
+class _LegacyContext:
+    """Older Playwright: ``clear_cookies`` has NO ``name`` kwarg.
+
+    Calling ``clear_cookies(name=...)`` therefore raises ``TypeError`` —
+    the exact signal the coherence helper falls back on.
+    """
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+    async def clear_cookies(self) -> None:  # no ``name`` param on purpose
+        self.cleared_all += 1
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_bcc_")
+    return BrowserManager(profiles_dir=root)
+
+
+def _inst(agent_id: str, context) -> types.SimpleNamespace:
+    return types.SimpleNamespace(agent_id=agent_id, context=context)
+
+
+def _current_sig(mgr: BrowserManager, agent_id: str) -> str:
+    return sp._hash_signature(mgr._build_session_binding_signature(agent_id))
+
+
+class TestSignatureMismatch:
+    @pytest.mark.asyncio
+    async def test_mismatch_drops_bound_keeps_generic(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-mismatch"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-new:8080"})
+        # Seed a DIFFERENT prior signature → forces the drop branch.
+        _binding_signatures[agent] = "deadbeefdeadbeef"
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Every bound cookie was cleared by name; no generic cookie was.
+        assert set(ctx.cleared_names) == set(_BOUND)
+        assert all(g not in ctx.cleared_names for g in _GENERIC)
+        assert ctx.cleared_all == 0  # targeted path, not clear-all
+        # The current signature is now the persisted baseline.
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestSignatureMatch:
+    @pytest.mark.asyncio
+    async def test_match_drops_nothing_and_skips_cookie_read(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-match"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-stable:8080"})
+        # Seed the SAME signature the agent will compute now.
+        _binding_signatures[agent] = _current_sig(mgr, agent)
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        # Unchanged identity ⇒ we don't even enumerate cookies.
+        assert ctx.cookies_calls == 0
+        # Signature is re-persisted (unchanged).
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestFirstRun:
+    @pytest.mark.asyncio
+    async def test_first_run_drops_nothing_but_persists_signature(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-first"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-first:8080"})
+        assert agent not in _binding_signatures  # no prior baseline
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        assert ctx.cookies_calls == 0  # nothing to invalidate on first run
+        # But the baseline IS recorded so the next change is detectable.
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestLegacyPlaywrightFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_clears_all_then_readds_non_bound(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-legacy"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-legacy:8080"})
+        _binding_signatures[agent] = "0000000000000000"  # force mismatch
+
+        ctx = _LegacyContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Fell back to clear-all …
+        assert ctx.cleared_all == 1
+        # … then re-added ONLY the non-bound cookies.
+        assert ctx.readded is not None
+        readded_names = {c["name"] for c in ctx.readded}
+        assert readded_names == set(_GENERIC)
+        assert all(b not in readded_names for b in _BOUND)
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)

--- a/tests/test_browser_parity_actions.py
+++ b/tests/test_browser_parity_actions.py
@@ -387,6 +387,31 @@ class TestDragDispatch:
         assert result["success"] is False
         assert result["error"]["code"] == "invalid_input"
 
+    @pytest.mark.asyncio
+    async def test_ref_stale_returns_ref_stale_envelope(self):
+        """A RefStale raised while resolving source/target refs must surface
+        the ``ref_stale`` recovery path (re-snapshot), not a misleading
+        ``service_unavailable`` from the outer handler."""
+        from src.browser.ref_handle import RefStale
+
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+        mgr._locator_from_ref = AsyncMock(  # type: ignore[assignment]
+            side_effect=RefStale("shadow host missing", ref="e1"),
+        )
+
+        result = await mgr.drag(
+            "agent-parity",
+            source_ref="e1",
+            target_ref="e2",
+        )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ref_stale"
+        # A drag that never resolved must not have touched the mouse.
+        inst.page.mouse.down.assert_not_called()
+
 
 class TestX11Drag:
     @pytest.mark.asyncio
@@ -423,6 +448,59 @@ class TestX11Drag:
         verbs = [c[1] for c in calls]
         assert verbs == ["mousedown", "mouseup"]
         assert calls[0][-1] == "1" and calls[1][-1] == "1"
+
+
+# ── Dialog listener attachment (restored-page coverage) ───────────────────
+
+
+class TestDialogListenerAttach:
+    def test_attaches_handler_to_every_restored_page(self):
+        """A persistent Camoufox profile can RESTORE multiple pages at launch.
+        Playwright has no context-level ``dialog`` event, so every existing
+        page — not just ``inst.page`` — needs its own page-level handler; else
+        a ``switch_tab`` to a restored tab silently auto-dismisses dialogs."""
+        mgr = _make_manager()
+        inst = _FakeInstance()
+
+        # Simulate a restored profile: three pages already open, the first of
+        # which is inst.page (so it must NOT be double-wired).
+        page_a = inst.page
+        page_a.on = MagicMock()
+        page_b = MagicMock()
+        page_c = MagicMock()
+        inst.context.pages = [page_a, page_b, page_c]
+        inst.context.on = MagicMock()
+        inst._dialog_attached = False
+
+        mgr._attach_dialog_listeners(inst)
+
+        # Every existing page wired for "dialog" exactly once.
+        for p in (page_a, page_b, page_c):
+            dialog_calls = [
+                c for c in p.on.call_args_list
+                if c.args and c.args[0] == "dialog"
+            ]
+            assert len(dialog_calls) == 1, f"page wired {len(dialog_calls)}x"
+        # Future pages covered via a single context-level "page" listener.
+        page_calls = [
+            c for c in inst.context.on.call_args_list
+            if c.args and c.args[0] == "page"
+        ]
+        assert len(page_calls) == 1
+        assert inst._dialog_attached is True
+
+    def test_idempotent_when_already_attached(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.context.pages = [inst.page]
+        inst.page.on = MagicMock()
+        inst.context.on = MagicMock()
+        inst._dialog_attached = True  # already wired
+
+        mgr._attach_dialog_listeners(inst)
+
+        inst.page.on.assert_not_called()
+        inst.context.on.assert_not_called()
 
 
 # ── Agent-side @tool forwarding ────────────────────────────────────────────

--- a/tests/test_browser_parity_actions.py
+++ b/tests/test_browser_parity_actions.py
@@ -1,0 +1,512 @@
+"""Behavior tests for the human-parity browser actions.
+
+Covers the three actions added on top of the base browser surface:
+
+  * ``set_dialog_policy`` / ``_on_dialog`` — native JS dialog handling. The
+    handler must ALWAYS resolve the dialog (accept or dismiss) — a pending
+    dialog wedges the page's JS loop — and record the message either way.
+  * ``grant_permissions`` — Firefox-scoped permission grants. Camera /
+    microphone / any non-Firefox string must be rejected with a structured
+    error BEFORE Playwright can raise a raw ``Unknown permission``.
+  * ``set_geolocation`` — sets context geolocation AND grants the
+    geolocation permission (Firefox needs both).
+  * ``drag`` — trusted-X11 drag when an X11 window exists, CDP mouse
+    fallback otherwise. ``_x11_drag`` presses button 1 down, moves with it
+    held, then releases.
+
+``BrowserManager._start_browser`` imports ``camoufox`` on its first line
+(not installed in CI), so we NEVER go through it — every test drives the
+handler methods directly against a fake instance, patching
+``get_or_start`` to return it (mirrors ``tests/test_binding_cookie_coherence``).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser.service import _FIREFOX_GRANTABLE_PERMISSIONS, BrowserManager
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_parity_")
+    return BrowserManager(profiles_dir=root)
+
+
+class _FakeInstance:
+    """Minimal CamoufoxInstance duck-type for the parity handlers."""
+
+    def __init__(self, *, x11_wid=None):
+        import asyncio
+
+        self.agent_id = "agent-parity"
+        self.x11_wid = x11_wid
+        self._user_control = False
+        self.dialog_policy = {"action": "dismiss", "text": ""}
+        self.last_dialog_message = None
+        self.refs: dict = {}
+        self._lock = asyncio.Lock()
+        # Context / page are MagicMocks with AsyncMock async methods.
+        self.context = MagicMock()
+        self.context.grant_permissions = AsyncMock()
+        self.context.set_geolocation = AsyncMock()
+        self.page = MagicMock()
+        self.page.mouse = MagicMock()
+        self.page.mouse.move = AsyncMock()
+        self.page.mouse.down = AsyncMock()
+        self.page.mouse.up = AsyncMock()
+
+    @property
+    def lock(self):
+        return self._lock
+
+    def touch(self):
+        pass
+
+    def subprocess_env(self):
+        # xdotool env for the X11 drag path; value is irrelevant here
+        # because subprocess.run is monkeypatched in the drag test.
+        return None
+
+
+def _patch_get_or_start(mgr: BrowserManager, inst: _FakeInstance) -> None:
+    mgr.get_or_start = AsyncMock(return_value=inst)  # type: ignore[assignment]
+
+
+# ── Native JS dialog handling ─────────────────────────────────────────────
+
+
+class _FakeDialog:
+    def __init__(self, message: str, dtype: str):
+        self.message = message
+        self.type = dtype
+        self.accept = AsyncMock()
+        self.dismiss = AsyncMock()
+
+
+class TestOnDialog:
+    @pytest.mark.asyncio
+    async def test_accept_policy_accepts_and_records(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.dialog_policy = {"action": "accept", "text": ""}
+        dialog = _FakeDialog("Delete this item?", "confirm")
+
+        await mgr._on_dialog(inst, dialog)
+
+        dialog.accept.assert_awaited_once()
+        dialog.dismiss.assert_not_called()
+        assert inst.last_dialog_message == {
+            "message": "Delete this item?",
+            "type": "confirm",
+        }
+
+    @pytest.mark.asyncio
+    async def test_dismiss_default_dismisses_but_still_records(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()  # default policy is dismiss
+        dialog = _FakeDialog("Leave site? Changes may not be saved.", "beforeunload")
+
+        await mgr._on_dialog(inst, dialog)
+
+        dialog.dismiss.assert_awaited_once()
+        dialog.accept.assert_not_called()
+        # Message stored even though we dismissed it.
+        assert inst.last_dialog_message["message"].startswith("Leave site?")
+        assert inst.last_dialog_message["type"] == "beforeunload"
+
+    @pytest.mark.asyncio
+    async def test_respond_passes_prompt_text(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.dialog_policy = {"action": "respond", "text": "Ada Lovelace"}
+        dialog = _FakeDialog("Your name?", "prompt")
+
+        await mgr._on_dialog(inst, dialog)
+
+        dialog.accept.assert_awaited_once_with("Ada Lovelace")
+
+    @pytest.mark.asyncio
+    async def test_always_resolves_even_when_accept_raises(self):
+        """A pending dialog wedges the page — a failed accept must fall back
+        to a dismiss so the dialog is never left pending."""
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.dialog_policy = {"action": "accept", "text": ""}
+        dialog = _FakeDialog("boom", "alert")
+        dialog.accept = AsyncMock(side_effect=RuntimeError("target closed"))
+
+        await mgr._on_dialog(inst, dialog)
+
+        dialog.dismiss.assert_awaited_once()
+
+
+class TestSetDialogPolicy:
+    @pytest.mark.asyncio
+    async def test_mutates_policy_and_returns_last_message(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.last_dialog_message = {"message": "prior", "type": "confirm"}
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.set_dialog_policy("agent-parity", action="accept")
+
+        assert result["success"] is True
+        assert inst.dialog_policy == {"action": "accept", "text": ""}
+        assert result["data"]["last_dialog"] == {"message": "prior", "type": "confirm"}
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_action(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.set_dialog_policy("agent-parity", action="explode")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        # get_or_start must not even run for a pure input error.
+        mgr.get_or_start.assert_not_called()
+
+
+# ── Permission grants + geolocation ───────────────────────────────────────
+
+
+class TestGrantPermissions:
+    @pytest.mark.asyncio
+    async def test_valid_firefox_permissions_granted(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.grant_permissions(
+            "agent-parity",
+            permissions=["geolocation", "notifications"],
+            origin="https://example.com",
+        )
+
+        assert result["success"] is True
+        inst.context.grant_permissions.assert_awaited_once_with(
+            ["geolocation", "notifications"],
+            origin="https://example.com",
+        )
+
+    @pytest.mark.asyncio
+    async def test_camera_rejected_without_calling_playwright(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.grant_permissions(
+            "agent-parity",
+            permissions=["camera"],
+        )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "camera" in result["error"]["message"]
+        # Never reached Playwright — no context call at all.
+        mgr.get_or_start.assert_not_called()
+        inst.context.grant_permissions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_microphone_rejected(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.grant_permissions(
+            "agent-parity",
+            permissions=["geolocation", "microphone"],
+        )
+
+        assert result["success"] is False
+        inst.context.grant_permissions.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_list_rejected(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.grant_permissions("agent-parity", permissions=[])
+        assert result["success"] is False
+
+    def test_allowlist_matches_firefox_reality(self):
+        assert _FIREFOX_GRANTABLE_PERMISSIONS == frozenset(
+            {
+                "geolocation",
+                "notifications",
+                "persistent-storage",
+                "push",
+                "screen-wake-lock",
+            }
+        )
+        assert "camera" not in _FIREFOX_GRANTABLE_PERMISSIONS
+        assert "microphone" not in _FIREFOX_GRANTABLE_PERMISSIONS
+
+
+class TestSetGeolocation:
+    @pytest.mark.asyncio
+    async def test_sets_coords_and_grants_geolocation(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.set_geolocation(
+            "agent-parity",
+            latitude=37.7749,
+            longitude=-122.4194,
+            accuracy=50,
+        )
+
+        assert result["success"] is True
+        inst.context.set_geolocation.assert_awaited_once_with(
+            {
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "accuracy": 50.0,
+            }
+        )
+        # Firefox needs the geolocation permission granted too.
+        inst.context.grant_permissions.assert_awaited_once_with(["geolocation"])
+        # Truth-in-advertising note about geo.enabled=False is surfaced.
+        assert "geo.enabled" in result["data"]["note"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_numeric_coords(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.set_geolocation(
+            "agent-parity",
+            latitude="north",
+            longitude=1.0,
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        mgr.get_or_start.assert_not_called()
+
+
+# ── Drag-and-drop ─────────────────────────────────────────────────────────
+
+
+class TestDragDispatch:
+    @pytest.mark.asyncio
+    async def test_x11_path_used_when_window_present(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=123)
+        _patch_get_or_start(mgr, inst)
+        mgr._x11_drag = AsyncMock()  # type: ignore[assignment]
+
+        result = await mgr.drag(
+            "agent-parity",
+            source_x=10,
+            source_y=20,
+            target_x=100,
+            target_y=200,
+        )
+
+        assert result["success"] is True
+        assert result["data"]["method"] == "x11"
+        mgr._x11_drag.assert_awaited_once_with(inst, 10, 20, 100, 200)
+        # CDP mouse untouched.
+        inst.page.mouse.down.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cdp_fallback_when_no_window(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.drag(
+            "agent-parity",
+            source_x=5,
+            source_y=6,
+            target_x=7,
+            target_y=8,
+        )
+
+        assert result["success"] is True
+        assert result["data"]["method"] == "cdp"
+        inst.page.mouse.move.assert_any_await(5, 6)
+        inst.page.mouse.down.assert_awaited_once()
+        inst.page.mouse.move.assert_any_await(7, 8)
+        inst.page.mouse.up.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ref_pair_resolves_bounding_boxes(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+
+        src_loc = MagicMock()
+        src_loc.bounding_box = AsyncMock(
+            return_value={"x": 0, "y": 0, "width": 40, "height": 40},
+        )
+        tgt_loc = MagicMock()
+        tgt_loc.bounding_box = AsyncMock(
+            return_value={"x": 200, "y": 200, "width": 40, "height": 40},
+        )
+        locators = {"e1": src_loc, "e2": tgt_loc}
+        mgr._locator_from_ref = AsyncMock(  # type: ignore[assignment]
+            side_effect=lambda inst, ref: locators.get(ref),
+        )
+
+        result = await mgr.drag(
+            "agent-parity",
+            source_ref="e1",
+            target_ref="e2",
+        )
+
+        assert result["success"] is True
+        # Points land inside each element's bbox (Fitts' sampler).
+        ax, ay = result["data"]["from"]
+        bx, by = result["data"]["to"]
+        assert 0 <= ax <= 40 and 0 <= ay <= 40
+        assert 200 <= bx <= 240 and 200 <= by <= 240
+        inst.page.mouse.up.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_args_rejected(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.drag("agent-parity")  # nothing supplied
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+
+class TestX11Drag:
+    @pytest.mark.asyncio
+    async def test_press_move_release_sequence(self, monkeypatch):
+        """``_x11_drag`` must move to source, press button 1, move to target
+        with it held, then release — verified via the xdotool call log."""
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=777)
+
+        moves: list[tuple[int, int]] = []
+
+        async def _fake_move(_inst, x, y):
+            moves.append((x, y))
+
+        monkeypatch.setattr(mgr, "_x11_move_to", _fake_move)
+
+        calls: list[list[str]] = []
+
+        class _FakeCompleted:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return _FakeCompleted()
+
+        fake_subprocess = types.SimpleNamespace(run=_fake_run)
+        monkeypatch.setattr("src.browser.service.subprocess", fake_subprocess)
+
+        await mgr._x11_drag(inst, 10, 20, 300, 400)
+
+        # Two moves: source then target.
+        assert moves == [(10, 20), (300, 400)]
+        # xdotool: mousedown 1 THEN mouseup 1, in that order.
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        assert calls[0][-1] == "1" and calls[1][-1] == "1"
+
+
+# ── Agent-side @tool forwarding ────────────────────────────────────────────
+
+
+def _mesh(action_capture: dict):
+    mc = MagicMock()
+
+    async def _cmd(action, params):
+        action_capture["action"] = action
+        action_capture["params"] = params
+        return {"success": True}
+
+    mc.browser_command = AsyncMock(side_effect=_cmd)
+    return mc
+
+
+class TestAgentToolForwarding:
+    @pytest.mark.asyncio
+    async def test_set_dialog_policy_tool(self):
+        from src.agent.builtins.browser_tool import browser_set_dialog_policy
+
+        cap: dict = {}
+        await browser_set_dialog_policy(
+            action="respond",
+            text="hi",
+            mesh_client=_mesh(cap),
+        )
+        assert cap["action"] == "set_dialog_policy"
+        assert cap["params"] == {"action": "respond", "text": "hi"}
+
+    @pytest.mark.asyncio
+    async def test_drag_tool_prefers_refs(self):
+        from src.agent.builtins.browser_tool import browser_drag
+
+        cap: dict = {}
+        await browser_drag(
+            source_ref="e1",
+            target_ref="e2",
+            mesh_client=_mesh(cap),
+        )
+        assert cap["action"] == "drag"
+        assert cap["params"] == {"source_ref": "e1", "target_ref": "e2"}
+
+    @pytest.mark.asyncio
+    async def test_drag_tool_coords(self):
+        from src.agent.builtins.browser_tool import browser_drag
+
+        cap: dict = {}
+        await browser_drag(
+            source_x=1,
+            source_y=2,
+            target_x=3,
+            target_y=4,
+            mesh_client=_mesh(cap),
+        )
+        assert cap["action"] == "drag"
+        assert cap["params"] == {
+            "source_x": 1,
+            "source_y": 2,
+            "target_x": 3,
+            "target_y": 4,
+        }
+
+    @pytest.mark.asyncio
+    async def test_grant_permissions_tool_omits_empty_origin(self):
+        from src.agent.builtins.browser_tool import browser_grant_permissions
+
+        cap: dict = {}
+        await browser_grant_permissions(
+            permissions=["geolocation"],
+            mesh_client=_mesh(cap),
+        )
+        assert cap["action"] == "grant_permissions"
+        assert cap["params"] == {"permissions": ["geolocation"]}
+
+    @pytest.mark.asyncio
+    async def test_set_geolocation_tool_includes_accuracy(self):
+        from src.agent.builtins.browser_tool import browser_set_geolocation
+
+        cap: dict = {}
+        await browser_set_geolocation(
+            latitude=1.5,
+            longitude=2.5,
+            accuracy=10,
+            mesh_client=_mesh(cap),
+        )
+        assert cap["action"] == "set_geolocation"
+        assert cap["params"] == {
+            "latitude": 1.5,
+            "longitude": 2.5,
+            "accuracy": 10,
+        }

--- a/tests/test_browser_parity_actions.py
+++ b/tests/test_browser_parity_actions.py
@@ -236,15 +236,21 @@ class TestGrantPermissions:
         assert result["success"] is False
 
     def test_allowlist_matches_firefox_reality(self):
+        # These are the ONLY four web permissions Playwright's Firefox engine
+        # maps (ffBrowser.js ``webPermissionToProtocol``): geolocation, push,
+        # persistent-storage, and notifications (→ desktop-notification).
+        # screen-wake-lock is Chromium-only — it is NOT in the FF map and
+        # ``grant_permissions`` raises "Unknown permission" for it, so it must
+        # never be in the allowlist.
         assert _FIREFOX_GRANTABLE_PERMISSIONS == frozenset(
             {
                 "geolocation",
                 "notifications",
                 "persistent-storage",
                 "push",
-                "screen-wake-lock",
             }
         )
+        assert "screen-wake-lock" not in _FIREFOX_GRANTABLE_PERMISSIONS
         assert "camera" not in _FIREFOX_GRANTABLE_PERMISSIONS
         assert "microphone" not in _FIREFOX_GRANTABLE_PERMISSIONS
 

--- a/tests/test_browser_proxy_hardening.py
+++ b/tests/test_browser_proxy_hardening.py
@@ -1,0 +1,421 @@
+"""Tests for the browser proxy-hardening trio.
+
+Covers three independent knobs added on top of the always-on binding
+signature (see ``test_binding_cookie_coherence.py``):
+
+  1. ``BROWSER_REQUIRE_PROXY`` (default off) — fail-closed egress control.
+     ``BrowserManager._enforce_require_proxy`` raises ``ProxyRequiredError``
+     when the flag is on and no proxy resolved, so the browser never
+     egresses from the datacenter IP. Proxy present OR flag off → proceeds.
+
+  2. ``BROWSER_PROXY_EGRESS_IP_CHECK`` (default off) — fold the REAL egress
+     IP (probed through the proxy) into the binding signature so a rotating
+     residential pool (one URL, changing IP) invalidates bound anti-bot
+     cookies. Probe failure / timeout / flag-off falls back to the UA+URL
+     signature and never raises.
+
+  3. No-proxy locale/TZ coherence WARNING — a one-time-per-agent diagnostic
+     (no behavior change) when GeoIP is off and a coarse non-US-locale vs
+     ``America/*`` container-TZ mismatch is detected.
+
+``_start_browser`` itself imports camoufox (absent in the test env), so the
+gate + probe + warning are exercised through their extracted helpers,
+mirroring the helper-level style of ``test_binding_cookie_coherence.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+
+import httpx
+import pytest
+
+from src.browser import flags
+from src.browser import session_persistence as sp
+from src.browser.service import BrowserManager, ProxyRequiredError, _binding_signatures
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Clean flag layers + binding-signature state + the new flags' env."""
+    # Operator-settings layer: point at a nonexistent file so a real
+    # config/settings.json can't leak BROWSER_* flags into these tests.
+    monkeypatch.setenv("OPENLEGION_SETTINGS_PATH", str(tmp_path / "settings.json"))
+    saved_agents = dict(flags._agent_overrides)
+    flags._agent_overrides.clear()
+    flags.reload_operator_settings()
+    # Durable binding-signature sidecar → tmp; clear the in-memory global.
+    monkeypatch.setenv("FINGERPRINT_STATE_PATH", str(tmp_path / "fp_state.json"))
+    _binding_signatures.clear()
+    # Ensure the three new flags start unset (default posture).
+    for name in (
+        "BROWSER_REQUIRE_PROXY",
+        "BROWSER_PROXY_EGRESS_IP_CHECK",
+        "BROWSER_PROXY_EGRESS_IP_ECHO_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    flags._agent_overrides.clear()
+    flags._agent_overrides.update(saved_agents)
+    flags.reload_operator_settings()
+    _binding_signatures.clear()
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_proxyhard_")
+    return BrowserManager(profiles_dir=root)
+
+
+# ── httpx fakes ─────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAsyncClient:
+    """Records constructor kwargs + the GET url; returns a canned IP."""
+
+    last_proxy: str | None = None
+    last_timeout: object = None
+    last_url: str | None = None
+    ctor_calls: int = 0
+    get_calls: int = 0
+    reply_text: str = "203.0.113.7"
+
+    def __init__(self, *, proxy=None, timeout=None):
+        type(self).last_proxy = proxy
+        type(self).last_timeout = timeout
+        type(self).ctor_calls += 1
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        type(self).last_url = url
+        type(self).get_calls += 1
+        return _FakeResp(type(self).reply_text)
+
+
+def _install_client(monkeypatch, cls=_FakeAsyncClient):
+    cls.ctor_calls = 0
+    cls.get_calls = 0
+    monkeypatch.setattr("httpx.AsyncClient", cls)
+    return cls
+
+
+def _mismatch_warned(caplog) -> bool:
+    """True if the locale/timezone-mismatch WARNING was emitted.
+
+    Asserting on the specific message (not ``caplog.records`` emptiness)
+    keeps the no-warning tests robust to unrelated log noise — e.g. a
+    Playwright-less environment where ``BrowserManager`` construction logs
+    a CRITICAL about the artifact-stream API.
+    """
+    return any("locale/timezone mismatch" in r.getMessage() for r in caplog.records)
+
+
+# ── 1. BROWSER_REQUIRE_PROXY (fail-closed) ──────────────────────────────────
+
+
+class TestRequireProxy:
+    def test_flag_on_no_proxy_refuses(self, monkeypatch):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_REQUIRE_PROXY", "true")
+        with pytest.raises(ProxyRequiredError) as exc:
+            mgr._enforce_require_proxy("agent-refuse", None)
+        assert exc.value.agent_id == "agent-refuse"
+        assert exc.value.retry_after_s > 0
+        assert "agent-refuse" in str(exc.value)
+
+    def test_flag_on_proxy_present_allows(self, monkeypatch):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_REQUIRE_PROXY", "true")
+        # A resolved proxy → never refused, even with the flag on.
+        mgr._enforce_require_proxy("agent-ok", {"server": "http://proxy:8080"})
+
+    def test_flag_off_no_proxy_allows(self, monkeypatch):
+        mgr = _make_manager()
+        # Default off → historical fail-open behavior preserved.
+        mgr._enforce_require_proxy("agent-open", None)
+
+    def test_per_agent_override_gates_independently(self, monkeypatch):
+        mgr = _make_manager()
+        # Operator-wide off, but one agent opted in via the override layer.
+        flags.set_agent_override("agent-strict", "BROWSER_REQUIRE_PROXY", "true")
+        mgr._enforce_require_proxy("agent-loose", None)  # unaffected → no raise
+        with pytest.raises(ProxyRequiredError):
+            mgr._enforce_require_proxy("agent-strict", None)
+
+
+# ── 2. BROWSER_PROXY_EGRESS_IP_CHECK (fold egress IP into signature) ─────────
+
+
+class TestEgressIpProbe:
+    @pytest.mark.asyncio
+    async def test_probe_folds_egress_ip_into_signature(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-egress"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert mgr._egress_ips[agent] == "203.0.113.7"
+        assert client.get_calls == 1
+        assert client.last_timeout == 5.0
+        assert client.last_url == "https://api.ipify.org"  # default echo url
+
+        sig = mgr._build_session_binding_signature(agent)
+        assert sig.get("egress_ip") == "203.0.113.7"
+        with_ip = sp._hash_signature(sig)
+        assert with_ip != url_only  # egress IP changes the hash
+
+    @pytest.mark.asyncio
+    async def test_probe_injects_credentials_into_proxy_url(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-creds"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(
+            agent,
+            {"server": "http://proxy:8080", "username": "u", "password": "p@ss"},
+        )
+        # Creds live in separate keys of the playwright-style dict; the probe
+        # re-assembles a percent-encoded httpx proxy URL.
+        assert client.last_proxy == "http://u:p%40ss@proxy:8080"
+
+    @pytest.mark.asyncio
+    async def test_custom_echo_url_used(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-echo"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_ECHO_URL", "https://echo.example/ip")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert client.last_url == "https://echo.example/ip"
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_falls_back_no_exception(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-boom"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _BoomClient(_FakeAsyncClient):
+            async def get(self, url):
+                raise RuntimeError("proxy dead")
+
+        _install_client(monkeypatch, _BoomClient)
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+
+        # Must NOT raise.
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert agent not in mgr._egress_ips
+        sig = mgr._build_session_binding_signature(agent)
+        assert "egress_ip" not in sig
+        assert sp._hash_signature(sig) == url_only  # UA+URL fallback
+
+    @pytest.mark.asyncio
+    async def test_probe_timeout_falls_back(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-timeout"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _SlowClient(_FakeAsyncClient):
+            async def get(self, url):
+                raise httpx.ConnectTimeout("slow")
+
+        _install_client(monkeypatch, _SlowClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_junk_response_not_cached(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-junk"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _JunkClient(_FakeAsyncClient):
+            reply_text = "<html>not an ip</html>"
+
+        _install_client(monkeypatch, _JunkClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        # ipaddress.ip_address() rejects the body → nothing cached.
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_probe(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-off"
+        # Flag unset (default off).
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert client.ctor_calls == 0  # no httpx client constructed at all
+        assert agent not in mgr._egress_ips
+        sig = mgr._build_session_binding_signature(agent)
+        assert "egress_ip" not in sig
+        assert sp._hash_signature(sig) == url_only
+
+    @pytest.mark.asyncio
+    async def test_probe_cached_not_reprobed(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-cache"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert client.get_calls == 1  # second call short-circuits on cache
+
+    @pytest.mark.asyncio
+    async def test_socks_scheme_skipped(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-socks"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        client = _install_client(monkeypatch)
+        # SOCKS was removed deliberately; the probe skips non-HTTP schemes.
+        await mgr._probe_egress_ip(agent, {"server": "socks5://proxy:1080"})
+        assert client.ctor_calls == 0
+        assert agent not in mgr._egress_ips
+
+    def test_set_proxy_config_clears_cached_egress(self):
+        mgr = _make_manager()
+        agent = "agent-rotate"
+        mgr._egress_ips[agent] = "198.51.100.1"
+        mgr.set_proxy_config(agent, {"server": "http://new:8080"})
+        # A re-push means the old egress IP is stale → dropped for re-probe.
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_rotated_egress_ip_invalidates_bound_cookies(self, monkeypatch):
+        """Compose: a rotated egress IP flips the signature, so the always-on
+        coherence hook drops bound anti-bot cookies while keeping generics."""
+        mgr = _make_manager()
+        agent = "agent-compose"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://rot:8080"})
+
+        # Baseline persisted from a prior launch under an OLD egress IP.
+        mgr._egress_ips[agent] = "198.51.100.1"
+        old_sig = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        _binding_signatures[agent] = old_sig
+        # Simulate a stop clearing the cache, then a fresh launch probing a
+        # ROTATED egress IP behind the same proxy URL.
+        del mgr._egress_ips[agent]
+
+        class _RotClient(_FakeAsyncClient):
+            reply_text = "198.51.100.9"
+
+        _install_client(monkeypatch, _RotClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://rot:8080"})
+        assert mgr._egress_ips[agent] == "198.51.100.9"
+        assert sp._hash_signature(mgr._build_session_binding_signature(agent)) != old_sig
+
+        ctx = _FakeCookieContext([_cookie("cf_clearance"), _cookie("datadome"), _cookie("session")])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+        assert set(ctx.cleared_names) == {"cf_clearance", "datadome"}
+        assert "session" not in ctx.cleared_names
+
+
+# ── 3. No-proxy locale/TZ coherence warning ─────────────────────────────────
+
+
+class TestLocaleTzWarning:
+    def test_mismatch_warns_once(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-GB")
+        monkeypatch.setenv("TZ", "America/New_York")
+
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-tz")
+        assert any("locale/timezone mismatch" in r.getMessage() for r in caplog.records)
+
+        caplog.clear()
+        mgr._warn_locale_tz_mismatch("agent-tz")  # second call
+        assert not caplog.records  # one-time-per-agent
+
+    def test_us_locale_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-US")
+        monkeypatch.setenv("TZ", "America/New_York")
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-us")
+        # Assert the specific mismatch warning is absent (robust to unrelated
+        # log noise, e.g. a Playwright-less env's construction warning) and
+        # that no per-agent warned-marker was set.
+        assert not _mismatch_warned(caplog)
+        assert "agent-us" not in mgr._tz_mismatch_warned
+
+    def test_matching_region_tz_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-GB")
+        monkeypatch.setenv("TZ", "Europe/London")  # region-consistent → no warn
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-uk")
+        assert not _mismatch_warned(caplog)
+        assert "agent-uk" not in mgr._tz_mismatch_warned
+
+    def test_localeless_tag_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en")  # no region subtag
+        monkeypatch.setenv("TZ", "America/New_York")
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-noregion")
+        assert not _mismatch_warned(caplog)
+        assert "agent-noregion" not in mgr._tz_mismatch_warned
+
+
+# ── shared cookie-context fake (mirrors test_binding_cookie_coherence) ───────
+
+
+def _cookie(name: str) -> dict:
+    return {"name": name, "value": "v-" + name, "domain": ".example.com", "path": "/"}
+
+
+def _inst(agent_id: str, context):
+    import types
+
+    return types.SimpleNamespace(agent_id=agent_id, context=context)
+
+
+class _FakeCookieContext:
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2056,6 +2056,13 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "browser_go_back",
     "browser_go_forward",
     "browser_solve_captcha",
+    # Human-parity mechanical actions — the generic "using browser_*"
+    # activity-feed verb reads fine (same treatment as the scroll/hover/
+    # press_key siblings above).
+    "browser_set_dialog_policy",
+    "browser_drag",
+    "browser_grant_permissions",
+    "browser_set_geolocation",
     "request_captcha_help",
     "request_browser_login",
     # Watch / pub-sub.

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -52,6 +52,7 @@ atexit.register(shutil.rmtree, _PROFILES_ROOT, ignore_errors=True)
 def _reset_fingerprint_state():
     """Each test starts with empty module-level fingerprint state."""
     from src.browser.service import (
+        _binding_signatures,
         _fingerprint_audit_buckets,
         _fingerprint_hard_burn_reason,
         _fingerprint_hard_burned,
@@ -63,12 +64,14 @@ def _reset_fingerprint_state():
     _fingerprint_audit_buckets.clear()
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
+    _binding_signatures.clear()
     yield
     _fingerprint_window.clear()
     _fingerprint_last_signal.clear()
     _fingerprint_audit_buckets.clear()
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
+    _binding_signatures.clear()
 
 
 class TestRollingWindow:

--- a/tests/test_fingerprint_state.py
+++ b/tests/test_fingerprint_state.py
@@ -1,0 +1,225 @@
+"""Tests for the durable fingerprint-state sidecar (burn + binding signatures).
+
+Covers:
+  * snapshot → restore round-trip preserves the rolling window (values AND
+    the ``maxlen`` bound), the hard-burned set, and the hard-burn reasons.
+  * binding-signature map round-trips.
+  * a ``deque`` longer than ``maxlen`` restores keeping only the last N.
+  * missing file restores an empty state (no raise).
+  * corrupt JSON / wrong-shape / wrong-version restores empty (no raise).
+  * the sidecar is written 0o600 (opaque state, but matches the codebase's
+    atomic-write posture).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections import deque
+
+from src.browser import fingerprint_state as fp
+
+
+def _snapshot(path, **overrides):
+    """Snapshot with sensible empty defaults; overrides fill in fields."""
+    kwargs = dict(
+        window={},
+        last_signal={},
+        hard_burned=set(),
+        hard_burn_reason={},
+        binding_signatures={},
+        path=path,
+    )
+    kwargs.update(overrides)
+    return fp.snapshot(**kwargs)
+
+
+class TestRoundTrip:
+    def test_window_values_and_maxlen_survive(self, tmp_path):
+        target = tmp_path / "fp.json"
+        window = {
+            "agent-a": deque([True, False, True], maxlen=10),
+            "agent-b": deque([False], maxlen=10),
+        }
+        assert _snapshot(target, window=window) is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True, False, True]
+        assert list(loaded.window["agent-b"]) == [False]
+        # Rebuilt as a bounded deque with the same maxlen — appending an
+        # 11th element evicts the oldest rather than growing unbounded.
+        restored = loaded.window["agent-a"]
+        assert isinstance(restored, deque)
+        assert restored.maxlen == 10
+        for _ in range(12):
+            restored.append(True)
+        assert len(restored) == 10
+
+    def test_full_window_at_maxlen_keeps_last_n(self, tmp_path):
+        target = tmp_path / "fp.json"
+        # 10 entries = a full window: 6 rejects then 4 accepts.
+        full = deque([True] * 6 + [False] * 4, maxlen=10)
+        assert _snapshot(target, window={"agent-a": full}) is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True] * 6 + [False] * 4
+        assert loaded.window["agent-a"].maxlen == 10
+
+    def test_oversized_list_truncates_to_maxlen_last_n(self, tmp_path):
+        # A hand-tampered / legacy file could hold more entries than maxlen;
+        # deque(iterable, maxlen=N) keeps the LAST N, so restore is safe.
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "saved_at": 0,
+                    "window": {"agent-a": [True, False, True, True, False]},
+                    "last_signal": {},
+                    "hard_burned": [],
+                    "hard_burn_reason": {},
+                    "binding_signatures": {},
+                }
+            )
+        )
+        loaded = fp.restore(target, window_maxlen=3)
+        assert list(loaded.window["agent-a"]) == [True, True, False]
+        assert loaded.window["agent-a"].maxlen == 3
+
+    def test_hard_burned_and_reasons_survive(self, tmp_path):
+        target = tmp_path / "fp.json"
+        ok = _snapshot(
+            target,
+            hard_burned={"agent-a", "agent-b"},
+            hard_burn_reason={
+                "agent-a": ("cloudflare", "cf-mitigated=block"),
+                "agent-b": ("perimeterx", "x-px-block-type=1"),
+            },
+            last_signal={"agent-a": 1234.5},
+        )
+        assert ok is True
+
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == {"agent-a", "agent-b"}
+        assert loaded.hard_burn_reason["agent-a"] == ("cloudflare", "cf-mitigated=block")
+        assert loaded.hard_burn_reason["agent-b"] == ("perimeterx", "x-px-block-type=1")
+        # Reasons restore as a 2-tuple (list-in-JSON → tuple in memory).
+        assert isinstance(loaded.hard_burn_reason["agent-a"], tuple)
+        assert loaded.last_signal["agent-a"] == 1234.5
+
+    def test_binding_signatures_round_trip(self, tmp_path):
+        target = tmp_path / "fp.json"
+        sigs = {"agent-a": "0011223344556677", "agent-b": "aabbccddeeff0011"}
+        assert _snapshot(target, binding_signatures=sigs) is True
+
+        loaded = fp.restore(target)
+        assert loaded.binding_signatures == sigs
+
+    def test_combined_round_trip(self, tmp_path):
+        target = tmp_path / "fp.json"
+        ok = _snapshot(
+            target,
+            window={"agent-a": deque([True, True], maxlen=10)},
+            last_signal={"agent-a": 42.0},
+            hard_burned={"agent-a"},
+            hard_burn_reason={"agent-a": ("datadome", "x-datadome=protected")},
+            binding_signatures={"agent-a": "cafebabecafebabe"},
+        )
+        assert ok is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True, True]
+        assert loaded.last_signal["agent-a"] == 42.0
+        assert loaded.hard_burned == {"agent-a"}
+        assert loaded.hard_burn_reason["agent-a"] == ("datadome", "x-datadome=protected")
+        assert loaded.binding_signatures["agent-a"] == "cafebabecafebabe"
+
+
+class TestNonFatalRestore:
+    def test_missing_file_restores_empty(self, tmp_path):
+        loaded = fp.restore(tmp_path / "does-not-exist.json")
+        assert loaded.window == {}
+        assert loaded.last_signal == {}
+        assert loaded.hard_burned == set()
+        assert loaded.hard_burn_reason == {}
+        assert loaded.binding_signatures == {}
+
+    def test_corrupt_json_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text("{not valid json at all")
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == set()
+        assert loaded.binding_signatures == {}
+
+    def test_wrong_shape_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text(json.dumps(["not", "a", "dict"]))
+        loaded = fp.restore(target)
+        assert loaded.window == {}
+
+    def test_wrong_version_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "hard_burned": ["agent-a"],
+                    "binding_signatures": {"agent-a": "sig"},
+                }
+            )
+        )
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == set()
+        assert loaded.binding_signatures == {}
+
+    def test_malformed_entries_skipped_not_fatal(self, tmp_path):
+        # Individual bad rows are dropped; the well-formed ones survive.
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "window": {"agent-a": [True], "bad": "not-a-list"},
+                    "last_signal": {"agent-a": 1.0, "bad": "nan-string"},
+                    "hard_burned": ["agent-a", 123],
+                    "hard_burn_reason": {"agent-a": ["cf", "block"], "bad": ["only-one"]},
+                    "binding_signatures": {"agent-a": "sig", "bad": 12345},
+                }
+            )
+        )
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True]
+        assert "bad" not in loaded.window
+        assert loaded.last_signal == {"agent-a": 1.0}
+        assert loaded.hard_burned == {"agent-a"}
+        assert loaded.hard_burn_reason == {"agent-a": ("cf", "block")}
+        assert loaded.binding_signatures == {"agent-a": "sig"}
+
+
+class TestFilePermissions:
+    def test_sidecar_is_owner_only(self, tmp_path):
+        target = tmp_path / "fp.json"
+        assert _snapshot(target, hard_burned={"agent-a"}) is True
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode == 0o600
+
+
+class TestEnvOverride:
+    def test_default_path_env_override(self, tmp_path, monkeypatch):
+        target = tmp_path / "custom_fp.json"
+        monkeypatch.setenv("FINGERPRINT_STATE_PATH", str(target))
+        # No explicit path → falls back to the env-configured location.
+        assert (
+            fp.snapshot(
+                window={},
+                last_signal={},
+                hard_burned={"agent-z"},
+                hard_burn_reason={},
+                binding_signatures={},
+            )
+            is True
+        )
+        assert target.exists()
+        loaded = fp.restore()
+        assert loaded.hard_burned == {"agent-z"}

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -193,6 +193,22 @@ class TestCanBrowserAction:
         for action in ("navigate", "upload_file", "brand_new_action"):
             assert browser_matrix.can_browser_action("wildcard-agent", action) is True
 
+    def test_human_parity_actions_gating(self, browser_matrix):
+        """The parity actions default-allow, honor the wildcard, and are
+        narrowable — the readonly agent (navigate/snapshot/screenshot only)
+        must NOT be granted them."""
+        for action in (
+            "set_dialog_policy", "grant_permissions",
+            "set_geolocation", "drag",
+        ):
+            # Default (None) and wildcard both allow.
+            assert browser_matrix.can_browser_action("legacy-agent", action) is True, action
+            assert browser_matrix.can_browser_action("wildcard-agent", action) is True, action
+            # A narrowed allowlist that omits them denies.
+            assert browser_matrix.can_browser_action("readonly-agent", action) is False, action
+            # can_use_browser=False overrides even a wildcard.
+            assert browser_matrix.can_browser_action("no-browser-agent", action) is False, action
+
     def test_specific_list_is_opt_out_restriction(self, browser_matrix):
         """Operators can narrow to a specific list — opt-out default-allow."""
         assert browser_matrix.can_browser_action("readonly-agent", "navigate") is True
@@ -279,6 +295,18 @@ class TestKnownBrowserActionsSet:
         from src.host.permissions import KNOWN_BROWSER_ACTIONS
         assert "solve_captcha" in KNOWN_BROWSER_ACTIONS
         assert "request_captcha_help" in KNOWN_BROWSER_ACTIONS
+
+    def test_human_parity_actions_present(self):
+        """Native dialog policy, Firefox permission grants + geolocation, and
+        drag-and-drop must be recognized by the mesh input validator so the
+        /mesh/browser/command proxy accepts them (else a clean 400 blocks
+        the whole action rather than the per-agent gate deciding)."""
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        for action in (
+            "set_dialog_policy", "grant_permissions",
+            "set_geolocation", "drag",
+        ):
+            assert action in KNOWN_BROWSER_ACTIONS, action
 
 
 class TestDefaultFallbackPropagatesBrowserActions:


### PR DESCRIPTION
Adds three human-parity browser actions so an agent can drive a browser the way a person does. Stacked on `fix/browser-proxy-fail-closed-egress` (PR #1171/#1172) — this PR's base is that branch, so the diff shows only these changes.

The browser is Camoufox (Firefox) via Playwright (Juggler — no CDP). Trusted input goes through X11/xdotool when an X11 window exists; otherwise CDP fallback. Each action is wired in the four standard places (permissions validator, browser-service route, service handler, agent `@tool`) and gated by `can_browser_action`.

## Actions

### 1. `set_dialog_policy` — native JS dialog handling
Previously there was **no** `page.on("dialog")` handler, so Playwright auto-dismissed every `alert` / `confirm` / `prompt` / `beforeunload` — dialog-gated flows failed silently. Now:
- A dialog handler is registered on the initial page **and** via `context.on("page", …)` so popups / OAuth windows are covered.
- `_on_dialog` records the dialog's message + type into `inst.last_dialog_message`, then resolves per policy (`accept` / `respond` → `dialog.accept(text)`, else `dialog.dismiss()`). It **always** resolves the dialog (a failed accept falls back to dismiss) so a pending dialog never wedges the page.
- `set_dialog_policy(action ∈ {accept,dismiss,respond}, text?)` mutates the policy and returns the last dialog message so the agent can read what a dialog said. **Default stays dismiss** (matches prior behavior — opt-in to accept).

### 2. `grant_permissions` + `set_geolocation` — scoped to Firefox reality
- `grant_permissions(permissions[], origin?)` allowlists to the **only** strings Playwright Firefox can grant: `geolocation`, `notifications`, `persistent-storage`, `push`, `screen-wake-lock`. Anything else — notably **camera / microphone / clipboard** — is rejected with a structured `invalid_input` error **before** Playwright can raise a raw `Unknown permission`.
- `set_geolocation(latitude, longitude, accuracy?, origin?)` calls `context.set_geolocation(...)` **and** grants the `geolocation` permission (Firefox needs both to deliver coords).

**Known limitation (not a bug):** camera / microphone access is **not possible** on the Firefox engine — that would require a Chromium stack.

**geo.enabled interaction:** the stealth profile sets `geo.enabled=False` (`stealth.py`) to avoid leaking a server's real location. With that pref on, pages will **not** receive the injected coordinates. `set_geolocation` still applies the override (never a silent no-op) and returns a `note` warning about the pref; an operator who needs live geo must flip `geo.enabled`.

### 3. `drag` — drag-and-drop via trusted X11
- `_x11_drag(inst, ax, ay, bx, by)`: move to source → xdotool `mousedown 1` → move to target with the button held (real drag events, `isTrusted=true`) → `mouseup 1`. Reuses the settle/dwell + subprocess-env shape of `_x11_click`.
- `drag` action accepts **either** two refs (`source_ref` / `target_ref`, resolved via `_locator_from_ref` + `_pick_click_target` bbox sampling) **or** two coordinate pairs. Uses `_x11_drag` when an X11 window is present; else CDP `page.mouse.move/down/move/up`.

**Known limitation (universal Playwright):** a pointer-based drag does **not** populate the HTML5 `DataTransfer` object, so `dragstart` / `dragover` / `drop`-based widgets (many React / SortableJS lists) won't respond. Works for pointer-driven sliders / reordering.

## Wiring (4 places + runtime gate lists)
- `src/host/permissions.py` — `set_dialog_policy`, `grant_permissions`, `set_geolocation`, `drag` added to `KNOWN_BROWSER_ACTIONS`.
- `src/browser/server.py` — four FastAPI routes.
- `src/browser/service.py` — `CamoufoxInstance.dialog_policy` / `last_dialog_message`; `_on_dialog` / `_attach_dialog_listeners` (called in `_start_browser`); `_x11_drag`; `set_dialog_policy` / `grant_permissions` / `set_geolocation` / `drag` handlers; `_FIREFOX_GRANTABLE_PERMISSIONS` allowlist.
- `src/agent/builtins/browser_tool.py` — four `@tool`s (`browser_set_dialog_policy`, `browser_drag`, `browser_grant_permissions`, `browser_set_geolocation`) documenting the limitations above.
- Runtime gate lists updated so the new tools disable with `can_use_browser`: `loop.py` `_RUNTIME_GATE_TOOLS["browser"]`, `tool_groups.py` `web_browse`, `cli/config.py` operator allowlist.

## Tests
- `tests/test_permissions.py` — new action names present in `KNOWN_BROWSER_ACTIONS` + gating test (default-allow, wildcard, narrowable, `can_use_browser=False` override).
- `tests/test_browser_parity_actions.py` — `_on_dialog` (accept/dismiss/respond + always-resolves), `set_dialog_policy`, `grant_permissions` (valid grant + camera/microphone rejection without touching Playwright), `set_geolocation` (coords + geolocation grant), `drag` (X11 vs CDP dispatch, ref-pair bbox resolution), `_x11_drag` (press→move→release order), and agent-tool param forwarding. Handlers are tested directly against a fake instance (never through `_start_browser`, which imports `camoufox`), mirroring `test_binding_cookie_coherence`.

CI lint gate (`ruff check src/ tests/`) is clean; `ruff format` was run only on the brand-new test file (the repo baseline is not `ruff format`-clean on `service.py`).
