### PR TITLE
feat(costs): durable pre-flight team budget envelope — B4 semantics (Phase 1 unit 2)

### DIFF
--- a/docs/plans/2026-07-04-agent-employee-platform-architecture.md
+++ b/docs/plans/2026-07-04-agent-employee-platform-architecture.md
@@ -561,6 +561,54 @@ and green (908 passed)**. Reviewed via a full pre-merge pass (findings + fixes r
   `teams/X/goals/Y` (inert — nothing reads such keys into prompts anymore), and
   `_fetch_goals` semantics (verified behavior-identical at all five prompt consumers).
 
+- **✅ Landed — Phase-1 unit 2: durable pre-flight team budget envelope (B4 complete;
+  in-memory `_team_budgets` deleted).** The envelope lives on the team row
+  (`budget_daily_usd`/`budget_monthly_usd`, columns since unit 1); costs.py only READS
+  it via `set_team_store()` wiring. New `CostTracker.team_envelope_check(agent, model)`
+  runs at the LLM-proxy chokepoint (`credentials.execute_api_call`) immediately after
+  the per-agent preflight — aggregate member spend + estimated call cost vs envelope,
+  distinct "Team budget exceeded for team 'X'" error (surfaces on `tasks.blocker_note`
+  via the existing failed-transition promotion; no new plumbing per the earlier B4 plan
+  correction). **THE B4 SEMANTICS FLIP, pinned both ways in tests:** unset/NULL/0
+  envelope = UNLIMITED (`test_zero_envelope_is_unlimited`,
+  `test_zero_envelope_does_not_block` at the proxy) while the per-agent ledger's
+  0-blocks-everything contract is explicitly UNCHANGED
+  (`test_zero_agent_budget_still_blocks`). Envelope checks fail OPEN on store read
+  errors (an additional governor must not take down the LLM path; the per-agent budget
+  still applies) and are skipped entirely on the OAuth path (inherits `_needs_budget`).
+  Surfaces: `PUT /mesh/teams/{id}/budget` (operator-or-internal; 0→NULL normalized so
+  "unlimited" has one stored shape; caps $10k daily/$100k monthly),
+  `manage_team(action="set_budget")` operator tool + `MeshClient.set_team_budget`;
+  `get_team_spend` rewritten store-backed (unknown team keeps the historical error-dict
+  contract so introspect's `"error" not in` guard is unchanged; known team now returns
+  limits — None = unlimited — making `/mesh/costs/team/{id}` and the introspect
+  `team_budget` block real for the first time). Old `set_team_budget`/`_team_budgets`
+  deleted with their tests (C.1 discipline). **B-pre #3 folded in:** the
+  no-settings-file default is now $50/$200 via `DEFAULT_DAILY_BUDGET_USD`/
+  `DEFAULT_MONTHLY_BUDGET_USD` constants single-sourced into the dashboard's
+  `_SYSTEM_SETTINGS_DEFAULTS` (was a silent $10 enforced vs $50 advertised).
+  Known accepted race: the proxy's budget lock is per-agent, so two members' concurrent
+  calls can both pass one envelope check — same post-hoc exposure class as the daily
+  ledger; the governor converges on the next call. Tests: `tests/test_team_budget.py`
+  (endpoint/tool/proxy E2E) + rewritten `test_costs.py` team classes.
+  **Adversarial review: 4 findings (1 low-medium, 3 low), all fixed pre-PR:**
+  (1) `image_gen` spend counted against the envelope but was never gated by it (its
+  preflight branch only ran per-agent `check_budget`) — an exhausted team could keep
+  spending real dollars through image generation; the envelope check now runs on that
+  branch too (fixed-cost service → gates on already-consumed headroom, no estimate);
+  (2) `NaN`/`Infinity` passed `_parse_limit`'s comparisons, silently storing NULL
+  (= unlimited) then 500ing on response render — non-finite values now 400 (pinned via
+  raw-body JSON, since `json.loads` accepts the non-standard literals);
+  (3) three residual hardcoded `$10` daily-default literals survived the B-pre #3
+  single-sourcing (`cli/runtime.py` config-budget apply, `cli/repl.py` /restart apply,
+  two dead dashboard fallbacks) — all now use the constants;
+  (4) `manage_team(set_budget)` is full-replace, so updating one limit silently cleared
+  the other — the tool description now says to supply BOTH fields every call.
+  Cleared as non-findings: envelope semantics on every path (0/NULL/negative =
+  unlimited, exactly-equal allowed, consistent with per-agent `<=`), SQL
+  parameterization, OAuth skip, single prod construction site for the wiring, and the
+  `get_team_spend` None-limit shape (no `.toFixed`/`:.2f` consumer exists).
+
 ### YOU ARE HERE → next phase
 Foundation (#1180/#1181/#1183/#1184) and the rename (#1185) are merged. Phase 0's removal
 column is fully done. Next, in order:

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2423,26 +2423,41 @@ async def compose_work_summary(
     name="manage_team",
     operator_only=True,
     description=(
-        "Team lifecycle action (archive / unarchive / propose-delete). "
-        "Destructive actions require user confirmation."
+        "Team lifecycle action (archive / unarchive / propose-delete / "
+        "set_budget). Destructive actions require user confirmation. "
+        "set_budget REPLACES the team's whole aggregate spend envelope in "
+        "USD (enforced across all members' LLM calls): supply BOTH "
+        "daily_usd and monthly_usd on every call — an omitted or 0 field "
+        "becomes unlimited, so updating just one limit clears the other."
     ),
     parameters={
         "action": {
             "type": "string",
-            "enum": ["archive", "unarchive", "propose_delete"],
+            "enum": ["archive", "unarchive", "propose_delete", "set_budget"],
         },
         "team_name": {"type": "string", "description": "Team name"},
+        "daily_usd": {
+            "type": "number",
+            "description": "set_budget only: daily envelope in USD (0 = unlimited)",
+        },
+        "monthly_usd": {
+            "type": "number",
+            "description": "set_budget only: monthly envelope in USD (0 = unlimited)",
+        },
     },
 )
 async def manage_team(
     action: str,
     team_name: str = "",
+    daily_usd: float | None = None,
+    monthly_usd: float | None = None,
     *,
     mesh_client=None,
     _messages=None,
     **_kw,
 ) -> dict:
-    """Team lifecycle dispatcher — archive, unarchive, or propose deletion."""
+    """Team lifecycle dispatcher — archive, unarchive, propose deletion,
+    or set the budget envelope (plan B4: unset/0 = unlimited)."""
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
@@ -2451,6 +2466,15 @@ async def manage_team(
     name = team_name
     if not name:
         return {"error": "team_name is required"}
+
+    if action == "set_budget":
+        for label, val in (("daily_usd", daily_usd), ("monthly_usd", monthly_usd)):
+            if val is not None and (isinstance(val, bool) or not isinstance(val, (int, float))):
+                return {"error": f"{label} must be a number (USD) or omitted"}
+        try:
+            return await mesh_client.set_team_budget(name, daily_usd, monthly_usd)
+        except Exception as e:
+            return {"error": f"Failed to set team budget: {e}"}
 
     if action == "archive":
         try:
@@ -2482,7 +2506,10 @@ async def manage_team(
             return {"error": f"Failed to propose delete: {e}"}
 
     return {
-        "error": f"Unknown action {action!r}; use archive|unarchive|propose_delete"
+        "error": (
+            f"Unknown action {action!r}; use "
+            "archive|unarchive|propose_delete|set_budget"
+        )
     }
 
 

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1797,6 +1797,19 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def set_team_budget(
+        self, name: str, daily_usd: float | None, monthly_usd: float | None,
+    ) -> dict:
+        """Set a team's budget envelope. None/0 = unlimited (plan B4)."""
+        client = await self._get_client()
+        response = await client.put(
+            f"{self.mesh_url}/mesh/teams/{name}/budget",
+            json={"daily_usd": daily_usd, "monthly_usd": monthly_usd},
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json()
+
     async def archive_team(self, name: str) -> dict:
         """Archive a team."""
         client = await self._get_client()

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -1362,10 +1362,11 @@ class REPLSession:
             fresh_cfg = _load_config()
             budget = fresh_cfg.get("agents", {}).get(name, {}).get("budget", {})
             if budget and self.ctx.cost_tracker:
+                from src.host.costs import DEFAULT_DAILY_BUDGET_USD, DEFAULT_MONTHLY_BUDGET_USD
                 self.ctx.cost_tracker.set_budget(
                     name,
-                    daily_usd=budget.get("daily_usd", 10.0),
-                    monthly_usd=budget.get("monthly_usd", 200.0),
+                    daily_usd=budget.get("daily_usd", DEFAULT_DAILY_BUDGET_USD),
+                    monthly_usd=budget.get("monthly_usd", DEFAULT_MONTHLY_BUDGET_USD),
                 )
             click.echo("Applied.")
         else:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -574,6 +574,9 @@ class RuntimeContext:
             db_path=os.environ.get("OPENLEGION_TEAMS_DB", "data/teams.db"),
             teams_dir=TEAMS_DIR,
         )
+        # Team budget envelope (plan B4): the cost tracker resolves each
+        # caller's team + envelope through the store at pre-flight time.
+        self.cost_tracker.set_team_store(self.teams_store)
         self.router = MessageRouter(
             self.permissions, self.agent_urls,
             trace_store=self.trace_store,
@@ -716,10 +719,11 @@ class RuntimeContext:
                 )
             budget = agent_cfg.get("budget", {})
             if budget:
+                from src.host.costs import DEFAULT_DAILY_BUDGET_USD, DEFAULT_MONTHLY_BUDGET_USD
                 self.cost_tracker.set_budget(
                     agent_id,
-                    daily_usd=budget.get("daily_usd", 10.0),
-                    monthly_usd=budget.get("monthly_usd", 200.0),
+                    daily_usd=budget.get("daily_usd", DEFAULT_DAILY_BUDGET_USD),
+                    monthly_usd=budget.get("monthly_usd", DEFAULT_MONTHLY_BUDGET_USD),
                 )
             # Guard the empty case: os.path.abspath("") resolves to the CWD
             # (the repo root), which would bind-mount the whole tree — .venv,

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2972,9 +2972,15 @@ def create_dashboard_router(
                 raw_daily = budget_val.get("daily_usd")
                 raw_monthly = budget_val.get("monthly_usd")
                 if raw_daily is not None or raw_monthly is not None:
+                    from src.host.costs import DEFAULT_DAILY_BUDGET_USD, DEFAULT_MONTHLY_BUDGET_USD
+
                     current = cost_tracker.check_budget(agent_id)
-                    daily = _parse_positive_float(raw_daily, "daily_usd", current.get("daily_limit", 10.0))
-                    monthly = _parse_positive_float(raw_monthly, "monthly_usd", current.get("monthly_limit", 200.0))
+                    daily = _parse_positive_float(
+                        raw_daily, "daily_usd", current.get("daily_limit", DEFAULT_DAILY_BUDGET_USD),
+                    )
+                    monthly = _parse_positive_float(
+                        raw_monthly, "monthly_usd", current.get("monthly_limit", DEFAULT_MONTHLY_BUDGET_USD),
+                    )
                     budget_apply = {"daily_usd": daily, "monthly_usd": monthly}
 
         if "thinking" in body:
@@ -3296,9 +3302,15 @@ def create_dashboard_router(
         raw_monthly = body.get("monthly_usd")
         if raw_daily is None and raw_monthly is None:
             raise HTTPException(status_code=400, detail="Provide daily_usd and/or monthly_usd")
+        from src.host.costs import DEFAULT_DAILY_BUDGET_USD, DEFAULT_MONTHLY_BUDGET_USD
+
         current = cost_tracker.check_budget(agent_id)
-        daily_usd = _parse_positive_float(raw_daily, "daily_usd", current.get("daily_limit", 10.0))
-        monthly_usd = _parse_positive_float(raw_monthly, "monthly_usd", current.get("monthly_limit", 200.0))
+        daily_usd = _parse_positive_float(
+            raw_daily, "daily_usd", current.get("daily_limit", DEFAULT_DAILY_BUDGET_USD),
+        )
+        monthly_usd = _parse_positive_float(
+            raw_monthly, "monthly_usd", current.get("monthly_limit", DEFAULT_MONTHLY_BUDGET_USD),
+        )
         cost_tracker.set_budget(agent_id, daily_usd=daily_usd, monthly_usd=monthly_usd)
         from src.cli.config import _update_agent_field
         _update_agent_field(agent_id, "budget", {"daily_usd": daily_usd, "monthly_usd": monthly_usd})
@@ -6568,9 +6580,14 @@ def create_dashboard_router(
         "lane_timeout_seconds",
     })
 
+    from src.host.costs import DEFAULT_DAILY_BUDGET_USD, DEFAULT_MONTHLY_BUDGET_USD
+
     _SYSTEM_SETTINGS_DEFAULTS: dict[str, float | int] = {
-        "default_daily_budget": 50.0,
-        "default_monthly_budget": 200.0,
+        # Single-sourced from costs.py (plan B-pre #3): the advertised
+        # default and the enforced no-settings-file fallback must never
+        # diverge (they were $50 vs $10 before).
+        "default_daily_budget": DEFAULT_DAILY_BUDGET_USD,
+        "default_monthly_budget": DEFAULT_MONTHLY_BUDGET_USD,
         "tool_timeout": 900,
         "browser_idle_timeout": 30,
         "health_poll_interval": 30,

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -21,6 +21,15 @@ from src.shared.utils import setup_logging
 
 logger = setup_logging("host.costs")
 
+# Single source of truth for the per-agent budget defaults (B-pre #3):
+# the dashboard's Settings page (`_SYSTEM_SETTINGS_DEFAULTS`) reads these
+# same constants, so the advertised default and the enforced default can
+# never diverge again (previously the file-absent code path silently
+# enforced $10/day while the dashboard advertised $50).
+DEFAULT_DAILY_BUDGET_USD = 50.0
+DEFAULT_MONTHLY_BUDGET_USD = 200.0
+
+
 def _default_budget() -> dict:
     """Read default budget from dashboard system settings, falling back to hardcoded defaults."""
     try:
@@ -28,12 +37,12 @@ def _default_budget() -> dict:
         if p.exists():
             data = json.loads(p.read_text())
             return {
-                "daily_usd": data.get("default_daily_budget", 50.0),
-                "monthly_usd": data.get("default_monthly_budget", 200.0),
+                "daily_usd": data.get("default_daily_budget", DEFAULT_DAILY_BUDGET_USD),
+                "monthly_usd": data.get("default_monthly_budget", DEFAULT_MONTHLY_BUDGET_USD),
             }
     except (json.JSONDecodeError, OSError):
         pass
-    return {"daily_usd": 10.0, "monthly_usd": 200.0}
+    return {"daily_usd": DEFAULT_DAILY_BUDGET_USD, "monthly_usd": DEFAULT_MONTHLY_BUDGET_USD}
 
 
 class CostTracker:
@@ -70,7 +79,14 @@ class CostTracker:
         self._budget_lock = threading.Lock()
         self.budgets: dict[str, dict[str, float]] = {}
         self._load_budgets()
-        self._team_budgets: dict[str, dict] = {}
+        # Team-envelope source (the TeamStore) — wired post-construction by
+        # the runtime via set_team_store(). None (e.g. bare tests) disables
+        # the envelope layer; the per-agent budget still applies.
+        self._team_store = None
+
+    def set_team_store(self, team_store) -> None:
+        """Wire the TeamStore so team envelopes can be resolved per call."""
+        self._team_store = team_store
 
     def _load_budgets(self) -> None:
         """Load per-agent budget overrides from disk (tolerant of missing/corrupt)."""
@@ -352,28 +368,97 @@ class CostTracker:
             "by_model": by_model,
         }
 
-    # ── Team-level budget enforcement ──────────────────────────────────
+    # ── Team-level budget enforcement (durable envelope, plan B4) ─────
+    #
+    # The envelope lives on the team row in the TeamStore (data/teams.db),
+    # not here — costs.py only reads it. SEMANTICS (the B4 flip): an
+    # unset/NULL/0 envelope means UNLIMITED, the opposite of the per-agent
+    # ledger's arithmetic where a 0 budget blocks everything. A brand-new
+    # enforced team layer defaulting to "block all members" would be the
+    # exact failure mode B4 warns about.
 
-    def set_team_budget(
-        self,
-        team: str,
-        members: list[str],
-        daily_usd: float = 50.0,
-        monthly_usd: float = 1000.0,
-    ) -> None:
-        """Set an aggregate budget for a team (sum of member agents)."""
-        self._team_budgets[team] = {
-            "members": members,
-            "daily_usd": daily_usd,
-            "monthly_usd": monthly_usd,
+    def _members_spend_totals(self, members: list[str], since: str) -> tuple[float, int]:
+        """Sum (cost, tokens) across member agents since a timestamp."""
+        if not members:
+            return 0.0, 0
+        placeholders = ",".join("?" for _ in members)
+        row = self.db.execute(
+            "SELECT SUM(cost_usd), SUM(total_tokens) FROM usage "
+            f"WHERE timestamp >= ? AND agent IN ({placeholders})",
+            [since, *members],
+        ).fetchone()
+        return float(row[0] or 0.0), int(row[1] or 0)
+
+    def team_envelope_check(self, agent: str, model: str, estimated_tokens: int = 4096) -> dict:
+        """Pre-flight team-envelope check for one member's upcoming call.
+
+        Returns ``{"allowed": True, "team": None}`` when the agent has no
+        team, no store is wired, or the team's envelope is unset/0
+        (= unlimited). Fails OPEN on store read errors — the envelope is
+        an additional governor on top of the always-on per-agent budget,
+        and a storage hiccup must not take down the whole LLM path.
+        """
+        store = self._team_store
+        if store is None or not agent:
+            return {"allowed": True, "team": None}
+        try:
+            team = store.team_of(agent)
+            if not team:
+                return {"allowed": True, "team": None}
+            trow = store.get_team(team)
+        except Exception as e:
+            logger.warning("Team envelope check skipped (store read failed): %s", e)
+            return {"allowed": True, "team": None}
+        if trow is None:
+            return {"allowed": True, "team": None}
+        daily_env = trow.get("budget_daily_usd") or 0.0
+        monthly_env = trow.get("budget_monthly_usd") or 0.0
+        if daily_env <= 0 and monthly_env <= 0:
+            # Unset / 0 / negative = unlimited (B4).
+            return {"allowed": True, "team": team, "daily_limit": None, "monthly_limit": None}
+
+        members = trow.get("members") or [agent]
+        estimated_cost = estimate_cost(model, total_tokens=estimated_tokens)
+        daily_used, _ = self._members_spend_totals(members, _period_to_since("today"))
+        monthly_used, _ = self._members_spend_totals(members, _period_to_since("month"))
+
+        daily_ok = daily_env <= 0 or (daily_used + estimated_cost) <= daily_env
+        monthly_ok = monthly_env <= 0 or (monthly_used + estimated_cost) <= monthly_env
+        allowed = daily_ok and monthly_ok
+        if not allowed:
+            logger.warning(
+                "Team envelope check failed for agent '%s' (team '%s'): "
+                "estimated $%.4f would exceed envelope (daily: $%.4f/$%.2f, monthly: $%.4f/$%.2f)",
+                agent, team, estimated_cost, daily_used, daily_env, monthly_used, monthly_env,
+            )
+        return {
+            "allowed": allowed,
+            "team": team,
+            "estimated_cost": round(estimated_cost, 6),
+            "daily_used": round(daily_used, 4),
+            "daily_limit": daily_env if daily_env > 0 else None,
+            "monthly_used": round(monthly_used, 4),
+            "monthly_limit": monthly_env if monthly_env > 0 else None,
         }
 
     def get_team_spend(self, team: str, period: str = "today") -> dict:
-        """Aggregate spend across all member agents for a team."""
-        tbudget = self._team_budgets.get(team)
-        if tbudget is None:
-            return {"team": team, "error": "No team budget configured"}
-        members = tbudget["members"]
+        """Aggregate spend across a team's members, with its envelope.
+
+        Unknown team (or no store wired) keeps the historical error-dict
+        contract — callers guard on ``"error" not in result``.
+        ``daily_limit``/``monthly_limit`` are None when the envelope is
+        unset/0 (= unlimited, plan B4).
+        """
+        store = self._team_store
+        trow = None
+        if store is not None:
+            try:
+                trow = store.get_team(team)
+            except Exception as e:
+                logger.warning("get_team_spend: store read failed: %s", e)
+        if trow is None:
+            return {"team": team, "error": "Unknown team (or no team store wired)"}
+        members = trow.get("members") or []
         total_cost = 0.0
         total_tokens = 0
         agent_breakdown = []
@@ -386,13 +471,15 @@ class CostTracker:
                 "cost": spend.get("total_cost", 0),
                 "tokens": spend.get("total_tokens", 0),
             })
+        daily_env = trow.get("budget_daily_usd") or 0.0
+        monthly_env = trow.get("budget_monthly_usd") or 0.0
         return {
             "team": team,
             "period": period,
             "total_cost": round(total_cost, 4),
             "total_tokens": total_tokens,
-            "daily_limit": tbudget["daily_usd"],
-            "monthly_limit": tbudget["monthly_usd"],
+            "daily_limit": daily_env if daily_env > 0 else None,
+            "monthly_limit": monthly_env if monthly_env > 0 else None,
             "agents": agent_breakdown,
         }
 

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1383,6 +1383,24 @@ class CredentialVault:
                                 f"/${budget_check['monthly_limit']:.2f} monthly"
                             ),
                         )
+                    # Team envelope applies to image_gen too — its fixed
+                    # costs land in the same usage ledger the envelope
+                    # sums, so an exhausted team must not keep spending
+                    # through image generation. Fixed-cost service → no
+                    # meaningful per-call estimate; this gates on
+                    # already-consumed headroom.
+                    envelope = self.cost_tracker.team_envelope_check(
+                        agent_id, request.params.get("model", "unknown"),
+                    )
+                    if not envelope["allowed"]:
+                        return APIProxyResponse(
+                            success=False,
+                            error=(
+                                f"Team budget exceeded for team "
+                                f"'{envelope['team']}': image generation is "
+                                f"paused until the envelope resets"
+                            ),
+                        )
                 else:
                     model = request.params.get("model", "unknown")
                     preflight = self.cost_tracker.preflight_check(agent_id, model)
@@ -1397,6 +1415,27 @@ class CredentialVault:
                                 f"/${preflight['monthly_limit']:.2f} monthly "
                                 f"(estimated next call: "
                                 f"${preflight['estimated_cost']:.4f})"
+                            ),
+                        )
+                    # Team envelope on top of the per-agent budget (plan
+                    # B4): unset/0 = unlimited; enforced pre-flight at the
+                    # same chokepoint so one runaway member can't drain the
+                    # whole team's allocation.
+                    envelope = self.cost_tracker.team_envelope_check(agent_id, model)
+                    if not envelope["allowed"]:
+                        _d = envelope.get("daily_limit")
+                        _m = envelope.get("monthly_limit")
+                        return APIProxyResponse(
+                            success=False,
+                            error=(
+                                f"Team budget exceeded for team "
+                                f"'{envelope['team']}': "
+                                f"${envelope['daily_used']:.2f}"
+                                f"/{f'${_d:.2f}' if _d else 'unlimited'} daily, "
+                                f"${envelope['monthly_used']:.2f}"
+                                f"/{f'${_m:.2f}' if _m else 'unlimited'} monthly "
+                                f"(estimated next call: "
+                                f"${envelope['estimated_cost']:.4f})"
                             ),
                         )
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7622,6 +7622,58 @@ def create_mesh_app(
     # confirmed via ``/mesh/config/confirm``. Archive must precede delete;
     # the gate is enforced server-side at propose time.
 
+    @app.put("/mesh/teams/{team_name}/budget")
+    async def set_team_budget_endpoint(team_name: str, request: Request) -> dict:
+        """Set a team's budget envelope (operator-only, plan B4).
+
+        Body ``{daily_usd, monthly_usd}`` — each a number or null.
+        SEMANTICS: null/0 = UNLIMITED (deliberately the opposite of the
+        per-agent ledger, where 0 blocks everything — see plan B4). The
+        envelope is enforced pre-flight at the LLM proxy across the sum
+        of all members' spend.
+        """
+        caller = _extract_verified_agent_id(request)
+        if not _caller_is_operator(caller, request) and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can manage teams")
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(400, "body must be a JSON object")
+
+        def _parse_limit(field: str, cap: float) -> float | None:
+            raw = body.get(field)
+            if raw is None:
+                return None
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+                raise HTTPException(400, f"{field} must be a number or null")
+            val = float(raw)
+            # NaN passes < and > comparisons and would store as NULL while
+            # the response render 500s — reject non-finite outright.
+            if val != val or val in (float("inf"), float("-inf")):
+                raise HTTPException(400, f"{field} must be a finite number")
+            if val < 0:
+                raise HTTPException(400, f"{field} must be >= 0 (0 or null = unlimited)")
+            if val > cap:
+                raise HTTPException(400, f"{field} exceeds the maximum of {cap:g}")
+            # Normalize 0 → NULL so "unlimited" has one stored shape.
+            return val or None
+
+        daily = _parse_limit("daily_usd", 10_000.0)
+        monthly = _parse_limit("monthly_usd", 100_000.0)
+        try:
+            teams_store.set_budget(team_name, daily, monthly)
+        except TeamNotFound:
+            raise HTTPException(404, f"Team '{team_name}' not found")
+        _emit_team_event(
+            event_bus, "team_updated", agent="operator", name=team_name,
+            extra={"field": "budget"},
+        )
+        return {
+            "team": team_name,
+            "budget_daily_usd": daily,
+            "budget_monthly_usd": monthly,
+            "unlimited": daily is None and monthly is None,
+        }
+
     @app.post("/mesh/teams/{team_name}/archive")
     async def archive_team_endpoint(team_name: str, request: Request) -> dict:
         """Archive a team (operator-only). Idempotent."""

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -32,7 +32,11 @@ class TestCostTracking:
     def test_track_oauth_records_tokens_at_zero_cost(self):
         """bill=False (OAuth/subscription): tokens recorded, cost_usd=0."""
         result = self.tracker.track(
-            "agent1", "anthropic/claude-sonnet-4-6", 1000, 500, bill=False,
+            "agent1",
+            "anthropic/claude-sonnet-4-6",
+            1000,
+            500,
+            bill=False,
         )
         assert result["cost"] == 0.0
         assert result["over_budget"] is False
@@ -58,7 +62,11 @@ class TestCostTracking:
         self.tracker.set_budget("agent1", daily_usd=0.01, monthly_usd=0.01)
         for _ in range(50):
             self.tracker.track(
-                "agent1", "anthropic/claude-opus-4-1", 50_000, 10_000, bill=False,
+                "agent1",
+                "anthropic/claude-opus-4-1",
+                50_000,
+                10_000,
+                bill=False,
             )
         assert self.tracker.check_budget("agent1")["allowed"] is True
         assert self.tracker.get_spend("agent1", "today")["total_cost"] == 0.0
@@ -152,9 +160,7 @@ class TestTraceIdStamping:
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def _trace_ids(self, agent: str) -> list:
-        rows = self.tracker.db.execute(
-            "SELECT trace_id FROM usage WHERE agent = ? ORDER BY id", (agent,)
-        ).fetchall()
+        rows = self.tracker.db.execute("SELECT trace_id FROM usage WHERE agent = ? ORDER BY id", (agent,)).fetchall()
         return [r[0] for r in rows]
 
     def test_track_stamps_active_trace_id(self):
@@ -222,9 +228,7 @@ class TestTraceIdStamping:
         )
         cols = {r[1] for r in t1.db.execute("PRAGMA table_info(usage)").fetchall()}
         assert "trace_id" in cols
