### PR TITLE
fix: post-merge review fixes for the #1180–#1185 stack

### DIFF
--- a/docs/plans/2026-07-04-agent-employee-platform-architecture.md
+++ b/docs/plans/2026-07-04-agent-employee-platform-architecture.md
@@ -412,6 +412,37 @@ as code lands.
 All five branch off `main`; a local integration merge of all four code branches is **conflict-free
 and green (908 passed)**. Reviewed via a full pre-merge pass (findings + fixes recorded above).
 
+- **✅ Landed — post-merge adversarial review of the merged stack (2b08fdd..main).**
+  Independent multi-agent review (6 finder dimensions, 3-lens adversarial verification per
+  finding) of #1180/#1181/#1183/#1184/#1185. Six findings confirmed 3/3, one 2/3; all fixed
+  in one follow-up PR:
+  1. The blackboard project→team re-key ran ungated on EVERY boot — a post-rename
+     `projects/…` key (now ordinary user data) would be silently re-keyed at next restart,
+     and via `UPDATE OR REPLACE` could destroy a newer `teams/…` sibling. Now gated on the
+     pre-executescript `PRAGMA user_version` (0 = pre-rename DB → migrate once).
+  2. CLI `/restart` never re-registered the health monitor after an archive deregistration
+     (#1180's follow-up fixed only the dashboard restart path) — mirrored the same guard.
+  3. Archive racing an in-flight `_try_restart`: `unregister` can't reach the coroutine
+     mid-`start_agent`; the restarted container survived archive. `_try_restart` now
+     re-checks `self.agents` post-start and rolls the container back.
+  4. The lane-rehydration startup hook ran `rehydrate_pending` on uvicorn's loop, creating
+     lane queues/workers on the WRONG loop (live wakes hop to `dispatch_loop`, mutating the
+     queue cross-thread). The hook now hops via `run_coroutine_threadsafe` like every other
+     enqueue call site.
+  5. `_direct_dispatch` converted transport error dicts (unreachable agent, 426 skew) into a
+     successful `"(no response)"` turn — ok-status trace + junk auto-notify to the
+     originating human channel, repeated per restart for rehydrated tasks of
+     unreachable/deleted assignees. Error dicts now record an `error` trace and return
+     `SILENT_REPLY_TOKEN` (task stays `pending` for at-least-once recovery). This also
+     closes the 2/3 finding: a protocol-skew 426 no longer masquerades as a completed turn.
+  6. Settle-window double dispatch: a task created+live-woken while the rehydrate sweep was
+     pending was still `pending` in SQLite → enqueued twice. `rehydrate_pending` now skips
+     rows with `created_at >= ` LaneManager construction time.
+  Everything else survived adversarial verification — notably the rename's auth/scoping
+  hunks (`_caller_teams` / `_is_team_member` / publish-subscribe prefix gates), the schema
+  collapse, the re-key's collision semantics on genuinely pre-rename DBs, and the protocol
+  handshake emit/check pair are clean.
+
 ### YOU ARE HERE → next phase
 Foundation (#1180/#1181/#1183/#1184) and the rename (#1185) are merged. Phase 0's removal
 column is fully done. Next, in order:

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -1442,6 +1442,14 @@ class REPLSession:
         self.ctx.router.register_agent(name, url)
         if isinstance(self.ctx.transport, HttpTransport):
             self.ctx.transport.register(name, url)
+        # Archive deregisters from the health monitor; a manual restart is
+        # one of the paths that must re-register (same guard as the
+        # dashboard restart endpoint) or the agent runs unmonitored.
+        if (
+            self.ctx.health_monitor is not None
+            and name not in getattr(self.ctx.health_monitor, "agents", {})
+        ):
+            self.ctx.health_monitor.register(name)
 
         # Wait for readiness
         ready = asyncio.run(self.ctx.runtime.wait_for_agent(name, timeout=60))

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1041,6 +1041,31 @@ class RuntimeContext:
                     headers=extra_headers or None,
                     timeout=effective_cap + 60,
                 )
+                # ``HttpTransport.request`` reports failures (unreachable
+                # container, HTTP error, 426 protocol skew) as an error dict
+                # instead of raising. Treating that as a successful turn
+                # would record an "ok" trace and auto-notify the literal
+                # string "(no response)" to the originating human channel.
+                # Return the silent token instead: the worker skips the
+                # notify, and a task-carrying wake stays ``pending`` for the
+                # at-least-once recovery paths.
+                if isinstance(result, dict) and result.get("error"):
+                    err = str(result.get("error"))
+                    duration_ms = int((_time.time() - t0) * 1000)
+                    logger.warning(
+                        "Dispatch to '%s' failed: %s (status_code=%s)",
+                        agent_name, err, result.get("status_code"),
+                    )
+                    if tid and self.trace_store:
+                        self.trace_store.record(
+                            trace_id=tid, source="dispatch", agent=agent_name,
+                            event_type="chat_response", duration_ms=duration_ms,
+                            status="error",
+                            meta={"error": err[:200],
+                                  "status_code": result.get("status_code")},
+                        )
+                    from src.shared.types import SILENT_REPLY_TOKEN
+                    return SILENT_REPLY_TOKEN
                 response = result.get("response", "(no response)")
                 duration_ms = int((_time.time() - t0) * 1000)
                 if tid and self.trace_store:

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -609,6 +609,19 @@ class HealthMonitor:
                 self.runtime.extra_env.pop("HTTPS_PROXY", None)
                 self.runtime.extra_env.pop("NO_PROXY", None)
 
+            # An archive/delete may have deregistered this agent while
+            # ``start_agent`` was running in the executor (its
+            # ``unregister`` can't reach this in-flight coroutine). Don't
+            # resurrect an intentionally-stopped agent: undo the start
+            # and bail before re-registering it with the router.
+            if agent_id not in self.agents:
+                logger.info(
+                    "Agent '%s' was deregistered during restart "
+                    "(archived/deleted) — stopping the restarted container.",
+                    agent_id,
+                )
+                await loop.run_in_executor(None, self.runtime.stop_agent, agent_id)
+                return
             self.router.register_agent(agent_id, url)
             health.consecutive_failures = 0
             health.restart_count += 1

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -80,6 +80,11 @@ class LaneManager:
         queue_maxsize: int | None = None,
     ):
         self._dispatch_fn = dispatch_fn
