### PR TITLE
feat(browser): human-parity actions — right-click, clipboard, network-idle (P2)

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -14,7 +14,7 @@ FROM python:3.12-slim
 # fingerprint is a detectable inconsistency. Font-cache rebuild for Firefox
 # profiles is handled by src/browser/profile_schema.py migration v2.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tini openbox wmctrl xdotool x11-xserver-utils unclutter-xfixes procps curl \
+    tini openbox wmctrl xdotool xclip x11-xserver-utils unclutter-xfixes procps curl \
     iptables gosu tzdata \
     libgtk-3-0 libatk1.0-0 libasound2 \
     libxcomposite1 libxdamage1 libxrandr2 libxkbcommon0 libgbm1 \

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1485,6 +1485,125 @@ async def browser_set_geolocation(
 
 
 @tool(
+    name="browser_right_click",
+    description=(
+        "Right-click (secondary / context-menu button) at an element ref or "
+        "at viewport coordinates — something a human can do but a normal click "
+        "cannot. Provide EITHER a 'ref' from browser_get_elements OR an (x, y) "
+        "viewport coordinate pair (CSS pixels); a ref wins when both are given. "
+        "IMPORTANT: a right-click usually opens the browser's NATIVE context "
+        "menu, which is NOT part of the page DOM — browser_get_elements will "
+        "NOT see its items. After right-clicking, drive the menu with "
+        "browser_press_key: ArrowDown/ArrowUp to move, Enter to activate, "
+        "Escape to dismiss. Many web apps also render their OWN in-page menu on "
+        "right-click; that one IS in the DOM and you can snapshot + click it."
+    ),
+    parameters={
+        "ref": {
+            "type": "string",
+            "description": "Ref of the element to right-click (e.g. 'e7').",
+            "default": "",
+        },
+        "x": {
+            "type": "number",
+            "description": "Viewport x (CSS px). Use with y when not using a ref.",
+        },
+        "y": {
+            "type": "number",
+            "description": "Viewport y (CSS px).",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_right_click(
+    ref: str = "", x: float | None = None, y: float | None = None,
+    *, mesh_client=None,
+) -> dict:
+    """Right-click at a ref or at (x, y) viewport coordinates."""
+    params: dict = {}
+    if ref:
+        params["ref"] = ref
+    else:
+        params["x"] = x
+        params["y"] = y
+    return await _browser_command(mesh_client, "right_click", params)
+
+
+@tool(
+    name="browser_write_clipboard",
+    description=(
+        "Write text to the system clipboard (the same clipboard a human "
+        "Ctrl+C / Ctrl+V uses), so you can then paste it into a field with "
+        "browser_press_key. Backed by the browser's async Clipboard API. "
+        "REQUIRES a secure (HTTPS) page — on a plain-http page the browser "
+        "rejects clipboard access and this returns an error rather than "
+        "hanging."
+    ),
+    parameters={
+        "text": {
+            "type": "string",
+            "description": "The text to place on the clipboard.",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_write_clipboard(text: str = "", *, mesh_client=None) -> dict:
+    """Write text to the system clipboard."""
+    return await _browser_command(mesh_client, "write_clipboard", {"text": text})
+
+
+@tool(
+    name="browser_read_clipboard",
+    description=(
+        "Read the current text contents of the system clipboard — useful to "
+        "capture what a page copied when you clicked a 'Copy' button (share "
+        "links, API keys, coupon codes) that never appears in the DOM. Backed "
+        "by the browser's async Clipboard API. REQUIRES a secure (HTTPS) page; "
+        "on a plain-http page the browser blocks clipboard reads and this "
+        "returns an error rather than hanging. Returns data.text."
+    ),
+    parameters={},
+    parallel_safe=False,
+)
+async def browser_read_clipboard(*, mesh_client=None) -> dict:
+    """Read the system clipboard contents."""
+    return await _browser_command(mesh_client, "read_clipboard")
+
+
+@tool(
+    name="browser_wait_for_network_idle",
+    description=(
+        "Wait until the page has no in-flight network requests (Playwright's "
+        "'networkidle'). Call this AFTER an action that fires background XHR / "
+        "fetch — search-as-you-type, infinite scroll, a form submit, adding to "
+        "a cart — to let the results settle before you snapshot with "
+        "browser_get_elements. 'timeout' is milliseconds (default 10000, capped "
+        "at 30000). Reaching the timeout is NOT an error: it returns "
+        "data.idle=False (some pages have persistent long-poll / websocket "
+        "traffic that never goes idle), so you can safely proceed."
+    ),
+    parameters={
+        "timeout": {
+            "type": "number",
+            "description": (
+                "Max time to wait in milliseconds (default 10000, capped at "
+                "30000)."
+            ),
+            "default": 10000,
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_wait_for_network_idle(
+    timeout: float = 10000, *, mesh_client=None,
+) -> dict:
+    """Wait for the page's network to go idle (non-fatal on timeout)."""
+    return await _browser_command(
+        mesh_client, "wait_for_network_idle", {"timeout": timeout},
+    )
+
+
+@tool(
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile, etc.) "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1532,12 +1532,11 @@ async def browser_right_click(
 @tool(
     name="browser_write_clipboard",
     description=(
-        "Write text to the system clipboard (the same clipboard a human "
+        "Write text to the browser's clipboard (the same clipboard a human "
         "Ctrl+C / Ctrl+V uses), so you can then paste it into a field with "
-        "browser_press_key. Backed by the browser's async Clipboard API. "
-        "REQUIRES a secure (HTTPS) page — on a plain-http page the browser "
-        "rejects clipboard access and this returns an error rather than "
-        "hanging."
+        "browser_press_key. Writes the browser's X clipboard directly, so it "
+        "works on any page (no HTTPS requirement); returns an error rather "
+        "than hanging if the clipboard is unavailable."
     ),
     parameters={
         "text": {
@@ -1555,12 +1554,12 @@ async def browser_write_clipboard(text: str = "", *, mesh_client=None) -> dict:
 @tool(
     name="browser_read_clipboard",
     description=(
-        "Read the current text contents of the system clipboard — useful to "
-        "capture what a page copied when you clicked a 'Copy' button (share "
-        "links, API keys, coupon codes) that never appears in the DOM. Backed "
-        "by the browser's async Clipboard API. REQUIRES a secure (HTTPS) page; "
-        "on a plain-http page the browser blocks clipboard reads and this "
-        "returns an error rather than hanging. Returns data.text."
+        "Read the current text contents of the browser's clipboard — useful "
+        "to capture what a page copied when you clicked a 'Copy' button (share "
+        "links, API keys, coupon codes) that never appears in the DOM. Reads "
+        "the browser's X clipboard directly, so it works on any page (no HTTPS "
+        "requirement); returns an error rather than hanging if the clipboard "
+        "is empty or unavailable. Returns data.text."
     ),
     parameters={},
     parallel_safe=False,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -168,6 +168,8 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
         "browser_solve_captcha", "browser_download",
         "browser_set_dialog_policy", "browser_drag",
         "browser_grant_permissions", "browser_set_geolocation",
+        "browser_right_click", "browser_read_clipboard",
+        "browser_write_clipboard", "browser_wait_for_network_idle",
     }),
 }
 

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -121,6 +121,8 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
             "browser_upload_file", "browser_solve_captcha", "browser_download",
             "browser_set_dialog_policy", "browser_drag",
             "browser_grant_permissions", "browser_set_geolocation",
+            "browser_right_click", "browser_read_clipboard",
+            "browser_write_clipboard", "browser_wait_for_network_idle",
         ),
     ),
 )

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -923,6 +923,52 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/right_click")
+    async def right_click(agent_id: str, request: Request):
+        """Right-click (secondary button) at a ref or viewport coords."""
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.right_click(
+            agent_id,
+            ref=body.get("ref"),
+            x=body.get("x"),
+            y=body.get("y"),
+        )
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/read_clipboard")
+    async def read_clipboard(agent_id: str, request: Request):
+        """Read the system clipboard (async Clipboard API, secure-context)."""
+        _verify_auth(request)
+        result = await manager.read_clipboard(agent_id)
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/write_clipboard")
+    async def write_clipboard(agent_id: str, request: Request):
+        """Write text to the system clipboard (async Clipboard API)."""
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.write_clipboard(
+            agent_id,
+            text=body.get("text", "") or "",
+        )
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/wait_for_network_idle")
+    async def wait_for_network_idle(agent_id: str, request: Request):
+        """Wait for no in-flight network requests (non-fatal on timeout)."""
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.wait_for_network_idle(
+            agent_id,
+            timeout=body.get("timeout", 10000),
+        )
+        await _apply_delay()
+        return result
+
     # ── Session persistence (Phase 10 §20) ────────────────────────────────
     #
     # Read-only summary + operator clear endpoint. Mounted on the browser

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -8669,6 +8669,10 @@ class BrowserManager:
                     )
 
                 _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
+                # Track the path actually taken: an X11 right-click that raises
+                # falls back to CDP, so ``_use_x11`` alone would mislabel a
+                # CDP-injected right-click as "x11".
+                method = "x11" if _use_x11 else "cdp"
                 if _use_x11:
                     try:
                         await self._x11_right_click_xy(inst, px, py)
@@ -8677,6 +8681,7 @@ class BrowserManager:
                             "X11 right-click failed for '%s', falling back "
                             "to CDP: %s", agent_id, e,
                         )
+                        method = "cdp"
                         await inst.page.mouse.click(px, py, button="right")
                 else:
                     await inst.page.mouse.click(px, py, button="right")
@@ -8685,7 +8690,7 @@ class BrowserManager:
                     "success": True,
                     "data": {
                         "at": [px, py],
-                        "method": "x11" if _use_x11 else "cdp",
+                        "method": method,
                         # Truth-in-advertising: the resulting menu is native,
                         # not DOM — the agent must drive it with press_key.
                         "note": (

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -7590,6 +7590,41 @@ class BrowserManager:
             ),
         )
 
+    async def _x11_right_click_xy(
+        self, inst: CamoufoxInstance, x: float, y: float,
+    ) -> None:
+        """Right-click at viewport coords (x, y) via xdotool button 3.
+
+        Same trusted-event rationale + Bezier/settle/dwell shape as
+        ``_x11_click_xy``, but presses the SECONDARY button (``3``) so the
+        browser fires a real ``contextmenu`` with ``isTrusted=true``. A
+        right-click typically opens a NATIVE context menu that is not part
+        of the DOM (so ``get_elements`` won't see it) — the agent normally
+        follows up with ``press_key`` (arrows / Enter) to drive it.
+        """
+        wid = inst.x11_wid
+        if not wid:
+            raise RuntimeError("No X11 window ID — cannot use xdotool right-click")
+        await self._x11_move_to(inst, int(x), int(y))
+        wid_s = str(wid)
+        loop = asyncio.get_running_loop()
+        await asyncio.sleep(pre_click_settle())
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "3"],
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
+            ),
+        )
+        await asyncio.sleep(click_dwell())
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "3"],
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
+            ),
+        )
+
     async def _x11_hover(self, inst: CamoufoxInstance, locator) -> None:
         """Move mouse to element via xdotool for isTrusted=true mousemove events."""
         await self._x11_ensure_in_viewport(inst, locator)
