### PR TITLE
feat(browser): truth-telling for navigate/snapshot — surface hard blocks + snapshot truncation

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -413,7 +413,12 @@ async def browser_warmup(
         "since the last snapshot — added/removed/changed elements with a "
         "'scope' label (same | modal_opened | modal_closed | frame_changed "
         "| navigation | tab_changed). Returns a full snapshot when scope is "
-        "navigation/tab_changed."
+        "navigation/tab_changed.\n\n"
+        "Dense pages are capped at 200 elements by default. When the result "
+        "carries truncated=true, elements past the cap were NOT included — "
+        "raise max_elements (up to 1000) to pull more, or use filter= / "
+        "from_ref= to narrow. Never assume the page has only the elements "
+        "shown when truncated=true."
     ),
     parameters={
         "filter": {
@@ -469,6 +474,16 @@ async def browser_warmup(
             ),
             "default": True,
         },
+        "max_elements": {
+            "type": "integer",
+            "description": (
+                "Override the 200-element snapshot cap (max 1000). Use "
+                "when a prior snapshot came back truncated=true and you "
+                "need the elements past the cap in one call. Prefer "
+                "filter= / from_ref= first when they'd narrow the page "
+                "enough — a larger cap costs more tokens."
+            ),
+        },
     },
     parallel_safe=False,
 )
@@ -478,6 +493,7 @@ async def browser_get_elements(
     diff_from_last: bool = False,
     frame: str | None = None,
     include_frames: bool = True,
+    max_elements: int | None = None,
     *,
     mesh_client=None,
 ) -> dict:
@@ -493,6 +509,8 @@ async def browser_get_elements(
         payload["frame"] = frame
     if not include_frames:
         payload["include_frames"] = False
+    if max_elements is not None:
+        payload["max_elements"] = max_elements
     return await _browser_command(mesh_client, "snapshot", payload)
 
 

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -324,6 +324,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             diff_from_last=_body_bool(body, "diff_from_last", False),
             frame=body.get("frame"),
             include_frames=_body_bool(body, "include_frames", True),
+            max_elements=body.get("max_elements"),
         )
 
     @app.post("/browser/{agent_id}/click")

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1037,12 +1037,15 @@ _HARD_BLOCK_STATUS_THRESHOLD = 400
 
 # Status codes that, on their own, mean "you were blocked / throttled"
 # rather than "page not found / server error". A bare bot wall often
-# returns a 403 (or 429/503 challenge) with NO vendor header, so the
-# status alone has to be enough to tell the agent the response it got
-# back is a wall, not the site's content. 404/410/500 are deliberately
-# absent — those are ordinary navigation failures, and flagging them as
-# blocks would train the agent to distrust normal misses.
-_BLOCK_STATUS_CODES: frozenset[int] = frozenset({401, 403, 407, 429, 451, 503})
+# returns a 403 (or a 429 throttle) with NO vendor header, so the status
+# alone has to be enough to tell the agent the response it got back is a
+# wall, not the site's content. 404/410/500/503 are deliberately absent:
+# those are ordinary navigation / server-availability failures, and
+# flagging them as blocks would train the agent to distrust normal misses
+# and transient outages. A 503 that IS an anti-bot challenge still
+# classifies as a vendor_block via its header (``_classify_hard_block``
+# fires on status >= 400), so only the ambiguous bare 503 is excluded.
+_BLOCK_STATUS_CODES: frozenset[int] = frozenset({401, 403, 407, 429, 451})
 
 
 def _classify_hard_block(headers: dict[str, str], status: int) -> tuple[str, str] | None:
@@ -5822,6 +5825,33 @@ class BrowserManager:
             # against the stale prior page.
             inst.refs = {}
             inst.last_snapshot.clear()
+            # Truth-telling: classify the main-document response NOW — before
+            # title extraction or captcha auto-solve can throw or navigate
+            # away — and record it on the instance immediately, so a later
+            # snapshot() echoes the block of the document we actually landed
+            # on even if the post-nav processing below fails. (A solver-driven
+            # navigation is handled after _check_captcha; tab/history changes
+            # are cleared in open_tab/switch_tab/go_back/go_forward.)
+            status_code: int | None = None
+            hard_block: dict | None = None
+            if nav_response is not None:
+                try:
+                    status_code = int(nav_response.status)
+                except Exception:
+                    status_code = None
+                # Playwright exposes ``headers`` as a plain dict property;
+                # isinstance-guard it so a non-mapping value can never reach
+                # the classifier (stays vendor-header classification, never a
+                # coincidental truthy object).
+                raw_headers = getattr(nav_response, "headers", None)
+                response_headers = (
+                    raw_headers if isinstance(raw_headers, dict) else {}
+                )
+                if status_code is not None:
+                    hard_block = _classify_navigation_block(
+                        response_headers, status_code,
+                    )
+            inst.last_nav_hard_block = hard_block
             if wait_ms > 0:
                 await asyncio.sleep(wait_ms / 1000 + navigation_jitter())
             try:
@@ -5866,37 +5896,20 @@ class BrowserManager:
                     and envelope.get("solver_outcome") != "solved"
                 ):
                     result["captcha"] = _with_legacy_fields(envelope)
