### PR TITLE
feat(llm): per-call model tiering hook — utility model for coordination traffic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,7 @@ mesh:
 
 llm:
   default_model: anthropic/claude-haiku-4-5-20251001
+  utility_model: anthropic/claude-haiku-4-5-20251001
   embedding_model: text-embedding-3-small
   failover:
     anthropic/claude-sonnet-4-6:
@@ -134,6 +135,7 @@ collaboration: true
 | `mesh.host` | string | `0.0.0.0` | Bind address for mesh server |
 | `mesh.port` | integer | `8420` | Mesh server port |
 | `llm.default_model` | string | -- | Default model for agents without explicit model |
+| `llm.utility_model` | string | *unset* | Optional cheap model for coordination/utility LLM traffic (context summarization, memory extraction/consolidation, heartbeats); deep task/chat reasoning stays on the agent's model. Injected into containers as `LLM_UTILITY_MODEL` and always accepted by the mesh model pin. Unset/empty = off (behavior identical to an untiered deployment). |
 | `llm.embedding_model` | string | *auto* | Model for memory embeddings. Auto-detected from the default LLM provider via `_PROVIDER_EMBEDDING_DEFAULTS` in `src/cli/runtime.py`: only the prefixes `openai/`, `gpt-`, `o1`, `o3`, `o4` resolve to `text-embedding-3-small`; everything else (Anthropic, Google, DeepSeek, xAI, Groq, …) falls through to `"none"`. Must produce 1536-dim vectors. Set to `"none"` to disable vector search (FTS5 keyword search still works). |
 | `llm.failover` | dict[string, list[string]] | -- | Per-model failover chains, typed as `dict[str, list[str]]` in `src/host/credentials.py`. Map each primary `provider/model` to an ordered fallback list. The legacy `{primary: ..., fallback: ...}` single-pair shape is **not** recognized and is silently ignored. |
 | `collaboration` | boolean | `true` | Allow inter-agent messaging |

--- a/docs/plans/2026-07-04-agent-employee-platform-architecture.md
+++ b/docs/plans/2026-07-04-agent-employee-platform-architecture.md
@@ -398,7 +398,6 @@ as code lands.
      delete it in a follow-up once dev instances have cycled (no users, so soon).
   6. Dev-container-only test failures exist (root user + forced HTTPS_PROXY break
      `test_builtins.py` chmod/http_tool tests locally); they pass in CI — don't chase them.
-
 ### PR ledger (as of 2026-07-04)
 | PR | Unit | CI |
 |---|---|---|
@@ -442,6 +441,23 @@ and green (908 passed)**. Reviewed via a full pre-merge pass (findings + fixes r
   hunks (`_caller_teams` / `_is_team_member` / publish-subscribe prefix gates), the schema
   collapse, the re-key's collision semantics on genuinely pre-rename DBs, and the protocol
   handshake emit/check pair are clean.
+- **✅ Landed — per-call model tiering hook (Phase-0 residual a).** New optional
+  `llm.utility_model` config (unset = byte-identical behavior). Both A.C4 blockers closed:
+  (1) `_enforce_model_pin` widened — the deployment-configured utility model is always
+  acceptable via the existing `_bare()` prefix-insensitive compare (operator-controlled
+  config, not agent-choosable; `is_model_compatible` still runs), read through the same
+  `_load_config()` the pin already uses; (2) agent-side `model=` threaded at the utility
+  call sites — `context.py` `_summarize_text` (all `_summarize_compact` chunk/fold calls
+  funnel through it), `_extract_and_store_facts`, `_maybe_consolidate_memory`, and
+  `loop.py` `execute_heartbeat` — via `llm.utility_model_kwargs()` (`{}` when off, so the
+  call shape is unchanged). Container wiring: `LLM_UTILITY_MODEL` injected at the
+  runtime-backend level (`runtime.py`, both Docker + Sandbox env builds, read fresh from
+  config per start) so every start path (boot, REPL /restart, health-monitor restart,
+  dashboard restart) is covered without per-caller plumbing; `LLMClient` picks it up
+  mirroring the `MESH_AUTH_TOKEN` ctor pattern. Spend split + broader tiering policy
+  deliberately NOT included (this is the hook only). Tests in `test_llm_model_pin.py`,
+  `test_llm.py`, `test_context.py`, `test_loop.py`, `test_runtime.py`.
+
 
 ### YOU ARE HERE → next phase
 Foundation (#1180/#1181/#1183/#1184) and the rename (#1185) are merged. Phase 0's removal

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -15,6 +15,7 @@ import time
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
+from src.agent.llm import utility_model_kwargs
 from src.agent.workspace import _MEMORY_HEAD_BUDGET
 from src.shared.models import get_context_window
 from src.shared.utils import sanitize_for_prompt, setup_logging
@@ -598,6 +599,9 @@ class ContextManager:
                 messages=[{"role": "user", "content": extract_prompt}],
                 max_tokens=1024,
                 temperature=0.3,
+                # Extraction is coordination overhead, not task reasoning —
+                # route to the cheap utility model when one is configured.
+                **utility_model_kwargs(self.llm),
             )
             raw = response.content.strip()
             # Strip markdown code fences if present (e.g. ```json\n...\n```)
@@ -767,6 +771,9 @@ class ContextManager:
                 system="You compile concise, durable agent memory.",
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=1500, temperature=0.3,
+                # Memory consolidation is maintenance overhead — cheap
+                # utility model when configured.
+                **utility_model_kwargs(llm),
             )
         except Exception as e:
             logger.warning("Memory consolidation LLM call failed: %s", e)