-        old = t1.db.execute(
-            "SELECT trace_id FROM usage WHERE agent = 'legacy'"
-        ).fetchone()
+        old = t1.db.execute("SELECT trace_id FROM usage WHERE agent = 'legacy'").fetchone()
         assert old[0] is None
         t1.close()
 
@@ -264,9 +268,11 @@ class TestBudgetEnforcement:
         assert budget["allowed"] is False
 
     def test_default_budget(self):
+        # B-pre #3: the no-settings-file fallback matches the dashboard's
+        # advertised default ($50/$200) — it was a silent $10 before.
         budget = self.tracker.check_budget("unknown_agent")
         assert budget["allowed"] is True
-        assert budget["daily_limit"] == 10.0
+        assert budget["daily_limit"] == 50.0
         assert budget["monthly_limit"] == 200.0
 
     def test_no_spend_is_allowed(self):
@@ -341,14 +347,20 @@ class TestBudgetOverrunWarning:
             assert any("exceeded monthly budget" in str(c) for c in calls)
 
 
-class TestProjectCostAggregation:
-    """Project-level cost tracking and budget enforcement."""
+class TestTeamCostAggregation:
+    """Team-level cost aggregation reads membership + envelope from the
+    TeamStore (the durable home since Phase 1) — costs.py holds no team
+    state of its own."""
 
     def setup_method(self):