-                # Truth-telling: surface the main-document HTTP status and,
-                # when the response is block-shaped (403/429/503 or a vendor
-                # block header), an explicit ``hard_block`` signal. Without
-                # this a challenge/wall page is returned as ordinary "success"
-                # content and the agent acts on the wall as if it were the
-                # site. ``success`` stays True — the navigation mechanically
-                # completed; the agent keys on ``hard_block`` (mirrors how a
-                # captcha is surfaced without failing the nav).
-                status_code: int | None = None
-                hard_block: dict | None = None
-                if nav_response is not None:
-                    try:
-                        status_code = int(nav_response.status)
-                    except Exception:
-                        status_code = None
-                    # Playwright exposes ``headers`` as a plain dict property;
-                    # isinstance-guard it so a non-mapping value can never
-                    # reach the classifier (and so it stays vendor-header
-                    # classification, never a coincidental truthy object).
-                    raw_headers = getattr(nav_response, "headers", None)
-                    response_headers = (
-                        raw_headers if isinstance(raw_headers, dict) else {}
-                    )
-                    if status_code is not None:
-                        result["data"]["http_status"] = status_code
-                        hard_block = _classify_navigation_block(
-                            response_headers, status_code,
-                        )
-                # Record on the instance (even when None) so the next
-                # snapshot reflects the current page's block state.
-                inst.last_nav_hard_block = hard_block
+                # Truth-telling: the main-document status + hard-block were
+                # classified above (before title/captcha could throw or the
+                # solver could navigate away). If a captcha AUTO-SOLVED during
+                # this navigate, the page moved past the challenge, so the
+                # response-derived block no longer describes the current
+                # document — drop it. ``success`` stays True; the agent keys
+                # on ``hard_block`` (mirrors how a captcha is surfaced without
+                # failing the nav).
+                if envelope.get("solver_outcome") == "solved":
+                    status_code = None
+                    hard_block = None
+                    inst.last_nav_hard_block = None
+                if status_code is not None:
+                    result["data"]["http_status"] = status_code
                 if hard_block is not None:
                     result["hard_block"] = hard_block
                 snapshot_succeeded = False
@@ -6850,14 +6863,19 @@ class BrowserManager:
                     # "Post" button behind the compose modal).  A modal-
                     # scoped click that can't find the element will timeout
                     # rather than hit the wrong target.
+                    # Full accumulator reset, matching the retry branch above,
+                    # so the post-fallback _walk(tree) is the ONLY contributor.
+                    # Without clearing refs/ref_counter/admitted_total too, the
+                    # discarded modal-scoping pass would leave phantom refs in
+                    # ``refs`` (absent from the rendered ``lines``) and inflate
+                    # the shown/total truncation counts.
+                    refs.clear()
                     lines.clear()
-                    # Same reset rationale as the retry branch above —
-                    # discard fallback's parallel structures (entries
-                    # for v2 rendering, ref_summary for §7.3 diff
-                    # baseline) so the post-fallback _walk(tree) is
-                    # the only contributor.
                     entries.clear()
                     ref_summary.clear()