@@ -8576,6 +8611,201 @@ class BrowserManager:
                     },
                 }
             except Exception as e:
+                return _err("service_unavailable", str(e))
+
+    async def right_click(
+        self, agent_id: str, ref: str | None = None,
+        x: float | None = None, y: float | None = None,
+    ) -> dict:
+        """Right-click (secondary button) at a ref or viewport coords.
+
+        Accepts EITHER a ``ref`` from ``get_elements`` (resolved to a
+        Fitts'-Law-sampled point inside its bbox) OR an ``(x, y)`` viewport
+        coordinate pair. A ref takes precedence when both are supplied.
+
+        Uses the trusted X11 path (``_x11_right_click_xy``, xdotool button
+        3) when the agent has an X11 window on an X11 site; falls back to
+        CDP ``page.mouse.click(x, y, button="right")``.
+
+        A right-click usually opens the browser's NATIVE context menu, which
+        is NOT part of the page DOM — ``get_elements`` will not see it. Drive
+        the menu with ``press_key`` (Down/Up arrows then Enter, or Escape to
+        dismiss).
+        """
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if inst._user_control:
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until "
+                        "control is released.",
+                    )
+                # Resolve the target point from ref or coords.
+                if ref:
+                    loc = await self._locator_from_ref(inst, ref)
+                    if not loc:
+                        return _err("ref_stale", f"Ref '{ref}' not found")
+                    box = await loc.bounding_box()
+                    if not box:
+                        return _err(
+                            "invalid_input",
+                            "element has no bounding box (not visible)",
+                        )
+                    px, py = self._pick_click_target(box)
+                elif x is not None and y is not None:
+                    for v in (x, y):
+                        if isinstance(v, bool) or not isinstance(v, (int, float)):
+                            return _err(
+                                "invalid_input",
+                                "right_click coordinates must be numbers",
+                            )
+                    px, py = int(x), int(y)
+                else:
+                    return _err(
+                        "invalid_input",
+                        "provide either a ref or (x, y) coordinates",
+                    )
+
+                _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
+                if _use_x11:
+                    try:
+                        await self._x11_right_click_xy(inst, px, py)
+                    except Exception as e:
+                        logger.warning(
+                            "X11 right-click failed for '%s', falling back "
+                            "to CDP: %s", agent_id, e,
+                        )
+                        await inst.page.mouse.click(px, py, button="right")
+                else:
+                    await inst.page.mouse.click(px, py, button="right")
+                await asyncio.sleep(action_delay())
+                return {
+                    "success": True,
+                    "data": {
+                        "at": [px, py],
+                        "method": "x11" if _use_x11 else "cdp",
+                        # Truth-in-advertising: the resulting menu is native,
+                        # not DOM — the agent must drive it with press_key.
+                        "note": (
+                            "a native context menu (if any) is not in the DOM; "
+                            "use press_key (arrows / Enter / Escape) to drive it"
+                        ),
+                    },
+                }
+            except Exception as e:
+                return _err("service_unavailable", str(e))
+
+    async def write_clipboard(self, agent_id: str, text: str = "") -> dict:
+        """Write ``text`` to the system clipboard via the async Clipboard API.
+
+        Backed by ``navigator.clipboard.writeText`` inside the page. Requires
+        a SECURE (HTTPS) context — on a plain-http page Firefox rejects the
+        call and the error is surfaced (never hangs). The stealth profile
+        enables the testing prefs that let this resolve programmatically
+        (see ``stealth.py``).
+        """
+        if not isinstance(text, str):
+            return _err("invalid_input", "text must be a string")
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if inst._user_control:
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until "
+                        "control is released.",
+                    )
+                await inst.page.evaluate(
+                    "(t) => navigator.clipboard.writeText(t)", text,
+                )
+                return {"success": True, "data": {"written": len(text)}}
+            except Exception as e:
+                # A rejected writeText (insecure context / permission) lands
+                # here — surface it as a structured error rather than hanging.
+                return _err("service_unavailable", str(e))
+
+    async def read_clipboard(self, agent_id: str) -> dict:
+        """Read the system clipboard via the async Clipboard API.
+
+        Backed by ``navigator.clipboard.readText`` inside the page. Firefox
+        blocks clipboard reads for web content by default — the stealth
+        profile's testing prefs (``stealth.py``) allow it programmatically.
+        Requires a SECURE (HTTPS) context; on a plain-http page the read
+        rejects and the error is surfaced rather than hanging. The returned
+        text is redacted through the per-agent redactor like other page text.
+        """
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if inst._user_control:
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until "
+                        "control is released.",
+                    )
+                text = await inst.page.evaluate(
+                    "() => navigator.clipboard.readText()",
+                )
+                text = text or ""
+                return {
+                    "success": True,
+                    "data": {"text": self.redactor.redact(agent_id, text)},
+                }
+            except Exception as e:
+                return _err("service_unavailable", str(e))
+
+    async def wait_for_network_idle(
+        self, agent_id: str, timeout: int = 10000,
+    ) -> dict:
+        """Wait until there are no in-flight network requests (networkidle).
+
+        Thin wrapper over Playwright's ``page.wait_for_load_state
+        ("networkidle")`` — useful after an action that triggers XHR / fetch
+        (search-as-you-type, infinite scroll, a form POST) to let the results
+        settle before snapshotting. ``timeout`` is milliseconds, default
+        10000, capped at 30000. Reaching the cap is NOT fatal: it returns a
+        structured ``idle=False`` result (the page may simply have long-poll /
+        websocket traffic that never goes idle) rather than raising.
+        """
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+            return _err("invalid_input", "timeout must be a number (ms)")
+        # Clamp to a sane window: at least 0, at most 30s.
+        timeout_ms = max(0, min(int(timeout), 30000))
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                await inst.page.wait_for_load_state(
+                    "networkidle", timeout=timeout_ms,
+                )
+                return {
+                    "success": True,
+                    "data": {"idle": True, "timeout_ms": timeout_ms},
+                }
+            except Exception as e:
+                # Playwright's ``TimeoutError`` does NOT subclass the builtin,
+                # so match it the way the rest of the file does — isinstance
+                # OR the "timeout" message heuristic. A timeout here is
+                # NON-FATAL: idle simply wasn't reached inside the window (the
+                # page may have persistent long-poll / websocket traffic), so
+                # return a structured idle=False rather than raising.
+                if isinstance(e, TimeoutError) or "timeout" in str(e).lower():
+                    return {
+                        "success": True,
+                        "data": {
+                            "idle": False,
+                            "timeout_ms": timeout_ms,
+                            "note": (
+                                "network did not go idle within the timeout; "
+                                "the page may have persistent (long-poll / "
+                                "websocket) traffic"
+                            ),
+                        },
+                    }
                 return _err("service_unavailable", str(e))
 
     async def type_text(self, agent_id: str, ref: str | None = None, selector: str | None = None,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -7616,14 +7616,20 @@ class BrowserManager:
                 capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
-        await asyncio.sleep(click_dwell())
-        await loop.run_in_executor(
-            None,
-            lambda: subprocess.run(
-                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "3"],
-                capture_output=True, timeout=3, env=inst.subprocess_env(),
-            ),
-        )
+        # Once button 3 is physically DOWN the release MUST always fire. An
+        # ``asyncio.CancelledError`` during the dwell (or any raise) would
+        # otherwise leave the secondary button held for the rest of the
+        # session — the same class of bug as the drag held-button leak.
+        try:
+            await asyncio.sleep(click_dwell())
+        finally:
+            await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "3"],
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
+                ),
+            )
 
     async def _x11_hover(self, inst: CamoufoxInstance, locator) -> None:
         """Move mouse to element via xdotool for isTrusted=true mousemove events."""
