### PR TITLE
feat: add JMT x402 Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ canonicalized parameters and results over a 15-call sliding window.
 | `wallet_execute` | Execute an Ethereum smart contract function (requires `[wallet]` extras) |
 | `get_system_status` | Query own runtime state: permissions, budget, fleet, cron, health |
 | `read_agent_history` | Read another agent's conversation logs |
+- [JMT x402 Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 paid x402 endpoints on Base mainnet: web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard. $0.001-$0.15/call USDC. Local LLM-powered.
 
 Custom tools are Python functions decorated with `@tool`, auto-discovered
 from the agent's `tools_dir` at startup. Agents can also create new tools


### PR DESCRIPTION
## What\n\nAdds JMT x402 Agent Tools — 25 paid x402 endpoints on Base mainnet.\n\n## Service Details\n\n- **URL:** https://jmt-x402-proxy.jmthomasofficial.workers.dev\n- **Network:** Base mainnet (eip155:8453)\n- **Endpoints:** 25 paid endpoints covering web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard\n- **Price range:** $0.001-$0.15 per call\n- **Currency:** USDC on Base\n- **Wallet:** 0x624FaF18C78456C8Da5bf156Cd77c1A2033F21c5\n- **Discovery:** /.well-known/x402, /openapi.json, /llms.txt\n\n## Verification\n\n- [x] curl -I https://jmt-x402-proxy.jmthomasofficial.workers.dev/api/search returns 402\n- [x] /.well-known/x402 returns valid x402 discovery document\n- [x] /openapi.json has x-payment-info on all paid operations