+                    ref_counter[0] = 0
+                    admitted_total[0] = 0
+                    occurrence_counts.clear()
                     lines.append(
                         "** A modal dialog is open but its elements could "
                         "not be isolated — elements with a (dialog: ...) "
@@ -12355,6 +12373,10 @@ class BrowserManager:
 
                 inst.page = new_page
                 inst.refs = {}  # Stale refs from previous tab's snapshot
+                # The hard-block signal is tied to the page navigate() last
+                # saw it on; a new tab has its own state, so clear it (else
+                # snapshot() would echo the previous tab's block on this one).
+                inst.last_nav_hard_block = None
                 inst.dialog_active = False
                 inst.dialog_detected = False
                 try:
@@ -12867,6 +12889,10 @@ class BrowserManager:
                 response = await inst.page.go_back(timeout=10000)
                 inst.dialog_active = False  # New page — stale modal state
                 inst.dialog_detected = False
+                # History nav lands on a different document; drop the stale
+                # per-page hard-block signal so snapshot() doesn't echo the
+                # previous page's block here.
+                inst.last_nav_hard_block = None
                 await asyncio.sleep(action_delay())
                 title = await inst.page.title()
                 url = self.redactor.redact(agent_id, inst.page.url)
@@ -12885,6 +12911,10 @@ class BrowserManager:
                 response = await inst.page.go_forward(timeout=10000)
                 inst.dialog_active = False  # New page — stale modal state
                 inst.dialog_detected = False
+                # History nav lands on a different document; drop the stale
+                # per-page hard-block signal so snapshot() doesn't echo the
+                # previous page's block here.
+                inst.last_nav_hard_block = None
                 await asyncio.sleep(action_delay())
                 title = await inst.page.title()
                 url = self.redactor.redact(agent_id, inst.page.url)
@@ -12936,6 +12966,10 @@ class BrowserManager:
                     inst.page = pages[tab_index]
                     await inst.page.bring_to_front()
                     inst.refs = {}  # Stale refs from previous tab's snapshot
+                    # Clear the per-page hard-block signal — this tab has its
+                    # own block state; navigate() will repopulate it. Without
+                    # this, snapshot() echoes the prior tab's block here.
+                    inst.last_nav_hard_block = None
                     inst.dialog_active = False  # New tab may not have a dialog
                     inst.dialog_detected = False
                     active_index = tab_index

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1035,6 +1035,15 @@ _HARD_BLOCK_HEADER_PROBES: tuple[tuple[str, str, "callable"], ...] = (
 )
 _HARD_BLOCK_STATUS_THRESHOLD = 400
 
+# Status codes that, on their own, mean "you were blocked / throttled"
+# rather than "page not found / server error". A bare bot wall often
+# returns a 403 (or 429/503 challenge) with NO vendor header, so the
+# status alone has to be enough to tell the agent the response it got
+# back is a wall, not the site's content. 404/410/500 are deliberately
+# absent — those are ordinary navigation failures, and flagging them as
+# blocks would train the agent to distrust normal misses.
+_BLOCK_STATUS_CODES: frozenset[int] = frozenset({401, 403, 407, 429, 451, 503})
+
 
 def _classify_hard_block(headers: dict[str, str], status: int) -> tuple[str, str] | None:
     """Return (vendor, header_or_status) when headers show an unambiguous block.
@@ -1059,6 +1068,43 @@ def _classify_hard_block(headers: dict[str, str], status: int) -> tuple[str, str
         except Exception:
             # A misshapen predicate must never block the response listener.
             continue
+    return None
+
+
+def _classify_navigation_block(
+    headers: dict[str, str], status: int,
+) -> dict | None:
+    """Return an agent-facing hard-block payload, or ``None`` for content.
+
+    Pure classification of a single (already-received) main-document
+    response. Two independent triggers:
+
+      * a known detection vendor fires an unambiguous block header
+        (delegated to :func:`_classify_hard_block`), or
+      * the status code is itself block-shaped (:data:`_BLOCK_STATUS_CODES`).
+
+    The vendor path is preferred when both fire because it names *who*
+    blocked us. The payload shape is agent-facing and stable::
+
+        {"status": int, "vendor": str | None,
+         "signal": str, "kind": "vendor_block" | "http_block"}
+    """
+    vendor_hit = _classify_hard_block(headers, status)
+    if vendor_hit is not None:
+        vendor, signal = vendor_hit
+        return {
+            "status": status,
+            "vendor": vendor,
+            "signal": signal,
+            "kind": "vendor_block",
+        }
+    if status in _BLOCK_STATUS_CODES:
+        return {
+            "status": status,
+            "vendor": None,
+            "signal": f"http_status={status}",
+            "kind": "http_block",
+        }
     return None
 
 
@@ -1494,6 +1540,12 @@ _FIREFOX_GRANTABLE_PERMISSIONS: frozenset[str] = frozenset({
 })
 
 _MAX_SNAPSHOT_ELEMENTS = 200
+# Hard ceiling on a caller-supplied ``max_elements`` override. A dense
+# page (feed, table, catalogue) can legitimately need more than the 200
+# default, but an unbounded cap would let one snapshot return tens of
+# thousands of refs — a token/latency footgun. 1000 covers real pages
+# while keeping the payload bounded.
+_MAX_SNAPSHOT_ELEMENTS_CEILING = 1000
 _MAX_WALK_DEPTH = 50
 
 _MAX_FRAME_NESTING = 3
@@ -1510,6 +1562,48 @@ _FRAME_ID_RE = re.compile(r"^f-[0-9a-f]{8}$")
 # punishing).
 _V2_MAX_INDENT_DEPTH = 4
 _V2_NO_LANDMARK_KEY = ""
+
+
+def _snapshot_truncation_fields(shown: int, total: int, cap: int) -> dict:
+    """Truncation metadata for a snapshot ``data`` payload.
+
+    Returns an EMPTY dict when nothing was dropped, so the common
+    (un-truncated) case adds no keys to the response and existing callers
+    see the historical shape. When elements were dropped past the cap it
+    reports the counts plus an actionable hint so the agent can recover
+    the rest instead of being confidently wrong about a dense page.
+    """
+    if total <= shown:
+        return {}
+    return {
+        "truncated": True,
+        "shown_elements": shown,
+        "total_elements": total,
+        "elements_omitted": total - shown,
+        "truncation_hint": (
+            f"{total - shown} more actionable element(s) exist past the "
+            f"{cap}-element snapshot cap and were NOT included. Re-request "
+            f"with a higher max_elements (up to "
+            f"{_MAX_SNAPSHOT_ELEMENTS_CEILING}), or narrow with "
+            f"filter= / from_ref= to bring the rest into view."
+        ),
+    }
+
+
+def _snapshot_truncation_notice(shown: int, total: int, cap: int) -> str:
+    """One-line, text-only truncation banner appended to the snapshot text.
+
+    Mirrors :func:`_snapshot_truncation_fields` for agents that read the
+    rendered ``snapshot`` string rather than the structured fields. Empty
+    when nothing was dropped.
+    """
+    if total <= shown:
+        return ""
+    return (
+        f"\n\n[snapshot truncated: showing {shown} of {total} elements "
+        f"(cap {cap}). {total - shown} not shown — re-request with a higher "
+        f"max_elements or narrow with filter= / from_ref=.]"
+    )
 
 
 def _format_snapshot_v2(
@@ -2916,6 +3010,13 @@ class CamoufoxInstance:
         # to True after the first navigate completes; subsequent navs may
         # use ``inst.page.url`` as the previous-URL hint.
         self.had_real_navigate: bool = False
+        # Truth-telling: the hard-block payload from the MOST RECENT
+        # navigate on this instance (``None`` when the last nav landed on
+        # ordinary content). Set by ``navigate`` on every nav and echoed
+        # by ``snapshot`` so a snapshot taken on an already-blocked page
+        # is reported as a block, not as content. Same shape as
+        # ``_classify_navigation_block``'s return.
+        self.last_nav_hard_block: dict | None = None
         # §6.3 navigator self-test result. ``None`` until the post-launch
         # probe runs. Populated dict (see ``BrowserManager._run_navigator_probe``)
         # exposes ``ok`` + ``mismatches`` + raw signal values for dashboard /
@@ -5674,9 +5775,13 @@ class BrowserManager:
                 goto_kwargs["referer"] = resolved_referer
 
             # Single retry on timeout — transient network issues get a second chance.
+            # Capture the main-document Response so we can surface its status
+            # and any hard-block signal to the agent (Playwright returns None
+            # only for same-document navigations, which a real ``goto`` isn't).
+            nav_response = None
             for attempt in range(2):
                 try:
-                    await inst.page.goto(url, **goto_kwargs)
+                    nav_response = await inst.page.goto(url, **goto_kwargs)
                     break
                 except Exception as e:
                     if attempt == 0 and "timeout" in str(e).lower():
@@ -5761,6 +5866,39 @@ class BrowserManager:
                     and envelope.get("solver_outcome") != "solved"
                 ):
                     result["captcha"] = _with_legacy_fields(envelope)
+                # Truth-telling: surface the main-document HTTP status and,
+                # when the response is block-shaped (403/429/503 or a vendor
+                # block header), an explicit ``hard_block`` signal. Without
+                # this a challenge/wall page is returned as ordinary "success"
+                # content and the agent acts on the wall as if it were the
+                # site. ``success`` stays True — the navigation mechanically
+                # completed; the agent keys on ``hard_block`` (mirrors how a
+                # captcha is surfaced without failing the nav).
+                status_code: int | None = None
+                hard_block: dict | None = None
+                if nav_response is not None:
+                    try:
+                        status_code = int(nav_response.status)
+                    except Exception:
+                        status_code = None
+                    # Playwright exposes ``headers`` as a plain dict property;
+                    # isinstance-guard it so a non-mapping value can never
+                    # reach the classifier (and so it stays vendor-header
+                    # classification, never a coincidental truthy object).
+                    raw_headers = getattr(nav_response, "headers", None)
+                    response_headers = (
+                        raw_headers if isinstance(raw_headers, dict) else {}
+                    )
+                    if status_code is not None:
+                        result["data"]["http_status"] = status_code
+                        hard_block = _classify_navigation_block(
+                            response_headers, status_code,
+                        )
+                # Record on the instance (even when None) so the next
+                # snapshot reflects the current page's block state.
+                inst.last_nav_hard_block = hard_block
+                if hard_block is not None:
+                    result["hard_block"] = hard_block
                 snapshot_succeeded = False
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
@@ -5821,6 +5959,7 @@ class BrowserManager:
         diff_from_last: bool = False,
         frame: str | None = None,
         include_frames: bool = True,
+        max_elements: int | None = None,
     ) -> dict:
         """Get accessibility tree with element refs.
 
@@ -5878,6 +6017,7 @@ class BrowserManager:
                 diff_from_last=diff_from_last,
                 frame=frame,
                 include_frames=include_frames,
+                max_elements=max_elements,
             )
             # §11.4 / §18.2 — surface and CLEAR any pending captcha
             # envelope captured by ``_with_captcha_redetect`` after a