@@ -1073,6 +1080,10 @@ class ContextManager:
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=max_tokens,
                     temperature=0.3,
+                    # Summarization (incl. every _summarize_compact chunk /
+                    # fold call, which all funnel through here) is context
+                    # overhead — cheap utility model when configured.
+                    **utility_model_kwargs(self.llm),
                 )
                 return response.content.strip() or None
             except Exception as e:

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -40,6 +40,21 @@ class LLMContextOverflowError(RuntimeError):
     pass
 
 
+def utility_model_kwargs(llm: object) -> dict[str, str]:
+    """``chat()`` kwargs that route a coordination/utility LLM call
+    (context summarization, memory extraction, heartbeat) to the
+    deployment's cheap utility model.
+
+    Returns ``{"model": <utility model>}`` when the client carries a
+    configured ``utility_model``, else ``{}`` — so with the feature off
+    the call shape stays byte-for-byte identical to today. ``getattr`` +
+    ``isinstance`` keep this safe for mocked clients in tests (a
+    ``MagicMock`` attribute is not a ``str`` → ``{}``).
+    """
+    model = getattr(llm, "utility_model", "")
+    return {"model": model} if isinstance(model, str) and model else {}
+
+
 class LLMClient:
     """LLM interface that routes all calls through the mesh API proxy."""
 
@@ -54,6 +69,7 @@ class LLMClient:
         embedding_model: str = "",
         thinking: str = "off",
         max_output_tokens: int = 16384,
+        utility_model: str | None = None,
     ):
         if thinking and thinking not in self.VALID_THINKING_LEVELS:
             logger.warning(
@@ -109,6 +125,17 @@ class LLMClient:
         self._client: httpx.AsyncClient | None = None
         self._client_lock = asyncio.Lock()
         self._auth_token: str = os.environ.get("MESH_AUTH_TOKEN", "")
+        # Per-call model tiering hook (Phase-0 residual a): the deployment's
+        # cheap model for coordination/utility LLM traffic (context
+        # summarization, memory extraction, heartbeat). Injected by the mesh
+        # as the LLM_UTILITY_MODEL container env (mirrors MESH_AUTH_TOKEN's
+        # env pickup); an explicit ctor kwarg wins for tests. Empty string =
+        # feature off — utility call sites then send exactly what they send
+        # today.
+        self.utility_model: str = (
+            utility_model if utility_model is not None
+            else os.environ.get("LLM_UTILITY_MODEL", "")
+        )
 
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is not None and not self._client.is_closed:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from src.agent.attachments import enrich_message_with_attachments
+from src.agent.llm import utility_model_kwargs
 from src.agent.loop_detector import ToolLoopDetector
 from src.agent.tool_groups import (
     GroupedPlan,
@@ -2558,6 +2559,10 @@ class AgentLoop:
                         system=system_prompt,
                         messages=messages,
                         tools=iter_tools,
+                        # Heartbeats are coordination traffic, not deep work —
+                        # route to the cheap utility model when configured
+                        # (per-call model tiering hook). No-op when unset.
+                        **utility_model_kwargs(self.llm),
                     )
                     # Bug 1 (codex P2 r2): tick after the LLM call returns —
                     # a single deep-research call can run >5 min, and bumping

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -109,6 +109,28 @@ class RuntimeBackend(abc.ABC):
         until wired, agents start with no MCP servers."""
         self._connectors = store
 
+    def _utility_model_from_config(self) -> str:
+        """Deployment-wide cheap model for coordination/utility LLM traffic
+        (``llm.utility_model`` in ``config/mesh.yaml``), injected as the
+        ``LLM_UTILITY_MODEL`` container env.
+
+        Read fresh from config at every container start — at the backend
+        level rather than per caller — so every start path (initial boot,
+        REPL /restart, health-monitor restart, dashboard restart, mesh
+        restart endpoint) picks it up without per-caller plumbing, and a
+        config edit applies on the next (re)start. Empty string = feature
+        off (the env var is then omitted entirely). Same source of truth
+        the mesh-side model pin reads, so agent-side tiered calls are
+        never 403'd.
+        """
+        try:
+            from src.cli.config import _load_config
+            value = _load_config().get("llm", {}).get("utility_model", "")
+        except Exception:
+            logger.debug("utility model: config load failed", exc_info=True)
+            return ""
+        return value if isinstance(value, str) else ""
+
     def _mcp_snapshot_for(self, agent_id: str) -> tuple[list[dict], int]:
         """``MCP_SERVERS``-shaped dicts for every connector assigned to
         this agent, plus the catalog generation the snapshot was taken
@@ -491,6 +513,9 @@ class DockerBackend(RuntimeBackend):
             )
         if thinking:
             environment["THINKING"] = thinking
