### PR TITLE
feat(browser): fail-closed proxy option, egress-IP binding, no-proxy TZ warning

### DIFF
--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -250,6 +250,18 @@ def main() -> None:
             await _cost_counter.restore()
         except Exception as exc:
             logger.warning("captcha_cost_counter.restore failed: %s", exc)
+        # Durable fingerprint burn + per-agent binding-signature state.
+        # Without this restore, a fingerprint flagged "burned" reads clean
+        # after a restart while its poisoned cookies persist on disk, and
+        # the binding-coherence check has no prior signature to compare
+        # against. Non-fatal — a missing / corrupt sidecar restores empty.
+        from src.browser.service import (
+            load_fingerprint_state as _load_fp_state,
+        )
+        try:
+            await _load_fp_state()
+        except Exception as exc:
+            logger.warning("load_fingerprint_state failed: %s", exc)
         await manager.start_cleanup_loop()
         logger.info("Browser service ready (max=%d, idle_timeout=%dm)", _MAX_BROWSERS, _IDLE_TIMEOUT)
         yield
@@ -257,6 +269,13 @@ def main() -> None:
             await _cost_counter.snapshot()
         except Exception as exc:
             logger.warning("captcha_cost_counter.snapshot failed: %s", exc)
+        from src.browser.service import (
+            persist_fingerprint_state as _persist_fp_state,
+        )
+        try:
+            await _persist_fp_state()
+        except Exception as exc:
+            logger.warning("persist_fingerprint_state failed: %s", exc)
         # ``stop_all`` tears down every per-agent X stack via
         # ``_teardown_per_agent_x_stack``; no global processes to reap.
         await manager.stop_all()