@@ -5894,6 +6034,16 @@ class BrowserManager:
                 data = result.setdefault("data", {})
                 data.setdefault("captcha", pending)
                 inst._pending_captcha_envelope = None
+            # Truth-telling: echo the last navigation's hard-block state so a
+            # snapshot taken on an already-blocked page isn't reported as
+            # ordinary content. Set by ``navigate``; cleared to None on a
+            # clean nav. Top-level, mirroring the navigate result shape.
+            if (
+                inst.last_nav_hard_block
+                and isinstance(result, dict)
+                and result.get("success")
+            ):
+                result.setdefault("hard_block", inst.last_nav_hard_block)
             return result
 
     async def _snapshot_impl(
@@ -5906,8 +6056,21 @@ class BrowserManager:
         _skip_baseline: bool = False,
         frame: str | None = None,
         include_frames: bool = True,
+        max_elements: int | None = None,
     ) -> dict:
         """Snapshot implementation.  Caller must hold ``inst.lock``."""
+        # Resolve the element cap once. ``None`` ⇒ the 200 default; an
+        # override is clamped to [1, ceiling] so a caller can pull a dense
+        # page in one wider walk without letting one snapshot balloon.
+        if max_elements is None:
+            effective_max = _MAX_SNAPSHOT_ELEMENTS
+        else:
+            try:
+                effective_max = max(
+                    1, min(int(max_elements), _MAX_SNAPSHOT_ELEMENTS_CEILING),
+                )
+            except (TypeError, ValueError):
+                effective_max = _MAX_SNAPSHOT_ELEMENTS
         # Read BROWSER_SNAPSHOT_FORMAT exactly once at entry so a flag
         # flip mid-call (operator settings hot-reload, agent override
         # change racing the snapshot) cannot produce mixed v1/v2 output