+        utility_model = self._utility_model_from_config()
+        if utility_model:
+            environment["LLM_UTILITY_MODEL"] = utility_model
         environment.update(self.extra_env)
         if env_overrides:
             environment.update(env_overrides)
@@ -1165,6 +1190,9 @@ class SandboxBackend(RuntimeBackend):
             )
         if thinking:
             env_cfg["THINKING"] = thinking
+        utility_model = self._utility_model_from_config()
+        if utility_model:
+            env_cfg["LLM_UTILITY_MODEL"] = utility_model
         env_cfg.update(self.extra_env)
         if env_overrides:
             env_cfg.update(env_overrides)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1266,6 +1266,25 @@ def create_mesh_app(
             allowed.update(m for m in extra if isinstance(m, str) and m)
         return allowed or None
 
+    def _deployment_utility_model() -> str:
+        """Deployment-configured cheap model for coordination/utility LLM
+        traffic (``llm.utility_model`` — per-call model tiering hook).
+
+        The value is operator/deployment-controlled, never agent-chosen,
+        so the model pin always accepts it: an agent cannot widen its own
+        allowlist through this. Read from the SAME config the container
+        env wiring (``LLM_UTILITY_MODEL`` in ``runtime.py``) serves, so
+        agent-side tiered calls (summarization, heartbeat) are never
+        403'd. Empty string = feature off (pin behavior unchanged).
+        """
+        try:
+            from src.cli.config import _load_config
+            value = _load_config().get("llm", {}).get("utility_model", "")
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("model-pin: utility model config load failed: %s", e)
+            return ""
+        return value if isinstance(value, str) else ""
+
     def _enforce_model_pin(agent_id: str, request: Request, api_request: APIProxyRequest) -> None:
         """403 when an agent requests an LLM model it isn't pinned to.
 
@@ -1305,6 +1324,15 @@ def create_mesh_app(
                 return name.rsplit("/", 1)[-1].lower()
 
             allowed_bare = {_bare(m) for m in allowed}
+            # The deployment-configured utility model is ALWAYS acceptable
+            # (per-call model tiering): it is operator-controlled config,
+            # so this widens nothing an agent can influence. Same
+            # prefix-insensitive compare as the allowlist so bare and
+            # prefixed spellings both pass. The is_model_compatible gate
+            # below still runs for it.
+            utility_model = _deployment_utility_model()
+            if utility_model:
+                allowed_bare.add(_bare(utility_model))
             if _bare(requested_model) not in allowed_bare:
                 _record_denial(
                     "permission", caller=agent_id, target=requested_model,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1370,3 +1370,114 @@ class TestChunkedSummarization:
         chunks = ContextManager._chunk_message_texts(msgs, chunk_size=100, tool_chars=200)
         assert len(chunks) == 1
         assert len(chunks[0]) <= 100
+
+
+# ── Per-call model tiering: utility model on summarization/extraction ──────
+#
+# When the LLMClient carries a configured utility_model (from the
+# LLM_UTILITY_MODEL container env), every ContextManager-internal utility
+# chat call (summarize, fact extraction, memory consolidation) must route to
+# it via model=. When unset, the call shape must be exactly today's — no
+# model kwarg at all.
+
+
+class TestUtilityModelTiering:
+    @pytest.mark.asyncio
+    async def test_summarize_text_uses_utility_model_when_configured(self):
+        llm = MagicMock()
+        llm.utility_model = "openai/gpt-4.1-nano"
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="a summary", tokens_used=10),
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm)
+
+        out = await cm._summarize_text("summarize this")
+
+        assert out == "a summary"
+        assert llm.chat.call_args.kwargs["model"] == "openai/gpt-4.1-nano"
+
+    @pytest.mark.asyncio
+    async def test_summarize_text_call_shape_unchanged_when_unset(self):
+        llm = MagicMock()
+        llm.utility_model = ""  # feature off
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="a summary", tokens_used=10),
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm)
+
+        await cm._summarize_text("summarize this")
+
+        assert "model" not in llm.chat.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_mocked_llm_without_utility_attr_treated_as_off(self):
+        """The standard MagicMock double (utility_model is a MagicMock,
+        not a str) must behave exactly like feature-off."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="a summary", tokens_used=10),
+        )
+        cm = ContextManager(max_tokens=1000, llm=llm)
+
+        await cm._summarize_text("summarize this")
+
+        assert "model" not in llm.chat.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_compaction_utility_calls_all_carry_utility_model(self):
+        """End-to-end through maybe_compact: both the fact-extraction call
+        and the summarize call ride the utility model."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            workspace = WorkspaceManager(workspace_dir=tmpdir)
+            llm = MagicMock()
+            llm.utility_model = "openai/gpt-4.1-nano"
+            llm.chat = AsyncMock(
+                side_effect=[
+                    LLMResponse(
+                        content='[{"key": "topic", "value": "tiering", "category": "fact"}]',
+                        tokens_used=30,
+                    ),
+                    LLMResponse(content="Summary: tiering.", tokens_used=30),
+                ]
+            )
+
+            cm = ContextManager(max_tokens=100, llm=llm, workspace=workspace)
+            msgs = _make_messages(10, chars_each=200)
+            _, did_compact = await cm.maybe_compact("system", msgs)
+
+            assert did_compact is True
+            assert llm.chat.call_count >= 2
+            for call in llm.chat.call_args_list:
+                assert call.kwargs["model"] == "openai/gpt-4.1-nano"
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_compaction_call_shape_unchanged_when_unset(self):
+        """Feature off → NO utility chat call carries a model kwarg
+        (byte-for-byte today's behavior)."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            workspace = WorkspaceManager(workspace_dir=tmpdir)
+            llm = MagicMock()
+            llm.utility_model = ""
+            llm.chat = AsyncMock(
+                side_effect=[
+                    LLMResponse(
+                        content='[{"key": "topic", "value": "tiering", "category": "fact"}]',
+                        tokens_used=30,
+                    ),
+                    LLMResponse(content="Summary: tiering.", tokens_used=30),
+                ]
+            )
+
+            cm = ContextManager(max_tokens=100, llm=llm, workspace=workspace)
+            msgs = _make_messages(10, chars_each=200)
+            _, did_compact = await cm.maybe_compact("system", msgs)
+
+            assert did_compact is True
+            for call in llm.chat.call_args_list:
+                assert "model" not in call.kwargs
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -481,3 +481,69 @@ def test_thinking_override_on_openai_reasoning_models():
     )
     llm.thinking_override = "high"
     assert llm._get_thinking_params() == {"reasoning_effort": "high"}