+        # Rehydration cutoff: only tasks created BEFORE this process's
+        # LaneManager existed can be restart-stranded. Anything newer was
+        # created through this process's live endpoints and already got its
+        # live wake — re-enqueueing it would double-dispatch.
+        self._boot_ts = time.time()
         # H7 — per-lane queue depth cap. Resolved once: kwarg wins, else
         # env default. ``<= 0`` means unbounded (asyncio.Queue(maxsize=0)).
         self._queue_maxsize = (
@@ -194,6 +199,10 @@ class LaneManager:
           * A re-enqueued task stays ``pending`` until the agent picks it up
             and transitions it, so a second restart before pickup simply
             re-enqueues it again — at-least-once, never lost.
+          * Rows created after this LaneManager was constructed are skipped —
+            they were created via this process's live endpoints and already
+            have a live wake in flight (the sweep runs post-settle, with the
+            mesh already serving), so re-enqueueing would double-dispatch.
           * Best-effort per row: one bad task must not abort the sweep, and a
             missing/failed store is a no-op (returns 0).
         """
@@ -211,6 +220,13 @@ class LaneManager:
             task_id = task.get("id")
             assignee = task.get("assignee") or ""
             if not assignee:
+                continue
+            # Skip rows created during THIS process's lifetime: their live
+            # wake is already in (or through) the lane, and the sweep runs
+            # after a settle delay with the mesh already serving requests —
+            # re-enqueueing them here would dispatch the same task twice.
+            created_at = task.get("created_at")
+            if isinstance(created_at, (int, float)) and created_at >= self._boot_ts:
                 continue
             message = (task.get("description") or task.get("title") or "").strip()
             if not message:

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -57,6 +57,11 @@ class Blackboard:
         self._init_schema()
 
     def _init_schema(self) -> None:
+        # Read BEFORE the executescript stamps ``user_version = 1``: a DB
+        # from before the project→team rename reports 0 here, which gates
+        # the one-shot re-key below. Post-rename ``projects/…`` is an
+        # ordinary user-choosable prefix, so the re-key must never re-run.
+        pre_rename_db = self.db.execute("PRAGMA user_version").fetchone()[0] == 0
         self.db.executescript("""
             CREATE TABLE IF NOT EXISTS entries (
                 key TEXT PRIMARY KEY,
@@ -113,17 +118,20 @@ class Blackboard:
         # One-shot re-key for the project→team rename: live entries and
         # persisted watcher patterns written under the pre-rename
         # ``projects/{team}/`` namespace move to ``teams/{team}/``.
-        # Idempotent (LIKE-guarded); OR REPLACE resolves the pathological
-        # both-spellings-exist collision in favour of the old row's value
-        # landing on the new key.
-        self.db.execute(
-            "UPDATE OR REPLACE entries SET key = 'teams/' || substr(key, 10) "
-            "WHERE key LIKE 'projects/%'"
-        )
-        self.db.execute(
-            "UPDATE OR REPLACE watchers SET pattern = 'teams/' || substr(pattern, 10) "
-            "WHERE pattern LIKE 'projects/%'"
-        )
+        # Runs ONLY when the DB pre-dates the canonical v1 schema
+        # (``user_version`` was 0 before this boot) — on a v1 DB a
+        # ``projects/…`` key is legitimate user data, not a leftover.
+        # OR REPLACE resolves the pathological both-spellings-exist
+        # collision in favour of the old row's value landing on the new key.
+        if pre_rename_db:
+            self.db.execute(
+                "UPDATE OR REPLACE entries SET key = 'teams/' || substr(key, 10) "
+                "WHERE key LIKE 'projects/%'"
+            )
+            self.db.execute(
+                "UPDATE OR REPLACE watchers SET pattern = 'teams/' || substr(pattern, 10) "
+                "WHERE pattern LIKE 'projects/%'"
+            )
         self.db.commit()
         self._load_watchers()
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -10278,7 +10278,22 @@ def create_mesh_app(
         # failure here must never break mesh startup.
         try:
             await asyncio.sleep(_LANE_REHYDRATE_SETTLE_S)
-            await lane_manager.rehydrate_pending()
+            # The lane queues/workers live on ``dispatch_loop`` (every live
+            # enqueue hops there via ``run_coroutine_threadsafe``). Running
+            # the rehydrate here on uvicorn's loop would create each
+            # assignee's lane — queue, lock, worker task — on the WRONG
+            # loop, and later live wakes would then mutate that queue from
+            # the dispatch thread without thread safety. Hop like every
+            # other enqueue call site; same-loop fallback covers
+            # tests/embedded setups that pass no dispatch loop.
+            if dispatch_loop is not None:
+                await asyncio.wrap_future(
+                    asyncio.run_coroutine_threadsafe(
+                        lane_manager.rehydrate_pending(), dispatch_loop,
+                    )
+                )
+            else:
+                await lane_manager.rehydrate_pending()
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("lane rehydration after boot failed: %s", e)
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1594,3 +1594,50 @@ class TestWorkplaceCLICommands:
         # And X-Origin so the human-confirmation gate accepts it
         assert "kind=human" in headers.get("X-Origin", "")
         assert "channel=cli" in headers.get("X-Origin", "")
+
+
+class TestRestartHealthReregistration:
+    """Archive deregisters an agent from the health monitor; a manual
+    ``/restart`` must re-register it (same guard as the dashboard restart
+    endpoint) or the revived agent runs permanently unmonitored."""
+
+    def _restart(self, health_monitor, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from src.cli import repl as repl_mod
+        from src.cli.repl import REPLSession
+
+        ctx = _MockCtx(agent_urls={"bot": "http://bot:8400"})
+        ctx.runtime = MagicMock()
+        ctx.runtime.start_agent.return_value = "http://bot:8400"
+        ctx.runtime.wait_for_agent = AsyncMock(return_value=True)
+        ctx.router = MagicMock()
+        ctx.transport = MagicMock()
+        ctx.health_monitor = health_monitor
+        monkeypatch.setattr(
+            repl_mod, "_load_config",
+            lambda: {"agents": {"bot": {}}, "llm": {"default_model": "m"}},
+        )
+        repl = REPLSession(ctx)
+        repl._restart_agent("bot")
+        return ctx
+
+    def test_restart_reregisters_deregistered_agent(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        health = MagicMock()
+        health.agents = {}  # archived → deregistered
+        self._restart(health, monkeypatch)
+        health.register.assert_called_once_with("bot")
+
+    def test_restart_leaves_registered_agent_alone(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        health = MagicMock()
+        health.agents = {"bot": object()}  # still monitored
+        self._restart(health, monkeypatch)
+        health.register.assert_not_called()
+
+    def test_restart_tolerates_missing_health_monitor(self, monkeypatch):
+        # ctx.health_monitor is None in embedded/test setups — no crash.
+        self._restart(None, monkeypatch)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -731,3 +731,57 @@ class TestFailedSelfHeal:
         # status is preserved — only clear_quarantine flips it back to healthy.
         assert h.quarantined is True
         assert h.status == "failed"
+
+
+class TestArchiveDuringInflightRestart:
+    @pytest.mark.asyncio
+    async def test_deregistered_mid_restart_is_stopped_not_registered(self):
+        """Archive/delete can deregister an agent while ``_try_restart`` is
+        inside its executor ``start_agent`` call — ``unregister`` can't reach
+        the in-flight coroutine. The restart must notice post-start and undo
+        itself instead of resurrecting an intentionally-stopped agent."""
+        monitor = _make_monitor({
+            "scout": {"role": "r", "tools_dir": "", "model": "m", "thinking": ""},
+        })
+        monitor.register("scout")
+        health = monitor.agents["scout"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+
+        def _start_agent(**kwargs):
+            # Simulate the concurrent archive landing while start_agent runs.
+            monitor.unregister("scout")
+            return "http://localhost:8401"
+
+        monitor.runtime.start_agent.side_effect = _start_agent
+        monitor.runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        with patch("src.host.health._load_config", return_value={}):
+            await monitor._try_restart("scout")
+
+        # Undone, not resurrected: container stopped again (once before the
+        # restart, once to roll it back) and never re-registered for routing.
+        assert monitor.runtime.stop_agent.call_count == 2
+        monitor.router.register_agent.assert_not_called()
+        assert "scout" not in monitor.agents
+
+    @pytest.mark.asyncio
+    async def test_normal_restart_still_registers(self):
+        """Sanity: without a concurrent deregistration the restart proceeds
+        exactly as before (router re-registered, health state updated)."""
+        monitor = _make_monitor({
+            "scout": {"role": "r", "tools_dir": "", "model": "m", "thinking": ""},
+        })
+        monitor.register("scout")
+        health = monitor.agents["scout"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+        monitor.runtime.start_agent.return_value = "http://localhost:8401"
+        monitor.runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        with patch("src.host.health._load_config", return_value={}):
+            await monitor._try_restart("scout")
+
+        monitor.router.register_agent.assert_called_once()
+        assert health.status == "healthy"
+        assert health.restart_count == 1

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -1218,3 +1218,96 @@ async def test_rehydrate_pending_survives_store_failure():
     lm.set_tasks_store(store)
     assert await lm.rehydrate_pending() == 0
     await lm.stop()
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_pending_skips_rows_created_after_boot():
+    """Rows created during THIS process's lifetime already got a live wake —
+    the sweep runs post-settle with the mesh serving, so re-enqueueing them
+    would dispatch the same task twice (settle-window double dispatch)."""
+    dispatched = []
+
+    async def dispatch(agent, message, **kwargs):
+        dispatched.append(kwargs.get("task_id"))
+        return "ok"
+
+    lm = LaneManager(dispatch_fn=dispatch)
+    store = MagicMock()
+    store.list_pending.return_value = [
+        {"id": "task_stranded", "assignee": "alpha", "description": "old work",
+         "title": "T", "origin": None, "trace_id": None,
+         "created_at": lm._boot_ts - 60},
+        {"id": "task_live_woken", "assignee": "alpha", "description": "new work",
+         "title": "T", "origin": None, "trace_id": None,
+         "created_at": lm._boot_ts + 60},
+    ]
+    lm.set_tasks_store(store)
+
+    n = await lm.rehydrate_pending()
+    assert n == 1
+    await asyncio.gather(*list(lm._rehydrate_tasks), return_exceptions=True)
+    assert dispatched == ["task_stranded"]
+    await lm.stop()
+
+
+def test_rehydrate_boot_hook_runs_on_dispatch_loop(tmp_path, monkeypatch):
+    """The startup hook must hop rehydration onto ``dispatch_loop``: the lane
+    queues/workers live there, and every live enqueue reaches them via
+    ``run_coroutine_threadsafe``. Rehydrating on uvicorn's loop instead would
+    create the assignee's queue/worker on the wrong loop and later live wakes
+    would mutate that queue cross-thread without thread safety."""
+    import threading
+    import time as _t
+
+    from fastapi.testclient import TestClient
+
+    import src.host.server as server_mod
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+
+    monkeypatch.setattr(server_mod, "_LANE_REHYDRATE_SETTLE_S", 0)
+    monkeypatch.setenv(
+        "OPENLEGION_ORCHESTRATION_TASKS_DB", str(tmp_path / "tasks.db"),
+    )
+
+    dispatch_loop = asyncio.new_event_loop()
+    threading.Thread(target=dispatch_loop.run_forever, daemon=True).start()
+
+    seen_loops = []
+
+    async def dispatch(agent, message, **kwargs):
+        seen_loops.append(asyncio.get_running_loop())
+        return "ok"
+
+    lm = LaneManager(dispatch_fn=dispatch)
+    store = MagicMock()
+    store.list_pending.return_value = [
+        {"id": "task_old", "assignee": "alpha", "description": "stranded",
+         "title": "T", "origin": None, "trace_id": None,
+         "created_at": lm._boot_ts - 60},
+    ]
+    lm.set_tasks_store(store)
+
+    perms = PermissionMatrix()
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    app = create_mesh_app(
+        blackboard=bb,
+        pubsub=PubSub(),
+        router=MessageRouter(perms, {}),
+        permissions=perms,
+        auth_tokens={"operator": "tok"},
+        lane_manager=lm,
+        dispatch_loop=dispatch_loop,
+    )
+    try:
+        with TestClient(app):
+            deadline = _t.time() + 10
+            while not seen_loops and _t.time() < deadline:
+                _t.sleep(0.05)
+        assert seen_loops, "rehydrated task never dispatched"
+        assert seen_loops[0] is dispatch_loop
+    finally:
+        asyncio.run_coroutine_threadsafe(lm.stop(), dispatch_loop).result(timeout=5)
+        dispatch_loop.call_soon_threadsafe(dispatch_loop.stop)
+        bb.close()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2489,3 +2489,61 @@ async def test_proxy_api_stream_sequential_trace_attribution(tmp_path):
         assert _usage_trace_ids(tracker) == ["tr_first0000001", None]
     finally:
         cleanup()
+
+
+# ── project→team re-key gating (post-merge review fix) ─────
+
+
+def test_rekey_migrates_legacy_projects_rows_once(tmp_path):
+    """A pre-rename DB (``user_version`` 0) gets its ``projects/…`` entries
+    and watcher patterns re-keyed to ``teams/…`` on open."""
+    import sqlite3
+
+    db_path = str(tmp_path / "bb.db")
+    bb = Blackboard(db_path=db_path)
+    bb.close()
+
+    # Simulate a pre-rename DB: legacy rows + version stamp rolled back.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO entries (key, value, written_by) VALUES (?, ?, ?)",
+        ("projects/alpha/tasks/t1", json.dumps({"note": "legacy"}), "agent1"),
+    )
+    conn.execute(
+        "INSERT INTO watchers (agent_id, pattern) VALUES (?, ?)",
+        ("agent1", "projects/alpha/tasks/agent1/*"),
+    )
+    conn.execute("PRAGMA user_version = 0")
+    conn.commit()
+    conn.close()
+
+    bb = Blackboard(db_path=db_path)
+    try:
+        assert bb.read("projects/alpha/tasks/t1") is None
+        entry = bb.read("teams/alpha/tasks/t1")
+        assert entry is not None and entry.value == {"note": "legacy"}
+        assert bb.get_agent_watches("agent1") == ["teams/alpha/tasks/agent1/*"]
+    finally:
+        bb.close()
+
+
+def test_rekey_never_reruns_on_canonical_v1_db(tmp_path):
+    """On a canonical-v1 DB, ``projects/…`` is ordinary user data: it must
+    survive a reopen untouched, and never clobber a ``teams/…`` sibling."""
+    db_path = str(tmp_path / "bb.db")
+    bb = Blackboard(db_path=db_path)
+    bb.write("teams/roadmap", {"state": "team-coordination"}, "agent1")
+    bb.write("projects/roadmap", {"note": "user-project"}, "agent1")
+    bb.add_watch("agent1", "projects/*")
+    bb.close()
+
+    bb = Blackboard(db_path=db_path)
+    try:
+        entry = bb.read("projects/roadmap")
+        assert entry is not None and entry.value == {"note": "user-project"}
+        team_entry = bb.read("teams/roadmap")
+        assert team_entry is not None
+        assert team_entry.value == {"state": "team-coordination"}
+        assert bb.get_agent_watches("agent1") == ["projects/*"]
+    finally:
+        bb.close()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3037,3 +3037,50 @@ class TestMeshBindFailFast:
         # We bailed before any app construction — so the "Started" banner can
         # never be printed on a failed bind.
         ctx.async_dispatch.assert_not_called()
+
+
+class TestDispatchTransportErrorSurfacing:
+    """A transport-level failure (unreachable container, HTTP error, 426
+    protocol skew) comes back from ``HttpTransport.request`` as an error dict,
+    not an exception. ``_direct_dispatch`` must not convert that into a
+    successful ``"(no response)"`` turn — that recorded an ``ok`` trace and
+    auto-notified the literal junk string to the originating human channel
+    (worst on the rehydration path: repeated on every restart)."""
+
+    @pytest.mark.asyncio
+    async def test_error_dict_returns_silent_token(self, monkeypatch):
+        from src.shared.types import SILENT_REPLY_TOKEN
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {"error": "HTTP 426", "status_code": 426}
+
+        result = await dispatch_fn("agent-x", "resume task")
+
+        assert result == SILENT_REPLY_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_error_dict_records_error_trace_not_ok(self, monkeypatch):
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+        ctx.trace_store = MagicMock()
+        transport.request.return_value = {"error": "Connection failed: boom"}
+
+        await dispatch_fn("agent-x", "resume task")
+
+        statuses = [
+            kwargs.get("status")
+            for _args, kwargs in ctx.trace_store.record.call_args_list
+            if kwargs.get("event_type") == "chat_response"
+        ]
+        assert statuses == ["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_response_key_without_error_is_unchanged(self, monkeypatch):
+        """A successful call that just lacks ``response`` keeps the legacy
+        ``"(no response)"`` placeholder — only genuine transport errors go
+        silent."""
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {}
+
+        result = await dispatch_fn("agent-x", "resume task")
+
+        assert result == "(no response)"


### PR DESCRIPTION
## Summary

Adversarial post-merge correctness review of the merged stack `2b08fdd..main` (#1180 health-monitor deregistration, #1181 protocol handshake, #1183 lane rehydration, #1184 personnel export, #1185 project→team rename). Six review dimensions, each finding independently verified by three adversarial lenses; 6 findings confirmed 3/3, one 2/3 — all seven fixed here. The rename's auth/scoping paths (`_caller_teams` / `_is_team_member` / publish-subscribe prefix gates), the schema collapse, and the handshake emit/check pair survived verification clean.

## Fixes

1. **`mesh.py` — blackboard re-key ran ungated on every boot.** The "one-shot" project→team re-key executed on every `Blackboard` construction: a post-rename `projects/…` key (now ordinary user-choosable data) was silently re-keyed to `teams/…` at the next restart, and `UPDATE OR REPLACE` would destroy a newer `teams/…` sibling (value + CAS version counter) with no timestamp comparison. Now gated on the pre-`executescript` `PRAGMA user_version` — it runs exactly once, on genuinely pre-rename DBs (version 0).
2. **`repl.py` — CLI `/restart` left revived agents unmonitored.** #1180's archive path deregisters from the health monitor, and its follow-up re-registers only on the dashboard restart path. The REPL restart now applies the same guard.
3. **`health.py` — archive racing an in-flight auto-restart.** `unregister` can't reach a `_try_restart` coroutine that is mid-`start_agent` in an executor thread, so the archived agent's container came back up and ran unmonitored. `_try_restart` now re-checks `self.agents` after `start_agent` returns and rolls the container back instead of re-registering it.
4. **`server.py` — lane rehydration ran on the wrong event loop.** The startup hook created lane queues/lock/worker tasks on uvicorn's loop, while every live enqueue hops to the dedicated `dispatch_loop` thread — later wakes would mutate those queues cross-thread without thread safety. The hook now hops via `run_coroutine_threadsafe` like every other enqueue call site (same-loop fallback when no dispatch loop is wired, e.g. tests).
5. **`runtime.py` — transport errors masqueraded as successful turns.** `HttpTransport.request` returns error dicts instead of raising; `_direct_dispatch` converted them to a successful `"(no response)"` turn — an `ok` trace row, and the literal junk string auto-notified to the originating human channel (repeated on every restart for rehydrated tasks with unreachable/deleted assignees; also the 426 protocol-skew rejection #1181 built to fail *loudly*). Error dicts now record an `error` trace and return `SILENT_REPLY_TOKEN`; the task stays `pending` for at-least-once recovery.
6. **`lanes.py` — settle-window double dispatch.** A task created and live-woken while the rehydrate sweep was pending was still `pending` in SQLite, so the sweep enqueued a second wake for it. `rehydrate_pending` now skips rows created after `LaneManager` construction — only pre-restart rows can be stranded.

## Testing

- 11 new regression tests across `test_lanes` / `test_mesh` / `test_health` / `test_runtime` / `test_cli_commands` (one per fix, plus loop-affinity and sanity counterparts).
- Targeted run of all touched suites + `test_archive_health_dereg` + `test_orchestration`: **658 passed, 0 failed**.
- `ruff check src/ tests/` clean.
- Appendix D of the plan doc updated with the review log (per the post-merge-review protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEVpeNmyVBoW6Va2LKe4iT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEVpeNmyVBoW6Va2LKe4iT)_