@@ -8644,7 +8650,14 @@ class BrowserManager:
                     )
                 # Resolve the target point from ref or coords.
                 if ref:
-                    loc = await self._locator_from_ref(inst, ref)
+                    # ``_locator_from_ref`` raises RefStale when the DOM has
+                    # shifted since snapshot; surface the ref_stale recovery
+                    # path (re-snapshot) rather than a misleading
+                    # ``service_unavailable`` from the outer handler.
+                    try:
+                        loc = await self._locator_from_ref(inst, ref)
+                    except RefStale as rs:
+                        return _err("ref_stale", str(rs))
                     if not loc:
                         return _err("ref_stale", f"Ref '{ref}' not found")
                     box = await loc.bounding_box()
@@ -8703,65 +8716,119 @@ class BrowserManager:
                 return _err("service_unavailable", str(e))
 
     async def write_clipboard(self, agent_id: str, text: str = "") -> dict:
-        """Write ``text`` to the system clipboard via the async Clipboard API.
+        """Write ``text`` to the browser's X11 clipboard via ``xclip``.
 
-        Backed by ``navigator.clipboard.writeText`` inside the page. Requires
-        a SECURE (HTTPS) context — on a plain-http page Firefox rejects the
-        call and the error is surfaced (never hangs). The stealth profile
-        enables the testing prefs that let this resolve programmatically
-        (see ``stealth.py``).
+        Scoped to THIS agent's X display (``inst.subprocess_env()`` pins
+        ``DISPLAY``, exactly like the xdotool input path) so one agent's
+        clipboard never bleeds into another's. Deliberately NOT backed by the
+        page's ``navigator.clipboard`` API: exposing that to web content would
+        let any visited HTTPS page read/write the clipboard silently (a data
+        exfiltration channel + a fleet-wide fingerprint tell). Fails safe — a
+        missing / failed ``xclip`` returns a structured error, never hangs.
         """
         if not isinstance(text, str):
             return _err("invalid_input", "text must be a string")
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            try:
-                if inst._user_control:
-                    return _err(
-                        "conflict",
-                        "User has browser control — action paused until "
-                        "control is released.",
-                    )
-                await inst.page.evaluate(
-                    "(t) => navigator.clipboard.writeText(t)", text,
+            if inst._user_control:
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until "
+                    "control is released.",
                 )
-                return {"success": True, "data": {"written": len(text)}}
+            loop = asyncio.get_running_loop()
+
+            def _run_xclip():
+                # ``xclip -i`` reads stdin into the CLIPBOARD selection, then
+                # forks to keep serving it. DEVNULL its stdout/stderr so
+                # subprocess.run does not block waiting for EOF on inherited
+                # pipe fds (the classic xclip daemonize hang); the timeout is
+                # the last-ditch guard against a wedged X server.
+                return subprocess.run(
+                    ["xclip", "-selection", "clipboard", "-i"],
+                    input=text.encode("utf-8"),
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=3,
+                    env=inst.subprocess_env(),
+                )
+
+            try:
+                result = await loop.run_in_executor(None, _run_xclip)
+            except FileNotFoundError:
+                return _err(
+                    "service_unavailable",
+                    "xclip is not available in the browser container",
+                )
+            except subprocess.TimeoutExpired:
+                return _err("service_unavailable", "xclip write timed out")
             except Exception as e:
-                # A rejected writeText (insecure context / permission) lands
-                # here — surface it as a structured error rather than hanging.
                 return _err("service_unavailable", str(e))
+            if result.returncode != 0:
+                return _err(
+                    "service_unavailable",
+                    f"xclip write failed (rc={result.returncode})",
+                )
+            return {"success": True, "data": {"written": len(text)}}
 
     async def read_clipboard(self, agent_id: str) -> dict:
-        """Read the system clipboard via the async Clipboard API.
+        """Read the browser's X11 clipboard via ``xclip``.
 
-        Backed by ``navigator.clipboard.readText`` inside the page. Firefox
-        blocks clipboard reads for web content by default — the stealth
-        profile's testing prefs (``stealth.py``) allow it programmatically.
-        Requires a SECURE (HTTPS) context; on a plain-http page the read
-        rejects and the error is surfaced rather than hanging. The returned
-        text is redacted through the per-agent redactor like other page text.
+        Scoped to THIS agent's X display. NOT backed by the page's
+        ``navigator.clipboard`` API (that would expose clipboard reads to any
+        visited page — see ``write_clipboard`` and ``stealth.py``). The
+        returned text is redacted through the per-agent redactor like other
+        page text. Fails safe — a missing / failed / empty clipboard returns
+        a structured error rather than hanging.
         """
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            try:
-                if inst._user_control:
-                    return _err(
-                        "conflict",
-                        "User has browser control — action paused until "
-                        "control is released.",
-                    )
-                text = await inst.page.evaluate(
-                    "() => navigator.clipboard.readText()",
+            if inst._user_control:
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until "
+                    "control is released.",
                 )