+        from src.host.teams import TeamStore
+
         self._tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self._tmpdir, "costs.db")
         self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
         self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        self.store = TeamStore(db_path=":memory:")
+        self.tracker.set_team_store(self.store)
 
     def teardown_method(self):
         self.tracker.close()
@@ -356,9 +368,9 @@ class TestProjectCostAggregation:
 
     def test_team_spend_aggregates_members(self):
         """get_team_spend sums spend across all member agents."""
-        self.tracker.set_team_budget(
-            "teamA", members=["alice", "bob"], daily_usd=50.0, monthly_usd=500.0,
-        )
+        self.store.create_team("teamA")
+        self.store.add_member("teamA", "alice")
+        self.store.add_member("teamA", "bob")
         self.tracker.track("alice", "openai/gpt-4o-mini", 1000, 500)
         self.tracker.track("bob", "openai/gpt-4o-mini", 2000, 1000)
 
@@ -372,19 +384,129 @@ class TestProjectCostAggregation:
         assert alice_spend["tokens"] == 1500
         assert bob_spend["tokens"] == 3000
 
-    def test_team_spend_no_budget_configured(self):
-        """get_team_spend returns error when no budget is set."""
+    def test_team_spend_unknown_team_errors(self):
+        """get_team_spend keeps the historical error-dict contract for an
+        unknown team (introspect guards on ``"error" not in``)."""
         result = self.tracker.get_team_spend("unknown", "today")
         assert "error" in result
 
