### PR TITLE
feat(browser): in-house DataDome image-slider captcha detect + solve (default-off)

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1487,17 +1487,36 @@ _SLIDER_PROBE_JS = r"""
 """
 
 
-# Selectors that mark the SOLVABLE slider control inside the puzzle frame.
-# DataDome obfuscates class names, so these are best-effort structural
-# guesses (the draggable handle + its track). If the class-name heuristics
-# ever stop matching, ``_classify_slider`` returns None and the caller
+# Shared selector tuples for the SOLVABLE slider — the SINGLE source used by
+# BOTH the classifier (``_classify_slider``, presence detection) and the
+# service-side solver (``_solve_slider``, element resolution) so the two can
+# never drift apart. DataDome obfuscates class names, so these are
+# best-effort structural guesses; a miss returns None and the caller
 # escalates — never a false ``solved``.
+#
+# ``_SLIDER_HANDLE_SELECTORS`` is ordered SPECIFIC → BROAD: semantic handle
+# markers (role / draggable / aria-label) first, class globs last. The broad
+# ``[class*="slider"]`` deliberately comes last because it also matches the
+# ``sliderContainer`` wrapper; the specific selectors win when present.
+# ``[class*="puzzle"]`` is intentionally NOT in the handle list — it belongs
+# to the background raster and would let the solver pick the same element as
+# both CV target and drag handle.
 _SLIDER_HANDLE_SELECTORS: tuple[str, ...] = (
-    '[class*="slider"]',
-    '[class*="sliderContainer"]',
-    '[class*="slide-button"]',
+    '[role="slider"]',
+    '[draggable="true"]',
     '[aria-label*="slider" i]',
+    '[class*="slide-button"]',
+    '[class*="slider"]',
+)
+
+# ``_SLIDER_BG_SELECTORS`` targets the puzzle RASTER we run CV over. ``canvas``
+# / ``img`` first (the actual image surface), class globs after.
+_SLIDER_BG_SELECTORS: tuple[str, ...] = (
+    "canvas",
     '[class*="puzzle"]',
+    '[class*="background"]',
+    '[class*="captcha__image"]',
+    "img",
 )
 
 

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1449,6 +1449,119 @@ async def _classify_behavioral(page) -> str | None:
     return None
 
 