--- a/src/browser/fingerprint_state.py
+++ b/src/browser/fingerprint_state.py
@@ -1,0 +1,253 @@
+"""Durable per-agent fingerprint-burn + binding-signature state.
+
+Two pieces of always-on browser identity state used to live only in
+``src/browser/service.py`` module globals, so they evaporated on a
+browser-service restart:
+
+  1. **Fingerprint-burn state** — the rolling accept/reject window, the
+     hard-burn set, and its reasons. When these were in-memory-only, a
+     fingerprint flagged "burned" (poisoned) read *clean* after a restart
+     even though the cookies that got it burned still sat on disk in the
+     Camoufox persistent profile. The operator would see a healthy agent
+     that instantly re-tripped every anti-bot vendor.
+
+  2. **Per-agent binding signatures** — a short opaque hash of the
+     ``(UA, proxy)`` identity the agent last launched with. The
+     always-on profile channel (``user_data_dir``) restores ALL cookies
+     on launch, including anti-bot trust tokens (``cf_clearance``,
+     ``datadome``, ``_abck`` …) that vendors bind to the original
+     ``(UA, IP)`` tuple. Replaying one of those under a rotated UA or a
+     different proxy egress is an instant 403 AND lowers the trust score
+     for the session lifetime. ``service._enforce_binding_cookie_coherence``
+     compares the persisted signature against the current one on each
+     launch and drops bound cookies on a mismatch — which requires the
+     signature to survive restarts.
+
+Both are identity state that must be durable, so they share one sidecar.
+
+The in-memory globals in ``service.py`` stay the source of truth
+in-process; this module is pure serialization. It deliberately does NOT
+import ``service`` (no cycle): callers pass the state in on
+:func:`snapshot` and receive a :class:`FingerprintState` back from
+:func:`restore`, then repopulate their own globals.
+
+Atomic-write + non-fatal-restore protocol mirrors
+:mod:`src.browser.captcha_cost_counter` (open ``0o600`` → ``fchmod`` →
+``json.dump`` → ``fsync`` → ``os.replace`` → ``chmod``). A missing or
+corrupt file restores empty rather than raising — a bad sidecar must
+never block browser-service startup.
+
+On-disk schema::
+
+    {
+      "version": 1,
+      "saved_at": <epoch seconds>,
+      "window": {"<agent_id>": [true, false, ...], ...},
+      "last_signal": {"<agent_id>": <epoch float>, ...},
+      "hard_burned": ["<agent_id>", ...],
+      "hard_burn_reason": {"<agent_id>": ["<vendor>", "<signal>"], ...},
+      "binding_signatures": {"<agent_id>": "<16-hex>", ...}
+    }
+
+Default path ``data/fingerprint_state.json``; env override
+``FINGERPRINT_STATE_PATH`` (consistent with ``CAPTCHA_COST_COUNTER_PATH``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.fingerprint_state")
+
+
+# Persistence path. Lives under ``data/`` alongside the captcha-cost
+# counter sidecar so all browser-service persistence stays under one
+# parent. Override-able via env for tests + custom deployments.
+_DEFAULT_PATH = "data/fingerprint_state.json"
+_SCHEMA_VERSION = 1
+# Default rolling-window bound. Mirrors ``service._FINGERPRINT_WINDOW_SIZE``
+# but kept as a local default so this module has NO import cycle back into
+# service.py. The live caller passes its own constant to :func:`restore`
+# (``window_maxlen=_FINGERPRINT_WINDOW_SIZE``) so the two can never drift
+# silently; the default only matters for standalone / test use.
+_DEFAULT_WINDOW_MAXLEN = 10
+
+
+def _state_path() -> Path:
+    """Return the fingerprint-state sidecar path (env-overridable)."""
+    return Path(os.environ.get("FINGERPRINT_STATE_PATH", _DEFAULT_PATH))
+
+
+@dataclass
+class FingerprintState:
+    """In-memory view of the persisted fingerprint state.
+
+    Field shapes match the ``service.py`` globals they seed so a caller
+    can ``.update()`` each straight in. ``window`` values are bounded
+    ``deque`` rebuilt with the caller-supplied ``maxlen`` on restore.
+    """
+
+    window: dict[str, deque] = field(default_factory=dict)
+    last_signal: dict[str, float] = field(default_factory=dict)
+    hard_burned: set[str] = field(default_factory=set)
+    hard_burn_reason: dict[str, tuple[str, str]] = field(default_factory=dict)
+    binding_signatures: dict[str, str] = field(default_factory=dict)
+
+
+def snapshot(
+    *,
+    window: Mapping[str, Iterable[bool]],
+    last_signal: Mapping[str, float],
+    hard_burned: Iterable[str],
+    hard_burn_reason: Mapping[str, Iterable[str]],
+    binding_signatures: Mapping[str, str],
+    path: Path | str | None = None,
+) -> bool:
+    """Atomically write the supplied state to ``path`` as JSON.
+
+    Synchronous by design: the ``service.py`` caller already holds the
+    fingerprint lock across its mutation, so there is no internal state
+    to guard here. Returns ``True`` on success; failures log + return
+    ``False`` rather than raise — the mutation / shutdown paths must not
+    abort because persistence failed (same posture as the captcha-cost
+    counter snapshot).
+
+    Atomic-write protocol: ``os.open`` the tmp sibling with mode 0o600
+    (no world-readable window), ``fchmod``, write + ``fsync``,
+    ``os.replace`` over the destination, then re-``chmod`` 0o600.
+    """
+    target = Path(path) if path else _state_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning("fingerprint_state snapshot: cannot create parent dir: %s", e)
+        return False
+
+    payload = {
+        "version": _SCHEMA_VERSION,
+        "saved_at": int(time.time()),
+        "window": {str(a): [bool(v) for v in w] for a, w in window.items()},
+        "last_signal": {str(a): float(t) for a, t in last_signal.items()},
+        "hard_burned": sorted(str(a) for a in hard_burned),
+        "hard_burn_reason": {str(a): [str(x) for x in r] for a, r in hard_burn_reason.items()},
+        "binding_signatures": {str(a): str(s) for a, s in binding_signatures.items()},
+    }
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        # Open with 0o600 from the start (umask-aware) so there is no
+        # world-readable window before the explicit chmod below.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        # We own ``fd`` until ``os.fdopen`` returns; ``fchmod`` / ``fdopen``
+        # can raise (OSError / MemoryError) which would leak the descriptor
+        # unless we close it in that narrow window. After fdopen returns the
+        # file object owns ``fd`` and the ``with`` block handles cleanup.
+        try:
+            os.fchmod(fd, 0o600)
+            fh = os.fdopen(fd, "w", encoding="utf-8")
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        with fh:
+            json.dump(payload, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+        # ``os.replace`` preserves the destination's mode on most
+        # filesystems but Python's docs are not load-bearing on this;
+        # explicit chmod after replace ensures 0o600 regardless of
+        # whether the target pre-existed.
+        os.chmod(target, 0o600)
+    except OSError as e:
+        logger.warning("fingerprint_state snapshot failed: %s", e)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def restore(
+    path: Path | str | None = None,
+    *,
+    window_maxlen: int = _DEFAULT_WINDOW_MAXLEN,
+) -> FingerprintState:
+    """Load state from ``path`` if it exists, returning a :class:`FingerprintState`.
+
+    Missing / unreadable / malformed files are non-fatal — log + return an
+    empty state. Every field is parsed defensively; a malformed individual
+    entry is skipped rather than aborting the whole restore. ``window``
+    deques are rebuilt with ``maxlen=window_maxlen`` so the bound survives
+    the round-trip (the live caller passes ``_FINGERPRINT_WINDOW_SIZE``).
+    """
+    target = Path(path) if path else _state_path()
+    state = FingerprintState()
+    if not target.exists():
+        return state
+    try:
+        with open(target, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("fingerprint_state restore: %s — starting empty", e)
+        return state
+    if not isinstance(payload, dict):
+        logger.warning(
+            "fingerprint_state restore: unexpected payload type — starting empty",
+        )
+        return state
+    version = payload.get("version")
+    if version != _SCHEMA_VERSION:
+        logger.warning(
+            "fingerprint_state restore: unexpected version %r (expected %d) — starting empty",
+            version,
+            _SCHEMA_VERSION,
+        )
+        return state
+
+    window = payload.get("window")
+    if isinstance(window, dict):
+        for agent_id, values in window.items():
+            if not isinstance(agent_id, str) or not isinstance(values, list):
+                continue
+            state.window[agent_id] = deque(
+                (bool(v) for v in values),
+                maxlen=window_maxlen,
+            )
+
+    last_signal = payload.get("last_signal")
+    if isinstance(last_signal, dict):
+        for agent_id, ts in last_signal.items():
+            if isinstance(agent_id, str) and isinstance(ts, (int, float)):
+                state.last_signal[agent_id] = float(ts)
+
+    hard_burned = payload.get("hard_burned")
+    if isinstance(hard_burned, list):
+        state.hard_burned = {a for a in hard_burned if isinstance(a, str)}
+
+    reasons = payload.get("hard_burn_reason")
+    if isinstance(reasons, dict):
+        for agent_id, pair in reasons.items():
+            if not isinstance(agent_id, str):
+                continue
+            if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                state.hard_burn_reason[agent_id] = (str(pair[0]), str(pair[1]))
+
+    sigs = payload.get("binding_signatures")
+    if isinstance(sigs, dict):
+        for agent_id, sig in sigs.items():
+            if isinstance(agent_id, str) and isinstance(sig, str):
+                state.binding_signatures[agent_id] = sig
+
+    return state

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -89,6 +89,31 @@ KNOWN_FLAGS: dict[str, str] = {
         "arrivals as bot signal. Operators who run high-volume tests "
         "against these platforms (or have measured no benefit) can "
         "disable globally or per-agent.",
+    # ── Proxy hardening ───────────────────────────────────────────────────
+    "BROWSER_REQUIRE_PROXY":
+        "true | false (DEFAULT FALSE) — fail closed when no proxy is "
+        "resolved for an agent. When true and the effective proxy config "
+        "is None, the browser REFUSES to launch for that agent rather "
+        "than egressing from the datacenter IP (a strong bot signal + a "
+        "deanonymization risk). Recoverable: the mesh re-pushes the proxy "
+        "config + resets, and the next launch succeeds. When false "
+        "(default) the historical fail-open behavior is preserved — launch "
+        "without a proxy and log a warning.",
+    "BROWSER_PROXY_EGRESS_IP_CHECK":
+        "true | false (DEFAULT FALSE) — when a proxy IS set, best-effort "
+        "probe the real egress IP through the proxy at launch and fold it "
+        "into the per-agent binding signature. Rotating residential pools "
+        "share ONE proxy URL across a changing egress IP, so a URL-only "
+        "signature never invalidates anti-bot bound cookies "
+        "(cf_clearance / datadome / _abck …) when the IP rotates — they "
+        "get replayed under a new IP for a guaranteed 403 + trust hit. "
+        "Probe failure / timeout falls back to the UA+URL signature "
+        "(never raises). Probed once per browser instance lifetime.",
+    "BROWSER_PROXY_EGRESS_IP_ECHO_URL":
+        "URL of an echo endpoint returning the caller's public IP as "
+        "plain text (default https://api.ipify.org). Fetched THROUGH the "
+        "agent's proxy with a 5s timeout when "
+        "BROWSER_PROXY_EGRESS_IP_CHECK is enabled.",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from src.browser.service import BrowserManager, BrowserPoolExhausted
+from src.browser.service import BrowserManager, BrowserPoolExhausted, ProxyRequiredError
 from src.shared.paths import resolve_under_root
 from src.shared.trace import TRACE_HEADER, current_trace_id
 from src.shared.types import AGENT_ID_RE_PATTERN
@@ -156,6 +156,27 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
                 "error": "browser_pool_full",
                 "message": str(exc),
                 "cap": exc.cap,
+                "retry_after_s": exc.retry_after_s,
+            },
+        )
+
+    # Fail-closed proxy handler — converts the typed exception raised by
+    # ``_start_browser`` when ``BROWSER_REQUIRE_PROXY`` is on and no proxy
+    # resolved into a structured, RECOVERABLE 503. The agent's model sees
+    # ``error="proxy_required"`` + a retry hint (the mesh pushes a proxy +
+    # resets shortly) instead of egressing from the datacenter IP or
+    # getting an opaque 500.
+    @app.exception_handler(ProxyRequiredError)
+    async def _proxy_required_handler(
+        request: Request, exc: ProxyRequiredError,
+    ):
+        return JSONResponse(
+            status_code=503,
+            headers={"Retry-After": str(exc.retry_after_s)},
+            content={
+                "error": "proxy_required",
+                "message": str(exc),
+                "agent_id": exc.agent_id,
                 "retry_after_s": exc.retry_after_s,
             },
         )

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -888,6 +888,15 @@ _fingerprint_hard_burned: set[str] = set()
 # {agent_id: (vendor, header_or_status)} — last hard-block reason captured
 # for operator visibility on the dashboard. Operator-only; never logged.
 _fingerprint_hard_burn_reason: dict[str, tuple[str, str]] = {}
+# {agent_id: signature} — short opaque hash of the (UA, proxy) identity the
+# agent last launched with, written by ``_enforce_binding_cookie_coherence``.
+# The always-on Camoufox persistent profile restores ALL cookies on launch,
+# so a changed identity must drop anti-bot bound cookies (cf_clearance et al.)
+# BEFORE they replay under the new fingerprint. Persisted alongside the burn
+# state so the signature survives a browser-service restart (Constraint #8:
+# a new module-level global, but lock-protected identity state consistent
+# with the surrounding fingerprint globals). Guarded by ``_fingerprint_lock``.
+_binding_signatures: dict[str, str] = {}
 
 
 def _get_fingerprint_lock() -> asyncio.Lock:
@@ -917,7 +926,11 @@ async def _record_fingerprint_outcome(
             _fingerprint_window[agent_id] = bucket
         bucket.append(bool(rejected))
         _fingerprint_last_signal[agent_id] = time.time()
-        return _is_burned_locked(bucket)
+        burned = _is_burned_locked(bucket)
+        # Persist across restarts so a poisoned window can't read clean
+        # after a browser-service bounce while its cookies survive on disk.
+        _snapshot_fingerprint_state_locked()
+        return burned
 
 
 def _is_burned_locked(bucket: deque[bool]) -> bool:
@@ -1027,6 +1040,8 @@ async def _force_fingerprint_burn(
         _fingerprint_hard_burned.add(agent_id)
         _fingerprint_hard_burn_reason[agent_id] = (vendor, reason)
         _fingerprint_last_signal[agent_id] = time.time()
+        # Persist so a vendor-confirmed hard block survives a restart.
+        _snapshot_fingerprint_state_locked()
     return not already
 
 
@@ -1100,7 +1115,61 @@ async def _reset_fingerprint_window(agent_id: str) -> bool:
         _fingerprint_last_signal.pop(agent_id, None)
         _fingerprint_hard_burned.discard(agent_id)
         _fingerprint_hard_burn_reason.pop(agent_id, None)
+        # Persist so the cleared slate survives a restart. Binding
+        # signatures are intentionally left intact — a manual reset is a
+        # burn-state concern; identity coherence is handled on next launch.
+        _snapshot_fingerprint_state_locked()
     return had_state
+
+
+def _snapshot_fingerprint_state_locked() -> bool:
+    """Durably persist the fingerprint burn + binding-signature state.
+
+    Caller MUST hold :func:`_get_fingerprint_lock`. Best-effort —
+    :func:`fingerprint_state.snapshot` logs + returns ``False`` on any I/O
+    failure and never raises, so a persistence hiccup can't break the
+    low-frequency mutation path that calls this (post-solve outcome,
+    hard-burn, operator reset, identity-signature update). Synchronous
+    file I/O under the async lock is acceptable at this call frequency
+    and mirrors the captcha-cost counter's snapshot posture.
+    """
+    from src.browser import fingerprint_state as _fp_state
+    return _fp_state.snapshot(
+        window=_fingerprint_window,
+        last_signal=_fingerprint_last_signal,
+        hard_burned=_fingerprint_hard_burned,
+        hard_burn_reason=_fingerprint_hard_burn_reason,
+        binding_signatures=_binding_signatures,
+    )
+
+
+async def persist_fingerprint_state() -> bool:
+    """Snapshot the fingerprint burn + binding-signature state (shutdown hook)."""
+    async with _get_fingerprint_lock():
+        return _snapshot_fingerprint_state_locked()
+
+
+async def load_fingerprint_state() -> None:
+    """Restore the fingerprint burn + binding-signature state (startup hook).
+
+    Non-fatal: a missing / corrupt sidecar restores empty. Repopulates
+    the in-process globals in place so existing references stay valid.
+    Without this, a fingerprint flagged "burned" would read clean after a
+    browser-service restart while its poisoned cookies persisted on disk.
+    """
+    from src.browser import fingerprint_state as _fp_state
+    loaded = _fp_state.restore(window_maxlen=_FINGERPRINT_WINDOW_SIZE)
+    async with _get_fingerprint_lock():
+        _fingerprint_window.clear()
+        _fingerprint_window.update(loaded.window)
+        _fingerprint_last_signal.clear()
+        _fingerprint_last_signal.update(loaded.last_signal)
+        _fingerprint_hard_burned.clear()
+        _fingerprint_hard_burned.update(loaded.hard_burned)
+        _fingerprint_hard_burn_reason.clear()
+        _fingerprint_hard_burn_reason.update(loaded.hard_burn_reason)
+        _binding_signatures.clear()
+        _binding_signatures.update(loaded.binding_signatures)
 
 
 # ── §22 — fingerprint audit aggregator (per-minute, no URL leak) ──────────
@@ -4262,6 +4331,17 @@ class BrowserManager:
             # through to Firefox (it owns the profile dir directly). The end
             # state is the same: cookies merged into the cookie jar; localStorage
             # seeded on each origin's first navigation via the init script.
+            #
+            # ALWAYS-ON identity coherence — runs on the persistent-profile
+            # channel regardless of BROWSER_SESSION_PERSISTENCE_ENABLED. The
+            # Camoufox profile dir restored every cookie above, including
+            # anti-bot trust tokens bound to the previous (UA, proxy). If the
+            # identity signature changed, drop those bound cookies here BEFORE
+            # any navigation so a rotated fingerprint can't replay a stale
+            # token into an instant 403 + trust-score hit. Must run before the
+            # opt-in sidecar restore so a re-added-then-invalidated ordering
+            # can't leak a bound cookie.
+            await self._enforce_binding_cookie_coherence(inst)
             await self._maybe_restore_session(inst)
 
             # §9.1 wire request listeners at the BrowserContext level so new
@@ -4333,6 +4413,135 @@ class BrowserManager:
             with contextlib.suppress(Exception):
                 await self._teardown_per_agent_x_stack(teardown_target)
             raise
+
+    async def _enforce_binding_cookie_coherence(
+        self, inst: CamoufoxInstance,
+    ) -> None:
+        """Drop anti-bot bound cookies from the profile when identity changed.
+
+        Camoufox's ``persistent_context=True`` profile dir (the always-on
+        channel) restores EVERY cookie on launch — including anti-bot trust
+        tokens (``cf_clearance``, ``datadome``, ``_abck`` …) that Cloudflare /
+        DataDome / PerimeterX bind to the original ``(UA, egress-IP)`` tuple.
+        Replaying one under a rotated UA or a different proxy is a guaranteed
+        403 AND lowers the trust score for the session lifetime. The opt-in
+        ``session_persistence`` sidecar already drops these on a signature
+        change; this mirrors that safety onto the always-on profile channel
+        so it runs regardless of ``BROWSER_SESSION_PERSISTENCE_ENABLED``.
+
+        Flow: compute the current ``(UA, proxy)`` signature; compare against
+        the per-agent signature persisted last launch. On a mismatch, drop
+        only the bound vendor cookies (never generic session cookies). Then
+        persist the current signature as the new baseline — including on the
+        first launch, when nothing is dropped. Best-effort throughout: any
+        failure is logged and the browser starts anyway.
+        """
+        from src.browser import session_persistence as _sp
+
+        agent_id = inst.agent_id
+        context = inst.context
+        try:
+            current_sig = _sp._hash_signature(
+                self._build_session_binding_signature(agent_id),
+            )
+        except Exception as e:
+            logger.debug(
+                "binding-coherence: signature build failed for '%s': %s",
+                agent_id, e,
+            )
+            return
+
+        async with _get_fingerprint_lock():
+            persisted_sig = _binding_signatures.get(agent_id)
+
+        # Only drop when we have a prior signature AND it changed. First
+        # launch (no prior signature) drops nothing but still records the
+        # baseline below.
+        if persisted_sig is not None and persisted_sig != current_sig:
+            try:
+                cookies = await context.cookies()
+            except Exception as e:
+                logger.warning(
+                    "binding-coherence: context.cookies() failed for '%s': %s",
+                    agent_id, e,
+                )
+                cookies = None
+            if cookies:
+                bound_names: list[str] = []
+                vendors: list[str] = []
+                for cookie in cookies:
+                    if not isinstance(cookie, dict):
+                        continue
+                    name = cookie.get("name")
+                    family = _sp.cookie_binding_vendor(name)
+                    if family is not None:
+                        bound_names.append(name)
+                        if family not in vendors:
+                            vendors.append(family)
+                if bound_names:
+                    dropped = await self._clear_bound_cookies(
+                        context, bound_names, cookies,
+                    )
+                    if dropped:
+                        logger.info(
+                            "binding-coherence for '%s': identity signature "
+                            "changed (persisted=%s current=%s); dropped %d "
+                            "cookie(s) bound to vendors: %s",
+                            agent_id, persisted_sig, current_sig, dropped,
+                            ",".join(vendors) or "(none)",
+                        )
+
+        # Record the current signature as the new baseline (first-run
+        # included) and durably persist it next to the burn state.
+        async with _get_fingerprint_lock():
+            _binding_signatures[agent_id] = current_sig
+            try:
+                _snapshot_fingerprint_state_locked()
+            except Exception as e:
+                logger.debug(
+                    "binding-coherence: state snapshot failed for '%s': %s",
+                    agent_id, e,
+                )
+
+    async def _clear_bound_cookies(
+        self, context, bound_names: list[str], all_cookies: list,
+    ) -> int:
+        """Delete the named cookies from ``context``; return the count removed.
+
+        Prefers Playwright's targeted ``clear_cookies(name=...)`` (>=1.43;
+        our pin is ~1.51). If that filtered form is unavailable (older
+        Playwright raising ``TypeError`` on the kwarg), falls back to
+        clearing ALL cookies then re-adding the non-bound subset — the same
+        end state (only bound cookies gone) via a coarser path.
+        """
+        bound_set = set(bound_names)
+        try:
+            for name in bound_names:
+                await context.clear_cookies(name=name)
+            return len(bound_names)
+        except TypeError:
+            # Older Playwright: no ``name`` kwarg. Fall through to the
+            # clear-all + re-add-non-bound path below.
+            pass
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: targeted clear_cookies failed (%s); "
+                "falling back to clear-all + re-add", e,
+            )
+        try:
+            await context.clear_cookies()
+            keep = [
+                c for c in all_cookies
+                if isinstance(c, dict) and c.get("name") not in bound_set
+            ]
+            if keep:
+                await context.add_cookies(keep)
+            return len(bound_names)
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: fallback clear/re-add failed: %s", e,
+            )
+            return 0
 
     async def _maybe_restore_session(self, inst: CamoufoxInstance) -> None:
         """§20 — restore cookies + localStorage from the per-agent sidecar.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -110,6 +110,37 @@ class BrowserPoolExhausted(RuntimeError):
         )
 
 
