### PR TITLE
feat(security): mesh→agent bearer auth on the agent server (B7)

### DIFF
--- a/docs/plans/2026-07-04-agent-employee-platform-architecture.md
+++ b/docs/plans/2026-07-04-agent-employee-platform-architecture.md
@@ -457,6 +457,23 @@ and green (908 passed)**. Reviewed via a full pre-merge pass (findings + fixes r
   mirroring the `MESH_AUTH_TOKEN` ctor pattern. Spend split + broader tiering policy
   deliberately NOT included (this is the hook only). Tests in `test_llm_model_pin.py`,
   `test_llm.py`, `test_context.py`, `test_loop.py`, `test_runtime.py`.
+- **✅ Landed — mesh→agent bearer auth on the agent server (Phase-0 residual (b), §4
+  closed-regardless / audit C1 second leg).** The agent server (:8400) now verifies
+  `Authorization: Bearer <MESH_AUTH_TOKEN>` on every request via an outermost middleware
+  (`_install_mesh_auth_guard`, constant-time compare; env unset = fail-open for dev/tests —
+  tokenless production is already blocked by the trust-tier boot gate). **B7 honored:
+  enforcement and caller wiring landed in the SAME change** — `Transport._resolve_headers`
+  attaches the per-agent token (the transport binds the runtime's LIVE `auth_tokens` dict
+  via `bind_tokens`, so every register path — initial start, /restart, health-monitor and
+  dashboard restarts, /mesh/register — plus restart token rotation is covered by one bind;
+  `register_token` exists for granular use); the mesh's three raw-httpx agent calls
+  (/history fallback, INTERFACE.md fallback, artifacts/ingest stream) attach it via
+  `_agent_bearer_headers`; the detached CLI (`openlegion chat`) fetches it from the new
+  loopback-internal-only `GET /mesh/agents/{id}/token`. **`GET /status` stays exempt**
+  (sole exemption — reachability probes: `is_reachable`, `wait_for_agent`, health poller,
+  CLI status). No in-container self-callers of :8400 exist (verified). Tests in
+  `tests/test_agent_bearer_auth.py` (20); touched suites green.
+
 
 
 ### YOU ARE HERE → next phase

--- a/docs/security.md
+++ b/docs/security.md
@@ -369,6 +369,15 @@ Each agent receives a unique auth token at startup (`MESH_AUTH_TOKEN`). All requ
 - Container-to-container communication bypassing the mesh
 - Unauthorized access to mesh endpoints
 
+### Mesh→Agent Bearer Auth (agent server)
+
+The same per-agent token authenticates the **reverse direction**. The agent's FastAPI server (:8400) requires `Authorization: Bearer <MESH_AUTH_TOKEN>` on every request (constant-time compare, `src/agent/server.py:_install_mesh_auth_guard`); previously it trusted the forgeable `x-mesh-internal` header alone (audit C1 second leg). Defense-in-depth for host-network-mode / published-port exposure — the ICC-off bridge and loopback port publish remain the primary network boundary.
+
+- **Sole exemption: `GET /status`** — the reachability probe (`Transport.is_reachable`, health monitor, `wait_for_agent`, detached CLI) must work tokenless. Everything else mutates state or returns agent-private data.
+- **Token unset → fail-open** (dev harnesses, tests). Tokenless *production* is already prevented by the mesh's boot fail-closed gate (empty `auth_tokens` under enforce mode → `SystemExit`).
+- **Callers**: the mesh `Transport` attaches the token automatically (bound to the runtime's live `auth_tokens` dict, so restart-rotated tokens need no re-wiring); the mesh's few raw-httpx agent calls use `_agent_bearer_headers`; the detached CLI (`openlegion chat`) fetches the token via `GET /mesh/agents/{id}/token`, which is disclosed **only** to loopback + `x-mesh-internal` callers (a leg agent containers can never satisfy — their traffic arrives from the Docker bridge).
+- A 401 from an agent server names the agent and the missing/wrong mesh→agent bearer, so operators can diagnose stale callers (tokens rotate on every container start).
+
 ### `BROWSER_AUTH_TOKEN` is a fleet-wide superuser credential
 
 `BROWSER_AUTH_TOKEN` is a **single, fleet-wide** bearer token. The browser service has **no per-agent identity**: `_verify_auth` (`src/browser/server.py`) compares the request's `Authorization: Bearer <token>` against the one shared token via `hmac.compare_digest` and nothing else. The service trusts the `agent_id` in the URL path (`/browser/{agent_id}/...`) entirely — it never cross-checks that the caller "is" that agent. **Any holder of `BROWSER_AUTH_TOKEN` can therefore drive ANY agent's browser** (navigate, screenshot, fill forms, read the accessibility tree, import session state, etc.).

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -224,6 +224,82 @@ def _install_protocol_version_guard(app: FastAPI) -> None:
         return await call_next(request)
 
 
+def _install_mesh_auth_guard(app: FastAPI, agent_id: str) -> None:
+    """Require the mesh→agent bearer token on every request (audit C1, B7).
+
+    The mesh mints a per-agent token at container start (``runtime.py
+    start_agent``) and injects it into the container as ``MESH_AUTH_TOKEN``.
+    That token already authenticates the agent→mesh direction; this guard
+    closes the loop by verifying the *same* token on the mesh→agent
+    direction, so a peer container (flat bridge) or a host-network caller
+    can no longer drive this agent by forging the ``x-mesh-internal``
+    header. Defense-in-depth: the ICC-off bridge + loopback port publish
+    remain the primary network boundary.
+
+    Behavior:
+      * ``MESH_AUTH_TOKEN`` unset/empty → fail-open (no enforcement). Dev
+        harnesses, tests, and tokenless deployments keep working; tokenless
+        *production* is already prevented upstream by the mesh's boot
+        fail-closed check (Constraint #12).
+      * Token set → every request must carry ``Authorization: Bearer
+        <token>`` (constant-time compare via ``hmac.compare_digest``).
+      * Sole exemption: ``GET /status``. It is the reachability probe used
+        by ``Transport.is_reachable``, ``DockerBackend.wait_for_agent``,
+        the health monitor, and the detached CLI — all must be able to
+        answer "is this container up?" without holding the token (B7).
+        No other endpoint is probe-shaped: everything else either mutates
+        state or returns agent-private data, so nothing else is exempt.
+
+    The token is captured at install time (env pickup in the app factory,
+    mirroring ``mesh_client.py``/``llm.py`` ctor pickup — Constraint #8:
+    no module-level globals). The container env never changes after boot;
+    a restart re-mints the token and rebuilds the app anyway.
+
+    Ordering: registered LAST in ``create_agent_app`` so it is the
+    OUTERMOST middleware (Starlette runs middlewares in reverse
+    registration order). Auth therefore runs before the protocol-version
+    guard and the body-size drain: an unauthenticated caller learns
+    nothing (not even the protocol version) and never causes the body
+    buffer work — 401 short-circuits before ``call_next``.
+    """
+    import hmac
+
+    expected = os.environ.get("MESH_AUTH_TOKEN", "")
+
+    if not expected:
+        return
+
+    from starlette.responses import JSONResponse as _StarletteJSONResponse
+
+    expected_bytes = expected.encode()
+
+    @app.middleware("http")
+    async def _enforce_mesh_auth(request: Request, call_next):
+        if request.method == "GET" and request.url.path == "/status":
+            return await call_next(request)
+        auth = request.headers.get("authorization", "")
+        scheme, _, presented = auth.partition(" ")
+        token = presented.strip() if scheme.lower() == "bearer" else ""
+        if not hmac.compare_digest(token.encode(), expected_bytes):
+            return _StarletteJSONResponse(
+                {
+                    "detail": (
+                        f"mesh→agent bearer token missing or wrong for agent "
+                        f"'{agent_id}': this agent server requires "
+                        "'Authorization: Bearer <MESH_AUTH_TOKEN>' on every "
+                        "request except GET /status. The mesh transport sends "
+                        "it automatically; a 401 here usually means a stale "
+                        "caller that predates this container's restart "
+                        "(tokens rotate on every agent start)."
+                    ),
+                    "agent": agent_id,
+                },
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        return await call_next(request)
+
+
 def create_agent_app(loop: AgentLoop) -> FastAPI:
     """Create the FastAPI application for an agent container."""
     # M19: disable interactive API docs / OpenAPI schema by default; gate dev
@@ -236,6 +312,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}", **_docs_kwargs)
     _install_body_size_limit(app)
     _install_protocol_version_guard(app)
+    # Registered last → outermost middleware → auth runs first (see docstring).
+    _install_mesh_auth_guard(app, loop.agent_id)
     _task_accept_lock = asyncio.Lock()
 
     @app.post("/task")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -306,16 +306,52 @@ def chat(name: str | None, port: int):
     click.echo("Type a message to chat. /help for commands.\n")
 
     try:
-        _single_agent_repl(agent_name=name, agent_url=agent_url, mesh_port=port)
+        _single_agent_repl(
+            agent_name=name, agent_url=agent_url, mesh_port=port,
+            headers=_agent_auth_headers(name, port),
+        )
     except KeyboardInterrupt:
         click.echo("\nDisconnected.")
 
 
-def _single_agent_repl(agent_name: str, agent_url: str, mesh_port: int = 8420) -> None:
+def _agent_auth_headers(agent_name: str, mesh_port: int) -> dict[str, str]:
+    """Fetch the mesh→agent bearer token for direct agent :8400 calls (B7).
+
+    The agent server requires ``Authorization: Bearer <MESH_AUTH_TOKEN>`` on
+    everything except ``GET /status``. The detached CLI runs in a separate
+    process from the mesh, so it can't read ``runtime.auth_tokens`` directly;
+    it asks the mesh's loopback-internal ``/mesh/agents/{id}/token`` endpoint
+    instead. Best-effort: a tokenless deployment (agent fails open) or an
+    older mesh without the endpoint yields empty headers and everything
+    keeps working as before.
+    """
+    import httpx
+
+    try:
+        resp = httpx.get(
+            f"http://localhost:{mesh_port}/mesh/agents/{agent_name}/token",
+            headers={"x-mesh-internal": "1"},
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            token = resp.json().get("token", "")
+            if token:
+                return {"Authorization": f"Bearer {token}"}
+    except Exception:
+        pass
+    return {}
+
+
+def _single_agent_repl(
+    agent_name: str, agent_url: str, mesh_port: int = 8420,
+    headers: dict[str, str] | None = None,
+) -> None:
     """Interactive chat REPL with a single agent (for detached mode)."""
     import httpx
 
     from src.cli.formatting import user_prompt
+
+    headers = headers or {}
 
     while True:
         try:
@@ -332,7 +368,7 @@ def _single_agent_repl(agent_name: str, agent_url: str, mesh_port: int = 8420) -
                 break
             elif cmd == "/reset":
                 try:
-                    httpx.post(f"{agent_url}/chat/reset", timeout=5)
+                    httpx.post(f"{agent_url}/chat/reset", headers=headers, timeout=5)
                     click.echo("Conversation reset.")
                 except Exception as e:
                     click.echo(f"Error: {e}", err=True)
@@ -412,12 +448,15 @@ def _single_agent_repl(agent_name: str, agent_url: str, mesh_port: int = 8420) -
 
         # Try streaming first, fall back to sync
         try:
-            _stream_detached_chat(agent_name, agent_url, user_input)
+            _stream_detached_chat(agent_name, agent_url, user_input, headers=headers)
         except (httpx.HTTPError, httpx.StreamError, OSError):
-            _sync_detached_chat(agent_name, agent_url, user_input)
+            _sync_detached_chat(agent_name, agent_url, user_input, headers=headers)
 
 
-def _stream_detached_chat(agent_name: str, agent_url: str, message: str) -> None:
+def _stream_detached_chat(
+    agent_name: str, agent_url: str, message: str,
+    headers: dict[str, str] | None = None,
+) -> None:
     """Stream a chat response via SSE."""
     import httpx
 
@@ -432,7 +471,7 @@ def _stream_detached_chat(agent_name: str, agent_url: str, message: str) -> None
     tool_count = 0
     with httpx.stream(
         "POST", f"{agent_url}/chat/stream",
-        json={"message": message}, timeout=120,
+        json={"message": message}, headers=headers or {}, timeout=120,
     ) as resp:
         resp.raise_for_status()
         for line in resp.iter_lines():
@@ -468,14 +507,18 @@ def _stream_detached_chat(agent_name: str, agent_url: str, message: str) -> None
         click.echo("")
 
 
-def _sync_detached_chat(agent_name: str, agent_url: str, message: str) -> None:
+def _sync_detached_chat(
+    agent_name: str, agent_url: str, message: str,
+    headers: dict[str, str] | None = None,
+) -> None:
     """Synchronous chat fallback."""
     import httpx
 
     from src.cli.formatting import display_response
 
     resp = httpx.post(
-        f"{agent_url}/chat", json={"message": message}, timeout=120,
+        f"{agent_url}/chat", json={"message": message},
+        headers=headers or {}, timeout=120,
     )
     if resp.status_code != 200:
         click.echo(f"Error: HTTP {resp.status_code}: {resp.text}", err=True)

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -480,6 +480,11 @@ class RuntimeContext:
         else:
             self.transport = HttpTransport()
             _ensure_docker_image()
+        # Mesh→agent bearer auth (B7): bind the runtime's LIVE token dict so
+        # every URL-registration path (initial start, /restart, health-monitor
+        # restart, dashboard restart, /mesh/register) automatically sends the
+        # current per-agent token — including tokens re-minted on restart.
+        self.transport.bind_tokens(self.runtime.auth_tokens)
 
     def _create_components(self) -> None:
         from src.cli.config import (
@@ -820,6 +825,9 @@ class RuntimeContext:
                     )
                     self.runtime.set_connector_store(self.connector_store)
                     self.transport = HttpTransport()
+                    # Fresh backend → fresh auth_tokens dict; re-bind so the
+                    # replacement transport keeps sending mesh→agent bearers.
+                    self.transport.bind_tokens(self.runtime.auth_tokens)
                     _ensure_docker_image()
                     url = self.runtime.start_agent(
                         agent_id=agent_id,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -917,6 +917,19 @@ def create_mesh_app(
     _auth_tokens = auth_tokens if auth_tokens is not None else {}
     _agent_teams = agent_teams if agent_teams is not None else {}
 
+    def _agent_bearer_headers(agent_id: str) -> dict[str, str]:
+        """Mesh→agent bearer auth header for direct (non-Transport) agent calls.
+
+        The agent server (B7) requires ``Authorization: Bearer
+        <MESH_AUTH_TOKEN>`` on every request except ``GET /status``. The
+        Transport layer attaches this automatically; the few endpoints below
+        that hit an agent URL with a raw httpx client must attach it
+        themselves. Empty dict when no token is known (tokenless dev mode —
+        the agent side fails open then too).
+        """
+        token = _auth_tokens.get(agent_id, "")
+        return {"Authorization": f"Bearer {token}"} if token else {}
+
     # Fail-closed startup gate for the operator trust tier.
     #
     # Threat model: under ``_TEAM_SCOPE_MODE=enforce`` the mesh derives
@@ -3334,6 +3347,32 @@ def create_mesh_app(
                 return filtered
         return full_fleet
 
+    @app.get("/mesh/agents/{agent_id}/token")
+    async def get_agent_mesh_token(agent_id: str, request: Request) -> dict:
+        """Disclose an agent's mesh→agent bearer token to loopback callers.
+
+        The agent server enforces ``Authorization: Bearer <MESH_AUTH_TOKEN>``
+        on every request except ``GET /status`` (B7). The mesh transport and
+        the in-process dashboard hold the token dict directly, but the
+        detached CLI (``openlegion chat`` / ``openlegion status`` in a
+        separate process) calls the agent's :8400 directly and needs the
+        token from somewhere. This endpoint hands it out ONLY to loopback +
+        ``x-mesh-internal`` callers (:func:`_is_internal_caller`) — the same
+        trust leg that already grants operator-tier access to a local human
+        process, and one an agent container can never satisfy (its requests
+        arrive from the Docker bridge, not loopback). 404 when the agent is
+        unknown or no token exists (tokenless dev mode — the agent side
+        fails open then, so the CLI simply sends no header).
+        """
+        if not _is_internal_caller(request):
+            _record_denial("permission", caller="external", gate="agents.token:internal-only")
+            raise HTTPException(403, "Agent token disclosure is loopback-internal only")
+        agent_id = _validate_agent_id(agent_id)
+        token = _auth_tokens.get(agent_id, "")
+        if not token:
+            raise HTTPException(404, f"No mesh auth token for agent: {agent_id}")
+        return {"agent_id": agent_id, "token": token}
+
     # === Agent Introspection ===
 
     @app.get("/mesh/introspect")
@@ -4400,7 +4439,10 @@ def create_mesh_app(
         import httpx
         try:
             async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.get(f"{agent_url}/history", params={"days": days})
+                resp = await client.get(
+                    f"{agent_url}/history", params={"days": days},
+                    headers=_agent_bearer_headers(agent_id),
+                )
                 resp.raise_for_status()
                 return resp.json()
         except Exception as e:
@@ -4526,7 +4568,10 @@ def create_mesh_app(
             import httpx
             try:
                 async with httpx.AsyncClient(timeout=10) as client:
-                    resp = await client.get(f"{agent_url}/workspace/INTERFACE.md")
+                    resp = await client.get(
+                        f"{agent_url}/workspace/INTERFACE.md",
+                        headers=_agent_bearer_headers(agent_id),
+                    )
                     if resp.status_code == 200:
                         content = resp.json().get("content", "")
                         if content and content.strip() not in ("", "# Interface"):
@@ -10454,6 +10499,9 @@ def create_mesh_app(
                 ingest_headers: dict = {
                     "X-Mesh-Internal": "1",
                     "Content-Type": "application/octet-stream",
+                    # Mesh→agent bearer auth (B7): the ingest POST streams
+                    # raw bytes with a plain httpx client, not the Transport.
+                    **_agent_bearer_headers(req_agent_id),
                 }
                 if incoming_trace:
                     ingest_headers["X-Trace-Id"] = incoming_trace

--- a/src/host/transport.py
+++ b/src/host/transport.py
@@ -26,11 +26,40 @@ logger = setup_logging("host.transport")
 class Transport(abc.ABC):
     """Abstract transport for reaching an agent's HTTP API."""
 
-    def _resolve_headers(self, headers: dict[str, str] | None) -> dict[str, str]:
-        """Return *headers* with mesh-internal marker and trace context.
+    def __init__(self) -> None:
+        # agent_id -> mesh→agent bearer token. The agent server (B7) requires
+        # ``Authorization: Bearer <MESH_AUTH_TOKEN>`` on every request except
+        # ``GET /status``; this mapping supplies the per-agent token. Wired
+        # via ``bind_tokens`` (production: the runtime's LIVE ``auth_tokens``
+        # dict, so restart-rotated tokens are picked up automatically) or
+        # ``register_token`` (granular, mirrors ``register(agent_id, url)``).
+        self._agent_tokens: dict[str, str] = {}
+
+    def register_token(self, agent_id: str, token: str) -> None:
+        """Record the mesh→agent bearer token for *agent_id*."""
+        self._agent_tokens[agent_id] = token
+
+    def bind_tokens(self, tokens: dict[str, str]) -> None:
+        """Bind a LIVE agent_id→token mapping (kept by reference, not copied).
+
+        Production wiring passes ``runtime.auth_tokens`` — the same dict the
+        backend mutates on every ``start_agent``/``remove_agent`` — so every
+        registration path (initial start, REPL /restart, health-monitor
+        restart, dashboard restart, /mesh/register) is covered by a single
+        bind at transport construction, and token rotation on container
+        restart needs no per-call-site re-sync.
+        """
+        self._agent_tokens = tokens
+
+    def _resolve_headers(
+        self, headers: dict[str, str] | None, agent_id: str | None = None,
+    ) -> dict[str, str]:
+        """Return *headers* with mesh-internal marker, trace context, and auth.
 
         Always injects X-Mesh-Internal so agent endpoints can distinguish
         mesh/dashboard requests from agent self-calls (http_request tool).
+        When the target agent's mesh→agent bearer token is known, attaches
+        it as ``Authorization`` (the agent server enforces it — audit C1/B7).
         """
         if headers is None:
             from src.shared.trace import trace_headers
@@ -40,6 +69,9 @@ class Transport(abc.ABC):
         # version-skewed mesh (rolling upgrade) instead of mis-decoding JSON.
         from src.shared.trace import PROTOCOL_VERSION, PROTOCOL_VERSION_HEADER
         headers.setdefault(PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION)
+        token = self._agent_tokens.get(agent_id) if agent_id else None
+        if token:
+            headers.setdefault("Authorization", f"Bearer {token}")
         return headers
 
     @abc.abstractmethod
@@ -91,6 +123,7 @@ class HttpTransport(Transport):
     """Direct HTTP transport -- for agents running in Docker containers."""
 
     def __init__(self) -> None:
+        super().__init__()
         self._urls: dict[str, str] = {}
         # One httpx.AsyncClient per event loop — each loop's client has
         # asyncio internals bound to that loop.  Keyed by id(loop).
@@ -134,7 +167,7 @@ class HttpTransport(Transport):
             client = await self._get_client()
             resp = await client.request(
                 method, f"{url}{path}", json=json, timeout=timeout,
-                headers=self._resolve_headers(headers),
+                headers=self._resolve_headers(headers, agent_id=agent_id),
             )
             resp.raise_for_status()
             return resp.json()
@@ -178,7 +211,7 @@ class HttpTransport(Transport):
             client = await self._get_client()
             async with client.stream(
                 method, f"{url}{path}", json=json, timeout=timeout,
-                headers=self._resolve_headers(headers),
+                headers=self._resolve_headers(headers, agent_id=agent_id),
             ) as resp:
                 resp.raise_for_status()
                 async for line in resp.aiter_lines():
@@ -222,7 +255,7 @@ class HttpTransport(Transport):
         try:
             resp = httpx.request(
                 method, f"{url}{path}", json=json, timeout=timeout,
-                headers=self._resolve_headers(headers),
+                headers=self._resolve_headers(headers, agent_id=agent_id),
             )
             resp.raise_for_status()
             return resp.json()
@@ -267,7 +300,7 @@ class SandboxTransport(Transport):
             "curl", "-s", "-X", method, url,
             "-H", "Content-Type: application/json",
         ]
-        for hk, hv in self._resolve_headers(headers).items():
+        for hk, hv in self._resolve_headers(headers, agent_id=agent_id).items():
             cmd.extend(["-H", f"{hk}: {hv}"])
         if json is not None:
             cmd.extend(["-d", json_module.dumps(json)])
@@ -329,7 +362,7 @@ class SandboxTransport(Transport):
             "curl", "-s", "-X", method, url,
             "-H", "Content-Type: application/json",
         ]
-        for hk, hv in self._resolve_headers(headers).items():
+        for hk, hv in self._resolve_headers(headers, agent_id=agent_id).items():
             cmd.extend(["-H", f"{hk}: {hv}"])
         if json is not None:
             cmd.extend(["-d", json_module.dumps(json)])

--- a/tests/test_agent_bearer_auth.py
+++ b/tests/test_agent_bearer_auth.py
@@ -1,0 +1,382 @@
+"""Mesh→agent bearer auth on the agent server (audit C1 second leg, B7).
+
+The mesh already mints a per-agent token (``runtime.auth_tokens``) that the
+container uses for the agent→mesh direction as ``MESH_AUTH_TOKEN``. This
+change closes the loop: mesh→agent requests carry ``Authorization: Bearer
+<that agent's token>`` and the agent server verifies it against its own
+``MESH_AUTH_TOKEN`` env. Enforcement and caller wiring land in the SAME
+change (B7): the Transport attaches the token per target agent, the mesh's
+direct httpx call sites use ``_agent_bearer_headers``, and the detached CLI
+fetches the token from the loopback-internal ``/mesh/agents/{id}/token``
+endpoint. ``GET /status`` stays tokenless so reachability probes keep
+working.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+
+from src.agent.server import create_agent_app
+
+TOKEN = "mesh-agent-token-123"
+
+
+def _make_agent_app():
+    """Minimal agent app harness — mirrors tests/test_protocol_version.py."""
+    loop = MagicMock()
+    loop.agent_id = "test_agent"
+    loop.role = "researcher"
+    loop.state = "idle"
+    loop._excluded_tools = frozenset()
+    loop.memory = None
+    loop.mesh_client = MagicMock()
+    loop.tools = MagicMock()
+    loop.tools.list_tools = MagicMock(return_value=[])
+    loop.tools.get_tool_definitions = MagicMock(return_value=[])
+    loop.tools.get_tool_sources = MagicMock(return_value={})
+    loop.tools.execute = AsyncMock(return_value={"ok": True})
+    loop.workspace = None
+    loop.get_status.return_value.model_dump.return_value = {"state": "idle"}
+    # /chat/reset awaits this — needed by the POST-requires-bearer test.
+    loop.reset_chat = AsyncMock()
+    return create_agent_app(loop)
+
+
+# ── agent server guard ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_correct_bearer_accepted(monkeypatch):
+    monkeypatch.setenv("MESH_AUTH_TOKEN", TOKEN)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get(
+            "/capabilities", headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_missing_bearer_rejected_with_diagnosable_body(monkeypatch):
+    monkeypatch.setenv("MESH_AUTH_TOKEN", TOKEN)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/capabilities")
+    assert resp.status_code == 401
+    body = resp.json()
+    # Operators must be able to diagnose: names the agent + the direction.
+    assert body["agent"] == "test_agent"
+    assert "bearer token" in body["detail"].lower()
+    assert "test_agent" in body["detail"]
+    assert resp.headers.get("www-authenticate") == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_wrong_bearer_rejected(monkeypatch):
+    monkeypatch.setenv("MESH_AUTH_TOKEN", TOKEN)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get(
+            "/capabilities", headers={"Authorization": "Bearer wrong-token"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_scheme_rejected(monkeypatch):
+    monkeypatch.setenv("MESH_AUTH_TOKEN", TOKEN)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get(
+            "/capabilities", headers={"Authorization": f"Basic {TOKEN}"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_token_unset_fails_open(monkeypatch):
+    """No MESH_AUTH_TOKEN env → no enforcement (dev harnesses, tests)."""
+    monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/capabilities")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_status_exempt_even_with_token(monkeypatch):
+    """GET /status is the reachability probe — must stay tokenless (B7)."""
+    monkeypatch.setenv("MESH_AUTH_TOKEN", TOKEN)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/status")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_post_requires_bearer(monkeypatch):
+    """The exemption is GET /status only; state-mutating verbs are gated."""
+    monkeypatch.setenv("MESH_AUTH_TOKEN", TOKEN)
+    app = _make_agent_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        denied = await client.post("/chat/reset")
+        allowed = await client.post(
+            "/chat/reset", headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+    assert denied.status_code == 401
+    assert allowed.status_code == 200
+
+
+# ── transport wiring (mesh side) ────────────────────────────────────────────
+
+
+def test_transport_registered_token_attached():
+    from src.host.transport import HttpTransport
+
+    t = HttpTransport()
+    t.register_token("alpha", "tok-alpha")
+    headers = t._resolve_headers(None, agent_id="alpha")
+    assert headers["Authorization"] == "Bearer tok-alpha"
+    # Existing behavior unchanged.
+    assert headers["x-mesh-internal"] == "1"
+
+
+def test_transport_unknown_agent_no_auth_header():
+    from src.host.transport import HttpTransport
+
+    t = HttpTransport()
+    t.register_token("alpha", "tok-alpha")
+    headers = t._resolve_headers(None, agent_id="beta")
+    assert "Authorization" not in headers
+    # No agent_id at all (legacy callers) → also no header.
+    assert "Authorization" not in t._resolve_headers(None)
+
+
+def test_transport_bind_tokens_live_mapping_sees_rotation():
+    """bind_tokens holds the mapping by reference — restart-rotated tokens
+    (runtime.start_agent re-mints into the same dict) are picked up without
+    any re-registration call."""
+    from src.host.transport import HttpTransport
+
+    live: dict[str, str] = {}
+    t = HttpTransport()
+    t.bind_tokens(live)
+    assert "Authorization" not in t._resolve_headers(None, agent_id="alpha")
+    live["alpha"] = "tok-after-restart"
+    headers = t._resolve_headers(None, agent_id="alpha")
+    assert headers["Authorization"] == "Bearer tok-after-restart"
+
+
+def test_transport_caller_supplied_authorization_not_clobbered():
+    from src.host.transport import HttpTransport
+
+    t = HttpTransport()
+    t.register_token("alpha", "tok-alpha")
+    headers = t._resolve_headers({"Authorization": "Bearer custom"}, agent_id="alpha")
+    assert headers["Authorization"] == "Bearer custom"
+
+
+def test_sandbox_transport_has_token_storage():
+    """SandboxTransport inherits the base token machinery (curl -H path)."""
+    from src.host.transport import SandboxTransport
+
+    t = SandboxTransport()
+    t.register_token("alpha", "tok-a")
+    assert t._resolve_headers(None, agent_id="alpha")["Authorization"] == "Bearer tok-a"
+
+
+# ── mesh token-disclosure endpoint (detached CLI wiring) ────────────────────
+
+
+def _build_mesh_app(tmp_path, auth_tokens):
+    """Mirrors the harness in tests/test_agent_registration.py."""
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+
+    perms = PermissionMatrix()
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    router = MessageRouter(perms, {})
+    app = create_mesh_app(
+        blackboard=bb,
+        pubsub=pubsub,
+        router=router,
+        permissions=perms,
+        auth_tokens=auth_tokens,
+    )
+    return app, router
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_loopback_internal_gets_token(tmp_path):
+    app, _router = _build_mesh_app(tmp_path, {"scout": "tok-scout"})
+    transport = ASGITransport(app=app, client=("127.0.0.1", 40000))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        resp = await client.get(
+            "/mesh/agents/scout/token", headers={"x-mesh-internal": "1"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"agent_id": "scout", "token": "tok-scout"}
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_rejects_non_loopback(tmp_path):
+    """Header alone is forgeable — a bridge-network agent must get 403."""
+    app, _router = _build_mesh_app(tmp_path, {"scout": "tok-scout"})
+    transport = ASGITransport(app=app, client=("172.18.0.5", 40000))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        resp = await client.get(
+            "/mesh/agents/scout/token", headers={"x-mesh-internal": "1"},
+        )
+    assert resp.status_code == 403
+
+
+def test_token_endpoint_rejects_missing_internal_header(tmp_path):
+    app, _router = _build_mesh_app(tmp_path, {"scout": "tok-scout"})
+    client = TestClient(app)
+    resp = client.get("/mesh/agents/scout/token")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_unknown_agent_404(tmp_path):
+    app, _router = _build_mesh_app(tmp_path, {"scout": "tok-scout"})
+    transport = ASGITransport(app=app, client=("127.0.0.1", 40000))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        resp = await client.get(
+            "/mesh/agents/nobody/token", headers={"x-mesh-internal": "1"},
+        )
+    assert resp.status_code == 404
+
+
+# ── mesh direct-httpx caller (history fallback → _agent_bearer_headers) ────
+
+
+@pytest.mark.asyncio
+async def test_history_fallback_sends_bearer(tmp_path, monkeypatch):
+    """The transport-less /history fallback attaches the agent's bearer.
+
+    Exercises the ``_agent_bearer_headers`` closure that the INTERFACE.md
+    fallback and the artifacts/ingest stream also use.
+    """
+    import httpx as httpx_mod
+
+    app, router = _build_mesh_app(tmp_path, {"scout": "tok-scout"})
+    router.register_agent("scout", "http://127.0.0.1:8401")
+
+    captured: dict = {}
+
+    class _FakeResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"history": []}
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, params=None, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers or {}
+            return _FakeResp()
+
+    monkeypatch.setattr(httpx_mod, "AsyncClient", _FakeClient)
+    transport = ASGITransport(app=app, client=("127.0.0.1", 40000))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        resp = await client.get(
+            "/mesh/agents/scout/history", headers={"x-mesh-internal": "1"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["headers"].get("Authorization") == "Bearer tok-scout"
+
+
+# ── detached CLI wiring ─────────────────────────────────────────────────────
+
+
+def test_cli_agent_auth_headers_fetches_token(monkeypatch):
+    import httpx as httpx_mod
+
+    from src.cli.main import _agent_auth_headers
+
+    calls: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"agent_id": "scout", "token": "tok-scout"}
+
+    def _fake_get(url, headers=None, timeout=None):
+        calls["url"] = url
+        calls["headers"] = headers
+        return _Resp()
+
+    monkeypatch.setattr(httpx_mod, "get", _fake_get)
+    headers = _agent_auth_headers("scout", 8420)
+    assert headers == {"Authorization": "Bearer tok-scout"}
+    assert calls["url"].endswith("/mesh/agents/scout/token")
+    assert calls["headers"] == {"x-mesh-internal": "1"}
+
+
+def test_cli_agent_auth_headers_tokenless_mesh_is_empty(monkeypatch):
+    """Older/tokenless mesh (404 or connection error) → empty headers, no crash."""
+    import httpx as httpx_mod
+
+    from src.cli.main import _agent_auth_headers
+
+    class _Resp:
+        status_code = 404
+
+        def json(self):  # pragma: no cover - not reached on 404
+            return {}
+
+    monkeypatch.setattr(httpx_mod, "get", lambda *a, **k: _Resp())
+    assert _agent_auth_headers("scout", 8420) == {}
+
+    def _boom(*a, **k):
+        raise httpx_mod.ConnectError("down")
+
+    monkeypatch.setattr(httpx_mod, "get", _boom)
+    assert _agent_auth_headers("scout", 8420) == {}
+
+
+def test_cli_sync_detached_chat_sends_bearer(monkeypatch):
+    import httpx as httpx_mod
+
+    from src.cli.main import _sync_detached_chat
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"response": "hi", "tool_calls_made": 0}
+
+    def _fake_post(url, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return _Resp()
+
+    monkeypatch.setattr(httpx_mod, "post", _fake_post)
+    _sync_detached_chat(
+        "scout", "http://127.0.0.1:8401", "hello",
+        headers={"Authorization": "Bearer tok-scout"},
+    )
+    assert captured["url"] == "http://127.0.0.1:8401/chat"
+    assert captured["headers"] == {"Authorization": "Bearer tok-scout"}


### PR DESCRIPTION
## Summary

Phase-0 residual (b) — the §4 "closed regardless" item, closing audit C1's second leg. The agent FastAPI server (:8400) previously authenticated callers by the forgeable `x-mesh-internal` header alone. The mesh already mints a per-agent token that rides into the container as `MESH_AUTH_TOKEN` (agent→mesh direction); the agent server now **verifies that same token on the mesh→agent direction**. Defense-in-depth for host-network-mode / published-port exposure — the ICC-off bridge remains the primary network boundary.

Per hazard B7, **enforcement and caller wiring land in the same change** so nothing breaks:

- **Agent-side guard** (`_install_mesh_auth_guard`): outermost middleware, `hmac.compare_digest`, 401 JSON that names the agent (tokens rotate per start, so operators can diagnose stale callers). `MESH_AUTH_TOKEN` unset → fail-open (dev/tests; tokenless production is already blocked by the mesh's trust-tier boot gate, Constraint #12). **Sole exemption: `GET /status`** — the reachability probe used by `is_reachable`, `wait_for_agent`, the health poller, and the detached CLI; every other endpoint mutates state or returns agent-private data. Auth runs before the protocol-version guard and body-size drain, so unauthenticated callers learn nothing and trigger no body buffering.
- **Transport**: `_resolve_headers` attaches `Authorization: Bearer <token>` per target agent (caller-supplied auth wins via setdefault). `bind_tokens` holds the runtime's **live** `auth_tokens` dict, bound once at transport construction — every URL-registration path (initial start, REPL `/restart`, health-monitor restart, dashboard restart, `/mesh/register`) and restart token rotation are covered with zero per-site sync.
- **Mesh raw-httpx agent calls** (history fallback, INTERFACE.md fallback, `artifacts/ingest` byte-stream) attach the token via a `_agent_bearer_headers` closure over the same dict.
- **Detached CLI** (`openlegion chat`, separate process): fetches the token from the new `GET /mesh/agents/{id}/token` endpoint — disclosed **only** to loopback + `x-mesh-internal` callers (`_is_internal_caller`, the trust leg bridge-network agents can never satisfy); 404 in tokenless mode; degrades to empty headers against an older mesh.
- **Verified no other callers**: dashboard goes through transport; channels/cron/lanes/chain-watcher dispatch via transport; the browser service never calls agent :8400; no in-container self-callers of :8400 exist.

## Testing

- New `tests/test_agent_bearer_auth.py` — 20 tests: guard on/off/wrong-token/`/status`-exempt, transport token attachment, token-endpoint gating, direct-caller header wiring, CLI degradation.
- Full fast suite in the dev worktree: **7800 passed, 15 failed — all 15 confined to `tests/test_builtins.py`** (the documented dev-container-only env failures; they pass in CI).
- Composed-tree verification after integrating on top of #1186 + #1187: 661 + 314 targeted tests green, `ruff check` clean.
- `docs/security.md` gains the mesh→agent auth section; plan-doc Appendix D updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEVpeNmyVBoW6Va2LKe4iT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEVpeNmyVBoW6Va2LKe4iT)_