+
+
+# ── Per-call model tiering: utility_model pickup + kwargs helper ──────────
+
+
+def test_utility_model_env_pickup(monkeypatch):
+    """LLM_UTILITY_MODEL container env populates utility_model (mirrors
+    the MESH_AUTH_TOKEN ctor pattern)."""
+    monkeypatch.setenv("LLM_UTILITY_MODEL", "openai/gpt-4.1-nano")
+    llm = LLMClient(mesh_url="http://mesh:8420", agent_id="a1")
+    assert llm.utility_model == "openai/gpt-4.1-nano"
+
+
+def test_utility_model_defaults_empty(monkeypatch):
+    """No env, no kwarg → feature off (empty string)."""
+    monkeypatch.delenv("LLM_UTILITY_MODEL", raising=False)
+    llm = LLMClient(mesh_url="http://mesh:8420", agent_id="a1")
+    assert llm.utility_model == ""
+
+
+def test_utility_model_ctor_kwarg_overrides_env(monkeypatch):
+    """Explicit ctor kwarg wins over the env var (test seam)."""
+    monkeypatch.setenv("LLM_UTILITY_MODEL", "env/model")
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1",
+        utility_model="kwarg/model",
+    )
+    assert llm.utility_model == "kwarg/model"
+
+
+def test_utility_model_ctor_empty_string_disables(monkeypatch):
+    """An explicit empty-string kwarg means OFF even when the env is set."""
+    monkeypatch.setenv("LLM_UTILITY_MODEL", "env/model")
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1", utility_model="",
+    )
+    assert llm.utility_model == ""
+
+
+def test_utility_model_kwargs_configured():
+    from src.agent.llm import utility_model_kwargs
+
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1",
+        utility_model="openai/gpt-4.1-nano",
+    )
+    assert utility_model_kwargs(llm) == {"model": "openai/gpt-4.1-nano"}
+
+
+def test_utility_model_kwargs_off_is_empty():
+    """Unset → {} so utility call sites keep today's exact call shape."""
+    from src.agent.llm import utility_model_kwargs
+
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1", utility_model="",
+    )
+    assert utility_model_kwargs(llm) == {}
+
+
+def test_utility_model_kwargs_tolerates_mocked_client():
+    """A MagicMock llm (the standard test double) has a non-str
+    utility_model attribute — the helper must treat that as OFF."""
+    from src.agent.llm import utility_model_kwargs
+
+    assert utility_model_kwargs(MagicMock()) == {}
+    assert utility_model_kwargs(object()) == {}

