### PR TITLE
feat(browser): select_option action for native <select> dropdowns

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1027,6 +1027,94 @@ async def browser_type(
 
 
 @tool(
+    name="browser_select_option",
+    description=(
+        "Choose an option in a native HTML <select> dropdown. Identify the "
+        "select by ref from browser_get_elements (role 'combobox' backed by "
+        "a real <select> tag — preferred) or a CSS selector. Pick the option "
+        "with EXACTLY ONE of: value (the <option>'s value attribute), label "
+        "(its visible text), or index (0-based position). This sets the "
+        "value directly and fires input/change events — it does NOT open "
+        "the browser's native dropdown popup (that popup isn't part of the "
+        "page DOM, so nothing can click into it). "
+        "This only works on a REAL <select> element. For a custom "
+        "(non-native) dropdown built from divs/listbox roles, use "
+        "browser_click to open it, then either browser_click the option or "
+        "browser_press_key with ArrowDown/Enter to navigate it — calling "
+        "this tool on one returns a not_a_select error."
+    ),
+    parameters={
+        "selector": {
+            "type": "string",
+            "description": "CSS selector of the <select> element. Not needed if ref is provided.",
+            "default": "",
+        },
+        "ref": {
+            "type": "string",
+            "description": (
+                "Preferred: element ref from browser_get_elements "
+                "(e.g. 'e5'), role combobox. Use this instead of selector "
+                "when available."
+            ),
+            "default": "",
+        },
+        "value": {
+            "type": "string",
+            "description": "The <option>'s value attribute to select. Provide exactly one of value/label/index.",
+        },
+        "label": {
+            "type": "string",
+            "description": "The option's visible text to select. Provide exactly one of value/label/index.",
+        },
+        "index": {
+            "type": "integer",
+            "description": "0-based position of the option to select. Provide exactly one of value/label/index.",
+        },
+        "snapshot_after": {
+            "type": "boolean",
+            "description": "Include element snapshot in the response (default false)",
+            "default": False,
+        },
+        "frame": {
+            "type": "string",
+            "description": (
+                "Optional frame selector for selector-based selection. "
+                "Matched as a URL substring against frame URLs, or as a "
+                "frame_id token from a prior snapshot. Refs from a "
+                "snapshot already carry their frame, so this argument is "
+                "redundant when ref is set and conflicts return an error."
+            ),
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_select_option(
+    selector: str = "", ref: str = "",
+    value: str | None = None, label: str | None = None, index: int | None = None,
+    snapshot_after: bool = False, frame: str | None = None,
+    *, mesh_client=None,
+) -> dict:
+    """Select an option in a native <select> dropdown by value, label, or index."""
+    if not selector and not ref:
+        return {"error": "Provide either 'ref' (from browser_get_elements) or 'selector' (CSS)"}
+    if value is None and label is None and index is None:
+        return {"error": "Provide one of 'value', 'label', or 'index'"}
+    if sum(x is not None for x in (value, label, index)) > 1:
+        return {"error": "Provide exactly one of 'value', 'label', or 'index' (not multiple)"}
+
+    cmd = {"ref": ref, "selector": selector, "snapshot_after": snapshot_after}
+    if value is not None:
+        cmd["value"] = value
+    if label is not None:
+        cmd["label"] = label
+    if index is not None:
+        cmd["index"] = index
+    if frame is not None:
+        cmd["frame"] = frame
+    return await _browser_command(mesh_client, "select_option", cmd)
+
+
+@tool(
     name="browser_hover",
     description=(
         "Move the mouse over an element without clicking it. "

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -151,6 +151,7 @@ _RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
         "browser_grant_permissions", "browser_set_geolocation",
         "browser_right_click", "browser_read_clipboard",
         "browser_write_clipboard", "browser_wait_for_network_idle",
+        "browser_select_option",
     }),
 }
 

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -124,6 +124,7 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
             "browser_grant_permissions", "browser_set_geolocation",
             "browser_right_click", "browser_read_clipboard",
             "browser_write_clipboard", "browser_wait_for_network_idle",
+            "browser_select_option",
         ),
     ),
 )

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -409,6 +409,23 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/select_option")
+    async def select_option(agent_id: str, request: Request):
+        _verify_auth(request)
+        body = await request.json()
+        result = await manager.select_option(
+            agent_id,
+            ref=body.get("ref"),
+            selector=body.get("selector"),
+            value=body.get("value"),
+            label=body.get("label"),
+            index=body.get("index"),
+            snapshot_after=_body_bool(body, "snapshot_after", False),
+            frame=body.get("frame"),
+        )
+        await _apply_delay()
+        return result
+
     # /browser/{agent_id}/evaluate endpoint intentionally removed —
     # arbitrary JS execution is an SSRF/sandbox-escape vector.
     # The evaluate() method remains on BrowserManager for internal use only.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -9454,6 +9454,206 @@ class BrowserManager:
                 action_result.setdefault("captcha", captcha_envelope)
             return action_result
 