-    def test_team_budget_limits(self):
-        """set_team_budget stores limits correctly."""
-        self.tracker.set_team_budget(
-            "proj", members=["a1"], daily_usd=100.0, monthly_usd=2000.0,
-        )
+    def test_team_spend_no_store_errors(self):
+        self.tracker.set_team_store(None)
+        result = self.tracker.get_team_spend("teamA", "today")
+        assert "error" in result
+
+    def test_team_envelope_limits_surface(self):
+        self.store.create_team("proj")
+        self.store.add_member("proj", "a1")
+        self.store.set_budget("proj", 100.0, 2000.0)
         result = self.tracker.get_team_spend("proj", "today")
         assert result["daily_limit"] == 100.0
         assert result["monthly_limit"] == 2000.0
+
+    def test_unset_envelope_surfaces_none(self):
+        """B4: unset envelope reads back as None (= unlimited), never 0."""
+        self.store.create_team("proj")
+        result = self.tracker.get_team_spend("proj", "today")
+        assert result["daily_limit"] is None
+        assert result["monthly_limit"] is None
+
+
+class TestTeamEnvelopeCheck:
+    """Pre-flight team envelope (plan B4). THE semantics flip pinned here:
+    an unset/NULL/0 envelope is UNLIMITED — the opposite of the per-agent
+    ledger where a 0 budget blocks everything."""
+
+    def setup_method(self):
+        from src.host.teams import TeamStore
+
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "costs.db")
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        self.store = TeamStore(db_path=":memory:")
+        self.tracker.set_team_store(self.store)
+        self.store.create_team("teamA")
+        self.store.add_member("teamA", "alice")
+        self.store.add_member("teamA", "bob")
+
+    def teardown_method(self):
+        self.tracker.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_unset_envelope_is_unlimited(self):
+        """No envelope configured → members are never team-blocked."""
+        self.tracker.track("alice", "openai/gpt-4o", 500_000, 250_000)
+        check = self.tracker.team_envelope_check("bob", "openai/gpt-4o")
+        assert check["allowed"] is True
+        assert check["team"] == "teamA"
+
+    def test_zero_envelope_is_unlimited(self):
+        """THE B4 flip: an explicit 0 envelope means UNLIMITED, not
+        block-everything (contrast test_zero_agent_budget_still_blocks)."""
+        self.store.set_budget("teamA", 0.0, 0.0)
+        self.tracker.track("alice", "openai/gpt-4o", 500_000, 250_000)
+        check = self.tracker.team_envelope_check("bob", "openai/gpt-4o")
+        assert check["allowed"] is True
+        assert check["daily_limit"] is None
+        assert check["monthly_limit"] is None
+
+    def test_zero_agent_budget_still_blocks(self):
+        """The PER-AGENT contract is unchanged by B4: a 0 agent budget
+        still blocks — only the team envelope treats 0 as unlimited."""
+        self.tracker.set_budget("alice", daily_usd=0.0, monthly_usd=0.0)
+        preflight = self.tracker.preflight_check("alice", "openai/gpt-4o")
+        assert preflight["allowed"] is False
+
+    def test_exceeded_daily_envelope_blocks(self):
+        self.store.set_budget("teamA", 0.001, None)
+        self.tracker.track("alice", "openai/gpt-4o", 10_000, 5_000)
+        check = self.tracker.team_envelope_check("bob", "openai/gpt-4o")
+        assert check["allowed"] is False
+        assert check["team"] == "teamA"
+        assert check["daily_limit"] == 0.001
+        assert check["monthly_limit"] is None
+        assert check["daily_used"] > 0
+
+    def test_exceeded_monthly_envelope_blocks(self):
+        self.store.set_budget("teamA", None, 0.001)
+        self.tracker.track("alice", "openai/gpt-4o", 10_000, 5_000)
+        check = self.tracker.team_envelope_check("bob", "openai/gpt-4o")
+        assert check["allowed"] is False
+        assert check["monthly_limit"] == 0.001
+
+    def test_envelope_aggregates_across_members(self):
+        """One member's spend counts against every member's headroom."""
+        self.store.set_budget("teamA", 50.0, None)
+        # alice spends nothing; bob's spend alone must not block alice
+        # under a generous envelope...
+        self.tracker.track("bob", "openai/gpt-4o-mini", 1000, 500)
+        assert self.tracker.team_envelope_check("alice", "openai/gpt-4o")["allowed"] is True
+        # ...but a tight envelope consumed by bob blocks alice too.
+        self.store.set_budget("teamA", 0.001, None)
+        self.tracker.track("bob", "openai/gpt-4o", 10_000, 5_000)
+        assert self.tracker.team_envelope_check("alice", "openai/gpt-4o")["allowed"] is False
+
+    def test_solo_agent_never_team_blocked(self):
+        check = self.tracker.team_envelope_check("loner", "openai/gpt-4o")
+        assert check["allowed"] is True
+        assert check["team"] is None
+
+    def test_no_store_wired_allows(self):
+        self.tracker.set_team_store(None)
+        check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
+        assert check["allowed"] is True
+
+    def test_store_error_fails_open(self):
+        """The envelope is an additional governor — a store hiccup must
+        not take down the LLM path (the per-agent budget still applies)."""
+
+        class _Boom:
+            def team_of(self, agent):
+                raise RuntimeError("db locked")
+
+        self.tracker.set_team_store(_Boom())
+        check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
+        assert check["allowed"] is True
 
 
 class TestCostTrackerCleanup:
@@ -517,7 +639,8 @@ class TestBudgetPersistence:
         tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
         # Point the persist path at an unwritable location so the write fails.
         with patch.object(
-            tracker, "budgets_path",
+            tracker,
+            "budgets_path",
             Path("/proc/nonexistent/agent_budgets.json"),
         ):
             with patch("src.host.costs.logger") as mock_logger:
@@ -586,6 +709,7 @@ class TestCostTrackerWithVault:
         try:
             tracker = CostTracker(db_path=os.path.join(tmpdir, "costs.db"))
             from src.host.credentials import CredentialVault
+
             vault = CredentialVault(cost_tracker=tracker)
             assert vault.cost_tracker is tracker
             tracker.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1333,6 +1333,7 @@ def test_watch_blackboard_permission_denied(tmp_path):
 def test_project_cost_endpoint(tmp_path):
     """Project cost endpoint returns aggregated spend."""
     from src.host.costs import CostTracker
+    from src.host.teams import TeamStore
 
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
     pubsub = PubSub()
@@ -1340,12 +1341,18 @@ def test_project_cost_endpoint(tmp_path):
     perms.permissions = {}
     router = MessageRouter(permissions=perms, agent_registry={})
     tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
-    tracker.set_team_budget("teamA", members=["alice", "bob"],
-                            daily_usd=50.0, monthly_usd=500.0)
+    store = TeamStore(db_path=":memory:")
+    store.create_team("teamA")
+    store.add_member("teamA", "alice")
+    store.add_member("teamA", "bob")
+    store.set_budget("teamA", 50.0, 500.0)
+    tracker.set_team_store(store)
     tracker.track("alice", "openai/gpt-4o-mini", 1000, 500)
     tracker.track("bob", "openai/gpt-4o-mini", 2000, 1000)
 