+class ProxyRequiredError(RuntimeError):
+    """Raised when ``BROWSER_REQUIRE_PROXY`` is on but no proxy resolved.
+
+    Fail-closed egress control. Without a proxy the container egresses
+    from the datacenter IP — a strong bot-cluster signal AND a
+    deanonymization risk (the real host IP leaks to every site the agent
+    visits). When the operator sets ``BROWSER_REQUIRE_PROXY=true`` and the
+    effective proxy config for an agent is ``None``, ``_start_browser``
+    refuses to launch and raises this instead of silently leaking.
+
+    Recoverable by design: the mesh pushes the per-agent proxy config
+    shortly after boot (which triggers a reset), so a later
+    ``get_or_start`` finds a proxy and launches normally. The browser
+    service FastAPI app maps this to HTTP 503 with ``Retry-After`` and a
+    structured ``error="proxy_required"`` envelope — the agent's model
+    sees a recoverable failure and can retry rather than an opaque 500.
+
+    The default is ``false`` (historical fail-open behavior); this only
+    fires when an operator opts in.
+    """
+
+    def __init__(self, *, agent_id: str, retry_after_s: int = 30):
+        self.agent_id = agent_id
+        self.retry_after_s = retry_after_s
+        super().__init__(
+            f"Browser start refused for '{agent_id}': BROWSER_REQUIRE_PROXY "
+            f"is on but no proxy is configured yet. The mesh should push a "
+            f"proxy + reset shortly; retry in ~{retry_after_s}s.",
+        )
+
+
 # ── §11.13 structured CAPTCHA detection envelope ──────────────────────────
 # Both helpers below produce literal-string enums (see plan §11.13). We do
 # NOT use Python ``enum.Enum``: the wire format is JSON strings, and a real