@@ -6079,6 +6242,12 @@ class BrowserManager:
                 else None
             )
             ref_counter = [0]
+            # Counts EVERY admitted element, including those past the emit
+            # cap. ``ref_counter`` stops at ``effective_max`` (it gates
+            # emission); ``admitted_total`` keeps counting so we can tell the
+            # agent how many elements it did NOT see. Both reset together in
+            # the modal re-scope branch below.
+            admitted_total = [0]
             # Counts occurrences of each (role, name) pair so we can
             # disambiguate duplicate elements (e.g. X's two composer nodes).
             occurrence_counts: dict[tuple, int] = {}
@@ -6163,7 +6332,8 @@ class BrowserManager:
                 else:
                     is_admitted = role in allowed_roles
                 if is_admitted:
-                    if ref_counter[0] < _MAX_SNAPSHOT_ELEMENTS:
+                    admitted_total[0] += 1
+                    if ref_counter[0] < effective_max:
                         ref_id = f"e{ref_counter[0]}"
                         ref_counter[0] += 1
 
@@ -6541,13 +6711,24 @@ class BrowserManager:
                         "\n".join(lines) if lines else "(no interactive elements)"
                     )
                 snapshot_text = self.redactor.redact(agent_id, snapshot_text)
+                trunc = _snapshot_truncation_fields(
+                    ref_counter[0], admitted_total[0], effective_max,
+                )
+                if trunc:
+                    snapshot_text += _snapshot_truncation_notice(
+                        ref_counter[0], admitted_total[0], effective_max,
+                    )
                 inst.m_snapshot_bytes.append(len(snapshot_text))
                 response_refs = {
                     rid: h.to_agent_dict() for rid, h in refs.items()
                 }
                 return {
                     "success": True,
-                    "data": {"snapshot": snapshot_text, "refs": response_refs},
+                    "data": {
+                        "snapshot": snapshot_text,
+                        "refs": response_refs,
+                        **trunc,
+                    },
                 }
 
             # When a modal dialog is open, scope to only dialog elements
@@ -6633,6 +6814,7 @@ class BrowserManager:
                     # ``diff_from_last`` call reports phantom removals.
                     ref_summary.clear()
                     ref_counter[0] = 0
+                    admitted_total[0] = 0
                     occurrence_counts.clear()
                     lines.append("** Modal dialog is open — only dialog elements are shown **")
                     # Re-query modal elements — handles go stale when SPAs
@@ -6756,6 +6938,18 @@ class BrowserManager:
                     "\n".join(lines) if lines else "(no interactive elements)"
                 )
             snapshot_text = self.redactor.redact(agent_id, snapshot_text)
+            # Truth-telling: if the walk admitted more elements than the cap
+            # let us emit, tell the agent — in the rendered text AND as
+            # structured fields — instead of silently dropping them. Empty
+            # dict / "" when nothing was dropped, so the common case is
+            # unchanged. Shared by every return path below via ``trunc``.
+            trunc = _snapshot_truncation_fields(
+                ref_counter[0], admitted_total[0], effective_max,
+            )
+            if trunc:
+                snapshot_text += _snapshot_truncation_notice(
+                    ref_counter[0], admitted_total[0], effective_max,
+                )
             # Record snapshot byte size for §4.6 metrics. Collected per call;
             # drained as p50/p95 on the next minute tick.
             inst.m_snapshot_bytes.append(len(snapshot_text))
@@ -6818,6 +7012,7 @@ class BrowserManager:
                             "snapshot": snapshot_text,
                             "refs": response_refs,
                             "scope": "navigation",
+                            **trunc,
                         },
                     }
                 if previous_baseline is None:
@@ -6831,14 +7026,17 @@ class BrowserManager:
                             "snapshot": snapshot_text,
                             "refs": response_refs,
                             "scope": "navigation",
+                            **trunc,
                         },
                     }
                 diff = _compute_snapshot_diff(
                     previous_baseline["refs_by_key"], ref_summary,
                 )
+                # A truncated walk means the diff baseline is incomplete, so
+                # the delta may miss elements past the cap — flag it.
                 return {
                     "success": True,
-                    "data": {**diff, "scope": scope},
+                    "data": {**diff, "scope": scope, **trunc},
                 }
 
             # Either diff_from_last=False, or scope is navigation/tab_changed
@@ -6848,6 +7046,7 @@ class BrowserManager:
             data: dict = {"snapshot": snapshot_text, "refs": response_refs}
             if diff_from_last:
                 data["scope"] = scope
+            data.update(trunc)
             return {"success": True, "data": data}
         except Exception as e:
             # Match the §2.3 error envelope used by the new from_ref /

--- a/tests/test_browser_truthful.py
+++ b/tests/test_browser_truthful.py
@@ -57,12 +57,22 @@ class TestClassifyNavigationBlock:
             "kind": "http_block",
         }
 
-    @pytest.mark.parametrize("status", [401, 403, 407, 429, 451, 503])
+    @pytest.mark.parametrize("status", [401, 403, 407, 429, 451])
     def test_block_shaped_statuses_flagged(self, status):
         out = _classify_navigation_block({}, status)
         assert out is not None
         assert out["kind"] == "http_block"
         assert out["status"] == status