-    app = create_mesh_app(bb, pubsub, router, perms, cost_tracker=tracker)
+    app = create_mesh_app(
+        bb, pubsub, router, perms, cost_tracker=tracker, teams_store=store,
+    )
     client = TestClient(app)
 
     resp = client.get("/mesh/costs/team/teamA", params={"period": "today"})
@@ -1355,6 +1362,7 @@ def test_project_cost_endpoint(tmp_path):
     assert data["total_tokens"] == 4500
     assert data["total_cost"] > 0
     assert len(data["agents"]) == 2
+    assert data["daily_limit"] == 50.0
 
     bb.close()
     tracker.close()

--- a/tests/test_team_budget.py
+++ b/tests/test_team_budget.py
@@ -1,0 +1,299 @@
+"""Team budget envelope (Phase 1 unit 2, plan B4).
+
+Covers the mesh endpoint (`PUT /mesh/teams/{team}/budget`), the
+`manage_team(action="set_budget")` operator tool routing, and the
+end-to-end pre-flight block at the LLM proxy chokepoint with a real
+CostTracker + TeamStore. THE B4 semantics — unset/0 envelope =
+UNLIMITED — are pinned at the costs layer in test_costs.py; here we pin
+the surfaces.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.host.costs import CostTracker
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.host.server import create_mesh_app
+from src.host.teams import TeamStore
+
+
+def _build_app(tmp_path, *, cost_tracker=None, teams_store=None):
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {}
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    router = MessageRouter(permissions=perms, agent_registry={"operator": "http://op:8400"})
+    app = create_mesh_app(
+        bb,
+        PubSub(),
+        router,
+        perms,
+        cost_tracker=cost_tracker,
+        teams_store=teams_store,
+        auth_tokens={"operator": "tok-op", "worker": "tok-w"},
+    )
+    return app, bb
+
+
+_OP = {"Authorization": "Bearer tok-op"}
+_WORKER = {"Authorization": "Bearer tok-w"}
+
+
+class TestBudgetEndpoint:
+    def test_operator_sets_budget(self, tmp_path):
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        app, bb = _build_app(tmp_path, teams_store=store)
+        try:
+            resp = TestClient(app).put(
+                "/mesh/teams/alpha/budget",
+                headers=_OP,
+                json={"daily_usd": 25.0, "monthly_usd": 400.0},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == {
+                "team": "alpha",
+                "budget_daily_usd": 25.0,
+                "budget_monthly_usd": 400.0,
+                "unlimited": False,
+            }
+            team = store.get_team("alpha")
+            assert team["budget_daily_usd"] == 25.0
+            assert team["budget_monthly_usd"] == 400.0
+        finally:
+            bb.close()
+
+    def test_zero_normalizes_to_unlimited(self, tmp_path):
+        """B4 at the API surface: 0 is stored as NULL so 'unlimited' has
+        exactly one stored shape."""
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        store.set_budget("alpha", 25.0, 400.0)
+        app, bb = _build_app(tmp_path, teams_store=store)
+        try:
+            resp = TestClient(app).put(
+                "/mesh/teams/alpha/budget",
+                headers=_OP,
+                json={"daily_usd": 0, "monthly_usd": None},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["unlimited"] is True
+            team = store.get_team("alpha")
+            assert team["budget_daily_usd"] is None
+            assert team["budget_monthly_usd"] is None
+        finally:
+            bb.close()
+
+    def test_worker_403(self, tmp_path):
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        app, bb = _build_app(tmp_path, teams_store=store)
+        try:
+            resp = TestClient(app).put(
+                "/mesh/teams/alpha/budget",
+                headers=_WORKER,
+                json={"daily_usd": 1},
+            )
+            assert resp.status_code == 403
+        finally:
+            bb.close()
+
+    def test_unknown_team_404(self, tmp_path):
+        app, bb = _build_app(tmp_path, teams_store=TeamStore(db_path=":memory:"))
+        try:
+            resp = TestClient(app).put(
+                "/mesh/teams/ghost/budget",
+                headers=_OP,
+                json={"daily_usd": 1},
+            )
+            assert resp.status_code == 404
+        finally:
+            bb.close()
+
+    def test_validation_400s(self, tmp_path):
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        app, bb = _build_app(tmp_path, teams_store=store)
+        client = TestClient(app)
+        try:
+            for body in (
+                {"daily_usd": -1},
+                {"daily_usd": "ten"},
+                {"daily_usd": True},
+                {"daily_usd": 999_999},
+                {"monthly_usd": 999_999_999},
+            ):
+                resp = client.put("/mesh/teams/alpha/budget", headers=_OP, json=body)
+                assert resp.status_code == 400, (body, resp.text)
+            # NaN/Infinity pass </> comparisons and would silently store
+            # as NULL (= unlimited) then 500 on response render. Python's
+            # json.loads accepts these non-standard literals, so they are
+            # reachable as raw bodies even though json.dumps refuses them.
+            for raw in ('{"daily_usd": NaN}', '{"daily_usd": Infinity}'):
+                resp = client.put(
+                    "/mesh/teams/alpha/budget",
+                    headers={**_OP, "Content-Type": "application/json"},
+                    content=raw,
+                )
+                assert resp.status_code == 400, (raw, resp.text)
+        finally:
+            bb.close()
+
+
+class TestCostsTeamEndpoint:
+    def test_team_costs_reflect_envelope(self, tmp_path):
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        store.add_member("alpha", "worker")
+        tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
+        tracker.set_team_store(store)
+        app, bb = _build_app(tmp_path, cost_tracker=tracker, teams_store=store)
+        try:
+            client = TestClient(app)
+            client.put(
+                "/mesh/teams/alpha/budget",
+                headers=_OP,
+                json={"daily_usd": 30.0},
+            )
+            resp = client.get("/mesh/costs/team/alpha", headers=_OP)
+            assert resp.status_code == 200, resp.text
+            data = resp.json()
+            assert data["daily_limit"] == 30.0
+            assert data["monthly_limit"] is None
+            assert data["agents"] == [{"agent": "worker", "cost": 0, "tokens": 0}]
+        finally:
+            bb.close()
+            tracker.close()
+
+
+class TestManageTeamTool:
+    @pytest.mark.asyncio
+    async def test_set_budget_routes_to_client(self):
+        from src.agent.builtins import operator_tools
+
+        mc = MagicMock()
+        mc.set_team_budget = AsyncMock(
+            return_value={"team": "alpha", "unlimited": False},
+        )
+        with patch.object(operator_tools, "_is_operator", return_value=True):
+            result = await operator_tools.manage_team(
+                action="set_budget",
+                team_name="alpha",
+                daily_usd=10.0,
+                monthly_usd=100.0,
+                mesh_client=mc,
+            )
+        assert result == {"team": "alpha", "unlimited": False}
+        mc.set_team_budget.assert_awaited_once_with("alpha", 10.0, 100.0)
+
+    @pytest.mark.asyncio
+    async def test_set_budget_rejects_non_numeric(self):
+        from src.agent.builtins import operator_tools
+
+        with patch.object(operator_tools, "_is_operator", return_value=True):
+            result = await operator_tools.manage_team(
+                action="set_budget",
+                team_name="alpha",
+                daily_usd="lots",
+                mesh_client=MagicMock(),
+            )
+        assert "error" in result
+
+
+class TestProxyEnvelopeBlock:
+    """End-to-end: the envelope blocks at the LLM proxy chokepoint with a
+    real CostTracker + TeamStore, and unset/0 does NOT block (B4)."""
+
+    def _vault_and_tracker(self, tmp_path, monkeypatch):
+        from src.host.credentials import CredentialVault
+
+        monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_OAUTH", raising=False)
+        monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", "sk-test")
+        tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        store.add_member("alpha", "worker")
+        tracker.set_team_store(store)
+        return CredentialVault(cost_tracker=tracker), tracker, store
+
+    def _chat_request(self):
+        from src.shared.types import APIProxyRequest
+
+        return APIProxyRequest(
+            service="llm",
+            action="chat",
+            params={
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_exhausted_envelope_blocks_member_call(self, tmp_path, monkeypatch):
+        vault, tracker, store = self._vault_and_tracker(tmp_path, monkeypatch)
+        store.set_budget("alpha", 0.001, None)
+        # Another member burns the whole envelope.
+        tracker.track("teammate-in-db", "openai/gpt-4o", 1, 1)
+        store.add_member("alpha", "teammate-in-db")
+        tracker.track("teammate-in-db", "openai/gpt-4o", 100_000, 50_000)
+
+        result = await vault.execute_api_call(self._chat_request(), agent_id="worker")
+        assert result.success is False
+        assert "Team budget exceeded" in result.error
+        assert "alpha" in result.error
+        tracker.close()
+
+    @pytest.mark.asyncio
+    async def test_zero_envelope_does_not_block(self, tmp_path, monkeypatch):
+        """B4 pinned at the proxy: 0 envelope = unlimited; the call reaches
+        the provider handler."""
+        vault, tracker, store = self._vault_and_tracker(tmp_path, monkeypatch)
+        store.set_budget("alpha", 0.0, 0.0)
+
+        async def mock_acompletion(model, messages, api_key, **kwargs):
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "ok"
+            resp.choices[0].message.tool_calls = None
+            resp.usage = MagicMock()
+            resp.usage.total_tokens = 10
+            resp.usage.prompt_tokens = 6
+            resp.usage.completion_tokens = 4
+            return resp
+
+        with patch("litellm.acompletion", side_effect=mock_acompletion):
+            result = await vault.execute_api_call(self._chat_request(), agent_id="worker")
+        assert result.success is True
+        tracker.close()
+
+
+class TestImageGenEnvelope:
+    @pytest.mark.asyncio
+    async def test_exhausted_envelope_blocks_image_gen(self, tmp_path, monkeypatch):
+        """image_gen spend lands in the same usage ledger the envelope
+        sums, so an exhausted team can't keep spending through it."""
+        from src.host.credentials import CredentialVault
+        from src.shared.types import APIProxyRequest
+
+        monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_OAUTH", raising=False)
+        tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        store.add_member("alpha", "worker")
+        store.add_member("alpha", "burner")
+        store.set_budget("alpha", 0.001, None)
+        tracker.set_team_store(store)
+        tracker.track("burner", "openai/gpt-4o", 100_000, 50_000)
+        vault = CredentialVault(cost_tracker=tracker)
+
+        req = APIProxyRequest(
+            service="image_gen",
+            action="generate",
+            params={"prompt": "a cat"},
+        )
+        result = await vault.execute_api_call(req, agent_id="worker")
+        assert result.success is False
+        assert "Team budget exceeded" in result.error
+        tracker.close()