@@ -3129,6 +3160,14 @@ class BrowserManager:
         self._playwright = None
         self.redactor = CredentialRedactor()
         self._proxy_configs: dict[str, dict | None] = {}
+        # Per-agent probed egress IP (BROWSER_PROXY_EGRESS_IP_CHECK). Cached
+        # for the browser instance's lifetime so we probe once at launch,
+        # never per navigation. Cleared on proxy re-push and on stop so the
+        # next launch re-probes against the (possibly rotated) egress.
+        self._egress_ips: dict[str, str] = {}
+        # Agents already warned about a no-proxy locale/TZ mismatch, so the
+        # coarse coherence warning fires at most once per agent.
+        self._tz_mismatch_warned: set[str] = set()
         self.boot_id: str = str(uuid.uuid4())
         self._captcha_solver = get_solver()
         self._metrics_sink = metrics_sink
@@ -4141,6 +4180,27 @@ class BrowserManager:
         else:
             logger.info("Starting Camoufox for '%s' (profile=%s, no proxy)", agent_id, profile_dir)
 
+        # Fail-closed egress control. When the operator has opted into
+        # BROWSER_REQUIRE_PROXY, refuse to launch without a proxy rather
+        # than egressing from the datacenter IP. Raises BEFORE allocating a
+        # display slot / spawning the X stack so nothing leaks on refusal.
+        # Recoverable: the mesh pushes the proxy + resets, and the next
+        # get_or_start finds a proxy and launches normally.
+        self._enforce_require_proxy(agent_id, _proxy_opt)
+
+        if _proxy_opt is None:
+            # Fail-open (default): launching without a proxy means GeoIP is
+            # off and the timezone falls back to the container TZ. Warn once
+            # per agent on a coarse locale/TZ mismatch (no behavior change).
+            self._warn_locale_tz_mismatch(agent_id)
+        else:
+            # Best-effort real-egress-IP probe (BROWSER_PROXY_EGRESS_IP_CHECK,
+            # default off). Only meaningful when a proxy IS set; folds the
+            # returned IP into the binding signature so a rotated residential
+            # egress invalidates bound anti-bot cookies. Never raises — a
+            # probe failure falls back to the UA+URL-only signature.
+            await self._probe_egress_ip(agent_id, _proxy_opt)
+
         # ── Per-agent X stack ─────────────────────────────────────────────
         # Allocate a (display, port) slot and bring up Xvnc + Openbox +
         # unclutter sized to the picked window resolution.  Camoufox is
@@ -4973,6 +5033,9 @@ class BrowserManager:
                 agent_id, e,
             )
         self._session_snapshot_elapsed_s.pop(agent_id, None)
+        # Drop the probed egress IP — its lifetime is one browser instance.
+        # The next launch re-probes (proxy may have rotated meanwhile).
+        self._egress_ips.pop(agent_id, None)
         # ``context.close()`` can wedge indefinitely when the underlying
         # Camoufox child has hung (X11 stuck, deadlocked on its own
         # mutex, or refusing SIGTERM). A 10s ceiling lets one bad
@@ -5084,15 +5147,159 @@ class BrowserManager:
             self._proxy_configs.pop(agent_id, None)
         else:
             self._proxy_configs[agent_id] = config
+        # A new (or cleared) proxy means the previously-probed egress IP
+        # is stale. Drop it so the next launch re-probes against the new
+        # egress — this is the automatic-recovery path after a rotation
+        # or a proxy re-push.
+        self._egress_ips.pop(agent_id, None)
 
     def get_proxy_config(self, agent_id: str) -> dict | None:
         """Get stored proxy config for an agent, or None."""
         return self._proxy_configs.get(agent_id)
 
+    def _enforce_require_proxy(self, agent_id: str, proxy_opt: dict | None) -> None:
+        """Refuse to launch without a proxy when ``BROWSER_REQUIRE_PROXY`` is on.
+
+        Fail-closed egress control. ``proxy_opt`` is the resolved
+        Playwright-style proxy dict (``None`` when no proxy will be used).
+        When it is ``None`` AND the operator opted into
+        ``BROWSER_REQUIRE_PROXY`` (default off), raise
+        :class:`ProxyRequiredError` so the browser never egresses from the
+        datacenter IP. Otherwise return quietly — a configured proxy or the
+        default fail-open posture both proceed to launch.
+
+        Split out from ``_start_browser`` so the gate is unit-testable
+        without driving a full (camoufox-dependent) launch.
+        """
+        if proxy_opt is not None:
+            return
+        from src.browser.flags import get_bool
+        if not get_bool("BROWSER_REQUIRE_PROXY", False, agent_id=agent_id):
+            return
+        logger.error(
+            "Refusing to start browser for '%s': BROWSER_REQUIRE_PROXY is on "
+            "but no proxy is configured — would egress from the datacenter "
+            "IP. Waiting for the mesh to push a proxy.",
+            agent_id,
+        )
+        raise ProxyRequiredError(agent_id=agent_id)
+
+    async def _probe_egress_ip(self, agent_id: str, proxy_arg: dict) -> None:
+        """Best-effort probe of the real egress IP through ``proxy_arg``.
+
+        Gated on ``BROWSER_PROXY_EGRESS_IP_CHECK`` (default off). When on
+        AND a proxy is set, fetch the echo URL
+        (``BROWSER_PROXY_EGRESS_IP_ECHO_URL``, default
+        ``https://api.ipify.org``) THROUGH the proxy with a 5s timeout and
+        cache the returned IP in ``self._egress_ips[agent_id]``. The cached
+        IP is folded into :meth:`_build_session_binding_signature`, so a
+        rotating residential pool (one proxy URL, changing egress IP) now
+        invalidates bound anti-bot cookies instead of replaying them under
+        a new IP for a guaranteed 403 + trust hit.
+
+        NEVER raises: any failure / timeout / flag-off leaves the cache
+        untouched, and the signature transparently falls back to UA+URL
+        only. Probes once per instance lifetime — a cached entry short-
+        circuits, so this is never per-navigation. Proxy credentials are
+        redacted from every log via :func:`redact_url`.
+        """
+        from src.browser.flags import get_bool, get_str
+        if not get_bool("BROWSER_PROXY_EGRESS_IP_CHECK", False, agent_id=agent_id):
+            return
+        if agent_id in self._egress_ips:
+            return  # already probed for this instance lifetime
+        server = (proxy_arg or {}).get("server")
+        if not server:
+            return
+        # Build an httpx proxy URL, re-injecting credentials from the
+        # playwright-style proxy dict (they live in separate keys there).
+        import ipaddress  # noqa: PLC0415 — local import keeps startup cheap
+        from urllib.parse import quote, urlsplit, urlunsplit
+        try:
+            parsed = urlsplit(server)
+        except ValueError:
+            return
+        scheme = (parsed.scheme or "").lower()
+        # Only HTTP(S) proxies are probeable here. SOCKS was removed
+        # deliberately (unreliable through the browser service); a SOCKS
+        # URL would also need httpx's socks extra. Skip → UA+URL fallback.
+        if scheme not in ("http", "https"):
+            return
+        netloc = parsed.netloc
+        if "@" in netloc:
+            netloc = netloc.rsplit("@", 1)[-1]  # drop any embedded userinfo
+        username = proxy_arg.get("username")
+        password = proxy_arg.get("password")
+        if username:
+            userinfo = quote(str(username), safe="")
+            if password:
+                userinfo += ":" + quote(str(password), safe="")
+            netloc = f"{userinfo}@{netloc}"
+        proxy_url = urlunsplit((parsed.scheme, netloc, parsed.path or "", "", ""))
+        echo_url = get_str(
+            "BROWSER_PROXY_EGRESS_IP_ECHO_URL",
+            "https://api.ipify.org",
+            agent_id=agent_id,
+        )
+        import httpx  # noqa: PLC0415 — local import (see _is_httpx_timeout)
+        try:
+            async with httpx.AsyncClient(proxy=proxy_url, timeout=5.0) as client:
+                resp = await client.get(echo_url)
+                resp.raise_for_status()
+                text = (resp.text or "").strip()
+            ip = ipaddress.ip_address(text)  # validates shape; raises on junk
+        except Exception as e:
+            logger.debug(
+                "egress-ip probe for '%s' via %s failed: %s",
+                agent_id, redact_url(proxy_url), e,
+            )
+            return
+        self._egress_ips[agent_id] = str(ip)
+        logger.info(
+            "egress-ip probe for '%s' succeeded via %s; folded into "
+            "binding signature", agent_id, redact_url(proxy_url),
+        )
+        logger.debug("egress-ip for '%s': %s", agent_id, str(ip))
+
+    def _warn_locale_tz_mismatch(self, agent_id: str) -> None:
+        """Warn once per agent on a coarse no-proxy locale/TZ mismatch.
+
+        With no proxy configured, GeoIP is off (Camoufox only enables it
+        when a proxy is set), so ``Intl`` timezone falls back to the
+        container ``TZ`` (default ``America/New_York``). If the agent
+        advertises a non-US ``BROWSER_LOCALE`` (e.g. ``en-GB``) while the
+        container TZ is ``America/*``, anti-bot vendors see a locale/
+        timezone mismatch — a real coherence signal.
+
+        Coarse heuristic only (no exhaustive locale→TZ table): a non-US
+        BCP-47 region subtag paired with an ``America/*`` TZ. No behavior
+        change — this is a diagnostic WARNING recommending a per-agent
+        proxy (for GeoIP TZ coherence) or a matching container TZ.
+        """
+        if agent_id in self._tz_mismatch_warned:
+            return
+        locale = os.environ.get("BROWSER_LOCALE", "en-US")
+        tz = os.environ.get("TZ", "America/New_York")
+        # BCP-47 region subtag = the token after the first '-' (upper-cased).
+        region = ""
+        if "-" in locale:
+            region = locale.split("-", 1)[1].split("-", 1)[0].upper()
+        if region and region != "US" and tz.startswith("America/"):
+            self._tz_mismatch_warned.add(agent_id)
+            logger.warning(
+                "Agent '%s': no proxy set, so GeoIP is off and the browser "
+                "timezone falls back to the container TZ (%s), which does "
+                "not match BROWSER_LOCALE (%s, region=%s). Anti-bot vendors "
+                "flag a locale/timezone mismatch. Recommend a per-agent "
+                "proxy (for GeoIP timezone coherence) or a container TZ "
+                "matching the locale region.",
+                agent_id, tz, locale, region,
+            )
+
     def _build_session_binding_signature(
         self, agent_id: str,
     ) -> dict[str, str | None]:
-        """Build a (UA, proxy) signature for cookie-binding invalidation.
+        """Build a (UA, proxy[, egress-IP]) signature for cookie-binding invalidation.
 
         Cloudflare / DataDome / PerimeterX bind tokens like ``cf_clearance``
         to the original (UA, IP) tuple. Replaying them under a rotated
@@ -5101,13 +5308,17 @@ class BrowserManager:
         detect the change and drop bound cookies before seeding the
         context.
 
-        We hash UA + proxy server URL (not the egress IP itself, which is
-        often unknown to us). For most operators a proxy URL change is a
-        proxy provider change, which usually means a different egress IP
-        — close enough to gate cookie reuse on.
+        We always hash UA + proxy server URL. When
+        ``BROWSER_PROXY_EGRESS_IP_CHECK`` is enabled and a launch-time
+        probe resolved the real egress IP (cached in ``self._egress_ips``),
+        we ALSO include it under ``egress_ip`` — this is what makes a
+        rotating residential pool (one URL, changing egress IP) invalidate
+        bound cookies. When the probe is off or failed, the key is omitted
+        and the hash is identical to the historical UA+URL signature.
 
-        Returns ``{"ua": ..., "proxy": ...}`` with ``None`` for fields we
-        don't know. ``None`` keys are dropped before hashing so an
+        Returns ``{"ua": ..., "proxy": ...}`` (plus ``egress_ip`` when
+        known) with ``None`` for fields we don't know. Falsy / ``None``
+        keys are dropped before hashing (see ``_hash_signature``) so an
         operator who never configures a proxy gets stable hashes across
         snapshots.
         """
@@ -5120,7 +5331,11 @@ class BrowserManager:
                 or proxy_cfg.get("url")
                 or None
             )
-        return {"ua": ua, "proxy": proxy_url}
+        sig: dict[str, str | None] = {"ua": ua, "proxy": proxy_url}
+        egress_ip = self._egress_ips.get(agent_id)
+        if egress_ip:
+            sig["egress_ip"] = egress_ip
+        return sig
 
     async def get_status(self, agent_id: str) -> dict:
         """Get status for a specific agent's browser.