-                text = text or ""
-                return {
-                    "success": True,
-                    "data": {"text": self.redactor.redact(agent_id, text)},
-                }
+            loop = asyncio.get_running_loop()
+
+            def _run_xclip():
+                # ``xclip -o`` prints the CLIPBOARD selection to stdout and
+                # exits (no daemonize on output), so capture_output is safe
+                # here; the timeout guards a wedged X server.
+                return subprocess.run(
+                    ["xclip", "-selection", "clipboard", "-o"],
+                    capture_output=True,
+                    timeout=3,
+                    env=inst.subprocess_env(),
+                )
+
+            try:
+                result = await loop.run_in_executor(None, _run_xclip)
+            except FileNotFoundError:
+                return _err(
+                    "service_unavailable",
+                    "xclip is not available in the browser container",
+                )
+            except subprocess.TimeoutExpired:
+                return _err("service_unavailable", "xclip read timed out")
             except Exception as e:
                 return _err("service_unavailable", str(e))
+            if result.returncode != 0:
+                # xclip exits non-zero when the clipboard is empty or has no
+                # text target — surface it rather than returning a phantom
+                # empty string.
+                err = (result.stderr or b"").decode("utf-8", "replace").strip()
+                return _err(
+                    "service_unavailable",
+                    err or "clipboard is empty or unavailable",
+                )
+            text = (result.stdout or b"").decode("utf-8", "replace")
+            return {
+                "success": True,
+                "data": {"text": self.redactor.redact(agent_id, text)},
+            }
 
     async def wait_for_network_idle(
         self, agent_id: str, timeout: int = 10000,

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -1109,18 +1109,15 @@ def _stealth_prefs(locale: str = "en-US") -> dict:
         # Blocking them causes silent auth failures.
         "dom.disable_open_during_load": False,
 
-        # ── Clipboard read/write (async Clipboard API) ────────────────────────
-        # Firefox gates ``navigator.clipboard.readText()`` behind a user
-        # gesture and blocks it entirely for web content by default, so the
-        # ``read_clipboard`` / ``write_clipboard`` browser actions would hang
-        # or reject without these. ``grant_permissions`` cannot help here —
-        # Firefox has no grantable clipboard permission (unlike Chromium).
-        # These testing prefs let the async Clipboard API resolve
-        # programmatically. Clipboard access still requires a SECURE (HTTPS)
-        # context; on plain-http pages the call rejects and the action
-        # surfaces that error rather than hanging.
-        "dom.events.testing.asyncClipboard": True,
-        "dom.events.asyncClipboard.readText": True,
+        # NOTE: the async Clipboard API is deliberately NOT enabled here.
+        # Prefs like ``dom.events.testing.asyncClipboard`` /
+        # ``dom.events.asyncClipboard.readText`` would let ANY HTTPS page an
+        # agent visits silently read and write the OS clipboard — a data
+        # exfiltration channel AND a fleet-wide fingerprint tell (Firefox does
+        # not expose these to normal web content). The ``read_clipboard`` /
+        # ``write_clipboard`` browser actions instead drive the X11 clipboard
+        # directly via ``xclip`` in ``service.py``, scoped to the agent's own
+        # display — no page-reachable Clipboard API required.
 
         # ── Telemetry and update checks ───────────────────────────────────────
         # These fire background XHR/DNS requests that look like bot traffic

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -1109,6 +1109,19 @@ def _stealth_prefs(locale: str = "en-US") -> dict:
         # Blocking them causes silent auth failures.
         "dom.disable_open_during_load": False,
 
+        # ── Clipboard read/write (async Clipboard API) ────────────────────────
+        # Firefox gates ``navigator.clipboard.readText()`` behind a user
+        # gesture and blocks it entirely for web content by default, so the
+        # ``read_clipboard`` / ``write_clipboard`` browser actions would hang
+        # or reject without these. ``grant_permissions`` cannot help here —
+        # Firefox has no grantable clipboard permission (unlike Chromium).
+        # These testing prefs let the async Clipboard API resolve
+        # programmatically. Clipboard access still requires a SECURE (HTTPS)
+        # context; on plain-http pages the call rejects and the action
+        # surfaces that error rather than hanging.
+        "dom.events.testing.asyncClipboard": True,
+        "dom.events.asyncClipboard.readText": True,
+
         # ── Telemetry and update checks ───────────────────────────────────────
         # These fire background XHR/DNS requests that look like bot traffic
         # patterns (non-page-triggered network activity).

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1763,6 +1763,8 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_download",
     "browser_set_dialog_policy", "browser_drag",
     "browser_grant_permissions", "browser_set_geolocation",
+    "browser_right_click", "browser_read_clipboard",
+    "browser_write_clipboard", "browser_wait_for_network_idle",
 ]
 
 # Grouped Tool Search bridge — pulls a deferred capability group's full schemas

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -79,6 +79,11 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     # trusted-X11 drag-and-drop. Default-allow like every other known
     # action; operators narrow via ``AgentPermissions.browser_actions``.
     "set_dialog_policy", "grant_permissions", "set_geolocation", "drag",