+    async def select_option(
+        self, agent_id: str, ref: str | None = None, selector: str | None = None,
+        value: str | list[str] | None = None,
+        label: str | list[str] | None = None,
+        index: int | list[int] | None = None,
+        snapshot_after: bool = False,
+        frame: str | None = None,
+    ) -> dict:
+        """Choose an option in a native ``<select>`` dropdown.
+
+        Sets the underlying DOM value and fires ``input``/``change``
+        directly via Playwright's ``locator.select_option`` — it does NOT
+        open the OS-native popup a real click on a Firefox ``<select>``
+        would show. That popup lives outside the page DOM entirely, so
+        nothing in this service's ref/snapshot machinery can see or
+        drive it; ``select_option`` sidesteps the popup rather than
+        operating it.
+
+        Only works on NATIVE ``<select>`` elements (ARIA role
+        ``combobox`` backed by a real ``<select>`` tag in a snapshot). A
+        custom ARIA dropdown built from divs/listbox roles is not a real
+        ``<select>`` — Playwright raises on it and this method returns
+        ``not_a_select`` directing the agent to ``browser_click`` +
+        ``press_key`` (ArrowDown/Enter) instead.
+
+        Identify the option with exactly one of ``value`` (the
+        ``<option>``'s ``value`` attribute), ``label`` (its visible
+        text), or ``index`` (0-based position). Each may be a single
+        string/int or a list of them for a multi-select — Playwright
+        treats whichever kwarg is supplied as authoritative.
+        """
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            async def _select_body() -> dict:
+                if inst._user_control:
+                    return {
+                        "success": False,
+                        "error": "User has browser control — action paused until control is released.",
+                    }
+                if value is None and label is None and index is None:
+                    return _err("invalid_input", "Provide one of value, label, or index")
+                if sum(x is not None for x in (value, label, index)) > 1:
+                    return _err(
+                        "invalid_input",
+                        "Provide exactly one of value, label, or index (not multiple)",
+                    )
+
+                resolved_frame = None
+                if frame is not None:
+                    try:
+                        resolved_frame = self._resolve_frame_arg(inst, frame)
+                    except RefStale as rs:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "ref_stale",
+                                "message": str(rs),
+                            },
+                        }
+                    if resolved_frame is None:
+                        return {
+                            "success": False,
+                            "error": (
+                                f"frame {frame!r} did not match any frame "
+                                "url-substring or frame_id"
+                            ),
+                        }
+
+                locator = None
+                if ref and ref in inst.refs:
+                    if frame is not None:
+                        ref_info = inst.refs[ref]
+                        resolved_frame_id = (
+                            inst._register_frame(resolved_frame)
+                            if resolved_frame is not None else None
+                        )
+                        # Caller asserted a specific frame; ref must agree.
+                        if ref_info.frame_id != resolved_frame_id:
+                            return {
+                                "success": False,
+                                "error": {
+                                    "code": "invalid_input",
+                                    "message": (
+                                        "frame argument conflicts with "
+                                        "ref's frame"
+                                    ),
+                                },
+                            }
+                    try:
+                        locator = await self._locator_from_ref(inst, ref)
+                    except RefStale as rs:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "ref_stale",
+                                "message": str(rs),
+                            },
+                        }
+                    if not locator:
+                        return {"success": False, "error": f"Ref '{ref}' not found"}
+                elif selector:
+                    if resolved_frame is not None:
+                        locator = resolved_frame.locator(selector).first
+                    else:
+                        locator = inst.page.locator(selector).first
+                else:
+                    return {"success": False, "error": "Must provide ref or selector"}
+
+                kwargs: dict = {}
+                if value is not None:
+                    kwargs["value"] = value
+                if label is not None:
+                    kwargs["label"] = label
+                if index is not None:
+                    kwargs["index"] = index
+
+                try:
+                    selected = await locator.select_option(**kwargs)
+                except Exception as e:
+                    msg_l = str(e).lower()
+                    # A detached/stale element (shadow ElementHandle that went away, closed
+                    # tab) — surface as ref_stale so the agent re-snapshots, NOT not_a_select.
+                    if "not attached" in msg_l or "detached" in msg_l:
+                        return {"success": False, "error": {"code": "ref_stale", "message": str(e)}}
+                    # Genuinely not a native <select> (custom ARIA dropdown). Match ONLY the
+                    # specific phrasing — "element is not a" alone is too broad.
+                    if "is not a <select>" in msg_l:
+                        return _err(
+                            "not_a_select",
+                            "Element is not a native <select>. For a custom dropdown, use "
+                            "browser_click to open it then browser_click the option, or "
+                            "press_key with ArrowDown/Enter.",
+                        )
+                    # Explicit no-matching-option phrasings.
+                    if (
+                        "did not find some options" in msg_l
+                        or "options not found" in msg_l
+                        or "no options matched" in msg_l
+                    ):
+                        return _err(
+                            "option_not_found",
+                            "No option matched the given value/label/index. Snapshot the "
+                            "select's options first.",
+                        )
+                    # A bare timeout is AMBIGUOUS — hidden/disabled/detached/still-loading, or
+                    # the option doesn't exist. Report honestly rather than guessing.
+                    if "timeout" in msg_l and "exceeded" in msg_l:
+                        return _err(
+                            "not_interactable",
+                            "The <select> did not accept the selection within the timeout — "
+                            "it may be hidden, disabled, still loading, detached, or the "
+                            "requested option doesn't exist. Snapshot it and verify.",
+                        )
+                    raise
+
+                landed = None
+                try:
+                    landed = await locator.input_value()
+                except Exception:
+                    pass
+
+                # A <select> whose change handler reverts the value makes Playwright
+                # return the requested option in ``selected`` while ``input_value()``
+                # shows the OLD value — a contradictory success. Verify it stuck.
+                if landed is not None and selected and landed not in selected:
+                    return _err(
+                        "selection_reverted",
+                        f"The <select> value did not change to the requested option "
+                        f"(page script may have reset it). Current value: {landed!r}.",
+                    )
+
+                result = {
+                    "success": True,
+                    "data": {
+                        "selected": selected,
+                        "value": landed,
+                        "ref": ref or selector,
+                    },
+                }
+                if snapshot_after:
+                    snap = await self._snapshot_impl(inst, agent_id)
+                    result["snapshot"] = snap.get("data", {})
+                return result
+
+            try:
+                action_result, captcha_envelope = await self._with_captcha_redetect(
+                    inst, _select_body(),
+                )
+            except Exception as e:
+                return _err("service_unavailable", str(e))
+
+            if (
+                captcha_envelope is not None
+                and isinstance(action_result, dict)
+                and action_result.get("success")
+            ):
+                action_result.setdefault("captcha", captcha_envelope)
+            return action_result
+
     async def evaluate(self, agent_id: str, expression: str) -> dict:
         """Execute JavaScript and return result.
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1754,6 +1754,7 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "browser_read_clipboard",
     "browser_write_clipboard",
     "browser_wait_for_network_idle",
+    "browser_select_option",
 ]
 
 # Grouped Tool Search bridge — pulls a deferred capability group's full schemas

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -108,6 +108,12 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset(
         "read_clipboard",
         "write_clipboard",
         "wait_for_network_idle",
+        # Native <select> dropdown support — sets the value via
+        # Playwright's ``locator.select_option`` (with a trusted-keyboard
+        # fallback for non-native dropdowns). Default-allow like every
+        # other known action; operators narrow via
+        # ``AgentPermissions.browser_actions``.
+        "select_option",
     }
 )
 

--- a/tests/test_browser_select_option.py
+++ b/tests/test_browser_select_option.py
@@ -1,0 +1,402 @@
+"""Tests for the ``select_option`` browser action — native <select> support.
+
+Covers:
+
+  * Agent-tool forwarding — ``browser_select_option`` emits the
+    ``select_option`` mesh action with the right params.
+  * Manager primary path — ``locator.select_option`` is called with
+    exactly the supplied kwarg (value/label/index) and the response
+    echoes the returned selection + the landed ``input_value()``.
+  * Manager error classification — an "is not a <select>" Playwright
+    error is classified as ``not_a_select``; an explicit no-matching-
+    option error is ``option_not_found``; a detached/not-attached
+    element is ``ref_stale``; a bare timeout is the honest, ambiguous
+    ``not_interactable`` (NOT option_not_found — the select may be
+    hidden/disabled/loading); missing value/label/index is rejected as
+    ``invalid_input`` before any locator resolution; supplying more than
+    one of value/label/index is also ``invalid_input``.
+  * Post-select verification — when the returned selection and the
+    landed ``input_value()`` disagree (a change handler reverted the
+    value), the result is ``selection_reverted``, not a false success.
+
+Mirrors ``tests/test_browser_parity_actions.py`` / ``tests/test_browser_captcha_redetect.py``:
+every test drives ``BrowserManager`` handler methods directly against a
+real ``CamoufoxInstance`` wrapping mocked Playwright objects (patching
+``get_or_start``) — no Docker, no real browser.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser.service import BrowserManager, CamoufoxInstance
+
+
+def _mk_page(*, url: str = "https://example.com"):
+    """Playwright-shaped page mock — ``evaluate`` backs the
+    ``_with_captcha_redetect`` install/read-back calls that
+    ``select_option`` is wrapped in (mirrors ``type_text``). Returning a
+    non-list keeps the wrapper on its fast "no captcha-shaped mutation"
+    path with no further side effects.
+    """
+    page = MagicMock()
+    page.url = url
+    page.evaluate = AsyncMock(return_value=[])
+    return page
+
+
+def _mk_inst(page=None, agent_id: str = "agent-select") -> CamoufoxInstance:
+    page = page if page is not None else _mk_page()
+    return CamoufoxInstance(agent_id, MagicMock(), MagicMock(), page)
+
+
+def _make_manager() -> BrowserManager:
+    root = tempfile.mkdtemp(prefix="ol_select_option_")
+    return BrowserManager(profiles_dir=root)
+
+
+def _patch_get_or_start(mgr: BrowserManager, inst: CamoufoxInstance) -> None:
+    mgr.get_or_start = AsyncMock(return_value=inst)  # type: ignore[assignment]
+
+
+def _mk_locator(*, select_option_result=None, select_option_error=None, input_value=""):
+    loc = MagicMock()
+    if select_option_error is not None:
+        loc.select_option = AsyncMock(side_effect=select_option_error)
+    else:
+        loc.select_option = AsyncMock(return_value=select_option_result or [])
+    loc.input_value = AsyncMock(return_value=input_value)
+    return loc
+
+
+# ── Manager: primary (native <select>) path ────────────────────────────────
+
+
+class TestSelectOptionPrimaryPath:
+    @pytest.mark.asyncio
+    async def test_selects_by_value_and_returns_selected(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(select_option_result=["red"], input_value="red")
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="red")
+
+        assert result["success"] is True
+        assert result["data"]["selected"] == ["red"]
+        assert result["data"]["value"] == "red"
+        assert result["data"]["ref"] == "e1"
+        loc.select_option.assert_awaited_once_with(value="red")
+
+    @pytest.mark.asyncio
+    async def test_selects_by_label(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        # Playwright's select_option returns option *values*; input_value()
+        # reports the same value — keep the mock self-consistent so the
+        # post-select verification (Fix 3) sees the value stuck.
+        loc = _mk_locator(select_option_result=["blue"], input_value="blue")
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", label="Blue")
+
+        assert result["success"] is True
+        loc.select_option.assert_awaited_once_with(label="Blue")
+
+    @pytest.mark.asyncio
+    async def test_selects_by_index(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(select_option_result=["opt3"], input_value="opt3")
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", index=2)
+
+        assert result["success"] is True
+        loc.select_option.assert_awaited_once_with(index=2)
+
+    @pytest.mark.asyncio
+    async def test_selector_path_used_when_no_ref(self):
+        mgr = _make_manager()
+        page = _mk_page()
+        loc = _mk_locator(select_option_result=["blue"], input_value="blue")
+        locator_chain = MagicMock()
+        locator_chain.first = loc
+        page.locator = MagicMock(return_value=locator_chain)
+        inst = _mk_inst(page=page)
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.select_option("agent-select", selector="#color", value="blue")
+
+        assert result["success"] is True
+        page.locator.assert_called_once_with("#color")
+        loc.select_option.assert_awaited_once_with(value="blue")
+
+
+# ── Manager: validation ─────────────────────────────────────────────────────
+
+
+class TestSelectOptionValidation:
+    @pytest.mark.asyncio
+    async def test_missing_value_label_index_returns_invalid_input(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.select_option("agent-select", ref="e1")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_missing_ref_and_selector_rejected(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+
+        result = await mgr.select_option("agent-select", value="red")
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_multiple_selectors_rejected_as_invalid_input(self):
+        """Playwright would treat value+label as two candidate matchers and
+        select whichever DOM option matches EITHER — non-deterministic. The
+        manager must reject 2+ selectors before touching the locator."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+        mgr._locator_from_ref = AsyncMock(return_value=_mk_locator())  # type: ignore[assignment]
+
+        result = await mgr.select_option(
+            "agent-select", ref="e1", value="US", label="Canada",
+        )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+
+# ── Manager: error classification ───────────────────────────────────────────
+
+
+class TestSelectOptionNotASelect:
+    @pytest.mark.asyncio
+    async def test_non_select_element_returns_not_a_select(self):
+        """A Playwright "is not a <select>" error lands on the classified
+        ``not_a_select`` directive — there is no keyboard fallback."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(
+            select_option_error=Exception("Element is not a <select> element."),
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="red")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "not_a_select"
+
+    @pytest.mark.asyncio
+    async def test_detached_element_classified_as_ref_stale(self):
+        """"Element is not attached to the DOM" matches the too-broad
+        "element is not a" prefix — it must map to ``ref_stale`` (re-snapshot),
+        NOT ``not_a_select``."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(
+            select_option_error=Exception(
+                "Element is not attached to the DOM",
+            ),
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="red")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ref_stale"
+
+
+class TestSelectOptionNotFound:
+    @pytest.mark.asyncio
+    async def test_bare_timeout_classified_as_not_interactable(self):
+        """A bare Playwright timeout is AMBIGUOUS — a hidden/disabled/detached
+        select produces the SAME error as a missing option. It must NOT be
+        reported as ``option_not_found``; the honest code is
+        ``not_interactable``."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(
+            select_option_error=Exception("Timeout 30000ms exceeded."),
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="ghost")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "not_interactable"
+
+    @pytest.mark.asyncio
+    async def test_did_not_find_some_options_classified_as_option_not_found(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(
+            select_option_error=Exception("did not find some options"),
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", label="ghost")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "option_not_found"
+
+
+class TestSelectOptionRevertedValue:
+    @pytest.mark.asyncio
+    async def test_reverted_value_classified_as_selection_reverted(self):
+        """Playwright returns the requested option in ``selected`` but a page
+        change-handler reset the DOM value, so ``input_value()`` shows the OLD
+        value. A contradictory selected/value must NOT report success."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        # select_option returns ["US"] but the select snapped back to "CA".
+        loc = _mk_locator(select_option_result=["US"], input_value="CA")
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="US")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "selection_reverted"
+
+
+class TestSelectOptionUnclassifiedErrorPropagates:
+    @pytest.mark.asyncio
+    async def test_unrelated_error_falls_to_service_unavailable(self):
+        """An exception that matches neither classifier re-raises out of
+        the body and is caught by the outer handler as ``service_unavailable``."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(select_option_error=RuntimeError("boom, unrelated"))
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="red")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+
+
+# ── Agent-side @tool forwarding ────────────────────────────────────────────
+
+
+def _mesh(action_capture: dict):
+    mc = MagicMock()
+
+    async def _cmd(action, params):
+        action_capture["action"] = action
+        action_capture["params"] = params
+        return {"success": True}
+
+    mc.browser_command = AsyncMock(side_effect=_cmd)
+    return mc
+
+
+class TestBrowserSelectOptionTool:
+    @pytest.mark.asyncio
+    async def test_emits_select_option_action_with_ref_and_value(self):
+        from src.agent.builtins.browser_tool import browser_select_option
+
+        cap: dict = {}
+        await browser_select_option(ref="e1", value="red", mesh_client=_mesh(cap))
+
+        assert cap["action"] == "select_option"
+        assert cap["params"] == {
+            "ref": "e1",
+            "selector": "",
+            "snapshot_after": False,
+            "value": "red",
+        }
+
+    @pytest.mark.asyncio
+    async def test_emits_label_and_selector(self):
+        from src.agent.builtins.browser_tool import browser_select_option
+
+        cap: dict = {}
+        await browser_select_option(
+            selector="#color", label="Red", mesh_client=_mesh(cap),
+        )
+
+        assert cap["action"] == "select_option"
+        assert cap["params"] == {
+            "ref": "",
+            "selector": "#color",
+            "snapshot_after": False,
+            "label": "Red",
+        }
+
+    @pytest.mark.asyncio
+    async def test_emits_index(self):
+        from src.agent.builtins.browser_tool import browser_select_option
+
+        cap: dict = {}
+        await browser_select_option(ref="e1", index=2, mesh_client=_mesh(cap))
+
+        assert cap["params"]["index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_ref_and_selector_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_select_option
+
+        result = await browser_select_option(value="red")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_value_label_index_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_select_option
+
+        result = await browser_select_option(ref="e1")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_selectors_returns_error(self):
+        """value + label together is non-deterministic in Playwright — the
+        tool must reject it before emitting a mesh action."""
+        from src.agent.builtins.browser_tool import browser_select_option
+
+        cap: dict = {}
+        result = await browser_select_option(
+            ref="e1", value="US", label="Canada", mesh_client=_mesh(cap),
+        )
+        assert "error" in result
+        assert "not multiple" in result["error"]
+        # No mesh action should have been emitted.
+        assert cap == {}

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2060,6 +2060,7 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "browser_read_clipboard",
     "browser_write_clipboard",
     "browser_wait_for_network_idle",
+    "browser_select_option",
     "request_captcha_help",
     "request_browser_login",
     # Watch / pub-sub.

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -203,6 +203,8 @@ class TestCanBrowserAction:
             # P2 parity actions.
             "right_click", "read_clipboard",
             "write_clipboard", "wait_for_network_idle",
+            # Native <select> dropdown support.
+            "select_option",
         ):
             # Default (None) and wildcard both allow.
             assert browser_matrix.can_browser_action("legacy-agent", action) is True, action
@@ -332,6 +334,8 @@ class TestKnownBrowserActionsSet:
             # P2 parity actions.
             "right_click", "read_clipboard",
             "write_clipboard", "wait_for_network_idle",
+            # Native <select> dropdown support.
+            "select_option",
         ):
             assert action in KNOWN_BROWSER_ACTIONS, action
 


### PR DESCRIPTION
## What

Adds a `select_option` browser action + `browser_select_option` agent tool to operate **native HTML `<select>` dropdowns** — choosing an option by `value`, visible `label`, or 0-based `index`, identified by `ref` (from a snapshot) or CSS `selector`.

## Why

Native `<select>` dropdowns can't be operated today:
- A `<select>` snapshots with role `combobox`; **clicking** it opens Firefox's OS-native popup, which isn't in the page DOM, so no follow-up snapshot/click can reach the options.
- **`fill_form`** falls through to `locator.fill()`, which raises "Element is not an `<input>`" → `not_fillable`.
- Nothing in the codebase called Playwright's `locator.select_option`.

This tool sets the value directly via `locator.select_option`, firing `input`/`change` **without** opening the popup.

## Truthful failure classification

The exception handler never tells the agent a wrong story:
- detached element → `ref_stale` (re-snapshot)
- genuinely not a `<select>` → `not_a_select`, directing custom-dropdown handling to `browser_click` + `press_key` (ArrowDown/Enter)
- explicit no-match → `option_not_found`
- ambiguous bare timeout (hidden/disabled/detached/loading/missing option) → `not_interactable`
- the landed value is **verified** against what was selected → `selection_reverted` when page script resets it

"Exactly one of value/label/index" is enforced at both the tool and service layers (Playwright otherwise treats multiple as separate candidates and picks by DOM order).

## Scope

Browser-dir only. Wires through `KNOWN_BROWSER_ACTIONS`, the three tool gate-lists, the service route, dashboard tool-map allowlist, and permission tests. Mirrors the `type_text` handler scaffolding. No `Dockerfile.browser`/`pyproject.toml` changes.

## Testing

New `tests/test_browser_select_option.py` (tool-emit, primary path by value/label/index/selector, exactly-one rejection, `selection_reverted`, `not_a_select`, detached→`ref_stale`, timeout→`not_interactable`, `service_unavailable`). Cross-cutting suites green (807 passed / 3 skipped). Reviewed as a principal engineer + independent Codex pass (found 5 real bugs — a false-positive keyboard fallback since removed, unenforced exactly-one, unverified selection, timeout misclassification, and an overly-broad `not_a_select` match colliding with "not attached" — all fixed).

Note: the original spec suggested a keyboard fallback; it was **removed** because it only ran on non-`<select>` elements where typing just echoes into a text input and `input_value()` matched the typed text — reporting `success:true` with nothing selected. Truthful `not_a_select` is strictly better.

Not deployed (merge ≠ deploy).