### PR DESCRIPTION
Phase 1 unit 2 of `docs/plans/2026-07-04-agent-employee-platform-architecture.md`: the team budget envelope goes from dead code (an in-memory `_team_budgets` dict with zero production writers, so `get_team_spend` always errored) to a durable, pre-flight-enforced governor at the economics chokepoint.

## What this does

- **Storage**: the envelope lives on the team row (`budget_daily_usd`/`budget_monthly_usd` — TeamStore columns shipped in #1189). `costs.py` only reads it, via `CostTracker.set_team_store()` wired at runtime boot. The dead `set_team_budget`/`_team_budgets` are deleted with their tests (C.1: the old side dies when the new lands).
- **Enforcement**: `CostTracker.team_envelope_check(agent, model)` runs in `credentials.execute_api_call` immediately after the per-agent preflight — aggregate member spend + estimated call cost vs envelope, with a distinct `Team budget exceeded for team 'X'` error (the task path already promotes proxy errors to `tasks.blocker_note`; no new plumbing, per the plan's earlier B4 correction). `image_gen` is gated too — its fixed costs land in the same usage ledger the envelope sums. OAuth calls inherit the existing budget skip. Checks fail **open** on store read errors: the envelope is an additional governor on top of the always-on per-agent budget, and a storage hiccup must not take down the LLM path.
- **THE B4 SEMANTICS FLIP, pinned both ways**: an unset/NULL/0 team envelope means **UNLIMITED** (`test_zero_envelope_is_unlimited`, and `test_zero_envelope_does_not_block` end-to-end at the proxy) — deliberately the opposite of the per-agent ledger, whose 0-blocks-everything arithmetic is explicitly unchanged and now has its own pin (`test_zero_agent_budget_still_blocks`). This is the exact failure mode B4 warned about: a new enforced team layer whose default blocks every member.
- **Surfaces**: `PUT /mesh/teams/{id}/budget` (operator-or-internal; 0→NULL normalized so "unlimited" has one stored shape; non-finite values rejected; $10k daily / $100k monthly caps), `manage_team(action="set_budget")` operator tool + `MeshClient.set_team_budget`. `get_team_spend` is rewritten store-backed — unknown teams keep the historical error-dict contract (introspect's `"error" not in` guard unchanged), known teams return limits with `None` = unlimited — which makes `GET /mesh/costs/team/{id}` and introspect's `team_budget` block return real data for the first time.
- **B-pre #3 folded in**: the no-settings-file budget default is now $50/$200 via `DEFAULT_DAILY_BUDGET_USD`/`DEFAULT_MONTHLY_BUDGET_USD`, single-sourced into the dashboard's settings defaults and the config-budget apply paths (previously a silent $10/day was enforced while the dashboard advertised $50).

## Known accepted race (documented in Appendix D)

The proxy's budget lock is per-agent, so two members' concurrent calls can each pass one envelope check — the same post-hoc exposure class as the existing daily ledger; the governor converges on the next call.

## Adversarial review (logged in Appendix D)

Four findings, all fixed in this PR: the `image_gen` envelope gap (spend counted against the envelope but wasn't gated by it — low-medium); `NaN`/`Infinity` passing validation and silently storing "unlimited" then 500ing (pinned via raw-body JSON since `json.loads` accepts the non-standard literals); three residual hardcoded `$10` defaults that survived the single-sourcing; and the `set_budget` full-replace footgun (tool description now says supply BOTH fields every call). Cleared as non-findings: envelope semantics on every path, SQL parameterization, OAuth skip, wiring coverage, and the None-limit response shape (no formatter consumer exists).

## Testing

Full CI-equivalent suite: **7905 passed, 67 skipped** (only the 15 known dev-container-only `tests/test_builtins.py` failures). Post-review-fix blast radius: 881 passed. New `tests/test_team_budget.py` (endpoint validation matrix, tool routing, proxy end-to-end block/allow with a real tracker + store, image_gen gate) + rewritten `test_costs.py` team classes. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Z3x9aq9Xk4njcFxPrVSTa

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z3x9aq9Xk4njcFxPrVSTa)_