+    # P2 human-parity actions: trusted right-click / native context menu,
+    # secure-context clipboard read + write, and an explicit network-idle
+    # wait. Default-allow like every other known action; operators narrow
+    # via ``AgentPermissions.browser_actions``.
+    "right_click", "read_clipboard", "write_clipboard", "wait_for_network_idle",
 })
 
 

--- a/tests/test_browser_parity_actions_p2.py
+++ b/tests/test_browser_parity_actions_p2.py
@@ -5,9 +5,10 @@ Covers the actions stacked on top of the P1 parity surface:
   * ``right_click`` — trusted X11 button-3 click when an X11 window exists
     (``_x11_right_click_xy``), CDP ``page.mouse.click(..., button="right")``
     fallback otherwise. Accepts a ref or (x, y) coords.
-  * ``read_clipboard`` / ``write_clipboard`` — the async Clipboard API driven
-    via ``page.evaluate``. A rejected evaluate (insecure context / permission)
-    must surface a structured error rather than hanging.
+  * ``read_clipboard`` / ``write_clipboard`` — the agent's X11 clipboard driven
+    via ``xclip`` (NOT the page's ``navigator.clipboard`` API, which would let
+    any visited page read/write the clipboard). A missing / failed / empty
+    ``xclip`` must surface a structured error rather than hanging.
   * ``wait_for_network_idle`` — ``page.wait_for_load_state("networkidle")``;
     a timeout returns a NON-FATAL ``idle=False`` result instead of raising.
 
@@ -153,6 +154,26 @@ class TestRightClick:
         assert result["error"]["code"] == "ref_stale"
 
     @pytest.mark.asyncio
+    async def test_ref_stale_exception_returns_ref_stale(self):
+        """A RefStale raised while resolving the ref (DOM shifted since
+        snapshot) must surface the ref_stale recovery path, not a misleading
+        service_unavailable from the outer handler."""
+        from src.browser.ref_handle import RefStale
+
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+        mgr._locator_from_ref = AsyncMock(  # type: ignore[assignment]
+            side_effect=RefStale("shadow host missing", ref="e3"),
+        )
+
+        result = await mgr.right_click("agent-parity", ref="e3")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ref_stale"
+        inst.page.mouse.click.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_missing_args_rejected(self):
         mgr = _make_manager()
         inst = _FakeInstance()
@@ -199,62 +220,135 @@ class TestX11RightClickXy:
         # Both xdotool calls target button 3, not 1.
         assert calls[0][-1] == "3" and calls[1][-1] == "3"
 
+    @pytest.mark.asyncio
+    async def test_mouseup_fires_in_finally_on_cancel(self, monkeypatch):
+        """A CancelledError during the click dwell (after button 3 is DOWN)
+        must still release the button — otherwise button 3 stays physically
+        held for the rest of the session (X11 corruption), the same class of
+        bug as the drag held-button leak."""
+        import src.browser.service as svc
+
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=555)
+
+        async def _fake_move(_inst, x, y):
+            return None
+
+        monkeypatch.setattr(mgr, "_x11_move_to", _fake_move)
+
+        calls: list[list[str]] = []
+
+        class _FakeCompletedProc:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return _FakeCompletedProc()
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        # Raise CancelledError on the 2nd asyncio.sleep — the dwell between
+        # mousedown (button held) and mouseup. The 1st (pre_click_settle)
+        # sleeps normally.
+        real_sleep = asyncio.sleep
+        state = {"n": 0}
+
+        async def _sleep(*a, **k):
+            state["n"] += 1
+            if state["n"] == 2:
+                raise asyncio.CancelledError()
+            return await real_sleep(0)
+
+        monkeypatch.setattr(svc.asyncio, "sleep", _sleep)
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._x11_right_click_xy(inst, 10, 20)
+
+        # Despite the cancel mid-dwell, mouseup 3 MUST have fired.
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        assert calls[0][-1] == "3" and calls[1][-1] == "3"
+
 
 # ── Clipboard ──────────────────────────────────────────────────────────────
 
 
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _patch_subprocess_run(monkeypatch, calls: list, result):
+    """Patch ONLY ``subprocess.run`` on the service module (keeping DEVNULL /
+    TimeoutExpired intact). ``result`` is returned, or raised if it is an
+    exception instance."""
+
+    def _run(cmd, *args, **kwargs):
+        calls.append({"cmd": cmd, "kwargs": kwargs})
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr("src.browser.service.subprocess.run", _run)
+
+
 class TestClipboard:
     @pytest.mark.asyncio
-    async def test_write_clipboard_calls_evaluate(self):
+    async def test_write_clipboard_pipes_to_xclip(self, monkeypatch):
+        """write_clipboard must pipe the text to ``xclip -selection clipboard
+        -i`` — the X clipboard, NOT the page's navigator.clipboard API."""
         mgr = _make_manager()
         inst = _FakeInstance()
         _patch_get_or_start(mgr, inst)
+        calls: list = []
+        _patch_subprocess_run(monkeypatch, calls, _FakeCompleted(returncode=0))
 
         result = await mgr.write_clipboard("agent-parity", text="hello world")
 
         assert result["success"] is True
         assert result["data"]["written"] == len("hello world")
-        inst.page.evaluate.assert_awaited_once_with(
-            "(t) => navigator.clipboard.writeText(t)", "hello world",
-        )
+        # navigator.clipboard was NOT used.
+        inst.page.evaluate.assert_not_called()
+        assert len(calls) == 1
+        assert calls[0]["cmd"] == ["xclip", "-selection", "clipboard", "-i"]
+        assert calls[0]["kwargs"]["input"] == b"hello world"
 
     @pytest.mark.asyncio