+
+    def test_bare_503_is_not_a_block_but_vendor_503_is(self):
+        # A bare 503 is ambiguous (maintenance / overload), so it is NOT a
+        # hard_block — only http_status is surfaced by the caller. A 503 that
+        # carries an anti-bot vendor header still classifies as a vendor_block.
+        assert _classify_navigation_block({}, 503) is None
+        vendor = _classify_navigation_block({"cf-mitigated": "block"}, 503)
+        assert vendor is not None
+        assert vendor["kind"] == "vendor_block"
+        assert vendor["vendor"] == "cloudflare"
 
     def test_cf_soft_challenge_still_http_block_by_status(self):
         # ``cf-mitigated: challenge`` is NOT a hard vendor block, but a 403
@@ -270,3 +280,31 @@ class TestSnapshotTruncation:
         # A snapshot taken while the page is a block must say so too.
         assert res["success"] is True
         assert res["hard_block"] == block
+
+    @pytest.mark.asyncio
+    async def test_switch_tab_clears_stale_hard_block(self):
+        # Regression: the block is per-page. Switching to another (clean)
+        # tab must clear last_nav_hard_block so snapshot() doesn't echo the
+        # previous tab's block on the new one (a truth-telling false positive).
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/s6")
+        clean = AsyncMock()
+        clean.url = "https://clean.example"
+        clean.title = AsyncMock(return_value="Clean")
+        clean.bring_to_front = AsyncMock()
+        blocked = AsyncMock()
+        blocked.url = "https://blocked.example"
+        blocked.title = AsyncMock(return_value="Blocked")
+        ctx = MagicMock()
+        ctx.pages = [clean, blocked]
+        inst = CamoufoxInstance("a1", MagicMock(), ctx, blocked)
+        inst.last_nav_hard_block = {
+            "status": 403, "vendor": None,
+            "signal": "http_status=403", "kind": "http_block",
+        }
+        mgr._instances["a1"] = inst
+
+        res = await mgr.switch_tab("a1", tab_index=0)
+
+        assert res["success"] is True
+        assert inst.page is clean
+        assert inst.last_nav_hard_block is None