+# ── §11.5 DataDome SOLVABLE image-slider classifier ───────────────────────
+#
+# DataDome serves TWO distinct challenges from ``captcha-delivery.com``:
+#   * the ``/blocker`` behavioral wall — no draggable widget, only a
+#     fingerprint verdict. Caught by ``_classify_behavioral`` above and
+#     kept as ``datadome-behavioral`` (escalate to a human). Do NOT relabel.
+#   * the image-slider puzzle — a piece the user drags into a notch. This
+#     one is solvable in-house via the trusted X11 drag, so it earns its
+#     own kind ``datadome-slider`` and a solve dispatch in the service.
+#
+# The top-page ``page.evaluate`` probe can only read the iframe ELEMENT's
+# ``src`` (the frame CONTENT is cross-origin), which is enough to tell the
+# ``/blocker`` wall apart from the puzzle host. To positively confirm the
+# draggable slider handle we then pierce the cross-origin frame with
+# Playwright's frame API (``page.frames`` → ``frame.query_selector``).
+
+_SLIDER_PROBE_JS = r"""
+() => {
+  const out = { dd_iframe: false, dd_blocker: false };
+  try {
+    // The iframe element lives in the TOP document; its ``src`` attribute
+    // is readable even though the framed document is cross-origin.
+    const dd = document.querySelectorAll(
+      'iframe[src*="captcha-delivery.com"]'
+    );
+    if (dd.length > 0) out.dd_iframe = true;
+    // Flag the behavioral ``/blocker`` wall so the caller can exclude it —
+    // that path stays ``datadome-behavioral``.
+    const blocker = document.querySelectorAll(
+      'iframe[src*="captcha-delivery.com/blocker"]'
+    );
+    if (blocker.length > 0) out.dd_blocker = true;
+  } catch (e) { /* defensive */ }
+  return out;
+}
+"""
+
+
+# Selectors that mark the SOLVABLE slider control inside the puzzle frame.
+# DataDome obfuscates class names, so these are best-effort structural
+# guesses (the draggable handle + its track). If the class-name heuristics
+# ever stop matching, ``_classify_slider`` returns None and the caller
+# escalates — never a false ``solved``.
+_SLIDER_HANDLE_SELECTORS: tuple[str, ...] = (
+    '[class*="slider"]',
+    '[class*="sliderContainer"]',
+    '[class*="slide-button"]',
+    '[aria-label*="slider" i]',
+    '[class*="puzzle"]',
+)
+
+
+def _datadome_slider_frame(page):
+    """Return the first ``captcha-delivery.com`` puzzle frame, or None.
+
+    Excludes the ``/blocker`` behavioral wall (which shares the host).
+    Never raises — best-effort frame discovery for both the classifier and
+    the in-house solver.
+    """
+    try:
+        frames = page.frames
+    except Exception:
+        return None
+    if not frames:
+        return None
+    for frame in frames:
+        try:
+            url = frame.url or ""
+        except Exception:
+            continue
+        if "captcha-delivery.com" in url and "/blocker" not in url:
+            return frame
+    return None
+
+
+async def _classify_slider(page) -> str | None:
+    """Positively detect the SOLVABLE DataDome image-slider puzzle.
+
+    Returns ``"datadome-slider"`` when a draggable slider handle is present
+    inside a ``captcha-delivery.com`` frame that is NOT the behavioral
+    ``/blocker`` wall; otherwise ``None``. Never raises.
+
+    This fills the §11.5 deferred hook that ``_classify_behavioral``'s
+    docstring points at: the behavioral classifier deliberately matches
+    ONLY ``/blocker`` and routes the solvable slider here.
+    """
+    try:
+        probe = await page.evaluate(_SLIDER_PROBE_JS)
+    except Exception:
+        logger.debug("_classify_slider: page.evaluate failed", exc_info=True)
+        return None
+    if not isinstance(probe, dict):
+        return None
+    # The ``/blocker`` wall is behavioral-only — never claim it as solvable.
+    if probe.get("dd_blocker"):
+        return None
+    if not probe.get("dd_iframe"):
+        return None
+    # Confirm the draggable handle lives inside the cross-origin puzzle
+    # frame via Playwright's frame API (top-page JS cannot see into it).
+    frame = _datadome_slider_frame(page)
+    if frame is None:
+        return None
+    for sel in _SLIDER_HANDLE_SELECTORS:
+        try:
+            handle = await frame.query_selector(sel)
+        except Exception:
+            continue
+        if handle is not None:
+            return "datadome-slider"
+    return None
+
+
 class CaptchaSolver:
     """Async CAPTCHA solver using 2Captcha or CapSolver HTTP APIs."""
 

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -134,6 +134,15 @@ KNOWN_FLAGS: dict[str, str] = {
     "CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH": "per-agent USD cap",
     "CAPTCHA_COST_LIMIT_USD_PER_TENANT_MONTH": "per-tenant USD cap",
     "CAPTCHA_DISABLED": "true | false (default false)",
+    "CAPTCHA_INHOUSE_SLIDER_ENABLED":
+        "true | false (DEFAULT FALSE) — opt-in in-house solve of the "
+        "DataDome image-slider puzzle (§11.5). When enabled AND the trusted "
+        "X11 input path is available, the service detects the solvable "
+        "slider, computes the gap offset via pure CV, and drives the "
+        "existing human-like X11 drag — no provider, no cost. Every failure "
+        "path (flag off, no X11, low confidence, exception) falls through to "
+        "the same request_captcha_help escalation as the behavioral kinds, "
+        "so flag-off behavior is byte-for-byte unchanged.",
     "CAPTCHA_SOLVER_PROXY_TYPE": "http | https | socks4 | socks5",
     "CAPTCHA_SOLVER_PROXY_ADDRESS": "dedicated solver proxy host",
     "CAPTCHA_SOLVER_PROXY_PORT": "int",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -32,6 +32,9 @@ from urllib.parse import urlparse
 from src.browser import captcha_policy
 from src.browser.captcha import (
     _ANTIBOT_KINDS,
+    _SLIDER_BG_SELECTORS,
+    _SLIDER_HANDLE_SELECTORS,
+    _SLIDER_PROBE_JS,
     SolveResult,
     _classify_behavioral,
     _classify_cf_state,
@@ -10166,11 +10169,13 @@ class BrowserManager:
              which DataDome reads as a bot — worse than escalating.
 
         Pipeline: locate the puzzle frame → grab the background raster + the
-        drag handle → CV the gap offset (``compute_slider_offset``) → drive
-        the trusted human-like ``_x11_drag`` → re-probe. Success is decided
-        by re-classification (the solvable slider is gone), NOT by the CV
-        confidence alone — a correct offset can still be rejected because
-        DataDome binds success to behavioral telemetry.
+        drag handle → CV the gap offset (``compute_slider_offset``, run off
+        the event loop) → drive the trusted human-like ``_x11_drag`` →
+        re-probe. Success requires POSITIVE confirmation the DataDome iframe
+        is gone (a successful probe reporting no iframe), NOT merely a null
+        classification — a transient probe failure must NOT read as solved,
+        and a correct offset can still be rejected because DataDome binds
+        success to behavioral telemetry.
 
         There is NO provider cost, so this deliberately bypasses the
         ``_metered_solve`` / cost-counter / circuit-breaker gate stack.
@@ -10191,27 +10196,12 @@ class BrowserManager:
             if frame is None:
                 return None
 
-            # Best-effort structural selectors for the puzzle background (the
-            # CV target) and the draggable handle, both inside the
-            # cross-origin ``captcha-delivery.com`` frame. DataDome
-            # obfuscates class names; a miss returns None and escalates
-            # (never a false "solved"). GeeTest/canvas + FunCaptcha are out
-            # of scope — they need ``toDataURL`` extraction.  # deferred
-            bg_selectors = (
-                "canvas",
-                '[class*="puzzle"]',
-                '[class*="background"]',
-                '[class*="captcha__image"]',
-                "img",
-            )
-            handle_selectors = (
-                '[class*="slider"]',
-                '[class*="sliderContainer"]',
-                '[class*="slide-button"]',
-                '[aria-label*="slider" i]',
-                '[class*="puzzle"]',
-            )
-
+            # Resolve the puzzle background (CV target) + the draggable handle
+            # inside the cross-origin ``captcha-delivery.com`` frame from the
+            # SHARED selector tuples (``captcha.py`` is the single source, so
+            # the classifier and solver can't drift). A miss returns None and
+            # escalates (never a false "solved"). GeeTest/canvas + FunCaptcha
+            # are out of scope — they need ``toDataURL`` extraction. # deferred
             async def _first(selectors: tuple[str, ...]):
                 for sel in selectors:
                     try:
@@ -10222,8 +10212,8 @@ class BrowserManager:
                         return el
                 return None
 
-            bg_el = await _first(bg_selectors)
-            handle_el = await _first(handle_selectors)
+            bg_el = await _first(_SLIDER_BG_SELECTORS)
+            handle_el = await _first(_SLIDER_HANDLE_SELECTORS)
             if bg_el is None or handle_el is None:
                 return None
 
@@ -10232,13 +10222,27 @@ class BrowserManager:
             if not bg_box or not handle_box:
                 return None
 
+            # Guard: the broad selectors can resolve the SAME element as both
+            # background and handle (coincident boxes). Dragging a handle
+            # onto itself is a no-op scored as an attempt — escalate instead.
+            if (
+                abs(bg_box["x"] - handle_box["x"]) < 0.5
+                and abs(bg_box["y"] - handle_box["y"]) < 0.5
+                and abs(bg_box["width"] - handle_box["width"]) < 0.5
+                and abs(bg_box["height"] - handle_box["height"]) < 0.5
+            ):
+                return None
+
             bg_bytes = await bg_el.screenshot()
             if not bg_bytes:
                 return None
 
             from src.browser.slider_solver import compute_slider_offset
 
-            res = compute_slider_offset(bg_bytes)
+            # Run the CPU-bound CV OFF the shared asyncio loop — a broad ``img``
+            # / ``canvas`` match could be a large screenshot, and the O(w·h)
+            # scan would otherwise stall every other agent on this service.
+            res = await asyncio.to_thread(compute_slider_offset, bg_bytes)
             if res is None:
                 return None
             gap_fraction, conf = res
@@ -10262,6 +10266,10 @@ class BrowserManager:
             # Can't drag left; clamp inside the background's width.
             max_delta = max(0.0, bg_box["width"] - 1.0)
             delta = min(max(delta, 0.0), max_delta)
+            # A ~zero delta would be a no-op drag scored as an attempt —
+            # escalate rather than pretend we tried.
+            if delta < 2.0:
+                return None
             end_x = hx + delta
             end_y = hy
 
@@ -10271,11 +10279,23 @@ class BrowserManager:
             # Let DataDome validate the drag + the page settle.
             await asyncio.sleep(1.0)
 
-            # Success = the solvable slider is no longer classifiable. A
-            # geometrically-correct offset can still be rejected, so we
-            # confirm via re-probe rather than trusting the CV verdict.
-            still = await _classify_slider(inst.page)
-            if still is not None:
+            # Success requires POSITIVE confirmation the slider is GONE — not
+            # merely the absence of a classification. ``_classify_slider``
+            # returns None for BOTH "solved" AND "probe failed / frame
+            # detached / evaluate raised", so reusing it here would turn a
+            # transient post-drag probe failure into a FALSE "solved". Instead
+            # re-run the top-page probe directly: solved ONLY when the
+            # evaluate SUCCEEDS and reports no DataDome iframe. Any exception
+            # / non-dict / still-present result ⇒ None (escalate).
+            try:
+                reprobe = await inst.page.evaluate(_SLIDER_PROBE_JS)
+            except Exception:
+                logger.debug(
+                    "_solve_slider: post-drag re-probe raised; escalating",
+                    exc_info=True,
+                )
+                return None
+            if not isinstance(reprobe, dict) or reprobe.get("dd_iframe"):
                 return None
 
             await _record_captcha_audit_event(
@@ -10549,23 +10569,36 @@ class BrowserManager:
                                     next_action="request_captcha_help",
                                 )
 
-                    # §11.5 — DataDome SOLVABLE image-slider puzzle. Runs
-                    # AFTER the behavioral pass so the ``/blocker`` wall is
-                    # already claimed as ``datadome-behavioral`` above and
+                    # §11.5 — DataDome SOLVABLE image-slider puzzle. The
+                    # ENTIRE branch is gated behind the DEFAULT-OFF
+                    # ``CAPTCHA_INHOUSE_SLIDER_ENABLED`` flag so flag-off is
+                    # fully INERT: no ``datadome-slider`` classification, no
+                    # ``skipped_behavioral`` audit, no early return — control
+                    # flows through to the pre-existing CF / site-policy /
+                    # generic-solver path EXACTLY as before this feature. The
+                    # flag check must precede ``_classify_slider`` for that.
+                    #
+                    # Runs AFTER the behavioral pass so the ``/blocker`` wall
+                    # is already claimed as ``datadome-behavioral`` above and
                     # never reaches here (invariant: ``/blocker`` stays
                     # behavioral). Only the solvable puzzle — a
                     # ``captcha-delivery.com`` frame WITHOUT ``/blocker`` and
                     # WITH a draggable handle — is classified here.
                     #
-                    # ``_solve_slider`` is fully gated on a DEFAULT-OFF flag
+                    # ``_solve_slider`` is independently gated on the same flag
                     # AND the trusted X11 input path; it returns a solved
                     # envelope on success or ``None`` to mean "not solved —
-                    # escalate". When it returns ``None`` (flag off / no X11 /
-                    # low CV confidence / any failure) we fall through to the
-                    # SAME ``request_captcha_help`` escalation the behavioral
-                    # kinds use, so flag-off behavior is byte-for-byte the
-                    # current escalate-to-human path.
-                    if not antibot_force_low_confidence:
+                    # escalate". When it returns ``None`` (no X11 / low CV
+                    # confidence / any failure) we escalate via the SAME
+                    # ``request_captcha_help`` shape the behavioral kinds use.
+                    from src.browser.flags import get_bool as _get_bool
+                    if (
+                        not antibot_force_low_confidence
+                        and _get_bool(
+                            "CAPTCHA_INHOUSE_SLIDER_ENABLED", False,
+                            agent_id=inst.agent_id,
+                        )
+                    ):
                         slider_kind = await _classify_slider(inst.page)
                         if slider_kind:
                             try:
@@ -10577,9 +10610,8 @@ class BrowserManager:
                                 return solved
                             logger.info(
                                 "DataDome solvable slider detected but not "
-                                "solved in-house (flag off / no X11 / low "
-                                "confidence / failure); escalating to "
-                                "request_captcha_help",
+                                "solved in-house (no X11 / low confidence / "
+                                "failure); escalating to request_captcha_help",
                             )
                             await _record_captcha_audit_event(
                                 inst.agent_id, "skipped_behavioral",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -36,6 +36,8 @@ from src.browser.captcha import (
     _classify_behavioral,
     _classify_cf_state,
     _classify_recaptcha,
+    _classify_slider,
+    _datadome_slider_frame,
     _redact_clientkey_text,
     get_solver,
 )
@@ -236,6 +238,12 @@ _VALID_CAPTCHA_KINDS: frozenset[str] = frozenset({
     "cf-interstitial-auto", "cf-interstitial-behavioral",
     "cf-interstitial-turnstile",
     "px-press-hold", "datadome-behavioral",
+    # §11.5 — DataDome SOLVABLE image-slider. Detected + solved in-house
+    # via the trusted X11 drag (no provider cost). NOT behavioral: it is
+    # deliberately absent from ``_BEHAVIORAL_KINDS`` because it CAN be
+    # solved. A solvable slider that isn't solved escalates like a
+    # behavioral kind, but the kind itself stays solver-attemptable.
+    "datadome-slider",
     # §19 — tier-1 anti-bot JS-challenge frameworks. Detection-only;
     # never solver-attempted. Caller routes to ``request_captcha_help``
     # for operator intervention via the VNC handoff.
@@ -10139,6 +10147,156 @@ class BrowserManager:
             lambda t, _inst=inst: _inst._fingerprint_monitor_tasks.discard(t),
         )
 
+    async def _solve_slider(
+        self, inst: CamoufoxInstance, page_url: str,
+    ) -> dict | None:
+        """In-house solve of the DataDome image-slider puzzle (§11.5).
+
+        Returns a SOLVED :func:`_captcha_envelope` on confirmed success, or
+        ``None`` to mean "I did not solve — caller should escalate to
+        ``request_captcha_help``". NEVER raises: any exception is swallowed
+        and reported as ``None`` so ``_check_captcha`` falls through to the
+        identical human-escalation path.
+
+        Fully gated:
+          1. ``CAPTCHA_INHOUSE_SLIDER_ENABLED`` — DEFAULT OFF. Off ⇒ ``None``
+             immediately ⇒ behavior is byte-for-byte the current escalate.
+          2. Trusted X11 input path (``inst.x11_wid`` + ``_is_x11_site``).
+             Without it, dragging would go via CDP (``isTrusted=false``),
+             which DataDome reads as a bot — worse than escalating.
+
+        Pipeline: locate the puzzle frame → grab the background raster + the
+        drag handle → CV the gap offset (``compute_slider_offset``) → drive
+        the trusted human-like ``_x11_drag`` → re-probe. Success is decided
+        by re-classification (the solvable slider is gone), NOT by the CV
+        confidence alone — a correct offset can still be rejected because
+        DataDome binds success to behavioral telemetry.
+
+        There is NO provider cost, so this deliberately bypasses the
+        ``_metered_solve`` / cost-counter / circuit-breaker gate stack.
+        """
+        try:
+            from src.browser.flags import get_bool
+
+            # Gate 1 — DEFAULT-OFF flag.
+            if not get_bool(
+                "CAPTCHA_INHOUSE_SLIDER_ENABLED", False, agent_id=inst.agent_id,
+            ):
+                return None
+            # Gate 2 — trusted X11 input path.
+            if not (getattr(inst, "x11_wid", None) and self._is_x11_site(inst)):
+                return None
+
+            frame = _datadome_slider_frame(inst.page)
+            if frame is None:
+                return None
+
+            # Best-effort structural selectors for the puzzle background (the
+            # CV target) and the draggable handle, both inside the
+            # cross-origin ``captcha-delivery.com`` frame. DataDome
+            # obfuscates class names; a miss returns None and escalates
+            # (never a false "solved"). GeeTest/canvas + FunCaptcha are out
+            # of scope — they need ``toDataURL`` extraction.  # deferred
+            bg_selectors = (
+                "canvas",
+                '[class*="puzzle"]',
+                '[class*="background"]',
+                '[class*="captcha__image"]',
+                "img",
+            )
+            handle_selectors = (
+                '[class*="slider"]',
+                '[class*="sliderContainer"]',
+                '[class*="slide-button"]',
+                '[aria-label*="slider" i]',
+                '[class*="puzzle"]',
+            )
+
+            async def _first(selectors: tuple[str, ...]):
+                for sel in selectors:
+                    try:
+                        el = await frame.query_selector(sel)
+                    except Exception:
+                        continue
+                    if el is not None:
+                        return el
+                return None
+
+            bg_el = await _first(bg_selectors)
+            handle_el = await _first(handle_selectors)
+            if bg_el is None or handle_el is None:
+                return None
+
+            bg_box = await bg_el.bounding_box()
+            handle_box = await handle_el.bounding_box()
+            if not bg_box or not handle_box:
+                return None
+
+            bg_bytes = await bg_el.screenshot()
+            if not bg_bytes:
+                return None
+
+            from src.browser.slider_solver import compute_slider_offset
+
+            res = compute_slider_offset(bg_bytes)
+            if res is None:
+                return None
+            gap_fraction, conf = res
+
+            # ``bounding_box`` returns main-viewport CSS pixels — exactly
+            # what ``_x11_drag`` wants (window/viewport-relative pixels).
+            hx = handle_box["x"] + handle_box["width"] / 2.0
+            hy = handle_box["y"] + handle_box["height"] / 2.0
+            # ``compute_slider_offset`` returns a DPR-independent WIDTH
+            # FRACTION (the element screenshot may be captured at 2× under a
+            # HiDPI profile). Convert it to CSS pixels against the
+            # background's OWN CSS box so the target is correct regardless of
+            # ``deviceScaleFactor``.
+            target_css_x = gap_fraction * bg_box["width"]
+            # The piece rests at the same horizontal offset as the handle
+            # within the background image; measure it from geometry rather
+            # than guessing. Falls back to 0 (piece at the left edge) when
+            # geometry is degenerate.
+            piece_resting_x = max(0.0, hx - bg_box["x"])
+            delta = target_css_x - piece_resting_x
+            # Can't drag left; clamp inside the background's width.
+            max_delta = max(0.0, bg_box["width"] - 1.0)
+            delta = min(max(delta, 0.0), max_delta)
+            end_x = hx + delta
+            end_y = hy
+
+            await self._x11_drag(
+                inst, int(hx), int(hy), int(end_x), int(end_y),
+            )
+            # Let DataDome validate the drag + the page settle.
+            await asyncio.sleep(1.0)
+
+            # Success = the solvable slider is no longer classifiable. A
+            # geometrically-correct offset can still be rejected, so we
+            # confirm via re-probe rather than trusting the CV verdict.
+            still = await _classify_slider(inst.page)
+            if still is not None:
+                return None
+
+            await _record_captcha_audit_event(
+                inst.agent_id, "solved", "datadome-slider", page_url,
+            )
+            confidence = "high" if conf >= 0.6 else "medium"
+            return _captcha_envelope(
+                kind="datadome-slider",
+                solver_attempted=True,
+                solver_outcome="solved",
+                solver_confidence=confidence,
+                next_action="solved",
+            )
+        except Exception:
+            logger.debug(
+                "_solve_slider raised; returning None so the caller "
+                "escalates to request_captcha_help",
+                exc_info=True,
+            )
+            return None
+
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
         """Check for CAPTCHA elements and attempt auto-solve if configured.
 
@@ -10390,6 +10548,50 @@ class BrowserManager:
                                     solver_confidence="behavioral-only",
                                     next_action="request_captcha_help",
                                 )
+
+                    # §11.5 — DataDome SOLVABLE image-slider puzzle. Runs
+                    # AFTER the behavioral pass so the ``/blocker`` wall is
+                    # already claimed as ``datadome-behavioral`` above and
+                    # never reaches here (invariant: ``/blocker`` stays
+                    # behavioral). Only the solvable puzzle — a
+                    # ``captcha-delivery.com`` frame WITHOUT ``/blocker`` and
+                    # WITH a draggable handle — is classified here.
+                    #
+                    # ``_solve_slider`` is fully gated on a DEFAULT-OFF flag
+                    # AND the trusted X11 input path; it returns a solved
+                    # envelope on success or ``None`` to mean "not solved —
+                    # escalate". When it returns ``None`` (flag off / no X11 /
+                    # low CV confidence / any failure) we fall through to the
+                    # SAME ``request_captcha_help`` escalation the behavioral
+                    # kinds use, so flag-off behavior is byte-for-byte the
+                    # current escalate-to-human path.
+                    if not antibot_force_low_confidence:
+                        slider_kind = await _classify_slider(inst.page)
+                        if slider_kind:
+                            try:
+                                page_url = inst.page.url or ""
+                            except Exception:
+                                page_url = ""
+                            solved = await self._solve_slider(inst, page_url)
+                            if solved is not None:
+                                return solved
+                            logger.info(
+                                "DataDome solvable slider detected but not "
+                                "solved in-house (flag off / no X11 / low "
+                                "confidence / failure); escalating to "
+                                "request_captcha_help",
+                            )
+                            await _record_captcha_audit_event(
+                                inst.agent_id, "skipped_behavioral",
+                                slider_kind, page_url,
+                            )
+                            return _captcha_envelope(
+                                kind=slider_kind,
+                                solver_attempted=False,
+                                solver_outcome="skipped_behavioral",
+                                solver_confidence="behavioral-only",
+                                next_action="request_captcha_help",
+                            )
 
                     # §11.3 — Cloudflare interstitial tri-state classifier.
                     # ``auto`` waits once and re-checks; ``behavioral``

--- a/src/browser/slider_solver.py
+++ b/src/browser/slider_solver.py
@@ -32,7 +32,23 @@ logger = setup_logging("browser.slider_solver")
 # Minimum normalized prominence for the detected peak to be trusted. Below
 # this the "gap" is indistinguishable from image texture and we return None
 # so the caller escalates rather than dragging to a guessed offset.
+#
+# KNOWN best-effort limitation (documented follow-up, NOT fixed here): the
+# score is a single peak-vertical-edge measure over the WHOLE image with a
+# fixed ``left_margin``. It can be fooled by any high-contrast vertical edge
+# that isn't the puzzle notch, and the margin doesn't scale with DPR / piece
+# width or restrict to a vertical band of interest (ROI). A real paired-edge
+# / gap-shape / ROI detector is deferred; the confidence threshold + the
+# default-off flag + the fail-safe re-probe in ``_solve_slider`` keep a
+# false peak from ever producing a false "solved".
 _MIN_CONFIDENCE = 0.35
+
+# Hard pixel-count cap. The service can hand us a large element screenshot
+# (broad ``img`` / ``canvas`` selectors), and the decode + O(w·h) scan run on
+# a worker thread but still allocate memory and burn CPU. A real slider bg is
+# ~300×200; a few-million-pixel ceiling rejects anything pathological while
+# leaving a comfortable margin.
+_MAX_IMAGE_PIXELS = 4_000_000
 
 
 def compute_slider_offset(
@@ -84,14 +100,27 @@ def compute_slider_offset(
 
     try:
         img = Image.open(io.BytesIO(background_png))
-        img = img.convert("L")
+        # ``.size`` reads the header only — cheap, before we load pixels.
+        width, height = img.size
     except Exception:
         logger.debug("compute_slider_offset: image decode failed", exc_info=True)
         return None
 
-    width, height = img.size
     # Need enough columns past the resting margin to have a search region.
     if width <= left_margin + 2 or height < 1:
+        return None
+    # Reject pathologically large images BEFORE the pixel load + O(w·h) scan.
+    if width * height > _MAX_IMAGE_PIXELS:
+        logger.debug(
+            "compute_slider_offset: image %dx%d exceeds %d px cap; skipping",
+            width, height, _MAX_IMAGE_PIXELS,
+        )
+        return None
+
+    try:
+        img = img.convert("L")
+    except Exception:
+        logger.debug("compute_slider_offset: grayscale convert failed", exc_info=True)
         return None
 
     try:

--- a/src/browser/slider_solver.py
+++ b/src/browser/slider_solver.py
@@ -1,0 +1,153 @@
+"""Pure-CV gap detection for the DataDome image-slider puzzle (§11.5).
+
+This module is deliberately dependency-thin and side-effect free: it takes
+the raw PNG bytes of a puzzle background and returns the horizontal offset
+of the notch (the "gap" the puzzle piece must slide into). It imports NO
+Playwright and NO browser-service code, so it is unit-testable against
+synthesized images.
+
+**Best-effort by design.** DataDome binds solve *success* to behavioral
+telemetry (the shape / timing / jitter of the drag), NOT just the final
+offset. A geometrically correct offset can still be rejected. The trusted
+X11 drag (``_x11_drag``) supplies the human-like motion; this module only
+supplies the target. Treat a returned offset as a hint, and always keep the
+human-escalation fallback intact.
+
+**Scope.** Only the DataDome IMAGE-SLIDER (a solid puzzle piece sliding into
+a notch in a background raster) is handled here. GeeTest / canvas-rendered
+sliders and FunCaptcha rotate/tile challenges are OUT of scope: they render
+the puzzle to a ``<canvas>`` whose pixels are only reachable via
+``toDataURL()`` extraction, not a plain element screenshot.  # deferred
+"""
+
+from __future__ import annotations
+
+import io
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.slider_solver")
+
+
+# Minimum normalized prominence for the detected peak to be trusted. Below
+# this the "gap" is indistinguishable from image texture and we return None
+# so the caller escalates rather than dragging to a guessed offset.
+_MIN_CONFIDENCE = 0.35
+
+
+def compute_slider_offset(
+    background_png: bytes,
+    *,
+    left_margin: int = 8,
+) -> tuple[float, float] | None:
+    """Locate the puzzle gap in a slider-captcha background image.
+
+    Args:
+        background_png: Raw PNG (or any Pillow-decodable) bytes of the
+            puzzle background — typically an element screenshot of the
+            DataDome puzzle canvas/image.
+        left_margin: Number of leading columns to ignore. The puzzle piece
+            rests against the left edge, so the strongest vertical edges
+            there belong to the piece itself, not the gap.
+
+    Returns:
+        ``(gap_fraction, confidence)`` where ``gap_fraction`` is the gap
+        column expressed as a fraction of the image width in ``[0.0, 1.0]``
+        (``peak_x / (width - 1)`` — 0.0 = left edge, 1.0 = right edge) and
+        ``confidence`` is a saturating ``0.0..1.0`` score, or ``None`` when
+        no sufficiently prominent gap is found.
+
+        The result is a WIDTH FRACTION, not a pixel column, on purpose:
+        Playwright element screenshots capture at the page's
+        ``deviceScaleFactor`` (so the screenshot may be 2× the element's CSS
+        width under a HiDPI profile), while the caller drives the drag in
+        CSS pixels from ``bounding_box()``. A fraction is device-pixel-ratio
+        independent — the caller multiplies it by the element's CSS width to
+        recover the correct CSS-pixel target regardless of DPR.
+
+    Approach (kept intentionally simple + deterministic): grayscale the
+    image, accumulate per-column horizontal-gradient energy
+    (``sum_y |p(x, y) - p(x-1, y)|`` — the signature of a vertical edge),
+    ignore the resting margin, take the peak column as the gap, normalize it
+    to a width fraction, and score prominence as ``peak / mean`` folded
+    through a saturating curve.
+
+    Pillow-only: no numpy (not a guaranteed dependency). Never raises —
+    returns ``None`` on any decode/processing failure so callers can treat
+    "couldn't solve" and "no gap" identically (both escalate).
+    """
+    try:
+        from PIL import Image
+    except Exception:  # pragma: no cover - Pillow is a hard dep
+        logger.debug("compute_slider_offset: Pillow unavailable", exc_info=True)
+        return None
+
+    try:
+        img = Image.open(io.BytesIO(background_png))
+        img = img.convert("L")
+    except Exception:
+        logger.debug("compute_slider_offset: image decode failed", exc_info=True)
+        return None
+
+    width, height = img.size
+    # Need enough columns past the resting margin to have a search region.
+    if width <= left_margin + 2 or height < 1:
+        return None
+
+    try:
+        # ``tobytes()`` returns a flat, row-major bytes buffer for mode "L"
+        # (one int per pixel). Preferred over the now-deprecated
+        # ``getdata()`` and available on the whole ``Pillow>=10.3`` range.
+        pixels = img.tobytes()
+    except Exception:
+        logger.debug("compute_slider_offset: tobytes failed", exc_info=True)
+        return None
+    if len(pixels) < width * height:
+        return None
+
+    # Per-column horizontal-gradient energy. Column x accumulates the
+    # absolute difference from column x-1 over every row; a vertical notch
+    # edge lights up a single column strongly.
+    col_energy = [0.0] * width
+    for y in range(height):
+        row_base = y * width
+        prev = pixels[row_base]
+        for x in range(1, width):
+            cur = pixels[row_base + x]
+            col_energy[x] += abs(cur - prev)
+            prev = cur
+
+    # The piece rests in the first ``left_margin`` columns — its own edges
+    # would otherwise win. Search strictly to the right of it.
+    search_start = max(1, left_margin)
+    if search_start >= width:
+        return None
+    region = col_energy[search_start:]
+    if not region:
+        return None
+
+    # Peak column (first max wins on ties — deterministic).
+    peak_val = region[0]
+    peak_idx = 0
+    for i, val in enumerate(region):
+        if val > peak_val:
+            peak_val = val
+            peak_idx = i
+    peak_x = search_start + peak_idx
+
+    mean = sum(region) / len(region)
+    eps = 1e-6
+    ratio = peak_val / (mean + eps)
+
+    # Saturating normalization: ratio == 1 (peak == mean, i.e. flat/uniform
+    # gradient) → confidence 0; a dominant peak → confidence → 1.
+    if ratio <= 1.0:
+        confidence = 0.0
+    else:
+        confidence = 1.0 - (1.0 / ratio)
+
+    if confidence < _MIN_CONFIDENCE:
+        return None
+    # Normalize to a DPR-independent width fraction in [0.0, 1.0].
+    gap_fraction = peak_x / max(1, width - 1)
+    return gap_fraction, confidence

--- a/tests/test_slider_solver.py
+++ b/tests/test_slider_solver.py
@@ -58,6 +58,20 @@ def _flat_png(*, width: int = 200, height: int = 100, value: int = 205) -> bytes
     return buf.getvalue()
 
 
+def _striped_png(*, width: int = 200, height: int = 100) -> bytes:
+    """High-contrast per-column stripe texture with NO localized gap.
+
+    Every adjacent column pair differs by the same amount, so per-column edge
+    energy is uniform → peak ≈ mean → confidence ≈ 0 → ``None``.
+    """
+    img = Image.new("L", (width, height))
+    row = [200 if x % 2 == 0 else 30 for x in range(width)]
+    img.putdata(row * height)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def _mk_inst(*, agent_id: str = "agent-1", x11_wid: int | None = None,
              page_url: str = "https://shop.example.com") -> CamoufoxInstance:
     page = MagicMock()
@@ -107,6 +121,19 @@ class TestComputeSliderOffset:
 
     def test_flat_image_returns_none(self):
         assert compute_slider_offset(_flat_png()) is None
+
+    def test_textured_no_gap_returns_none(self):
+        # Finding 8: a high-contrast texture with no localized notch has no
+        # prominent peak (peak ≈ mean) ⇒ confidence below threshold ⇒ None.
+        assert compute_slider_offset(_striped_png()) is None
+
+    def test_oversize_image_returns_none(self):
+        # Finding 6: images beyond the pixel cap are rejected BEFORE the
+        # pixel load + O(w·h) scan (protects the shared event loop). Use a
+        # notched image that WOULD otherwise detect a gap, so a None result
+        # proves the cap fired rather than a plain no-gap outcome.
+        big = _png_with_notch(width=2100, height=2000, notch_x=1000, notch_w=8)
+        assert compute_slider_offset(big) is None
 
     def test_garbage_bytes_returns_none(self):
         assert compute_slider_offset(b"not-a-png") is None
@@ -254,8 +281,11 @@ class TestSolveSlider:
             "src.browser.slider_solver.compute_slider_offset",
             lambda *a, **k: (0.5, 0.9),
         )
-        # Re-probe: slider gone ⇒ success.
-        monkeypatch.setattr(svc, "_classify_slider", AsyncMock(return_value=None))
+        # Re-probe: the top-page probe SUCCEEDS and reports no DataDome
+        # iframe ⇒ positively absent ⇒ solved.
+        inst.page.evaluate = AsyncMock(
+            return_value={"dd_iframe": False, "dd_blocker": False},
+        )
         monkeypatch.setattr(svc, "_record_captcha_audit_event", AsyncMock())
 
         envelope = await mgr._solve_slider(inst, inst.page.url)
@@ -271,7 +301,7 @@ class TestSolveSlider:
         assert envelope["solver_confidence"] == "high"
 
     @pytest.mark.asyncio
-    async def test_success_reprobe_still_present_returns_none(self, mgr, monkeypatch):
+    async def test_reprobe_still_present_returns_none(self, mgr, monkeypatch):
         monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
         monkeypatch.setattr(svc.asyncio, "sleep", AsyncMock())
         inst = _mk_inst(x11_wid=12345)
@@ -286,32 +316,100 @@ class TestSolveSlider:
             "src.browser.slider_solver.compute_slider_offset",
             lambda *a, **k: (0.5, 0.9),
         )
-        # Re-probe: slider STILL present ⇒ DataDome rejected the drag.
-        monkeypatch.setattr(
-            svc, "_classify_slider", AsyncMock(return_value="datadome-slider"),
+        # Re-probe: iframe STILL present ⇒ DataDome rejected the drag.
+        inst.page.evaluate = AsyncMock(
+            return_value={"dd_iframe": True, "dd_blocker": False},
         )
         # Drag fired, but the result is "not solved" (escalate).
         assert await mgr._solve_slider(inst, inst.page.url) is None
         mgr._x11_drag.assert_awaited_once()
 
-
-# ── §11.5 integration: _check_captcha preserves escalation with flag off ─────
-
-
-class TestCheckCaptchaEscalationPreserved:
     @pytest.mark.asyncio
-    async def test_slider_detected_flag_off_escalates(self, mgr, monkeypatch):
-        monkeypatch.delenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", raising=False)
-        # A captcha selector matches so we enter classification.
-        page = MagicMock()
-        page.url = "https://shop.example.com"
-        locator = MagicMock()
-        locator.count = AsyncMock(return_value=1)
-        page.locator = MagicMock(return_value=locator)
-        inst = CamoufoxInstance("agent-1", MagicMock(), MagicMock(), page)
-        inst.x11_wid = 12345
+    async def test_reprobe_failure_is_not_solved(self, mgr, monkeypatch):
+        # Finding 4: a transient post-drag probe FAILURE must NOT read as
+        # solved. The drag fires, but the re-probe raising ⇒ None (escalate).
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        monkeypatch.setattr(svc.asyncio, "sleep", AsyncMock())
+        inst = _mk_inst(x11_wid=12345)
+        mgr._x11_drag = AsyncMock()
+        bg_el = _mk_element(
+            box={"x": 10, "y": 60, "width": 260, "height": 160},
+            screenshot=b"PNGBYTES",
+        )
+        handle_el = _mk_element(box={"x": 20, "y": 100, "width": 40, "height": 40})
+        _wire_frame(monkeypatch, bg_el=bg_el, handle_el=handle_el)
+        monkeypatch.setattr(
+            "src.browser.slider_solver.compute_slider_offset",
+            lambda *a, **k: (0.5, 0.9),
+        )
+        # Re-probe RAISES (frame detached / navigation) — must NOT be solved.
+        inst.page.evaluate = AsyncMock(side_effect=RuntimeError("frame detached"))
+        assert await mgr._solve_slider(inst, inst.page.url) is None
+        mgr._x11_drag.assert_awaited_once()
 
-        # Positively classify a solvable slider; keep audit side-effect quiet.
+    @pytest.mark.asyncio
+    async def test_bg_and_handle_same_box_returns_none(self, mgr, monkeypatch):
+        # Finding 7: when the broad selectors resolve the SAME element for
+        # both background and handle (coincident boxes), a drag would be a
+        # no-op — escalate instead of dragging.
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        inst = _mk_inst(x11_wid=12345)
+        mgr._x11_drag = AsyncMock()
+        same_box = {"x": 10, "y": 60, "width": 260, "height": 160}
+        bg_el = _mk_element(box=dict(same_box), screenshot=b"PNGBYTES")
+        handle_el = _mk_element(box=dict(same_box))
+        _wire_frame(monkeypatch, bg_el=bg_el, handle_el=handle_el)
+        assert await mgr._solve_slider(inst, inst.page.url) is None
+        mgr._x11_drag.assert_not_called()
+
+
+# ── §11.5 integration: _check_captcha flag gating ────────────────────────────
+
+
+def _mk_check_captcha_inst(*, agent_id: str = "agent-1") -> CamoufoxInstance:
+    """A CamoufoxInstance whose page reports a matching captcha selector."""
+    page = MagicMock()
+    page.url = "https://shop.example.com"
+    locator = MagicMock()
+    locator.count = AsyncMock(return_value=1)
+    page.locator = MagicMock(return_value=locator)
+    inst = CamoufoxInstance(agent_id, MagicMock(), MagicMock(), page)
+    inst.x11_wid = 12345
+    return inst
+
+
+class TestCheckCaptchaFlagGating:
+    @pytest.mark.asyncio
+    async def test_flag_off_branch_is_inert(self, mgr, monkeypatch):
+        # Finding 5: flag off ⇒ the whole slider branch is skipped —
+        # _classify_slider is never even called, no datadome-slider envelope,
+        # and control falls through to the pre-existing downstream path.
+        monkeypatch.delenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", raising=False)
+        inst = _mk_check_captcha_inst()
+
+        classify = AsyncMock(return_value="datadome-slider")
+        monkeypatch.setattr(svc, "_classify_slider", classify)
+        audit = AsyncMock()
+        monkeypatch.setattr(svc, "_record_captcha_audit_event", audit)
+        mgr._x11_drag = AsyncMock()
+
+        envelope = await mgr._check_captcha(inst)
+
+        classify.assert_not_called()
+        assert envelope["kind"] != "datadome-slider"
+        # No slider audit event was written by the (skipped) branch.
+        for call in audit.await_args_list:
+            assert "datadome-slider" not in call.args
+        mgr._x11_drag.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_unsolved_escalates(self, mgr, monkeypatch):
+        # Flag on but the solve can't proceed (no X11) ⇒ escalate via the
+        # same request_captcha_help shape the behavioral kinds use.
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        inst = _mk_check_captcha_inst()
+        inst.x11_wid = None  # gate 2 in _solve_slider fails ⇒ not solved
+
         monkeypatch.setattr(
             svc, "_classify_slider", AsyncMock(return_value="datadome-slider"),
         )
@@ -320,7 +418,6 @@ class TestCheckCaptchaEscalationPreserved:
 
         envelope = await mgr._check_captcha(inst)
 
-        # Flag off ⇒ _solve_slider returns None ⇒ identical escalation.
         assert envelope["captcha_found"] is True
         assert envelope["kind"] == "datadome-slider"
         assert envelope["solver_attempted"] is False

--- a/tests/test_slider_solver.py
+++ b/tests/test_slider_solver.py
@@ -1,0 +1,328 @@
+"""Tests for the §11.5 in-house DataDome image-slider detect + solve.
+
+Covers three layers, all behind the DEFAULT-OFF
+``CAPTCHA_INHOUSE_SLIDER_ENABLED`` flag:
+
+  * ``slider_solver.compute_slider_offset`` — pure CV gap detection on
+    synthesized images (Pillow only, no browser).
+  * ``captcha._classify_slider`` — positive detection of the SOLVABLE
+    slider vs the ``/blocker`` behavioral wall (which must stay
+    ``datadome-behavioral``).
+  * ``BrowserManager._solve_slider`` — the gated solve dispatch: flag off
+    or no X11 ⇒ ``None`` (escalate); flag on + X11 + CV offset ⇒ trusted
+    ``_x11_drag`` + success re-probe ⇒ solved envelope.
+  * ``BrowserManager._check_captcha`` integration — a solvable slider with
+    the flag OFF still escalates via ``request_captcha_help`` (no
+    regression to the current escalate-to-human behavior).
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image, ImageDraw
+
+from src.browser import captcha as captcha_mod
+from src.browser import service as svc
+from src.browser.service import BrowserManager, CamoufoxInstance
+from src.browser.slider_solver import compute_slider_offset
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _png_with_notch(
+    *, width: int = 200, height: int = 100, notch_x: int, notch_w: int = 4,
+    bg: int = 205, notch: int = 25,
+) -> bytes:
+    """Synthesize a light-gray grayscale PNG with a dark vertical bar.
+
+    The bar's vertical edges are the strongest horizontal-gradient columns,
+    so ``compute_slider_offset`` should peak within ~``notch_w`` px of
+    ``notch_x``.
+    """
+    img = Image.new("L", (width, height), bg)
+    draw = ImageDraw.Draw(img)
+    left = notch_x - notch_w // 2
+    draw.rectangle([left, 0, left + notch_w - 1, height - 1], fill=notch)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _flat_png(*, width: int = 200, height: int = 100, value: int = 205) -> bytes:
+    img = Image.new("L", (width, height), value)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _mk_inst(*, agent_id: str = "agent-1", x11_wid: int | None = None,
+             page_url: str = "https://shop.example.com") -> CamoufoxInstance:
+    page = MagicMock()
+    page.url = page_url
+    inst = CamoufoxInstance(agent_id, MagicMock(), MagicMock(), page)
+    inst.x11_wid = x11_wid
+    return inst
+
+
+def _mk_element(*, box: dict | None = None, screenshot: bytes | None = None):
+    el = MagicMock()
+    el.bounding_box = AsyncMock(return_value=box)
+    el.screenshot = AsyncMock(return_value=screenshot)
+    return el
+
+
+# ── §11.5 CV: compute_slider_offset ──────────────────────────────────────────
+
+
+class TestComputeSliderOffset:
+    def test_detects_known_notch(self):
+        known_x = 130
+        width = 200
+        png = _png_with_notch(width=width, notch_x=known_x, notch_w=4)
+        res = compute_slider_offset(png)
+        assert res is not None
+        gap_fraction, conf = res
+        # Contract: a DPR-independent width fraction in [0, 1] that maps
+        # back to the known column via ``fraction * (width - 1)``.
+        assert 0.0 <= gap_fraction <= 1.0
+        assert abs(gap_fraction * (width - 1) - known_x) <= 4
+        assert conf > 0.7
+
+    def test_dpr_independent_fraction(self):
+        # The SAME logical notch at two image widths (1x and 2x) must yield
+        # ~the same fraction — this is exactly the property that makes the
+        # result safe to combine with CSS-pixel bounding boxes under any
+        # ``deviceScaleFactor`` (element screenshots capture at DPR).
+        res1 = compute_slider_offset(
+            _png_with_notch(width=200, notch_x=130, notch_w=4),
+        )
+        res2 = compute_slider_offset(
+            _png_with_notch(width=400, notch_x=260, notch_w=8),
+        )
+        assert res1 is not None and res2 is not None
+        assert abs(res1[0] - res2[0]) < 0.02
+
+    def test_flat_image_returns_none(self):
+        assert compute_slider_offset(_flat_png()) is None
+
+    def test_garbage_bytes_returns_none(self):
+        assert compute_slider_offset(b"not-a-png") is None
+
+    def test_left_margin_ignored(self):
+        # A notch INSIDE the resting margin must not be reported — the piece
+        # lives there. Only the right-of-margin region is searched.
+        png = _png_with_notch(notch_x=3, notch_w=2)
+        assert compute_slider_offset(png, left_margin=8) is None
+
+
+# ── §11.5 classifier: _classify_slider ───────────────────────────────────────
+
+
+def _mk_page_for_classify(*, probe: dict, frame_url: str = "",
+                          handle_present: bool = False) -> MagicMock:
+    page = MagicMock()
+    page.evaluate = AsyncMock(return_value=probe)
+    if frame_url:
+        frame = MagicMock()
+        frame.url = frame_url
+        frame.query_selector = AsyncMock(
+            return_value=(MagicMock() if handle_present else None),
+        )
+        page.frames = [frame]
+    else:
+        page.frames = []
+    return page
+
+
+class TestClassifySlider:
+    @pytest.mark.asyncio
+    async def test_solvable_slider_present(self):
+        page = _mk_page_for_classify(
+            probe={"dd_iframe": True, "dd_blocker": False},
+            frame_url="https://geo.captcha-delivery.com/captcha/?initialCid=x",
+            handle_present=True,
+        )
+        assert await captcha_mod._classify_slider(page) == "datadome-slider"
+
+    @pytest.mark.asyncio
+    async def test_blocker_wall_stays_behavioral(self):
+        # The /blocker wall must NOT be claimed as a solvable slider — it
+        # stays datadome-behavioral (handled by _classify_behavioral).
+        page = _mk_page_for_classify(
+            probe={"dd_iframe": True, "dd_blocker": True},
+            frame_url="https://geo.captcha-delivery.com/captcha/?initialCid=x",
+            handle_present=True,
+        )
+        assert await captcha_mod._classify_slider(page) is None
+
+    @pytest.mark.asyncio
+    async def test_no_datadome_iframe(self):
+        page = _mk_page_for_classify(probe={"dd_iframe": False, "dd_blocker": False})
+        assert await captcha_mod._classify_slider(page) is None
+
+    @pytest.mark.asyncio
+    async def test_iframe_but_no_handle(self):
+        page = _mk_page_for_classify(
+            probe={"dd_iframe": True, "dd_blocker": False},
+            frame_url="https://geo.captcha-delivery.com/captcha/?initialCid=x",
+            handle_present=False,
+        )
+        assert await captcha_mod._classify_slider(page) is None
+
+    @pytest.mark.asyncio
+    async def test_evaluate_failure_returns_none(self):
+        page = MagicMock()
+        page.evaluate = AsyncMock(side_effect=RuntimeError("cross-origin"))
+        assert await captcha_mod._classify_slider(page) is None
+
+
+# ── §11.5 solve dispatch: _solve_slider ──────────────────────────────────────
+
+
+@pytest.fixture()
+def mgr(tmp_path):
+    return BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+
+
+def _wire_frame(monkeypatch, *, bg_el, handle_el) -> None:
+    """Point the service-side frame lookup at a mock puzzle frame."""
+    frame = MagicMock()
+    frame.url = "https://geo.captcha-delivery.com/captcha/?initialCid=x"
+
+    async def _qs(sel):
+        if "slider" in sel or "slide-button" in sel:
+            return handle_el
+        return bg_el
+
+    frame.query_selector = _qs
+    monkeypatch.setattr(svc, "_datadome_slider_frame", lambda page: frame)
+
+
+class TestSolveSlider:
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_none(self, mgr, monkeypatch):
+        monkeypatch.delenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", raising=False)
+        inst = _mk_inst(x11_wid=12345)
+        mgr._x11_drag = AsyncMock()
+        assert await mgr._solve_slider(inst, inst.page.url) is None
+        mgr._x11_drag.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_but_no_x11_returns_none(self, mgr, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        inst = _mk_inst(x11_wid=None)
+        mgr._x11_drag = AsyncMock()
+        assert await mgr._solve_slider(inst, inst.page.url) is None
+        mgr._x11_drag.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cv_none_returns_none(self, mgr, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        inst = _mk_inst(x11_wid=12345)
+        mgr._x11_drag = AsyncMock()
+        bg_el = _mk_element(
+            box={"x": 10, "y": 60, "width": 260, "height": 160},
+            screenshot=b"PNG",
+        )
+        handle_el = _mk_element(box={"x": 20, "y": 100, "width": 40, "height": 40})
+        _wire_frame(monkeypatch, bg_el=bg_el, handle_el=handle_el)
+        monkeypatch.setattr(
+            "src.browser.slider_solver.compute_slider_offset",
+            lambda *a, **k: None,
+        )
+        assert await mgr._solve_slider(inst, inst.page.url) is None
+        mgr._x11_drag.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success_drags_and_returns_envelope(self, mgr, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        monkeypatch.setattr(svc.asyncio, "sleep", AsyncMock())
+        inst = _mk_inst(x11_wid=12345)
+        mgr._x11_drag = AsyncMock()
+
+        bg_el = _mk_element(
+            box={"x": 10, "y": 60, "width": 260, "height": 160},
+            screenshot=b"PNGBYTES",
+        )
+        handle_el = _mk_element(box={"x": 20, "y": 100, "width": 40, "height": 40})
+        _wire_frame(monkeypatch, bg_el=bg_el, handle_el=handle_el)
+        # CV returns a WIDTH FRACTION (DPR-independent), not a pixel column.
+        monkeypatch.setattr(
+            "src.browser.slider_solver.compute_slider_offset",
+            lambda *a, **k: (0.5, 0.9),
+        )
+        # Re-probe: slider gone ⇒ success.
+        monkeypatch.setattr(svc, "_classify_slider", AsyncMock(return_value=None))
+        monkeypatch.setattr(svc, "_record_captcha_audit_event", AsyncMock())
+
+        envelope = await mgr._solve_slider(inst, inst.page.url)
+
+        # Geometry: hx=40, hy=120; target_css_x=fraction(0.5)*bg_w(260)=130;
+        # piece_resting_x=hx-bg_x=30; delta=130-30=100; end_x=40+100=140.
+        mgr._x11_drag.assert_awaited_once_with(inst, 40, 120, 140, 120)
+        assert envelope is not None
+        assert envelope["kind"] == "datadome-slider"
+        assert envelope["solver_attempted"] is True
+        assert envelope["solver_outcome"] == "solved"
+        assert envelope["next_action"] == "solved"
+        assert envelope["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_success_reprobe_still_present_returns_none(self, mgr, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", "true")
+        monkeypatch.setattr(svc.asyncio, "sleep", AsyncMock())
+        inst = _mk_inst(x11_wid=12345)
+        mgr._x11_drag = AsyncMock()
+        bg_el = _mk_element(
+            box={"x": 10, "y": 60, "width": 260, "height": 160},
+            screenshot=b"PNGBYTES",
+        )
+        handle_el = _mk_element(box={"x": 20, "y": 100, "width": 40, "height": 40})
+        _wire_frame(monkeypatch, bg_el=bg_el, handle_el=handle_el)
+        monkeypatch.setattr(
+            "src.browser.slider_solver.compute_slider_offset",
+            lambda *a, **k: (0.5, 0.9),
+        )
+        # Re-probe: slider STILL present ⇒ DataDome rejected the drag.
+        monkeypatch.setattr(
+            svc, "_classify_slider", AsyncMock(return_value="datadome-slider"),
+        )
+        # Drag fired, but the result is "not solved" (escalate).
+        assert await mgr._solve_slider(inst, inst.page.url) is None
+        mgr._x11_drag.assert_awaited_once()
+
+
+# ── §11.5 integration: _check_captcha preserves escalation with flag off ─────
+
+
+class TestCheckCaptchaEscalationPreserved:
+    @pytest.mark.asyncio
+    async def test_slider_detected_flag_off_escalates(self, mgr, monkeypatch):
+        monkeypatch.delenv("CAPTCHA_INHOUSE_SLIDER_ENABLED", raising=False)
+        # A captcha selector matches so we enter classification.
+        page = MagicMock()
+        page.url = "https://shop.example.com"
+        locator = MagicMock()
+        locator.count = AsyncMock(return_value=1)
+        page.locator = MagicMock(return_value=locator)
+        inst = CamoufoxInstance("agent-1", MagicMock(), MagicMock(), page)
+        inst.x11_wid = 12345
+
+        # Positively classify a solvable slider; keep audit side-effect quiet.
+        monkeypatch.setattr(
+            svc, "_classify_slider", AsyncMock(return_value="datadome-slider"),
+        )
+        monkeypatch.setattr(svc, "_record_captcha_audit_event", AsyncMock())
+        mgr._x11_drag = AsyncMock()
+
+        envelope = await mgr._check_captcha(inst)
+
+        # Flag off ⇒ _solve_slider returns None ⇒ identical escalation.
+        assert envelope["captcha_found"] is True
+        assert envelope["kind"] == "datadome-slider"
+        assert envelope["solver_attempted"] is False
+        assert envelope["next_action"] == "request_captcha_help"
+        mgr._x11_drag.assert_not_called()


### PR DESCRIPTION
## Why

Roadmap item 2 of `docs/plans/2026-07-02-stealth-browser-human-parity.md`. The solvable DataDome image-slider is **deliberately excluded** from today's behavioral classifier — `_classify_behavioral` matches only the `/blocker` wall and its docstring says the solvable slider "routes through §11.5 (deferred)." This PR fills that deferred hook: detect the solvable slider and solve it in-house by driving the trusted, human-like `_x11_drag` merged in #1173 — **no external solver, no provider cost.**

## What changed

**Detection** (`captcha.py`) — new `_classify_slider` positively labels the solvable slider `datadome-slider`: a `captcha-delivery.com` frame **without** `/blocker` and **with** a draggable handle (confirmed via Playwright's cross-origin frame API, since top-page JS can't see into the frame). The `/blocker` behavioral wall stays `datadome-behavioral` — untouched.

**Solve** (`service.py`) — `_solve_slider` is fully gated behind **two** conditions:
1. `CAPTCHA_INHOUSE_SLIDER_ENABLED` — **default false**.
2. The trusted X11 input path (`inst.x11_wid` + `_is_x11_site`) — without it a drag goes via CDP (`isTrusted=false`), which DataDome reads as a bot.

It locates the puzzle frame, screenshots the background element, computes the gap via a pure-Pillow CV module (`slider_solver.compute_slider_offset`, returning a **DPR-independent width fraction**), converts to CSS pixels against the element's own box, and drives `_x11_drag`. **Success is confirmed by re-classification, not CV confidence** — DataDome binds success to behavioral telemetry, so a geometrically-correct offset can still be rejected.

**Fail-safe by construction.** Every failure path — flag off, no X11, low CV confidence, wrong selectors, any exception — returns `None` and falls through to the **same `request_captcha_help` escalation** the behavioral kinds already use. So with the flag off (the default), a solvable slider escalates to a human exactly as today; the only change is a more precise `kind` label.

**Untouched:** `_BEHAVIORAL_KINDS`, `request_captcha_help`, `_metered_solve` / cost-counter / circuit-breaker (in-house solve has no provider cost, so it bypasses that gate cleanly). No new browser action, no permission changes, no new dependencies.

**Deferred (noted in code):** GeeTest / canvas-rendered sliders and FunCaptcha — they render to a `<canvas>` reachable only via `toDataURL()` extraction, not a plain element screenshot.

## Honest expectations

DataDome scores the drag's motion telemetry, not just the final offset. The human-like `_x11_drag` (Bézier + Fitts velocity + tremor + overshoot) supplies realistic motion, but expected real-world success is **modest** — which is exactly why this ships default-off with the human-escalation fallback fully intact. The deliverable is a correct, safe, tested, measurable pipeline you can enable per-deployment, not a guaranteed bypass.

## Testing

- New `tests/test_slider_solver.py` (16): CV known-notch / flat / garbage / **DPR-independence** (same logical notch at 1× and 2× width → same fraction); classifier slider-vs-`/blocker` / no-iframe / no-handle; solve dispatch (flag off → None, no X11 → None, CV-none → None, success → `_x11_drag` called with the computed CSS delta + solved envelope, re-probe-still-present → escalate); and `_check_captcha` flag-off → `next_action == "request_captcha_help"` (escalation preserved, no regression).
- Full captcha regression sweep green (`test_browser_solve_captcha`, `test_check_captcha_metered`, `test_browser_captcha_redetect`, `test_captcha_envelope`, …) — no changes to existing paths.
- `uvx ruff@latest` clean. No `Dockerfile.browser` / `pyproject.toml` changes → no build-and-smoke.

## Deploy note

Default-off; no behavior change until an operator sets `CAPTCHA_INHOUSE_SLIDER_ENABLED=true`. Orthogonal to the in-flight Teams/Threads/Drive overhaul (touches only `src/browser/`).