--- a/tests/test_llm_model_pin.py
+++ b/tests/test_llm_model_pin.py
@@ -400,3 +400,107 @@ async def test_prefix_insensitive_does_not_allow_different_bare_name(pin_setup):
     )
     assert resp.status_code == 403, resp.text
     assert "not authorized to use model" in resp.text
+
+
+# ── Per-call model tiering: the deployment utility model always passes ──
+#
+# ``llm.utility_model`` is operator/deployment-controlled config (the same
+# value injected into containers as LLM_UTILITY_MODEL), so the pin accepts
+# it for every agent — an agent cannot pick an arbitrary model through it.
+# The is_model_compatible credential gate still applies.
+
+
+@pytest.mark.asyncio
+async def test_utility_model_accepted_for_pinned_worker(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["llm"]["utility_model"] = (
+        "openai/gpt-4.1-nano"
+    )
+    resp = await _post(
+        app, _req("openai/gpt-4.1-nano"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert pin_setup["vault"].calls[-1]["model"] == "openai/gpt-4.1-nano"
+
+
+@pytest.mark.asyncio
+async def test_utility_model_accepted_bare_request_spelling(pin_setup):
+    """Configured prefixed, requested bare — the same _bare() compare the
+    allowlist uses must apply to the utility model."""
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["llm"]["utility_model"] = (
+        "openai/gpt-4.1-nano"
+    )
+    resp = await _post(
+        app, _req("gpt-4.1-nano"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert pin_setup["vault"].calls[-1]["model"] == "gpt-4.1-nano"
+
+
+@pytest.mark.asyncio
+async def test_utility_model_accepted_prefixed_request_spelling(pin_setup):
+    """Configured bare, requested prefixed."""
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["llm"]["utility_model"] = "gpt-4.1-nano"
+    resp = await _post(
+        app, _req("openai/gpt-4.1-nano"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_third_model_still_403_when_utility_model_set(pin_setup):
+    """The utility carve-out widens the pin by exactly one model — an
+    arbitrary third model is still rejected."""
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["llm"]["utility_model"] = (
+        "openai/gpt-4.1-nano"
+    )
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not authorized to use model" in resp.text
+    assert pin_setup["vault"].calls == []
+
+
+@pytest.mark.asyncio
+async def test_utility_model_still_subject_to_compatibility_gate(pin_setup):
+    """Passing the pin is not a credential bypass: is_model_compatible
+    still runs for the utility model."""
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["llm"]["utility_model"] = (
+        "openai/gpt-4.1-nano"
+    )
+    pin_setup["vault"]._compatible = False
+    resp = await _post(
+        app, _req("openai/gpt-4.1-nano"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not compatible" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_no_utility_model_pin_unchanged(pin_setup):
+    """Feature off (llm.utility_model absent) → the pin behaves exactly
+    as before: the would-be utility model is just another off-allowlist
+    model and 403s."""
+    app = pin_setup["app"]
+    assert "utility_model" not in pin_setup["cfg_holder"]["cfg"]["llm"]
+    resp = await _post(
+        app, _req("openai/gpt-4.1-nano"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not authorized to use model" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_empty_utility_model_pin_unchanged(pin_setup):
+    """Explicit empty string is OFF, not a wildcard."""
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["llm"]["utility_model"] = ""
+    resp = await _post(
+        app, _req("openai/gpt-4.1-nano"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -5480,3 +5480,39 @@ class TestEmergencyPruneCalibration:
         )
         assert progressed is True, "forced-progress backstop must shed content"
         assert len(loop._chat_messages) < before_n
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_uses_utility_model_when_configured():
+    """Per-call model tiering: heartbeats are coordination traffic, so a
+    configured utility model (LLM_UTILITY_MODEL) rides the heartbeat's
+    LLM call as model=."""
+    loop = _make_loop()
+    loop.llm.utility_model = "openai/gpt-4.1-nano"
+    loop.llm.chat = AsyncMock(
+        return_value=LLMResponse(content="HEARTBEAT_OK", tokens_used=50),
+    )
+    loop.mesh_client.introspect = AsyncMock(return_value={})
+
+    result = await loop.execute_heartbeat("Check stuff")
+
+    assert result["skipped"] is False
+    assert result["outcome"] == "ok"
+    assert loop.llm.chat.call_args.kwargs["model"] == "openai/gpt-4.1-nano"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_call_shape_unchanged_without_utility_model():
+    """Feature off (empty utility_model) → the heartbeat LLM call carries
+    no model kwarg — byte-for-byte today's behavior."""
+    loop = _make_loop()
+    loop.llm.utility_model = ""
+    loop.llm.chat = AsyncMock(
+        return_value=LLMResponse(content="HEARTBEAT_OK", tokens_used=50),
+    )
+    loop.mesh_client.introspect = AsyncMock(return_value={})
+
+    result = await loop.execute_heartbeat("Check stuff")
+
+    assert result["outcome"] == "ok"
+    assert "model" not in loop.llm.chat.call_args.kwargs

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3084,3 +3084,84 @@ class TestDispatchTransportErrorSurfacing:
         result = await dispatch_fn("agent-x", "resume task")
 
         assert result == "(no response)"
+
+
+# ── Per-call model tiering: LLM_UTILITY_MODEL container env ────────────────
+#
+# ``llm.utility_model`` is injected at the runtime-backend level (read fresh
+# from config at every container start) so EVERY start path — initial boot,
+# REPL /restart, health-monitor restart, dashboard restart — carries it
+# without per-caller plumbing. Unset = the env var is omitted entirely.
+
+
+class TestUtilityModelEnv:
+    def _make_sandbox(self, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        backend = SandboxBackend.__new__(SandboxBackend)
+        backend.project_root = project_root
+        backend.mesh_host_port = 8420
+        backend.agents = {}
+        backend.auth_tokens = {}
+        backend.extra_env = {}
+        backend._workspace_root = tmp_path / ".openlegion" / "agents"
+        backend._workspace_root.mkdir(parents=True)
+        return backend
+
+    def test_env_present_when_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "src.cli.config._load_config",
+            lambda *a, **k: {"llm": {"utility_model": "openai/gpt-4.1-nano"}},
+        )
+        backend = self._make_sandbox(tmp_path)
+        ws = backend._prepare_workspace(
+            agent_id="tiered", role="test", tools_dir="",
+            system_prompt="", model="openai/gpt-4o-mini",
+        )
+        env_content = (ws / ".agent.env").read_text()
+        assert "LLM_UTILITY_MODEL=openai/gpt-4.1-nano" in env_content
+
+    def test_env_absent_when_unset(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "src.cli.config._load_config",
+            lambda *a, **k: {"llm": {"default_model": "openai/gpt-4o-mini"}},
+        )
+        backend = self._make_sandbox(tmp_path)
+        ws = backend._prepare_workspace(
+            agent_id="untiered", role="test", tools_dir="",
+            system_prompt="", model="openai/gpt-4o-mini",
+        )
+        env_content = (ws / ".agent.env").read_text()
+        assert "LLM_UTILITY_MODEL" not in env_content
+
+    def test_env_absent_when_empty_string(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "src.cli.config._load_config",
+            lambda *a, **k: {"llm": {"utility_model": ""}},
+        )
+        backend = self._make_sandbox(tmp_path)
+        ws = backend._prepare_workspace(
+            agent_id="empty", role="test", tools_dir="",
+            system_prompt="", model="",
+        )
+        env_content = (ws / ".agent.env").read_text()
+        assert "LLM_UTILITY_MODEL" not in env_content
+
+    def test_helper_reads_config_and_survives_load_failure(self, monkeypatch):
+        backend = SandboxBackend.__new__(SandboxBackend)
+        monkeypatch.setattr(
+            "src.cli.config._load_config",
+            lambda *a, **k: {"llm": {"utility_model": "cheap/model"}},
+        )
+        assert backend._utility_model_from_config() == "cheap/model"
+        # Non-string value → treated as unset.
+        monkeypatch.setattr(
+            "src.cli.config._load_config",
+            lambda *a, **k: {"llm": {"utility_model": 42}},
+        )
+        assert backend._utility_model_from_config() == ""
+        # A config read failure must never block an agent start.
+        def _boom(*a, **k):
+            raise OSError("unreadable")
+        monkeypatch.setattr("src.cli.config._load_config", _boom)
+        assert backend._utility_model_from_config() == ""


### PR DESCRIPTION
## Summary

Phase-0 residual (a) from the agent-employee platform plan (A.C4): the **hook** that lets coordination/utility LLM traffic run on a cheap model while deep task/chat reasoning stays on the agent's model. With `llm.utility_model` unset (the default), behavior is byte-for-byte identical to today — the env var is omitted and every call site sends exactly what it sends now.

Both A.C4 blockers are closed in one change:

1. **Mesh-side pin widened.** `_enforce_model_pin` 403s any model outside an agent's `allowed_models`; the deployment-configured utility model is now always acceptable (via the existing `_bare()` provider-prefix-insensitive compare). This cannot widen an agent's own allowlist — the value is operator/deployment config, never agent-chosen — and the `is_model_compatible` credential gate still runs for it.
2. **Agent-side `model=` threaded at the utility call sites**, via a new `utility_model_kwargs()` helper that returns `{}` when the feature is off:
   - `context.py` — `_summarize_text` (every `_summarize_compact` chunk/fold call funnels through it), `_extract_and_store_facts`, `_maybe_consolidate_memory`
   - `loop.py` — `execute_heartbeat`'s LLM call
   - The main task/chat reasoning path is untouched.

**Wiring:** `LLM_UTILITY_MODEL` is injected at the runtime-backend level (both `DockerBackend` and `SandboxBackend` env builds, read fresh from config at each container start), so every start path — initial boot, REPL `/restart`, health-monitor restart, dashboard restart — carries it with zero per-caller plumbing. `LLMClient` picks it up mirroring the `MESH_AUTH_TOKEN` ctor pattern, with a ctor kwarg override for tests. The pin and the container env read the same `_load_config()` source, so tiered agent-side calls are never 403'd.

Deliberately **not** included (scope discipline — this is the hook only): the coordination-vs-work spend split (B2, gates Phase 3), cost-category tagging, per-agent utility overrides, and any dashboard surface.

## Testing

- 25 new tests: 7 pin tests (`test_llm_model_pin.py` — both model spellings pass, arbitrary third model still 403s, compatibility gate still applies, unset = unchanged), 7 `LLMClient`/helper tests, 5 context tests (on/off call shapes), 2 heartbeat tests, 4 runtime env-wiring tests.
- Targeted suites on the final tree: `test_llm_model_pin` + `test_llm` + `test_context` + `test_loop` + `test_costs` = **409 passed**; `test_runtime` = **185 passed** (includes the merge-resolved file).
- `ruff check src/ tests/` clean.
- Appendix D updated (entry ordered after the post-merge-review log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEVpeNmyVBoW6Va2LKe4iT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEVpeNmyVBoW6Va2LKe4iT)_