-    async def test_read_clipboard_returns_text(self):
+    async def test_read_clipboard_reads_from_xclip(self, monkeypatch):
+        """read_clipboard must return the stdout of ``xclip -selection
+        clipboard -o``."""
         mgr = _make_manager()
         inst = _FakeInstance()
-        inst.page.evaluate = AsyncMock(return_value="copied text")
         _patch_get_or_start(mgr, inst)
+        calls: list = []
+        _patch_subprocess_run(
+            monkeypatch, calls,
+            _FakeCompleted(returncode=0, stdout=b"copied text"),
+        )
 
         result = await mgr.read_clipboard("agent-parity")
 
         assert result["success"] is True
         assert result["data"]["text"] == "copied text"
-        inst.page.evaluate.assert_awaited_once_with(
-            "() => navigator.clipboard.readText()",
-        )
+        inst.page.evaluate.assert_not_called()
+        assert calls[0]["cmd"] == ["xclip", "-selection", "clipboard", "-o"]
 
     @pytest.mark.asyncio
-    async def test_read_clipboard_none_becomes_empty(self):
+    async def test_read_clipboard_missing_xclip_is_structured_error(self, monkeypatch):
+        """A missing xclip binary must fail safe with a structured error, not
+        raise (fail-closed for the feature)."""
         mgr = _make_manager()
         inst = _FakeInstance()
-        inst.page.evaluate = AsyncMock(return_value=None)
         _patch_get_or_start(mgr, inst)
