### PR TITLE
feat(browser): set-of-marks screenshot annotation for reliable visual clicking

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -673,6 +673,135 @@ async def browser_screenshot(
 
 
 @tool(
+    name="browser_screenshot_marks",
+    description=(
+        "Take a viewport screenshot with numbered boxes (set-of-marks) drawn "
+        "over every clickable element, and get back a 'marks' list mapping "
+        "each number to that element. Use this on canvas / WebGL / map / "
+        "image-heavy pages where a plain browser_get_elements snapshot misses "
+        "or can't localize the visual target — you SEE the numbered box in the "
+        "image, then click it. Each entry in 'marks' has: 'mark' (the number "
+        "on the image), 'ref' (PREFERRED — click it with browser_click(ref="
+        "...), resolution-stable), 'role'/'name' (what it is), and 'x'/'y' "
+        "(the element's CSS-pixel centre — click with browser_click_xy(x, y) "
+        "when a ref click isn't viable). Defaults: WebP quality=75, up to 50 "
+        "marks. 'marks_truncated'=true means more clickable elements exist "
+        "than were labelled (raise max_marks or narrow the view). "
+        "'snapshot_truncated'=true means the page had more elements than the "
+        "a11y snapshot cap, so some clickable targets may be unlabelled — "
+        "scroll or narrow the view to reach them. 'annotated'=false means the "
+        "boxes couldn't be drawn (image still usable, marks still mapped). "
+        "Prefer clicking by ref over x/y."
+    ),
+    parameters={
+        "format": {
+            "type": "string",
+            "description": (
+                "Image format: 'webp' (default, smaller, lossy) or 'png' "
+                "(lossless, larger)."
+            ),
+            "default": "webp",
+        },
+        "quality": {
+            "type": "integer",
+            "description": (
+                "WebP quality 1–100 (default 75). Ignored for PNG."
+            ),
+            "default": 75,
+        },
+        "scale": {
+            "type": "number",
+            "description": (
+                "Resize factor 0.5–1.0 (default 1.0). Mark outlines and "
+                "numbers are size-compensated for the downscale, so they stay "
+                "legible in the final image even at 0.5."
+            ),
+            "default": 1.0,
+        },
+        "max_marks": {
+            "type": "integer",
+            "description": (
+                "Max numbered elements to label, 1–100 (default 50). Beyond "
+                "this the response sets marks_truncated=true."
+            ),
+            "default": 50,
+        },
+    },
+    parallel_safe=False,
+    loop_exempt=True,
+)
+async def browser_screenshot_marks(
+    format: str = "webp",
+    quality: int = 75,
+    scale: float = 1.0,
+    max_marks: int = 50,
+    *,
+    mesh_client=None,
+) -> dict:
+    """Take an annotated (set-of-marks) screenshot via the browser service.
+
+    Same ``_image`` handling as :func:`browser_screenshot`: extracts
+    ``image_base64`` from the raw result *before* ``_deep_redact`` runs
+    (the broad credential patterns would corrupt the image payload) and
+    re-attaches it under ``_image`` so ``_run_tool`` can build a
+    multimodal content block. The ``marks`` list — each binding a drawn
+    number to a ``ref`` + CSS-centre coords — survives redaction and is
+    returned to the agent alongside the image.
+    """
+    if not mesh_client:
+        return {"error": "Browser requires mesh connectivity"}
+    try:
+        raw = await mesh_client.browser_command(
+            "screenshot_marks",
+            {
+                "format": format,
+                "quality": quality,
+                "scale": scale,
+                "max_marks": max_marks,
+            },
+        )
+    except Exception as e:
+        return {"error": _deep_redact(str(e))}
+
+    # Pull out image data before redaction can corrupt it.
+    # Browser service returns {"success": ..., "data":
+    #   {"image_base64": ..., "format": "webp"|"png", "marks": [...], ...}}
+    image_data = None
+    actual_format = "png"
+    if isinstance(raw, dict):
+        data = raw.get("data")
+        if isinstance(data, dict) and data.get("image_base64"):
+            image_data = data.pop("image_base64")
+            actual_format = (data.get("format") or "png").lower()
+
+    result = _deep_redact(raw)
+
+    if image_data:
+        media_type = "image/webp" if actual_format == "webp" else "image/png"
+        result["_image"] = {"data": image_data, "media_type": media_type}
+        # Give the LLM a short text summary instead of the raw base64 blob.
+        # Status must reflect whether annotation ACTUALLY happened — an image
+        # exists even when boxes couldn't be drawn (Pillow missing / draw
+        # failed / no marks), so keying off ``data.annotated`` avoids claiming
+        # "annotated" when it isn't. ``data`` here is the same dict we popped
+        # ``image_base64`` from (pre-redaction) — reuse it directly.
+        if isinstance(data, dict):
+            n_marks = len(data.get("marks", []))
+            if data.get("annotated"):
+                result.setdefault(
+                    "status", f"annotated screenshot captured, {n_marks} marks",
+                )
+            else:
+                result.setdefault(
+                    "status",
+                    f"screenshot captured (annotation unavailable), "
+                    f"{n_marks} marks mapped",
+                )
+
+    return result
+
+
+@tool(
     name="browser_click",
     description=(
         "Click an element on the current page. Preferred: use ref from "

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -139,7 +139,8 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
     # Mirrors the @tool names in ``builtins/browser_tool.py``.
     "browser": frozenset({
         "browser_navigate", "browser_warmup", "browser_get_elements",
-        "browser_wait_for", "browser_screenshot", "browser_click",
+        "browser_wait_for", "browser_screenshot", "browser_screenshot_marks",
+        "browser_click",
         "browser_click_xy", "browser_type", "browser_hover", "browser_scroll",
         "browser_reset", "browser_press_key", "browser_go_back",
         "browser_go_forward", "browser_switch_tab", "browser_find_text",

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -112,7 +112,8 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
         intent="research or interact with websites (browser automation)",
         tools=(
             "browser_navigate", "browser_warmup", "browser_get_elements",
-            "browser_wait_for", "browser_screenshot", "browser_click",
+            "browser_wait_for", "browser_screenshot",
+            "browser_screenshot_marks", "browser_click",
             "browser_click_xy", "browser_type", "browser_hover",
             "browser_scroll", "browser_reset", "browser_press_key",
             "browser_go_back", "browser_go_forward", "browser_switch_tab",

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -425,6 +425,18 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             scale=body.get("scale", 1.0),
         )
 
+    @app.post("/browser/{agent_id}/screenshot_marks")
+    async def screenshot_marks(agent_id: str, request: Request):
+        _verify_auth(request)
+        body = await request.json()
+        return await manager.screenshot_marks(
+            agent_id,
+            format=body.get("format", "webp"),
+            quality=body.get("quality", 75),
+            scale=body.get("scale", 1.0),
+            max_marks=body.get("max_marks", 50),
+        )
+
     @app.post("/browser/{agent_id}/reset")
     async def reset(agent_id: str, request: Request):
         _verify_auth(request)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -2670,6 +2670,134 @@ def _encode_screenshot(
         return png_bytes, "png", w, h
 
 
+def _draw_set_of_marks(
+    png_bytes: bytes,
+    marks: list[dict],
+    css_w: float,
+    css_h: float,
+    *,
+    scale: float = 1.0,
+    agent_id: str = "",
+) -> bytes:
+    """Overlay numbered set-of-marks annotations onto a viewport PNG.
+
+    ``marks`` is a list of dicts each carrying ``mark`` (the integer label)
+    and ``box`` = ``(bx, by, bw, bh)`` in **CSS pixels** (Playwright
+    ``bounding_box`` space). For each mark this draws a red rectangle
+    outline around the element plus a small filled label box at its
+    top-left corner holding the mark number in white — giving a
+    vision-capable agent a stable numbered target it can click by ref or
+    by CSS-centre coordinate (see :meth:`BrowserManager.screenshot_marks`).
+
+    DPR-correct: the CSS→image scale is derived from the ACTUAL decoded
+    image size vs the CSS viewport, so a retina 2× PNG lands the boxes on
+    the right pixels. Returns the SAME ``png_bytes`` object unchanged when
+    Pillow is unavailable or anything in the draw path fails — the caller
+    keys off the object identity to report whether annotation actually
+    happened (graceful degrade: an un-annotated screenshot still beats an
+    error).
+
+    The function is intentionally synchronous and pure — trivial to unit
+    test. Callers should offload it to a worker thread (Pillow releases
+    the GIL during its C-level draw/encode steps).
+    """
+    # Pillow is the only draw backend; without it we can't annotate. Return
+    # the original object (identity preserved) so the caller can detect the
+    # no-op and flag ``annotated=False`` rather than lying.
+    try:
+        from io import BytesIO
+
+        from PIL import Image, ImageDraw, ImageFont
+    except ImportError:
+        logger.debug(
+            "Pillow not installed; set-of-marks annotation skipped (agent=%s)",
+            agent_id,
+        )
+        return png_bytes
+
+    # No marks or an unusable CSS viewport → nothing to draw. Guarding the
+    # css dims here keeps the CSS→image divide below safe.
+    if not marks or css_w <= 0 or css_h <= 0:
+        return png_bytes
+
+    # Same decompression-bomb cap the encode path pins — module-level global,
+    # idempotent set (see ``_encode_screenshot``).
+    if Image.MAX_IMAGE_PIXELS != 50_000_000:
+        Image.MAX_IMAGE_PIXELS = 50_000_000
+
+    try:
+        img = Image.open(BytesIO(png_bytes))
+        # Normalize to RGB so the draw ops and the PNG re-encode below don't
+        # hit a palette-mode surprise.
+        if img.mode not in ("RGB", "RGBA"):
+            img = img.convert("RGB")
+        img_w, img_h = img.size
+        # CSS→image scale. A retina PNG is 2× the CSS viewport, so a box at
+        # CSS (x,y) is multiplied up into image pixels before drawing.
+        sx = img_w / css_w
+        sy = img_h / css_h
+
+        # Size-compensate the drawing primitives so they stay ~constant in the
+        # FINAL image: ``screenshot_marks`` draws on the NATIVE image, then
+        # ``_encode_screenshot`` downscales by ``scale`` — at ``scale=0.5`` a
+        # 2px outline / 12px number would render at ~1px / ~6px. Inflate by
+        # ``1/scale`` up front so the post-downscale size is what we intend.
+        msf = 1.0 / scale if 0 < scale < 1 else 1.0
+        outline_w = max(2, round(2 * msf))
+
+        draw = ImageDraw.Draw(img)
+        try:
+            # Pillow ≥10 accepts a ``size`` for the built-in bitmap font;
+            # older Pillow ignores/rejects it — fall back on ANY exception so
+            # a stale install can't break annotation entirely.
+            font = ImageFont.load_default(size=round(12 * msf))
+        except Exception:
+            try:
+                font = ImageFont.load_default()
+            except Exception:
+                font = None
+        outline = (255, 0, 0)  # high-visibility red
+        text_fill = (255, 255, 255)  # white number on the red label bg
+
+        for m in marks:
+            box = m.get("box")
+            if not box or len(box) != 4:
+                continue
+            bx, by, bw, bh = box
+            x0 = bx * sx
+            y0 = by * sy
+            x1 = (bx + bw) * sx
+            y1 = (by + bh) * sy
+            draw.rectangle([x0, y0, x1, y1], outline=outline, width=outline_w)
+
+            label = str(m.get("mark", ""))
+            # Size the label background to the text via ``textbbox`` (Pillow
+            # ≥8); fall back to a fixed estimate when it's unavailable.
+            try:
+                left, top, right, bottom = draw.textbbox((0, 0), label, font=font)
+                tw, th = right - left, bottom - top
+            except Exception:
+                tw, th = 7 * len(label), 11
+            pad = 2
+            draw.rectangle(
+                [x0, y0, x0 + tw + 2 * pad, y0 + th + 2 * pad], fill=outline,
+            )
+            if font is not None:
+                draw.text((x0 + pad, y0 + pad), label, fill=text_fill, font=font)
+            else:
+                draw.text((x0 + pad, y0 + pad), label, fill=text_fill)
+
+        out = BytesIO()
+        img.save(out, format="PNG")
+        return out.getvalue()
+    except Exception as e:
+        logger.warning(
+            "Set-of-marks annotation failed (%s); returning un-annotated PNG",
+            e,
+        )
+        return png_bytes
+
+
 # ── §11.4 / §18.2 captcha re-detection after non-navigate actions ──────────
 #
 # Two-call install/read-back pattern: install a MutationObserver before the
@@ -9454,6 +9582,225 @@ class BrowserManager:
             "bytes": len(encoded),
             "viewport": viewport_data,
             "image": {"width": img_w, "height": img_h},
+        }
+        if click_scale is not None:
+            data["click_scale"] = click_scale
+        return {"success": True, "data": data}
+
+    async def screenshot_marks(
+        self,
+        agent_id: str,
+        format: str = "webp",
+        quality: int = 75,
+        scale: float = 1.0,
+        max_marks: int = 50,
+    ) -> dict:
+        """Viewport screenshot with numbered set-of-marks overlays.
+
+        A plain :meth:`screenshot` leaves a vision-capable agent guessing
+        pixel coordinates on canvas / WebGL / map / image-heavy pages where
+        the accessibility snapshot alone can't localize a target. This
+        annotates the viewport capture with a numbered box around every
+        actionable element (buttons, links, inputs, …) resolved from the
+        current a11y snapshot, and returns a ``marks`` map binding each
+        label to:
+
+        - a ``ref`` — click it with the existing ``click`` action
+          (``browser_click(ref=...)``, the preferred, resolution-stable
+          path); and
+        - ``x`` / ``y`` — the element's CSS-pixel centre, clickable via
+          ``click_xy`` when a ref click isn't viable.
+
+        Always a VIEWPORT capture (never full-page) so ``click_scale`` and
+        the CSS-centre coordinates map cleanly into the click space. Marks
+        carry no new instance state — the ref in each entry resolves via
+        the same machinery as any snapshot ref.
+        """
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        # Validate inputs exactly like ``screenshot`` — reject unknown formats,
+        # clamp quality/scale to their documented ranges.
+        from src.browser.flags import get_str
+        if not format:
+            format = get_str(
+                "BROWSER_SCREENSHOT_FORMAT", "webp", agent_id=agent_id,
+            )
+        fmt = format.strip().lower()
+        if fmt not in ("webp", "png"):
+            return {"success": False, "error": f"Unsupported screenshot format: {format!r}"}
+        try:
+            quality = int(quality)
+        except (TypeError, ValueError):
+            quality = 75
+        quality = max(1, min(100, quality))
+        try:
+            scale_f = float(scale)
+        except (TypeError, ValueError):
+            scale_f = 1.0
+        scale_f = max(0.5, min(1.0, scale_f))
+        try:
+            max_marks_i = max(1, min(100, int(max_marks)))
+        except (TypeError, ValueError):
+            max_marks_i = 50
+
+        marks: list[dict] = []
+        marks_truncated = False
+        async with inst.lock:
+            # Refresh refs to the live DOM WITHOUT perturbing the diff
+            # baseline (``_skip_baseline=True``) — the returned marks must
+            # reference elements that exist right now.
+            snap = await self._snapshot_impl(inst, agent_id, _skip_baseline=True)
+            if not snap.get("success"):
+                return snap
+            # Whether the a11y snapshot itself dropped elements past its own
+            # ``_MAX_SNAPSHOT_ELEMENTS`` cap (PR #1201 truncation fields). Kept
+            # DISTINCT from ``marks_truncated`` (the max_marks cap) so we never
+            # claim completeness when upstream already dropped clickable targets.
+            snap_data = snap.get("data", {}) if isinstance(snap, dict) else {}
+            snapshot_truncated = bool(snap_data.get("truncated"))
+            try:
+                # Viewport-only capture — set-of-marks is for click targeting,
+                # which can only reach the current viewport.
+                png_bytes = await inst.page.screenshot(full_page=False)
+            except Exception as e:
+                return {"success": False, "error": str(e)}
+            # Captured under the lock so it reflects the viewport at capture
+            # time. May be ``None`` in some Playwright configs (same caveat
+            # as ``screenshot``'s ``viewport_size`` read).
+            raw_viewport = inst.page.viewport_size
+            vw = vh = 0
+            if isinstance(raw_viewport, dict):
+                vw = int(raw_viewport.get("width") or 0)
+                vh = int(raw_viewport.get("height") or 0)
+
+            # Mirror ``_find_text_impl``: iterate refs, resolve each to a live
+            # locator, keep only visible, in-viewport, actionable elements.
+            next_mark = 1
+            for ref_id, handle in inst.refs.items():
+                if handle.role not in _ACTIONABLE_ROLES:
+                    continue
+                # One bad ref (stale shadow host, closed tab, resolver error)
+                # must not abort the whole capture. ``RefStale`` is an
+                # ``Exception`` subclass, so the broad catch covers it.
+                try:
+                    locator = await self._locator_from_ref(inst, ref_id)
+                except Exception:
+                    continue
+                if locator is None:
+                    continue
+                try:
+                    if not await locator.is_visible():
+                        continue
+                except Exception:
+                    continue
+                try:
+                    box = await locator.bounding_box()
+                except Exception:
+                    continue
+                if not box:
+                    continue
+                bx = float(box.get("x", 0))
+                by = float(box.get("y", 0))
+                bw = float(box.get("width", 0))
+                bh = float(box.get("height", 0))
+                if bw <= 0 or bh <= 0:
+                    continue
+                # In-viewport intersection test, identical to
+                # ``_find_text_impl``. Skip when a viewport is known and the
+                # box lies fully outside it.
+                if vw > 0 and vh > 0:
+                    in_viewport = (
+                        bx + bw > 0 and by + bh > 0
+                        and bx < vw and by < vh
+                    )
+                    if not in_viewport:
+                        continue
+                if next_mark > max_marks_i:
+                    marks_truncated = True
+                    break
+                # Click point = centre of the element's VISIBLE intersection
+                # with the viewport, kept strictly inside it (click_xy rejects
+                # x>=vw / y>=vh).
+                vx0 = max(bx, 0.0)
+                vy0 = max(by, 0.0)
+                vx1 = min(bx + bw, float(vw)) if vw > 0 else bx + bw
+                vy1 = min(by + bh, float(vh)) if vh > 0 else by + bh
+                cx = (vx0 + vx1) / 2
+                cy = (vy0 + vy1) / 2
+                if vw > 0:
+                    cx = min(cx, float(vw) - 1.0)
+                if vh > 0:
+                    cy = min(cy, float(vh) - 1.0)
+                cx = max(cx, 0.0)
+                cy = max(cy, 0.0)
+                marks.append({
+                    "mark": next_mark,
+                    "ref": ref_id,
+                    "role": handle.role,
+                    "name": sanitize_for_prompt(
+                        self.redactor.redact(agent_id, handle.name or ""),
+                    )[:80],
+                    "box": (bx, by, bw, bh),
+                    "x": round(cx, 1),
+                    "y": round(cy, 1),
+                })
+                next_mark += 1
+
+        # Draw + encode OUTSIDE the lock — Pillow work must not hold the
+        # per-instance lock (it would block concurrent browser ops for this
+        # agent). css dims come from the viewport; when it's unknown we skip
+        # drawing (css_w == 0 short-circuits the helper) and omit click_scale,
+        # matching ``screenshot``.
+        css_w = float(vw)
+        css_h = float(vh)
+        annotated_png = await asyncio.to_thread(
+            _draw_set_of_marks,
+            png_bytes, marks, css_w, css_h, scale=scale_f, agent_id=agent_id,
+        )
+        # Identity check: the helper returns the SAME object when Pillow is
+        # missing or the draw failed — that's our "was it annotated?" signal.
+        annotated = annotated_png is not png_bytes
+        encoded, used_format, img_w, img_h = await asyncio.to_thread(
+            _encode_screenshot,
+            annotated_png, fmt, quality, scale_f, agent_id=agent_id,
+        )
+        b64 = base64.b64encode(encoded).decode()
+
+        # Coordinate-mapping metadata — identical semantics to ``screenshot``.
+        # Always a viewport capture here, so ``click_scale`` applies whenever
+        # the viewport is known and the encoded image has real dimensions.
+        viewport_data = None
+        click_scale = None
+        if isinstance(raw_viewport, dict):
+            css_vw = raw_viewport.get("width")
+            css_vh = raw_viewport.get("height")
+            if isinstance(css_vw, (int, float)) and isinstance(css_vh, (int, float)):
+                viewport_data = {"width": css_vw, "height": css_vh}
+                if img_w > 0 and img_h > 0:
+                    click_scale = {"x": css_vw / img_w, "y": css_vh / img_h}
+
+        # Strip the internal CSS ``box`` tuple — the agent gets mark/ref/role/
+        # name/x/y only.
+        public_marks = [
+            {
+                "mark": m["mark"], "ref": m["ref"], "role": m["role"],
+                "name": m["name"], "x": m["x"], "y": m["y"],
+            }
+            for m in marks
+        ]
+
+        data = {
+            "image_base64": b64,
+            "format": used_format,
+            "bytes": len(encoded),
+            "viewport": viewport_data,
+            "image": {"width": img_w, "height": img_h},
+            "marks": public_marks,
+            "marks_shown": len(public_marks),
+            "marks_truncated": marks_truncated,
+            "snapshot_truncated": snapshot_truncated,
+            "marks_max": max_marks_i,
+            "annotated": annotated,
         }
         if click_scale is not None:
             data["click_scale"] = click_scale

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1727,6 +1727,7 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_get_elements",
     "browser_wait_for",
     "browser_screenshot",
+    "browser_screenshot_marks",
     "browser_click",
     "browser_click_xy",
     "browser_type",

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -47,6 +47,7 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset(
         "type",
         "hover",
         "screenshot",
+        "screenshot_marks",
         "reset",
         "focus",
         "status",

--- a/tests/test_browser_set_of_marks.py
+++ b/tests/test_browser_set_of_marks.py
@@ -1,0 +1,441 @@
+"""Tests for the set-of-marks screenshot annotation feature.
+
+Two layers, both hermetic (no Docker, no real browser):
+
+1. The pure ``_draw_set_of_marks`` helper — valid-PNG output, graceful
+   no-op identity, and DPR-correct coordinate math.
+2. ``BrowserManager.screenshot_marks`` with the a11y/locator machinery
+   mocked, plus the ``browser_screenshot_marks`` agent tool wrapper's
+   ``_image`` extraction and param plumbing.
+"""
+
+import atexit
+import base64
+import shutil
+import tempfile
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser.ref_handle import RefHandle
+from src.browser.service import (
+    BrowserManager,
+    CamoufoxInstance,
+    _draw_set_of_marks,
+)
+
+_PROFILES_ROOT = tempfile.mkdtemp(prefix="ol_test_set_of_marks_")
+atexit.register(shutil.rmtree, _PROFILES_ROOT, ignore_errors=True)
+
+
+def _make_png_bytes(width: int = 200, height: int = 200) -> bytes:
+    """Render a real PNG of a known pixel size with deterministic content."""
+    from PIL import Image
+    img = Image.new("RGB", (width, height))
+    pixels = img.load()
+    for y in range(height):
+        for x in range(width):
+            pixels[x, y] = (x * 3 % 256, y * 3 % 256, (x + y) % 256)
+    out = BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()
+
+
+def _open(png_bytes: bytes):
+    from PIL import Image
+    return Image.open(BytesIO(png_bytes)).convert("RGB")
+
+
+class TestDrawSetOfMarks:
+    """The pure ``_draw_set_of_marks`` helper."""
+
+    def test_valid_png_output_differs_from_input(self):
+        """With marks + Pillow present, output is a NEW valid PNG object."""
+        png = _make_png_bytes(200, 200)
+        marks = [{"mark": 1, "box": (10, 10, 20, 20)}]
+        out = _draw_set_of_marks(png, marks, css_w=200, css_h=200, agent_id="a1")
+        # New object (identity differs — annotation happened).
+        assert out is not png
+        # Still a valid PNG of the same dimensions.
+        img = _open(out)
+        assert img.size == (200, 200)
+
+    def test_empty_marks_returns_same_object(self):
+        """No marks → nothing to draw → SAME object (annotated=False signal)."""
+        png = _make_png_bytes(64, 48)
+        out = _draw_set_of_marks(png, [], css_w=64, css_h=48, agent_id="a1")
+        assert out is png
+
+    def test_zero_css_dims_returns_same_object(self):
+        """Unusable CSS viewport (0) → SAME object, no divide-by-zero."""
+        png = _make_png_bytes(64, 48)
+        marks = [{"mark": 1, "box": (1, 1, 2, 2)}]
+        assert _draw_set_of_marks(png, marks, 0, 0, agent_id="a1") is png
+
+    def test_dpr_correct_coordinate_scaling(self):
+        """A retina 2× PNG (image 200×200, CSS viewport 100×100) must scale
+        each CSS box up by 2× before drawing. A CSS box at (10,10,20,20)
+        lands its outline at image pixels (20,20)-(60,60); assert the drawn
+        red edge is there and a far region is untouched."""
+        png = _make_png_bytes(200, 200)
+        original = _open(png)
+        marks = [{"mark": 1, "box": (10, 10, 20, 20)}]
+        out = _draw_set_of_marks(png, marks, css_w=100, css_h=100, agent_id="a1")
+        assert out is not png
+        img = _open(out)
+
+        # Top edge of the DPR-scaled rectangle (y≈20, x within 20..60) is red.
+        assert img.getpixel((40, 20)) == (255, 0, 0)
+        # A pixel well outside the box + label is untouched vs the original.
+        assert img.getpixel((150, 150)) == original.getpixel((150, 150))
+        # Sanity: if scaling were 1× (bug), (40,20) would NOT be on the
+        # rectangle (which would sit at 10..30) — the assertion above pins it.
+
+    def test_bad_box_shape_skipped_not_fatal(self):
+        """A malformed box entry is skipped; a good one still draws."""
+        png = _make_png_bytes(200, 200)
+        marks = [
+            {"mark": 1, "box": (10, 10)},          # wrong arity → skipped
+            {"mark": 2, "box": (50, 50, 20, 20)},  # good → drawn
+        ]
+        out = _draw_set_of_marks(png, marks, css_w=200, css_h=200)
+        assert out is not png
+        assert _open(out).size == (200, 200)
+
+    def test_outline_thicker_at_downscale(self):
+        """Marks are size-compensated: at scale<1 the outline (and label) are
+        drawn thicker on the native image so they survive the downscale. Assert
+        the scale=0.5 render lays down strictly more red than scale=1.0."""
+        png = _make_png_bytes(200, 200)
+        marks = [{"mark": 1, "box": (50, 50, 100, 60)}]
+
+        def _red_count(scale: float) -> int:
+            out = _draw_set_of_marks(
+                png, marks, css_w=200, css_h=200, scale=scale, agent_id="a1",
+            )
+            assert out is not png
+            img = _open(out)
+            return sum(
+                1
+                for y in range(img.height)
+                for x in range(img.width)
+                if img.getpixel((x, y)) == (255, 0, 0)
+            )
+
+        assert _red_count(0.5) > _red_count(1.0)
+
+
+def _fake_locator(box, visible=True):
+    loc = AsyncMock()
+    loc.is_visible = AsyncMock(return_value=visible)
+    loc.bounding_box = AsyncMock(return_value=box)
+    return loc
+
+
+def _ref(role, name):
+    return RefHandle.light_dom(
+        page_id="p", scope_root=None, role=role, name=name,
+        occurrence=0, disabled=False,
+    )
+
+
+def _make_mgr(agent_id, png_bytes, viewport):
+    mgr = BrowserManager(profiles_dir=f"{_PROFILES_ROOT}/profiles")
+    mock_page = AsyncMock()
+    mock_page.screenshot = AsyncMock(return_value=png_bytes)
+    mock_page.viewport_size = viewport
+    inst = CamoufoxInstance(agent_id, MagicMock(), MagicMock(), mock_page)
+    mgr._instances[agent_id] = inst
+    # Snapshot is a no-op here — refs are pre-populated by the caller.
+    mgr._snapshot_impl = AsyncMock(return_value={"success": True})
+    return mgr, inst
+
+
+class TestScreenshotMarksManager:
+    """``BrowserManager.screenshot_marks`` mark-building + coordinate output."""
+
+    @pytest.mark.asyncio
+    async def test_builds_marks_for_actionable_visible_refs(self):
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        inst.refs = {
+            "e0": _ref("button", "Play"),
+            "e1": _ref("heading", "Title"),   # not actionable → skipped
+            "e2": _ref("link", "Home"),
+        }
+        locators = {
+            "e0": _fake_locator({"x": 100, "y": 200, "width": 50, "height": 20}),
+            "e2": _fake_locator({"x": 300, "y": 400, "width": 80, "height": 30}),
+        }
+
+        async def _resolve(_inst, ref):
+            return locators.get(ref)
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png", scale=1.0)
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["marks_shown"] == 2
+        assert data["marks_truncated"] is False
+        assert data["marks_max"] == 50
+        assert data["annotated"] is True
+        assert data["viewport"] == {"width": 800, "height": 600}
+        assert data["image"] == {"width": 800, "height": 600}
+        assert data["click_scale"] == {"x": 1.0, "y": 1.0}
+        # Mark 1 → e0 (button), centre = (100+25, 200+10).
+        assert data["marks"][0] == {
+            "mark": 1, "ref": "e0", "role": "button",
+            "name": "Play", "x": 125.0, "y": 210.0,
+        }
+        assert data["marks"][1]["ref"] == "e2"
+        assert data["marks"][1]["mark"] == 2
+        # Internal CSS box tuple must be stripped from the wire shape.
+        assert all("box" not in m for m in data["marks"])
+        # Image is real base64 and byte count matches.
+        assert len(base64.b64decode(data["image_base64"])) == data["bytes"]
+
+    @pytest.mark.asyncio
+    async def test_out_of_viewport_ref_skipped(self):
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        inst.refs = {
+            "e0": _ref("button", "In"),
+            "e1": _ref("button", "Off"),
+        }
+        locators = {
+            "e0": _fake_locator({"x": 10, "y": 10, "width": 40, "height": 20}),
+            # x >= viewport width → fully off-screen.
+            "e1": _fake_locator({"x": 900, "y": 10, "width": 40, "height": 20}),
+        }
+
+        async def _resolve(_inst, ref):
+            return locators.get(ref)
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png")
+        marks = result["data"]["marks"]
+        assert [m["ref"] for m in marks] == ["e0"]
+
+    @pytest.mark.asyncio
+    async def test_edge_element_click_point_strictly_inside_viewport(self):
+        """An element touching the right edge must yield x < vw (click_xy
+        rejects x>=vw). The click point is the centre of the visible
+        intersection, clamped strictly inside — NOT the raw centre clamped
+        to the edge."""
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        inst.refs = {"e0": _ref("button", "Edge")}
+        # x=790,width=100 in an 800px viewport → raw centre 840 (off-screen).
+        locators = {
+            "e0": _fake_locator({"x": 790, "y": 10, "width": 100, "height": 20}),
+        }
+
+        async def _resolve(_inst, ref):
+            return locators.get(ref)
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png")
+        mark = result["data"]["marks"][0]
+        assert mark["ref"] == "e0"
+        # Strictly clickable: x < viewport width, and y in bounds.
+        assert mark["x"] < 800.0
+        assert 0.0 <= mark["y"] < 600.0
+        # Centre of the visible slice [790..800] → 795.
+        assert mark["x"] == 795.0
+
+    @pytest.mark.asyncio
+    async def test_snapshot_truncation_propagates(self):
+        """When the a11y snapshot itself dropped elements past its cap,
+        ``snapshot_truncated`` must be True and stay DISTINCT from
+        ``marks_truncated``."""
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        mgr._snapshot_impl = AsyncMock(
+            return_value={"success": True, "data": {"truncated": True}},
+        )
+        inst.refs = {"e0": _ref("button", "One")}
+        locators = {
+            "e0": _fake_locator({"x": 10, "y": 10, "width": 40, "height": 20}),
+        }
+
+        async def _resolve(_inst, ref):
+            return locators.get(ref)
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png")
+        data = result["data"]
+        assert data["snapshot_truncated"] is True
+        # marks_truncated tracks the max_marks cap only — untouched here.
+        assert data["marks_truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_not_truncated_by_default(self):
+        """No upstream truncation → ``snapshot_truncated`` is False."""
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        inst.refs = {"e0": _ref("button", "One")}
+        locators = {
+            "e0": _fake_locator({"x": 10, "y": 10, "width": 40, "height": 20}),
+        }
+
+        async def _resolve(_inst, ref):
+            return locators.get(ref)
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png")
+        assert result["data"]["snapshot_truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_max_marks_truncates(self):
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        inst.refs = {
+            "e0": _ref("button", "One"),
+            "e1": _ref("button", "Two"),
+        }
+        locators = {
+            "e0": _fake_locator({"x": 10, "y": 10, "width": 40, "height": 20}),
+            "e1": _fake_locator({"x": 60, "y": 60, "width": 40, "height": 20}),
+        }
+
+        async def _resolve(_inst, ref):
+            return locators.get(ref)
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png", max_marks=1)
+        data = result["data"]
+        assert data["marks_shown"] == 1
+        assert data["marks_truncated"] is True
+        assert data["marks_max"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_ref_does_not_abort_capture(self):
+        """A ref whose resolution raises must be skipped, not fatal."""
+        from src.browser.ref_handle import RefStale
+        png = _make_png_bytes(800, 600)
+        mgr, inst = _make_mgr("a1", png, {"width": 800, "height": 600})
+        inst.refs = {
+            "e0": _ref("button", "Bad"),
+            "e1": _ref("button", "Good"),
+        }
+        good = _fake_locator({"x": 10, "y": 10, "width": 40, "height": 20})
+
+        async def _resolve(_inst, ref):
+            if ref == "e0":
+                raise RefStale("tab closed", ref=ref)
+            return good
+        mgr._locator_from_ref = _resolve
+
+        result = await mgr.screenshot_marks("a1", format="png")
+        assert result["success"] is True
+        assert [m["ref"] for m in result["data"]["marks"]] == ["e1"]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_rejected(self):
+        png = _make_png_bytes(100, 100)
+        mgr, _inst = _make_mgr("a1", png, {"width": 100, "height": 100})
+        result = await mgr.screenshot_marks("a1", format="gif")
+        assert result["success"] is False
+        assert "gif" in result["error"].lower()
+
+
+class TestScreenshotMarksTool:
+    """The ``browser_screenshot_marks`` agent-tool wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_emits_action_and_extracts_image(self):
+        from src.agent.builtins.browser_tool import browser_screenshot_marks
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "image_base64": base64.b64encode(b"IMG").decode(),
+                "format": "webp",
+                "marks": [{"mark": 1, "ref": "e0", "x": 10.0, "y": 20.0}],
+                "marks_shown": 1,
+            },
+        })
+
+        result = await browser_screenshot_marks(
+            format="png", quality=90, scale=0.8, max_marks=10, mesh_client=mc,
+        )
+
+        mc.browser_command.assert_awaited_once_with(
+            "screenshot_marks",
+            {"format": "png", "quality": 90, "scale": 0.8, "max_marks": 10},
+        )
+        # Image extracted into _image, popped from data before redaction.
+        assert result["_image"] == {
+            "data": base64.b64encode(b"IMG").decode(),
+            "media_type": "image/webp",
+        }
+        assert "image_base64" not in result["data"]
+        # The marks map survives redaction.
+        assert result["data"]["marks"][0]["ref"] == "e0"
+
+    @pytest.mark.asyncio
+    async def test_defaults(self):
+        from src.agent.builtins.browser_tool import browser_screenshot_marks
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_screenshot_marks(mesh_client=mc)
+        mc.browser_command.assert_awaited_once_with(
+            "screenshot_marks",
+            {"format": "webp", "quality": 75, "scale": 1.0, "max_marks": 50},
+        )
+
+    @pytest.mark.asyncio
+    async def test_status_reflects_annotation_happened(self):
+        """When the service reports ``annotated=True`` the status says so and
+        includes the mark count."""
+        from src.agent.builtins.browser_tool import browser_screenshot_marks
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "image_base64": base64.b64encode(b"IMG").decode(),
+                "format": "webp",
+                "marks": [{"mark": 1, "ref": "e0", "x": 1.0, "y": 2.0}],
+                "annotated": True,
+            },
+        })
+        result = await browser_screenshot_marks(mesh_client=mc)
+        assert "annotated screenshot captured" in result["status"]
+        assert "1 marks" in result["status"]
+
+    @pytest.mark.asyncio
+    async def test_status_does_not_claim_annotated_when_draw_failed(self):
+        """An image exists even when annotation didn't happen (Pillow missing /
+        draw failed / no marks). Status must NOT claim 'annotated'."""
+        from src.agent.builtins.browser_tool import browser_screenshot_marks
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "image_base64": base64.b64encode(b"IMG").decode(),
+                "format": "png",
+                "marks": [{"mark": 1, "ref": "e0", "x": 1.0, "y": 2.0}],
+                "annotated": False,
+            },
+        })
+        result = await browser_screenshot_marks(mesh_client=mc)
+        # An image is still attached.
+        assert result["_image"]["media_type"] == "image/png"
+        # But the status is honest about annotation being unavailable.
+        assert "annotated screenshot captured" not in result["status"]
+        assert "annotation unavailable" in result["status"]
+        assert "1 marks mapped" in result["status"]
+
+    @pytest.mark.asyncio
+    async def test_no_mesh_client(self):
+        from src.agent.builtins.browser_tool import browser_screenshot_marks
+
+        result = await browser_screenshot_marks(mesh_client=None)
+        assert "error" in result
+        assert "mesh" in result["error"].lower()

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2033,6 +2033,7 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     # download/reset/go_back/go_forward/solve_captcha share the
     # generic "using browser_*" fallback which reads fine).
     "browser_warmup",
+    "browser_screenshot_marks",
     "browser_switch_tab",
     "browser_open_tab",
     "browser_inspect_requests",

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -212,6 +212,20 @@ class TestCanBrowserAction:
             # can_use_browser=False overrides even a wildcard.
             assert browser_matrix.can_browser_action("no-browser-agent", action) is False, action
 
+    def test_screenshot_marks_action_gating(self, browser_matrix):
+        """The set-of-marks capture is a distinct action from ``screenshot``:
+        default-allow, honors the wildcard, and is narrowable. The
+        readonly-agent allows ``screenshot`` but NOT ``screenshot_marks``,
+        so a narrowed allowlist must deny it."""
+        # Default (None) and wildcard both allow.
+        assert browser_matrix.can_browser_action("legacy-agent", "screenshot_marks") is True
+        assert browser_matrix.can_browser_action("wildcard-agent", "screenshot_marks") is True
+        # readonly-agent allows plain screenshot but not screenshot_marks.
+        assert browser_matrix.can_browser_action("readonly-agent", "screenshot") is True
+        assert browser_matrix.can_browser_action("readonly-agent", "screenshot_marks") is False
+        # can_use_browser=False overrides even a wildcard.
+        assert browser_matrix.can_browser_action("no-browser-agent", "screenshot_marks") is False
+
     def test_specific_list_is_opt_out_restriction(self, browser_matrix):
         """Operators can narrow to a specific list — opt-out default-allow."""
         assert browser_matrix.can_browser_action("readonly-agent", "navigate") is True
@@ -283,6 +297,13 @@ class TestKnownBrowserActionsSet:
         from src.host.permissions import KNOWN_BROWSER_ACTIONS
         assert "upload_file" in KNOWN_BROWSER_ACTIONS
         assert "download" in KNOWN_BROWSER_ACTIONS
+
+    def test_screenshot_marks_present(self):
+        """The set-of-marks capture action must be recognized by the mesh
+        input validator so ``/mesh/browser/command`` accepts it (else a
+        clean 400 blocks the action before the per-agent gate decides)."""
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "screenshot_marks" in KNOWN_BROWSER_ACTIONS
 
     def test_phase_5_find_text_and_open_tab_present(self):
         """Phase 5 §8.5 / §8.6 default-allow actions registered with the


### PR DESCRIPTION
## What

Adds a `screenshot_marks` browser action + `browser_screenshot_marks` agent tool: a **set-of-marks** annotated viewport screenshot. It draws numbered boxes over every actionable element (resolved from the a11y snapshot's refs) and returns a `marks` map binding each number to:
- a `ref` — click via the existing `browser_click(ref=…)` (preferred, resolution-stable), and
- `x`/`y` — the element's CSS-pixel centre, clickable via `browser_click_xy`.

## Why

This is the accuracy unlock for **canvas / WebGL / map / image-heavy** pages where the accessibility snapshot alone can't localize a target. The agent loop is already multimodal (it sees its own screenshots and can drive `click_xy`); the missing piece was acting *reliably* on what it sees. Numbered marks let the model click "mark 7" instead of guessing raw pixels.

## Design notes

- **New action, not a flag on `screenshot`** — discoverability: the model should reach for this on visual pages, and plain `screenshot` stays untouched.
- **No new click surface** — the marks map carries `ref` + CSS `x`/`y`, so clicks route through existing paths.
- **Server-side Pillow drawing** — no DOM injection, no layout shift, no stealth tell. Degrades gracefully to the map + un-annotated image when Pillow is absent.
- Builds on #1205's coordinate mapping (`viewport`/`image`/`click_scale`). Marks are **DPR-correct** (retina 2× lands boxes on the right pixels) and **size-compensated** so labels stay legible under `scale<1` downscale.
- **Truth-telling**: `snapshot_truncated` surfaces the upstream a11y element cap; the click centre is the element's *visible-intersection* centre kept strictly inside the viewport (so the returned `x`/`y` is always a valid `click_xy` target); the tool `status` never claims annotation when Pillow was unavailable.

## Scope

Browser-dir only. Wires through `KNOWN_BROWSER_ACTIONS`, the three tool gate-lists (`loop.py`, `tool_groups.py`, `cli/config.py`), the browser service route, dashboard tool-map allowlist, and permission tests. No `Dockerfile.browser`/`pyproject.toml` changes (Pillow already a browser-side dep).

## Testing

New `tests/test_browser_set_of_marks.py` (19 tests: pure-helper coordinate math incl. the DPR 2× case, edge-element strictly-clickable centre, mark-building/viewport-filter/truncation, non-fatal stale-ref, tool `_image` extraction + honest status). Cross-cutting suites green (permissions, dashboard tool-map, loop gating, builtins, browser-parity: 809 passed / 3 skipped). Reviewed as a principal engineer + independent Codex pass (found 4 real bugs — edge-element un-clickable coord, `marks_truncated` honesty, label legibility at `scale<1`, status truthfulness — all fixed).

Not deployed (merge ≠ deploy).