--- a/tests/test_browser_truthful.py
+++ b/tests/test_browser_truthful.py
@@ -1,0 +1,272 @@
+"""Truth-telling for the agent browser.
+
+Two independent gaps closed here:
+
+1. ``navigate`` / ``snapshot`` never surfaced hard-block state, so a bare
+   403 / vendor-challenge page was returned as ordinary "success" content.
+2. The snapshot walk silently dropped every element past the 200-element
+   cap, so an agent was confidently wrong about dense pages.
+
+These tests pin the pure classifiers plus the navigate / snapshot
+integration surfaces. No Docker / live browser needed — the page is
+mocked, matching the harness in ``test_browser_service.py``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser.service import (
+    _MAX_SNAPSHOT_ELEMENTS,
+    _MAX_SNAPSHOT_ELEMENTS_CEILING,
+    BrowserManager,
+    CamoufoxInstance,
+    _classify_navigation_block,
+    _snapshot_truncation_fields,
+    _snapshot_truncation_notice,
+)
+
+_PROFILES_ROOT = "/tmp/ol_test_truthful"
+
+
+# ── Pure classifier: _classify_navigation_block ──────────────────────────
+
+class TestClassifyNavigationBlock:
+    def test_cloudflare_hard_block_on_403(self):
+        out = _classify_navigation_block({"cf-mitigated": "block"}, 403)
+        assert out == {
+            "status": 403,
+            "vendor": "cloudflare",
+            "signal": "cf-mitigated=block",
+            "kind": "vendor_block",
+        }
+
+    def test_datadome_protected_is_vendor_block(self):
+        out = _classify_navigation_block({"x-datadome": "protected"}, 403)
+        assert out is not None
+        assert out["vendor"] == "datadome"
+        assert out["kind"] == "vendor_block"
+
+    def test_bare_403_no_vendor_header_is_http_block(self):
+        out = _classify_navigation_block({}, 403)
+        assert out == {
+            "status": 403,
+            "vendor": None,
+            "signal": "http_status=403",
+            "kind": "http_block",
+        }
+
+    @pytest.mark.parametrize("status", [401, 403, 407, 429, 451, 503])
+    def test_block_shaped_statuses_flagged(self, status):
+        out = _classify_navigation_block({}, status)
+        assert out is not None
+        assert out["kind"] == "http_block"
+        assert out["status"] == status
+
+    def test_cf_soft_challenge_still_http_block_by_status(self):
+        # ``cf-mitigated: challenge`` is NOT a hard vendor block, but a 403
+        # is block-shaped on its own, so the agent must still be told.
+        out = _classify_navigation_block({"cf-mitigated": "challenge"}, 403)
+        assert out is not None
+        assert out["kind"] == "http_block"
+        assert out["vendor"] is None
+
+    @pytest.mark.parametrize("status", [200, 204, 301, 302, 404, 410, 500])
+    def test_content_and_ordinary_failures_not_flagged(self, status):
+        # 404/410/500 are "not found" / "server error", not anti-bot walls.
+        assert _classify_navigation_block({}, status) is None
+
+    def test_vendor_header_on_200_is_not_a_block(self):
+        # Vendor block headers can ride accepted-but-watched 200 responses;
+        # the status floor keeps us from burning on those.
+        assert _classify_navigation_block({"cf-mitigated": "block"}, 200) is None
+
+
+# ── Pure helpers: truncation fields + notice ─────────────────────────────
+
+class TestTruncationHelpers:
+    def test_not_truncated_returns_empty(self):
+        assert _snapshot_truncation_fields(shown=50, total=50, cap=200) == {}
+        assert _snapshot_truncation_notice(shown=50, total=50, cap=200) == ""
+
+    def test_truncated_reports_counts_and_hint(self):
+        fields = _snapshot_truncation_fields(shown=200, total=340, cap=200)
+        assert fields["truncated"] is True
+        assert fields["shown_elements"] == 200
+        assert fields["total_elements"] == 340
+        assert fields["elements_omitted"] == 140
+        assert "max_elements" in fields["truncation_hint"]
+        assert str(_MAX_SNAPSHOT_ELEMENTS_CEILING) in fields["truncation_hint"]
+
+    def test_notice_mentions_the_shortfall(self):
+        notice = _snapshot_truncation_notice(shown=200, total=340, cap=200)
+        assert "showing 200 of 340" in notice
+        assert "140 not shown" in notice
+
+
+# ── navigate() hard-block surfacing ──────────────────────────────────────
+
+def _nav_page(status, headers):
+    """A mock page whose goto returns a real Response-shaped stub."""
+    page = AsyncMock()
+    page.goto = AsyncMock(
+        return_value=SimpleNamespace(status=status, headers=dict(headers)),
+    )
+    page.title = AsyncMock(return_value="Title")
+    page.url = "https://example.com"
+    page.evaluate = AsyncMock(return_value="page text")
+    return page
+
+
+class TestNavigateHardBlock:
+    @pytest.mark.asyncio
+    async def test_bare_403_surfaces_http_block(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/p1")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _nav_page(403, {}))
+        mgr._instances["a1"] = inst
+
+        res = await mgr.navigate("a1", "https://example.com", wait_ms=0)
+
+        # success stays True — the nav mechanically completed — but the
+        # block is now explicit rather than masquerading as content.
+        assert res["success"] is True
+        assert res["data"]["http_status"] == 403
+        assert res["hard_block"]["kind"] == "http_block"
+        assert res["hard_block"]["status"] == 403
+        assert inst.last_nav_hard_block == res["hard_block"]
+
+    @pytest.mark.asyncio
+    async def test_vendor_block_names_the_vendor(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/p2")
+        page = _nav_page(403, {"cf-mitigated": "block"})
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page)
+        mgr._instances["a1"] = inst
+
+        res = await mgr.navigate("a1", "https://example.com", wait_ms=0)
+
+        assert res["hard_block"]["kind"] == "vendor_block"
+        assert res["hard_block"]["vendor"] == "cloudflare"
+
+    @pytest.mark.asyncio
+    async def test_clean_200_has_status_but_no_block(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/p3")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _nav_page(200, {}))
+        mgr._instances["a1"] = inst
+
+        res = await mgr.navigate("a1", "https://example.com", wait_ms=0)
+
+        assert res["success"] is True
+        assert res["data"]["http_status"] == 200
+        assert "hard_block" not in res
+        assert inst.last_nav_hard_block is None
+
+    @pytest.mark.asyncio
+    async def test_clean_nav_clears_prior_block(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/p4")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _nav_page(200, {}))
+        # Pretend a previous nav had been blocked.
+        inst.last_nav_hard_block = {
+            "status": 403, "vendor": None,
+            "signal": "http_status=403", "kind": "http_block",
+        }
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate("a1", "https://example.com", wait_ms=0)
+
+        assert inst.last_nav_hard_block is None
+
+
+# ── snapshot() truncation + hard-block echo ──────────────────────────────
+
+def _snapshot_page(n_buttons):
+    tree = {
+        "role": "WebArea", "name": "",
+        "children": [
+            {"role": "button", "name": f"Btn {i}"} for i in range(n_buttons)
+        ],
+    }
+    page = AsyncMock()
+    page.url = "https://example.com"
+    page.evaluate = AsyncMock(return_value=tree)
+    page.query_selector_all = AsyncMock(return_value=[])
+    page.viewport_size = {"width": 1280, "height": 800}
+    page.accessibility = MagicMock()
+    page.accessibility.snapshot = AsyncMock(return_value=tree)
+    return page
+
+
+class TestSnapshotTruncation:
+    @pytest.mark.asyncio
+    async def test_dense_page_reports_truncation(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/s1")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _snapshot_page(250))
+        mgr._instances["a1"] = inst
+
+        res = await mgr.snapshot("a1", include_frames=False)
+        data = res["data"]
+
+        assert data["truncated"] is True
+        assert data["shown_elements"] == _MAX_SNAPSHOT_ELEMENTS
+        assert data["total_elements"] >= 250
+        assert data["elements_omitted"] == data["total_elements"] - _MAX_SNAPSHOT_ELEMENTS
+        assert len(data["refs"]) == _MAX_SNAPSHOT_ELEMENTS
+        assert "truncated: showing 200 of" in data["snapshot"]
+
+    @pytest.mark.asyncio
+    async def test_max_elements_override_pulls_more(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/s2")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _snapshot_page(250))
+        mgr._instances["a1"] = inst
+
+        res = await mgr.snapshot("a1", include_frames=False, max_elements=300)
+        data = res["data"]
+
+        assert "truncated" not in data
+        assert len(data["refs"]) >= 250
+
+    @pytest.mark.asyncio
+    async def test_max_elements_clamped_to_ceiling(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/s3")
+        inst = CamoufoxInstance(
+            "a1", MagicMock(), MagicMock(),
+            _snapshot_page(_MAX_SNAPSHOT_ELEMENTS_CEILING + 50),
+        )
+        mgr._instances["a1"] = inst
+
+        # Ask for way more than the ceiling — the effective cap is clamped.
+        res = await mgr.snapshot("a1", include_frames=False, max_elements=99999)
+        data = res["data"]
+
+        assert data["truncated"] is True
+        assert data["shown_elements"] == _MAX_SNAPSHOT_ELEMENTS_CEILING
+        assert len(data["refs"]) == _MAX_SNAPSHOT_ELEMENTS_CEILING
+
+    @pytest.mark.asyncio
+    async def test_small_page_not_truncated(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/s4")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _snapshot_page(5))
+        mgr._instances["a1"] = inst
+
+        res = await mgr.snapshot("a1", include_frames=False)
+        data = res["data"]
+
+        assert "truncated" not in data
+        assert "truncated: showing" not in data["snapshot"]
+
+    @pytest.mark.asyncio
+    async def test_snapshot_echoes_prior_nav_block(self):
+        mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/s5")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), _snapshot_page(3))
+        block = {
+            "status": 403, "vendor": "datadome",
+            "signal": "x-datadome=protected", "kind": "vendor_block",
+        }
+        inst.last_nav_hard_block = block
+        mgr._instances["a1"] = inst
+
+        res = await mgr.snapshot("a1", include_frames=False)
+
+        # A snapshot taken while the page is a block must say so too.
+        assert res["success"] is True
+        assert res["hard_block"] == block


### PR DESCRIPTION
## Why

Roadmap item 1 (truth-telling) from `docs/plans/2026-07-02-stealth-browser-human-parity.md`. An end-to-end trace found the agent browser can be **confidently wrong** in two ways that have nothing to do with stealth — the browser knows the truth but never hands it to the acting agent:

1. **A hard block is returned as success content.** `navigate()` discarded the `page.goto()` `Response` and always returned `success: true` with body/snapshot text. A `403/429/503` challenge — or a vendor block (Cloudflare / DataDome / PerimeterX / Akamai) — came back looking like the site. The only block signal (`_record_response_for_burn` flipping internal fingerprint state) reached the agent solely through the captcha envelope and the dashboard health payload, **never in the navigate/snapshot result the agent reads.**

2. **Snapshot silently drops elements past the 200 cap.** The walk stopped emitting refs at `_MAX_SNAPSHOT_ELEMENTS` with no signal, so on a dense page (feed, table, catalogue) the agent believed it had seen everything.

## What changed

**Part A — hard-block surfacing** (`service.py`)
- New `_BLOCK_STATUS_CODES {401,403,407,429,451,503}` + `_classify_navigation_block()` (wraps the existing vendor probes; adds bare-status detection — a wall's 403 has no vendor header).
- `navigate()` captures the main-document response, always adds `http_status` to the result, and attaches a top-level `hard_block = {status, vendor, signal, kind}` when block-shaped. **`success` stays `true`** — the nav mechanically completed and the agent keys on `hard_block`, mirroring how a captcha is surfaced without failing the nav.
- The block is recorded on the instance (`last_nav_hard_block`) and echoed by `snapshot()`, so a snapshot on an already-blocked page is truthful too. Cleared on a clean nav.

**Part B — snapshot truncation** (`service.py` + `server.py` + `browser_tool.py`)
- The walk now counts **every** admitted element and reports `truncated` / `shown_elements` / `total_elements` / `elements_omitted` + a one-line notice in the snapshot text.
- New `max_elements` param (clamped to a **1000** ceiling) lets an agent pull a dense page in one wider walk. Threaded agent tool → mesh (forwarded verbatim) → browser service. **No new browser action** (`snapshot` already exists), so no permission / action-list / gate-list changes.

**Deferred (noted):** true offset-based pagination (page-2 refs `e200..e399`) needs occurrence-window correctness in the walk — a heavier change. The `truncated` flag + `max_elements` already remove the "confidently wrong" failure; offset pagination is a clean follow-up only if 1000 isn't enough for real pages.

## Testing

- New `tests/test_browser_truthful.py` (30 tests): pure classifiers (block-shaped statuses flagged; 200/301/404/410/500 not; vendor-on-200 respects the status floor; CF soft-challenge still HTTP-block by status), truncation helpers, `navigate()` hard-block surfacing + vendor naming + clean-nav clears prior block, snapshot truncation + `max_elements` override + ceiling clamp + prior-nav-block echo.
- Full browser suite green (`test_browser_service`, `test_builtins`, `test_browser_fill_form`, `test_browser_metrics`) — **828 passed, 7 skipped, 0 failed**; also clean under `-W error::RuntimeWarning`. No regressions.
- `uvx ruff@latest` clean. No `Dockerfile.browser` / `pyproject.toml` changes → no build-and-smoke.

## Deploy note

Behavior is agent-visible via new result fields; no config or migration. Orthogonal to the in-flight Teams/Threads/Drive overhaul (touches only `src/browser/service.py`, `src/browser/server.py`, `src/agent/builtins/browser_tool.py`).