-
-        result = await mgr.read_clipboard("agent-parity")
-
-        assert result["success"] is True
-        assert result["data"]["text"] == ""
-
-    @pytest.mark.asyncio
-    async def test_read_clipboard_rejection_surfaces_error(self):
-        """An insecure-context / permission rejection must be a structured
-        error, never a hang."""
-        mgr = _make_manager()
-        inst = _FakeInstance()
-        inst.page.evaluate = AsyncMock(
-            side_effect=RuntimeError("Clipboard read blocked (insecure context)"),
+        calls: list = []
+        _patch_subprocess_run(
+            monkeypatch, calls, FileNotFoundError("xclip"),
         )
-        _patch_get_or_start(mgr, inst)
 
         result = await mgr.read_clipboard("agent-parity")
 
@@ -262,13 +356,47 @@ class TestClipboard:
         assert result["error"]["code"] == "service_unavailable"
 
     @pytest.mark.asyncio
-    async def test_write_clipboard_rejection_surfaces_error(self):
+    async def test_read_clipboard_empty_is_structured_error(self, monkeypatch):
+        """xclip exits non-zero on an empty clipboard (no STRING target) — that
+        must surface as an error, never a phantom empty string or a hang."""
         mgr = _make_manager()
         inst = _FakeInstance()
-        inst.page.evaluate = AsyncMock(
-            side_effect=RuntimeError("writeText blocked"),
-        )
         _patch_get_or_start(mgr, inst)
+        calls: list = []
+        _patch_subprocess_run(
+            monkeypatch, calls,
+            _FakeCompleted(returncode=1, stderr=b"Error: target STRING not available"),
+        )
+
+        result = await mgr.read_clipboard("agent-parity")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_write_clipboard_missing_xclip_is_structured_error(self, monkeypatch):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+        calls: list = []
+        _patch_subprocess_run(
+            monkeypatch, calls, FileNotFoundError("xclip"),
+        )
+
+        result = await mgr.write_clipboard("agent-parity", text="x")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_write_clipboard_nonzero_is_structured_error(self, monkeypatch):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+        calls: list = []
+        _patch_subprocess_run(
+            monkeypatch, calls, _FakeCompleted(returncode=1),
+        )
 
         result = await mgr.write_clipboard("agent-parity", text="x")
 

--- a/tests/test_browser_parity_actions_p2.py
+++ b/tests/test_browser_parity_actions_p2.py
@@ -1,0 +1,400 @@
+"""Behavior tests for the P2 human-parity browser actions.
+
+Covers the actions stacked on top of the P1 parity surface:
+
+  * ``right_click`` — trusted X11 button-3 click when an X11 window exists
+    (``_x11_right_click_xy``), CDP ``page.mouse.click(..., button="right")``
+    fallback otherwise. Accepts a ref or (x, y) coords.
+  * ``read_clipboard`` / ``write_clipboard`` — the async Clipboard API driven
+    via ``page.evaluate``. A rejected evaluate (insecure context / permission)
+    must surface a structured error rather than hanging.
+  * ``wait_for_network_idle`` — ``page.wait_for_load_state("networkidle")``;
+    a timeout returns a NON-FATAL ``idle=False`` result instead of raising.
+
+``BrowserManager._start_browser`` imports ``camoufox`` (not installed in CI),
+so we NEVER go through it — every test drives the handler methods directly
+against a fake instance, patching ``get_or_start`` to return it (mirrors
+``tests/test_browser_parity_actions``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser.service import BrowserManager
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_parity_p2_")
+    return BrowserManager(profiles_dir=root)
+
+
+class _FakeInstance:
+    """Minimal CamoufoxInstance duck-type for the P2 parity handlers."""
+
+    def __init__(self, *, x11_wid=None):
+        self.agent_id = "agent-parity"
+        self.x11_wid = x11_wid
+        self._user_control = False
+        self.refs: dict = {}
+        self._lock = asyncio.Lock()
+        self.page = MagicMock()
+        self.page.mouse = MagicMock()
+        self.page.mouse.click = AsyncMock()
+        self.page.evaluate = AsyncMock()
+        self.page.wait_for_load_state = AsyncMock()
+
+    @property
+    def lock(self):
+        return self._lock
+
+    def touch(self):
+        pass
+
+    def subprocess_env(self):
+        # xdotool env for the X11 path; value is irrelevant here because
+        # subprocess.run is monkeypatched in the X11 test.
+        return None
+
+
+def _patch_get_or_start(mgr: BrowserManager, inst: _FakeInstance) -> None:
+    mgr.get_or_start = AsyncMock(return_value=inst)  # type: ignore[assignment]
+
+
+# ── Right-click ────────────────────────────────────────────────────────────
+
+
+class TestRightClick:
+    @pytest.mark.asyncio
+    async def test_x11_path_used_when_window_present(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=123)
+        _patch_get_or_start(mgr, inst)
+        mgr._x11_right_click_xy = AsyncMock()  # type: ignore[assignment]
+
+        result = await mgr.right_click("agent-parity", x=42, y=84)
+
+        assert result["success"] is True
+        assert result["data"]["method"] == "x11"
+        assert result["data"]["at"] == [42, 84]
+        mgr._x11_right_click_xy.assert_awaited_once_with(inst, 42, 84)
+        # CDP mouse untouched on the trusted path.
+        inst.page.mouse.click.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cdp_fallback_uses_right_button(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.right_click("agent-parity", x=5, y=6)
+
+        assert result["success"] is True
+        assert result["data"]["method"] == "cdp"
+        inst.page.mouse.click.assert_awaited_once_with(5, 6, button="right")
+
+    @pytest.mark.asyncio
+    async def test_x11_failure_falls_back_to_cdp(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=999)
+        _patch_get_or_start(mgr, inst)
+        mgr._x11_right_click_xy = AsyncMock(  # type: ignore[assignment]
+            side_effect=RuntimeError("xdotool missing"),
+        )
+
+        result = await mgr.right_click("agent-parity", x=1, y=2)
+
+        # Fell back to CDP with the secondary button.
+        assert result["success"] is True
+        inst.page.mouse.click.assert_awaited_once_with(1, 2, button="right")
+
+    @pytest.mark.asyncio
+    async def test_ref_resolves_bounding_box(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+
+        loc = MagicMock()
+        loc.bounding_box = AsyncMock(
+            return_value={"x": 100, "y": 100, "width": 40, "height": 40},
+        )
+        mgr._locator_from_ref = AsyncMock(  # type: ignore[assignment]
+            return_value=loc,
+        )
+
+        result = await mgr.right_click("agent-parity", ref="e3")
+
+        assert result["success"] is True
+        px, py = result["data"]["at"]
+        # Point lands inside the element's bbox (Fitts' sampler).
+        assert 100 <= px <= 140 and 100 <= py <= 140
+        inst.page.mouse.click.assert_awaited_once_with(px, py, button="right")
+
+    @pytest.mark.asyncio
+    async def test_stale_ref_rejected(self):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=None)
+        _patch_get_or_start(mgr, inst)
+        mgr._locator_from_ref = AsyncMock(  # type: ignore[assignment]
+            return_value=None,
+        )
+
+        result = await mgr.right_click("agent-parity", ref="gone")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ref_stale"
+
+    @pytest.mark.asyncio
+    async def test_missing_args_rejected(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.right_click("agent-parity")  # no ref, no coords
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+
+class TestX11RightClickXy:
+    @pytest.mark.asyncio
+    async def test_press_release_uses_button_3(self, monkeypatch):
+        """``_x11_right_click_xy`` must move to the point, then press + release
+        xdotool button 3 (the secondary/context-menu button)."""
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=777)
+
+        moves: list[tuple[int, int]] = []
+
+        async def _fake_move(_inst, x, y):
+            moves.append((x, y))
+
+        monkeypatch.setattr(mgr, "_x11_move_to", _fake_move)
+
+        calls: list[list[str]] = []
+
+        class _FakeCompleted:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return _FakeCompleted()
+
+        fake_subprocess = types.SimpleNamespace(run=_fake_run)
+        monkeypatch.setattr("src.browser.service.subprocess", fake_subprocess)
+
+        await mgr._x11_right_click_xy(inst, 30, 60)
+
+        assert moves == [(30, 60)]
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        # Both xdotool calls target button 3, not 1.
+        assert calls[0][-1] == "3" and calls[1][-1] == "3"
+
+
+# ── Clipboard ──────────────────────────────────────────────────────────────
+
+
+class TestClipboard:
+    @pytest.mark.asyncio
+    async def test_write_clipboard_calls_evaluate(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.write_clipboard("agent-parity", text="hello world")
+
+        assert result["success"] is True
+        assert result["data"]["written"] == len("hello world")
+        inst.page.evaluate.assert_awaited_once_with(
+            "(t) => navigator.clipboard.writeText(t)", "hello world",
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_clipboard_returns_text(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.page.evaluate = AsyncMock(return_value="copied text")
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.read_clipboard("agent-parity")
+
+        assert result["success"] is True
+        assert result["data"]["text"] == "copied text"
+        inst.page.evaluate.assert_awaited_once_with(
+            "() => navigator.clipboard.readText()",
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_clipboard_none_becomes_empty(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.page.evaluate = AsyncMock(return_value=None)
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.read_clipboard("agent-parity")
+
+        assert result["success"] is True
+        assert result["data"]["text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_read_clipboard_rejection_surfaces_error(self):
+        """An insecure-context / permission rejection must be a structured
+        error, never a hang."""
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.page.evaluate = AsyncMock(
+            side_effect=RuntimeError("Clipboard read blocked (insecure context)"),
+        )
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.read_clipboard("agent-parity")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_write_clipboard_rejection_surfaces_error(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.page.evaluate = AsyncMock(
+            side_effect=RuntimeError("writeText blocked"),
+        )
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.write_clipboard("agent-parity", text="x")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+
+
+# ── Network-idle wait ──────────────────────────────────────────────────────
+
+
+class TestWaitForNetworkIdle:
+    @pytest.mark.asyncio
+    async def test_idle_reached(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.wait_for_network_idle("agent-parity", timeout=5000)
+
+        assert result["success"] is True
+        assert result["data"]["idle"] is True
+        assert result["data"]["timeout_ms"] == 5000
+        inst.page.wait_for_load_state.assert_awaited_once_with(
+            "networkidle", timeout=5000,
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_non_fatal(self):
+        """A Playwright timeout (message contains 'Timeout ... exceeded') must
+        return a structured idle=False, NOT raise."""
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.page.wait_for_load_state = AsyncMock(
+            side_effect=RuntimeError("Timeout 10000ms exceeded"),
+        )
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.wait_for_network_idle("agent-parity")
+
+        assert result["success"] is True
+        assert result["data"]["idle"] is False
+        assert "note" in result["data"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_capped_at_30s(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.wait_for_network_idle("agent-parity", timeout=99999)
+
+        assert result["success"] is True
+        assert result["data"]["timeout_ms"] == 30000
+        inst.page.wait_for_load_state.assert_awaited_once_with(
+            "networkidle", timeout=30000,
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_timeout_error_is_fatal(self):
+        mgr = _make_manager()
+        inst = _FakeInstance()
+        inst.page.wait_for_load_state = AsyncMock(
+            side_effect=RuntimeError("target crashed"),
+        )
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.wait_for_network_idle("agent-parity")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+
+
+# ── Agent-side @tool forwarding ────────────────────────────────────────────
+
+
+def _mesh(action_capture: dict):
+    mc = MagicMock()
+
+    async def _cmd(action, params):
+        action_capture["action"] = action
+        action_capture["params"] = params
+        return {"success": True}
+
+    mc.browser_command = AsyncMock(side_effect=_cmd)
+    return mc
+
+
+class TestAgentToolForwarding:
+    @pytest.mark.asyncio
+    async def test_right_click_prefers_ref(self):
+        from src.agent.builtins.browser_tool import browser_right_click
+
+        cap: dict = {}
+        await browser_right_click(ref="e9", x=1, y=2, mesh_client=_mesh(cap))
+        assert cap["action"] == "right_click"
+        assert cap["params"] == {"ref": "e9"}
+
+    @pytest.mark.asyncio
+    async def test_right_click_coords(self):
+        from src.agent.builtins.browser_tool import browser_right_click
+
+        cap: dict = {}
+        await browser_right_click(x=11, y=22, mesh_client=_mesh(cap))
+        assert cap["action"] == "right_click"
+        assert cap["params"] == {"x": 11, "y": 22}
+
+    @pytest.mark.asyncio
+    async def test_write_clipboard_tool(self):
+        from src.agent.builtins.browser_tool import browser_write_clipboard
+
+        cap: dict = {}
+        await browser_write_clipboard(text="paste me", mesh_client=_mesh(cap))
+        assert cap["action"] == "write_clipboard"
+        assert cap["params"] == {"text": "paste me"}
+
+    @pytest.mark.asyncio
+    async def test_read_clipboard_tool(self):
+        from src.agent.builtins.browser_tool import browser_read_clipboard
+
+        cap: dict = {}
+        await browser_read_clipboard(mesh_client=_mesh(cap))
+        assert cap["action"] == "read_clipboard"
+        assert cap["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_wait_for_network_idle_tool(self):
+        from src.agent.builtins.browser_tool import browser_wait_for_network_idle
+
+        cap: dict = {}
+        await browser_wait_for_network_idle(timeout=8000, mesh_client=_mesh(cap))
+        assert cap["action"] == "wait_for_network_idle"
+        assert cap["params"] == {"timeout": 8000}

--- a/tests/test_browser_parity_actions_p2.py
+++ b/tests/test_browser_parity_actions_p2.py
@@ -112,6 +112,9 @@ class TestRightClick:
         # Fell back to CDP with the secondary button.
         assert result["success"] is True
         inst.page.mouse.click.assert_awaited_once_with(1, 2, button="right")
+        # The reported method must reflect the path ACTUALLY taken (cdp),
+        # not the x11 preference that raised and fell back.
+        assert result["data"]["method"] == "cdp"
 
     @pytest.mark.asyncio
     async def test_ref_resolves_bounding_box(self):

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2063,6 +2063,10 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "browser_drag",
     "browser_grant_permissions",
     "browser_set_geolocation",
+    "browser_right_click",
+    "browser_read_clipboard",
+    "browser_write_clipboard",
+    "browser_wait_for_network_idle",
     "request_captcha_help",
     "request_browser_login",
     # Watch / pub-sub.

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -200,6 +200,9 @@ class TestCanBrowserAction:
         for action in (
             "set_dialog_policy", "grant_permissions",
             "set_geolocation", "drag",
+            # P2 parity actions.
+            "right_click", "read_clipboard",
+            "write_clipboard", "wait_for_network_idle",
         ):
             # Default (None) and wildcard both allow.
             assert browser_matrix.can_browser_action("legacy-agent", action) is True, action
@@ -305,6 +308,9 @@ class TestKnownBrowserActionsSet:
         for action in (
             "set_dialog_policy", "grant_permissions",
             "set_geolocation", "drag",
+            # P2 parity actions.
+            "right_click", "read_clipboard",
+            "write_clipboard", "wait_for_network_idle",
         ):
             assert action in KNOWN_BROWSER_ACTIONS, action
 


### PR DESCRIPTION
## Human-parity browser actions (P2)

Stacked on **#1173** (`fix/browser-parity-actions-p1`). Adds three more capabilities a human at the same Camoufox (Firefox) browser has but agents lacked. **Four action names:** `right_click`, `read_clipboard`, `write_clipboard`, `wait_for_network_idle`.

> Base this on the P1 branch — review/merge **#1173 first**.

### 1. Right-click / context menu (`right_click`)
Agents could left-click but never open a context menu. Adds a trusted X11 path (`_x11_right_click_xy` issues `xdotool ... button 3`, reusing the same Bezier move + settle/dwell shape as `_x11_click_xy` so the `contextmenu` event reads `isTrusted=true`), with a CDP `page.mouse.click(..., button="right")` fallback when no X11 window exists. Accepts a `ref` or `(x, y)`. A right-click usually opens a **native** context menu that is not in the DOM, so the tool description and the result `note` tell the agent to drive it with `press_key` (arrows / Enter / Escape).

### 2. Clipboard read/write (`read_clipboard`, `write_clipboard`)
Firefox blocks `navigator.clipboard` for web content by default and `grant_permissions` cannot help (Firefox has no grantable clipboard permission, unlike Chromium). The working path is two stealth prefs — `dom.events.testing.asyncClipboard` + `dom.events.asyncClipboard.readText` — that let the async Clipboard API resolve programmatically. Both actions drive `navigator.clipboard` via `page.evaluate`. Clipboard APIs require a **secure (HTTPS)** context; on http pages they reject — the handler surfaces the error rather than hanging. `read_clipboard` runs its result through the per-agent credential redactor like other page text.

### 3. Network-idle wait (`wait_for_network_idle`)
Only selector-based waits existed. Wraps `page.wait_for_load_state("networkidle")` (timeout default 10000ms, capped 30000) so agents can let XHR/fetch settle after search-as-you-type, infinite scroll, or a form POST before snapshotting. Reaching the timeout is **non-fatal** (pages with persistent long-poll / websocket traffic never go idle) — it returns a structured `idle=False` result instead of raising.

### Wiring
Each action is wired exactly the way P1 wired its four: `KNOWN_BROWSER_ACTIONS` (permissions), a browser-service route + handler, an agent `@tool`, and the three browser runtime-gate / tool-group lists (`loop.py`, `tool_groups.py`, `cli/config.py`) — so they disable with `can_use_browser` and narrow via `browser_actions`. The generic `/mesh/browser/command` proxy needs no change (it validates against `KNOWN_BROWSER_ACTIONS` and forwards to `/browser/{agent}/{action}`).

### Dashboard completeness guard
Also allowlists the **P1 + P2** parity tools in the `verbForTool` completeness guard (`test_dashboard_ui.py`). The P1 commit added its four tools without touching the dashboard, so that guard was already failing for all eight on this stacked base; the generic "using browser_*" activity-feed fallback reads fine for these mechanical actions, matching the sibling scroll / hover / press_key entries.

### Tests
New `tests/test_browser_parity_actions_p2.py` (21 tests) drives the handler methods directly against a fake instance (never through `_start_browser`, which imports camoufox): right-click X11-vs-CDP dispatch + button-3 sequence + ref/coord resolution, clipboard evaluate scripts + rejection surfacing, network-idle success/timeout-non-fatal/cap, and agent-side `@tool` forwarding. `tests/test_permissions.py` extends the known-set + gating tests with the four new names.

- `ruff check src/ tests/` — clean (both repo ruff and latest).
- Targeted suite (`test_dashboard_ui` + `test_permissions` + both parity files): **328 passed, 3 skipped**.
- Full fast suite: the only new/deterministic failure was the dashboard completeness guard, now fixed. (Remaining full-run reds are pre-existing order-dependent credentials/templates state pollution — pass in isolation; CI shards per-file with `--dist=loadfile`.)