--- a/src/browser/session_persistence.py
+++ b/src/browser/session_persistence.py
@@ -179,6 +179,30 @@ def _hash_signature(parts: dict[str, str | None]) -> str:
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
 
 
+def cookie_binding_vendor(name: str) -> str | None:
+    """Return the vendor family if ``name`` is a binding-sensitive cookie, else ``None``.
+
+    THE single source of truth for "is this an anti-bot bound cookie" —
+    shared by the opt-in sidecar restore path
+    (:func:`_drop_binding_sensitive_cookies`) and the always-on profile
+    coherence check in ``service._enforce_binding_cookie_coherence``.
+
+    Match rule (unchanged from the original inline matcher): case-
+    insensitive; a cookie matches a prefix when its lowercased name
+    equals the prefix OR starts with it. The returned family is the
+    prefix's leading ``_``-delimited segment (or the whole prefix when
+    that segment is empty, e.g. ``_abck`` → ``_abck``) so operators see
+    "we dropped Cloudflare tokens" without leaking specific cookie names.
+    """
+    if not isinstance(name, str):
+        return None
+    lowered = name.lower()
+    for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
+        if lowered == prefix or lowered.startswith(prefix):
+            return prefix.split("_", 1)[0] or prefix
+    return None
+
+
 def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int:
     """Strip cookies whose names match the binding-sensitive prefix list.
 
@@ -195,20 +219,12 @@ def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int
         if not isinstance(cookie, dict):
             kept.append(cookie)
             continue
-        name = (cookie.get("name") or "").lower()
-        bound = False
-        for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
-            if name == prefix or name.startswith(prefix):
-                bound = True
-                # Track which vendor families we dropped (de-dupe by
-                # caller). Helps operators see "we dropped Cloudflare
-                # tokens" without leaking specific cookie names.
-                family = prefix.split("_", 1)[0] or prefix
-                if family not in vendors_seen:
-                    vendors_seen.append(family)
-                break
-        if bound:
+        family = cookie_binding_vendor(cookie.get("name") or "")
+        if family is not None:
             dropped += 1
+            # Track which vendor families we dropped (de-dupe by caller).
+            if family not in vendors_seen:
+                vendors_seen.append(family)
         else:
             kept.append(cookie)
     state["cookies"] = kept

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,23 @@ os.environ["OPENLEGION_SKIP_TRUST_TIER_BOOT_GATE"] = "1"
 # e2e runs with real keys keep working.
 os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
 
+# Redirect the durable fingerprint-state sidecar off the real ``data/``
+# path for the whole session. The browser service now snapshots fingerprint
+# burn + binding-signature state on every low-frequency mutation
+# (``_record_fingerprint_outcome`` / ``_force_fingerprint_burn`` /
+# ``_reset_fingerprint_window`` and the launch-time binding-coherence check),
+# so any test that drives those would otherwise write ``data/fingerprint_state.json``
+# in the repo root. A per-pid temp path keeps each xdist/shard worker isolated;
+# ``setdefault`` so a test that needs a specific path can still override.
+import tempfile as _tempfile  # noqa: E402
+
+os.environ.setdefault(
+    "FINGERPRINT_STATE_PATH",
+    os.path.join(
+        _tempfile.gettempdir(), f"ol_test_fingerprint_state_{os.getpid()}.json",
+    ),
+)
+
 # Time-returning helpers consumed by ``src.browser.service`` via
 # ``from src.browser.timing import X``. ``scroll_increment`` and
 # ``scroll_ramp`` are intentionally excluded — they return pixel counts

--- a/tests/test_binding_cookie_coherence.py
+++ b/tests/test_binding_cookie_coherence.py
@@ -1,0 +1,203 @@
+"""Tests for the always-on bound-cookie identity-coherence check.
+
+``BrowserManager._enforce_binding_cookie_coherence`` mirrors the opt-in
+session-persistence sidecar's binding-drop onto the always-on Camoufox
+persistent-profile channel. When the agent's ``(UA, proxy)`` signature
+changed since last launch, anti-bot bound cookies (cf_clearance, datadome,
+_abck, …) must be dropped BEFORE they replay under the new fingerprint —
+otherwise an instant 403 + trust-score hit. Runs regardless of
+``BROWSER_SESSION_PERSISTENCE_ENABLED``.
+
+Covers:
+  * mismatched persisted signature → matching bound cookies removed,
+    non-bound (generic session) cookies retained; new signature persisted.
+  * matching persisted signature → nothing dropped (cookies never read).
+  * first run (no persisted signature) → nothing dropped, signature
+    persisted so the NEXT identity change is detectable.
+  * legacy Playwright without ``clear_cookies(name=...)`` → clear-all +
+    re-add of the non-bound subset (same end state).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import types
+
+import pytest
+
+from src.browser import session_persistence as sp
+from src.browser.service import BrowserManager
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Clean binding-signature global + a private state sidecar per test."""
+    from src.browser.service import _binding_signatures
+
+    monkeypatch.setenv(
+        "FINGERPRINT_STATE_PATH",
+        str(tmp_path / "fp_state.json"),
+    )
+    _binding_signatures.clear()
+    yield
+    _binding_signatures.clear()
+
+
+def _cookie(name: str) -> dict:
+    return {
+        "name": name,
+        "value": "v-" + name,
+        "domain": ".example.com",
+        "path": "/",
+    }
+
+
+# A realistic mix: three vendor-bound cookies + two generic session cookies.
+_BOUND = ["cf_clearance", "datadome", "_abck"]
+_GENERIC = ["session", "csrftoken"]
+
+
+class _FakeContext:
+    """Playwright BrowserContext duck-type supporting name-filtered clear."""
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cookies_calls = 0
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        self.cookies_calls += 1
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)
+
+
+class _LegacyContext:
+    """Older Playwright: ``clear_cookies`` has NO ``name`` kwarg.
+
+    Calling ``clear_cookies(name=...)`` therefore raises ``TypeError`` —
+    the exact signal the coherence helper falls back on.
+    """
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+    async def clear_cookies(self) -> None:  # no ``name`` param on purpose
+        self.cleared_all += 1
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_bcc_")
+    return BrowserManager(profiles_dir=root)
+
+
+def _inst(agent_id: str, context) -> types.SimpleNamespace:
+    return types.SimpleNamespace(agent_id=agent_id, context=context)
+
+
+def _current_sig(mgr: BrowserManager, agent_id: str) -> str:
+    return sp._hash_signature(mgr._build_session_binding_signature(agent_id))
+
+
+class TestSignatureMismatch:
+    @pytest.mark.asyncio
+    async def test_mismatch_drops_bound_keeps_generic(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-mismatch"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-new:8080"})
+        # Seed a DIFFERENT prior signature → forces the drop branch.
+        _binding_signatures[agent] = "deadbeefdeadbeef"
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Every bound cookie was cleared by name; no generic cookie was.
+        assert set(ctx.cleared_names) == set(_BOUND)
+        assert all(g not in ctx.cleared_names for g in _GENERIC)
+        assert ctx.cleared_all == 0  # targeted path, not clear-all
+        # The current signature is now the persisted baseline.
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestSignatureMatch:
+    @pytest.mark.asyncio
+    async def test_match_drops_nothing_and_skips_cookie_read(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-match"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-stable:8080"})
+        # Seed the SAME signature the agent will compute now.
+        _binding_signatures[agent] = _current_sig(mgr, agent)
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        # Unchanged identity ⇒ we don't even enumerate cookies.
+        assert ctx.cookies_calls == 0
+        # Signature is re-persisted (unchanged).
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestFirstRun:
+    @pytest.mark.asyncio
+    async def test_first_run_drops_nothing_but_persists_signature(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-first"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-first:8080"})
+        assert agent not in _binding_signatures  # no prior baseline
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        assert ctx.cookies_calls == 0  # nothing to invalidate on first run
+        # But the baseline IS recorded so the next change is detectable.
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestLegacyPlaywrightFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_clears_all_then_readds_non_bound(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-legacy"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-legacy:8080"})
+        _binding_signatures[agent] = "0000000000000000"  # force mismatch
+
+        ctx = _LegacyContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Fell back to clear-all …
+        assert ctx.cleared_all == 1
+        # … then re-added ONLY the non-bound cookies.
+        assert ctx.readded is not None
+        readded_names = {c["name"] for c in ctx.readded}
+        assert readded_names == set(_GENERIC)
+        assert all(b not in readded_names for b in _BOUND)
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)

--- a/tests/test_browser_proxy_hardening.py
+++ b/tests/test_browser_proxy_hardening.py
@@ -1,0 +1,421 @@
+"""Tests for the browser proxy-hardening trio.
+
+Covers three independent knobs added on top of the always-on binding
+signature (see ``test_binding_cookie_coherence.py``):
+
+  1. ``BROWSER_REQUIRE_PROXY`` (default off) — fail-closed egress control.
+     ``BrowserManager._enforce_require_proxy`` raises ``ProxyRequiredError``
+     when the flag is on and no proxy resolved, so the browser never
+     egresses from the datacenter IP. Proxy present OR flag off → proceeds.
+
+  2. ``BROWSER_PROXY_EGRESS_IP_CHECK`` (default off) — fold the REAL egress
+     IP (probed through the proxy) into the binding signature so a rotating
+     residential pool (one URL, changing IP) invalidates bound anti-bot
+     cookies. Probe failure / timeout / flag-off falls back to the UA+URL
+     signature and never raises.
+
+  3. No-proxy locale/TZ coherence WARNING — a one-time-per-agent diagnostic
+     (no behavior change) when GeoIP is off and a coarse non-US-locale vs
+     ``America/*`` container-TZ mismatch is detected.
+
+``_start_browser`` itself imports camoufox (absent in the test env), so the
+gate + probe + warning are exercised through their extracted helpers,
+mirroring the helper-level style of ``test_binding_cookie_coherence.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+
+import httpx
+import pytest
+
+from src.browser import flags
+from src.browser import session_persistence as sp
+from src.browser.service import BrowserManager, ProxyRequiredError, _binding_signatures
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Clean flag layers + binding-signature state + the new flags' env."""
+    # Operator-settings layer: point at a nonexistent file so a real
+    # config/settings.json can't leak BROWSER_* flags into these tests.
+    monkeypatch.setenv("OPENLEGION_SETTINGS_PATH", str(tmp_path / "settings.json"))
+    saved_agents = dict(flags._agent_overrides)
+    flags._agent_overrides.clear()
+    flags.reload_operator_settings()
+    # Durable binding-signature sidecar → tmp; clear the in-memory global.
+    monkeypatch.setenv("FINGERPRINT_STATE_PATH", str(tmp_path / "fp_state.json"))
+    _binding_signatures.clear()
+    # Ensure the three new flags start unset (default posture).
+    for name in (
+        "BROWSER_REQUIRE_PROXY",
+        "BROWSER_PROXY_EGRESS_IP_CHECK",
+        "BROWSER_PROXY_EGRESS_IP_ECHO_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    flags._agent_overrides.clear()
+    flags._agent_overrides.update(saved_agents)
+    flags.reload_operator_settings()
+    _binding_signatures.clear()
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_proxyhard_")
+    return BrowserManager(profiles_dir=root)
+
+
+# ── httpx fakes ─────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAsyncClient:
+    """Records constructor kwargs + the GET url; returns a canned IP."""
+
+    last_proxy: str | None = None
+    last_timeout: object = None
+    last_url: str | None = None
+    ctor_calls: int = 0
+    get_calls: int = 0
+    reply_text: str = "203.0.113.7"
+
+    def __init__(self, *, proxy=None, timeout=None):
+        type(self).last_proxy = proxy
+        type(self).last_timeout = timeout
+        type(self).ctor_calls += 1
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        type(self).last_url = url
+        type(self).get_calls += 1
+        return _FakeResp(type(self).reply_text)
+
+
+def _install_client(monkeypatch, cls=_FakeAsyncClient):
+    cls.ctor_calls = 0
+    cls.get_calls = 0
+    monkeypatch.setattr("httpx.AsyncClient", cls)
+    return cls
+
+
+def _mismatch_warned(caplog) -> bool:
+    """True if the locale/timezone-mismatch WARNING was emitted.
+
+    Asserting on the specific message (not ``caplog.records`` emptiness)
+    keeps the no-warning tests robust to unrelated log noise — e.g. a
+    Playwright-less environment where ``BrowserManager`` construction logs
+    a CRITICAL about the artifact-stream API.
+    """
+    return any("locale/timezone mismatch" in r.getMessage() for r in caplog.records)
+
+
+# ── 1. BROWSER_REQUIRE_PROXY (fail-closed) ──────────────────────────────────
+
+
+class TestRequireProxy:
+    def test_flag_on_no_proxy_refuses(self, monkeypatch):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_REQUIRE_PROXY", "true")
+        with pytest.raises(ProxyRequiredError) as exc:
+            mgr._enforce_require_proxy("agent-refuse", None)
+        assert exc.value.agent_id == "agent-refuse"
+        assert exc.value.retry_after_s > 0
+        assert "agent-refuse" in str(exc.value)
+
+    def test_flag_on_proxy_present_allows(self, monkeypatch):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_REQUIRE_PROXY", "true")
+        # A resolved proxy → never refused, even with the flag on.
+        mgr._enforce_require_proxy("agent-ok", {"server": "http://proxy:8080"})
+
+    def test_flag_off_no_proxy_allows(self, monkeypatch):
+        mgr = _make_manager()
+        # Default off → historical fail-open behavior preserved.
+        mgr._enforce_require_proxy("agent-open", None)
+
+    def test_per_agent_override_gates_independently(self, monkeypatch):
+        mgr = _make_manager()
+        # Operator-wide off, but one agent opted in via the override layer.
+        flags.set_agent_override("agent-strict", "BROWSER_REQUIRE_PROXY", "true")
+        mgr._enforce_require_proxy("agent-loose", None)  # unaffected → no raise
+        with pytest.raises(ProxyRequiredError):
+            mgr._enforce_require_proxy("agent-strict", None)
+
+
+# ── 2. BROWSER_PROXY_EGRESS_IP_CHECK (fold egress IP into signature) ─────────
+
+
+class TestEgressIpProbe:
+    @pytest.mark.asyncio
+    async def test_probe_folds_egress_ip_into_signature(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-egress"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert mgr._egress_ips[agent] == "203.0.113.7"
+        assert client.get_calls == 1
+        assert client.last_timeout == 5.0
+        assert client.last_url == "https://api.ipify.org"  # default echo url
+
+        sig = mgr._build_session_binding_signature(agent)
+        assert sig.get("egress_ip") == "203.0.113.7"
+        with_ip = sp._hash_signature(sig)
+        assert with_ip != url_only  # egress IP changes the hash
+
+    @pytest.mark.asyncio
+    async def test_probe_injects_credentials_into_proxy_url(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-creds"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(
+            agent,
+            {"server": "http://proxy:8080", "username": "u", "password": "p@ss"},
+        )
+        # Creds live in separate keys of the playwright-style dict; the probe
+        # re-assembles a percent-encoded httpx proxy URL.
+        assert client.last_proxy == "http://u:p%40ss@proxy:8080"
+
+    @pytest.mark.asyncio
+    async def test_custom_echo_url_used(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-echo"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_ECHO_URL", "https://echo.example/ip")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert client.last_url == "https://echo.example/ip"
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_falls_back_no_exception(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-boom"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _BoomClient(_FakeAsyncClient):
+            async def get(self, url):
+                raise RuntimeError("proxy dead")
+
+        _install_client(monkeypatch, _BoomClient)
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+
+        # Must NOT raise.
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert agent not in mgr._egress_ips
+        sig = mgr._build_session_binding_signature(agent)
+        assert "egress_ip" not in sig
+        assert sp._hash_signature(sig) == url_only  # UA+URL fallback
+
+    @pytest.mark.asyncio
+    async def test_probe_timeout_falls_back(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-timeout"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _SlowClient(_FakeAsyncClient):
+            async def get(self, url):
+                raise httpx.ConnectTimeout("slow")
+
+        _install_client(monkeypatch, _SlowClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_junk_response_not_cached(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-junk"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+
+        class _JunkClient(_FakeAsyncClient):
+            reply_text = "<html>not an ip</html>"
+
+        _install_client(monkeypatch, _JunkClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        # ipaddress.ip_address() rejects the body → nothing cached.
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_probe(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-off"
+        # Flag unset (default off).
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        url_only = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+
+        assert client.ctor_calls == 0  # no httpx client constructed at all
+        assert agent not in mgr._egress_ips
+        sig = mgr._build_session_binding_signature(agent)
+        assert "egress_ip" not in sig
+        assert sp._hash_signature(sig) == url_only
+
+    @pytest.mark.asyncio
+    async def test_probe_cached_not_reprobed(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-cache"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://proxy:8080"})
+        client = _install_client(monkeypatch)
+
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        await mgr._probe_egress_ip(agent, {"server": "http://proxy:8080"})
+        assert client.get_calls == 1  # second call short-circuits on cache
+
+    @pytest.mark.asyncio
+    async def test_socks_scheme_skipped(self, monkeypatch):
+        mgr = _make_manager()
+        agent = "agent-socks"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        client = _install_client(monkeypatch)
+        # SOCKS was removed deliberately; the probe skips non-HTTP schemes.
+        await mgr._probe_egress_ip(agent, {"server": "socks5://proxy:1080"})
+        assert client.ctor_calls == 0
+        assert agent not in mgr._egress_ips
+
+    def test_set_proxy_config_clears_cached_egress(self):
+        mgr = _make_manager()
+        agent = "agent-rotate"
+        mgr._egress_ips[agent] = "198.51.100.1"
+        mgr.set_proxy_config(agent, {"server": "http://new:8080"})
+        # A re-push means the old egress IP is stale → dropped for re-probe.
+        assert agent not in mgr._egress_ips
+
+    @pytest.mark.asyncio
+    async def test_rotated_egress_ip_invalidates_bound_cookies(self, monkeypatch):
+        """Compose: a rotated egress IP flips the signature, so the always-on
+        coherence hook drops bound anti-bot cookies while keeping generics."""
+        mgr = _make_manager()
+        agent = "agent-compose"
+        monkeypatch.setenv("BROWSER_PROXY_EGRESS_IP_CHECK", "true")
+        mgr.set_proxy_config(agent, {"server": "http://rot:8080"})
+
+        # Baseline persisted from a prior launch under an OLD egress IP.
+        mgr._egress_ips[agent] = "198.51.100.1"
+        old_sig = sp._hash_signature(mgr._build_session_binding_signature(agent))
+        _binding_signatures[agent] = old_sig
+        # Simulate a stop clearing the cache, then a fresh launch probing a
+        # ROTATED egress IP behind the same proxy URL.
+        del mgr._egress_ips[agent]
+
+        class _RotClient(_FakeAsyncClient):
+            reply_text = "198.51.100.9"
+
+        _install_client(monkeypatch, _RotClient)
+        await mgr._probe_egress_ip(agent, {"server": "http://rot:8080"})
+        assert mgr._egress_ips[agent] == "198.51.100.9"
+        assert sp._hash_signature(mgr._build_session_binding_signature(agent)) != old_sig
+
+        ctx = _FakeCookieContext([_cookie("cf_clearance"), _cookie("datadome"), _cookie("session")])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+        assert set(ctx.cleared_names) == {"cf_clearance", "datadome"}
+        assert "session" not in ctx.cleared_names
+
+
+# ── 3. No-proxy locale/TZ coherence warning ─────────────────────────────────
+
+
+class TestLocaleTzWarning:
+    def test_mismatch_warns_once(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-GB")
+        monkeypatch.setenv("TZ", "America/New_York")
+
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-tz")
+        assert any("locale/timezone mismatch" in r.getMessage() for r in caplog.records)
+
+        caplog.clear()
+        mgr._warn_locale_tz_mismatch("agent-tz")  # second call
+        assert not caplog.records  # one-time-per-agent
+
+    def test_us_locale_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-US")
+        monkeypatch.setenv("TZ", "America/New_York")
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-us")
+        # Assert the specific mismatch warning is absent (robust to unrelated
+        # log noise, e.g. a Playwright-less env's construction warning) and
+        # that no per-agent warned-marker was set.
+        assert not _mismatch_warned(caplog)
+        assert "agent-us" not in mgr._tz_mismatch_warned
+
+    def test_matching_region_tz_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en-GB")
+        monkeypatch.setenv("TZ", "Europe/London")  # region-consistent → no warn
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-uk")
+        assert not _mismatch_warned(caplog)
+        assert "agent-uk" not in mgr._tz_mismatch_warned
+
+    def test_localeless_tag_no_warning(self, monkeypatch, caplog):
+        mgr = _make_manager()
+        monkeypatch.setenv("BROWSER_LOCALE", "en")  # no region subtag
+        monkeypatch.setenv("TZ", "America/New_York")
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            mgr._warn_locale_tz_mismatch("agent-noregion")
+        assert not _mismatch_warned(caplog)
+        assert "agent-noregion" not in mgr._tz_mismatch_warned
+
+
+# ── shared cookie-context fake (mirrors test_binding_cookie_coherence) ───────
+
+
+def _cookie(name: str) -> dict:
+    return {"name": name, "value": "v-" + name, "domain": ".example.com", "path": "/"}
+
+
+def _inst(agent_id: str, context):
+    import types
+
+    return types.SimpleNamespace(agent_id=agent_id, context=context)
+
+
+class _FakeCookieContext:
+    def __init__(self, cookies: list[dict]):
+        self._cookies = cookies
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+        self.readded: list[dict] | None = None
+
+    async def cookies(self) -> list[dict]:
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:
+        self.readded = list(cookies)

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -52,6 +52,7 @@ atexit.register(shutil.rmtree, _PROFILES_ROOT, ignore_errors=True)
 def _reset_fingerprint_state():
     """Each test starts with empty module-level fingerprint state."""
     from src.browser.service import (
+        _binding_signatures,
         _fingerprint_audit_buckets,
         _fingerprint_hard_burn_reason,
         _fingerprint_hard_burned,
@@ -63,12 +64,14 @@ def _reset_fingerprint_state():
     _fingerprint_audit_buckets.clear()
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
+    _binding_signatures.clear()
     yield
     _fingerprint_window.clear()
     _fingerprint_last_signal.clear()
     _fingerprint_audit_buckets.clear()
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
+    _binding_signatures.clear()
 
 
 class TestRollingWindow:

--- a/tests/test_fingerprint_state.py
+++ b/tests/test_fingerprint_state.py
@@ -1,0 +1,225 @@
+"""Tests for the durable fingerprint-state sidecar (burn + binding signatures).
+
+Covers:
+  * snapshot → restore round-trip preserves the rolling window (values AND
+    the ``maxlen`` bound), the hard-burned set, and the hard-burn reasons.
+  * binding-signature map round-trips.
+  * a ``deque`` longer than ``maxlen`` restores keeping only the last N.
+  * missing file restores an empty state (no raise).
+  * corrupt JSON / wrong-shape / wrong-version restores empty (no raise).
+  * the sidecar is written 0o600 (opaque state, but matches the codebase's
+    atomic-write posture).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections import deque
+
+from src.browser import fingerprint_state as fp
+
+
+def _snapshot(path, **overrides):
+    """Snapshot with sensible empty defaults; overrides fill in fields."""
+    kwargs = dict(
+        window={},
+        last_signal={},
+        hard_burned=set(),
+        hard_burn_reason={},
+        binding_signatures={},
+        path=path,
+    )
+    kwargs.update(overrides)
+    return fp.snapshot(**kwargs)
+
+
+class TestRoundTrip:
+    def test_window_values_and_maxlen_survive(self, tmp_path):
+        target = tmp_path / "fp.json"
+        window = {
+            "agent-a": deque([True, False, True], maxlen=10),
+            "agent-b": deque([False], maxlen=10),
+        }
+        assert _snapshot(target, window=window) is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True, False, True]
+        assert list(loaded.window["agent-b"]) == [False]
+        # Rebuilt as a bounded deque with the same maxlen — appending an
+        # 11th element evicts the oldest rather than growing unbounded.
+        restored = loaded.window["agent-a"]
+        assert isinstance(restored, deque)
+        assert restored.maxlen == 10
+        for _ in range(12):
+            restored.append(True)
+        assert len(restored) == 10
+
+    def test_full_window_at_maxlen_keeps_last_n(self, tmp_path):
+        target = tmp_path / "fp.json"
+        # 10 entries = a full window: 6 rejects then 4 accepts.
+        full = deque([True] * 6 + [False] * 4, maxlen=10)
+        assert _snapshot(target, window={"agent-a": full}) is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True] * 6 + [False] * 4
+        assert loaded.window["agent-a"].maxlen == 10
+
+    def test_oversized_list_truncates_to_maxlen_last_n(self, tmp_path):
+        # A hand-tampered / legacy file could hold more entries than maxlen;
+        # deque(iterable, maxlen=N) keeps the LAST N, so restore is safe.
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "saved_at": 0,
+                    "window": {"agent-a": [True, False, True, True, False]},
+                    "last_signal": {},
+                    "hard_burned": [],
+                    "hard_burn_reason": {},
+                    "binding_signatures": {},
+                }
+            )
+        )
+        loaded = fp.restore(target, window_maxlen=3)
+        assert list(loaded.window["agent-a"]) == [True, True, False]
+        assert loaded.window["agent-a"].maxlen == 3
+
+    def test_hard_burned_and_reasons_survive(self, tmp_path):
+        target = tmp_path / "fp.json"
+        ok = _snapshot(
+            target,
+            hard_burned={"agent-a", "agent-b"},
+            hard_burn_reason={
+                "agent-a": ("cloudflare", "cf-mitigated=block"),
+                "agent-b": ("perimeterx", "x-px-block-type=1"),
+            },
+            last_signal={"agent-a": 1234.5},
+        )
+        assert ok is True
+
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == {"agent-a", "agent-b"}
+        assert loaded.hard_burn_reason["agent-a"] == ("cloudflare", "cf-mitigated=block")
+        assert loaded.hard_burn_reason["agent-b"] == ("perimeterx", "x-px-block-type=1")
+        # Reasons restore as a 2-tuple (list-in-JSON → tuple in memory).
+        assert isinstance(loaded.hard_burn_reason["agent-a"], tuple)
+        assert loaded.last_signal["agent-a"] == 1234.5
+
+    def test_binding_signatures_round_trip(self, tmp_path):
+        target = tmp_path / "fp.json"
+        sigs = {"agent-a": "0011223344556677", "agent-b": "aabbccddeeff0011"}
+        assert _snapshot(target, binding_signatures=sigs) is True
+
+        loaded = fp.restore(target)
+        assert loaded.binding_signatures == sigs
+
+    def test_combined_round_trip(self, tmp_path):
+        target = tmp_path / "fp.json"
+        ok = _snapshot(
+            target,
+            window={"agent-a": deque([True, True], maxlen=10)},
+            last_signal={"agent-a": 42.0},
+            hard_burned={"agent-a"},
+            hard_burn_reason={"agent-a": ("datadome", "x-datadome=protected")},
+            binding_signatures={"agent-a": "cafebabecafebabe"},
+        )
+        assert ok is True
+
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True, True]
+        assert loaded.last_signal["agent-a"] == 42.0
+        assert loaded.hard_burned == {"agent-a"}
+        assert loaded.hard_burn_reason["agent-a"] == ("datadome", "x-datadome=protected")
+        assert loaded.binding_signatures["agent-a"] == "cafebabecafebabe"
+
+
+class TestNonFatalRestore:
+    def test_missing_file_restores_empty(self, tmp_path):
+        loaded = fp.restore(tmp_path / "does-not-exist.json")
+        assert loaded.window == {}
+        assert loaded.last_signal == {}
+        assert loaded.hard_burned == set()
+        assert loaded.hard_burn_reason == {}
+        assert loaded.binding_signatures == {}
+
+    def test_corrupt_json_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text("{not valid json at all")
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == set()
+        assert loaded.binding_signatures == {}
+
+    def test_wrong_shape_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text(json.dumps(["not", "a", "dict"]))
+        loaded = fp.restore(target)
+        assert loaded.window == {}
+
+    def test_wrong_version_restores_empty(self, tmp_path):
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "hard_burned": ["agent-a"],
+                    "binding_signatures": {"agent-a": "sig"},
+                }
+            )
+        )
+        loaded = fp.restore(target)
+        assert loaded.hard_burned == set()
+        assert loaded.binding_signatures == {}
+
+    def test_malformed_entries_skipped_not_fatal(self, tmp_path):
+        # Individual bad rows are dropped; the well-formed ones survive.
+        target = tmp_path / "fp.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "window": {"agent-a": [True], "bad": "not-a-list"},
+                    "last_signal": {"agent-a": 1.0, "bad": "nan-string"},
+                    "hard_burned": ["agent-a", 123],
+                    "hard_burn_reason": {"agent-a": ["cf", "block"], "bad": ["only-one"]},
+                    "binding_signatures": {"agent-a": "sig", "bad": 12345},
+                }
+            )
+        )
+        loaded = fp.restore(target, window_maxlen=10)
+        assert list(loaded.window["agent-a"]) == [True]
+        assert "bad" not in loaded.window
+        assert loaded.last_signal == {"agent-a": 1.0}
+        assert loaded.hard_burned == {"agent-a"}
+        assert loaded.hard_burn_reason == {"agent-a": ("cf", "block")}
+        assert loaded.binding_signatures == {"agent-a": "sig"}
+
+
+class TestFilePermissions:
+    def test_sidecar_is_owner_only(self, tmp_path):
+        target = tmp_path / "fp.json"
+        assert _snapshot(target, hard_burned={"agent-a"}) is True
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode == 0o600
+
+
+class TestEnvOverride:
+    def test_default_path_env_override(self, tmp_path, monkeypatch):
+        target = tmp_path / "custom_fp.json"
+        monkeypatch.setenv("FINGERPRINT_STATE_PATH", str(target))
+        # No explicit path → falls back to the env-configured location.
+        assert (
+            fp.snapshot(
+                window={},
+                last_signal={},
+                hard_burned={"agent-z"},
+                hard_burn_reason={},
+                binding_signatures={},
+            )
+            is True
+        )
+        assert target.exists()
+        loaded = fp.restore()
+        assert loaded.hard_burned == {"agent-z"}


### PR DESCRIPTION
Replaces #1172, which GitHub auto-closed when #1171's base branch was deleted during the bottom-up stacked merge. Content unchanged (proxy hardening: BROWSER_REQUIRE_PROXY fail-closed, egress-IP folded into the binding signature, no-proxy TZ warning). Reviewed clean by both the local review pass and Codex; validated green in the combined-stack CI.