### PR TITLE
feat(config,host,dashboard): hiring wizard v2 — config file-lock, role unfrozen, goals-driven hiring (Phase-4 unit 2)

### DIFF
--- a/src/agent/builtins/fleet_tool.py
+++ b/src/agent/builtins/fleet_tool.py
@@ -41,8 +41,10 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
         "to see available templates. This creates all agents defined in the template "
         "and starts them. Returns the list of created agent IDs. Pass "
         "`agent_overrides` to tune individual slots (model, instructions, soul, "
-        "heartbeat, interface) at creation time -- avoids 5+ follow-up edit_agent "
-        "round-trips. Note: `role` is fixed by the template and cannot be overridden. "
+        "heartbeat, interface, role) at creation time -- avoids 5+ follow-up "
+        "edit_agent round-trips. Hiring into an existing team: pick the closest "
+        "template as the hire's starting resume, override `role` from the job "
+        "description you drafted, then call add_agents_to_team to join it. "
         "Note: agent creation is per-slot -- a mid-loop failure leaves earlier-created "
         "agents in place. Verify the returned `created` list matches your intent and "
         "inspect the on-disk fleet."
@@ -63,10 +65,10 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
                 "Optional per-agent overrides keyed by agent name from the template. "
                 "Each value is an object with any of: 'model', 'instructions' "
                 "(<=12000 chars), 'soul' (<=4000 chars), 'heartbeat' (no cap), "
-                "'interface' (<=4000 chars). Unknown agent names or fields are "
-                "rejected with HTTP 400; oversized fields with HTTP 413. "
-                "Note: `role` is intentionally NOT overrideable; templates fix the "
-                "role per slot. Use a separate fleet template if you need different roles."
+                "'interface' (<=4000 chars), 'role' (no cap). Unknown agent names or "
+                "fields are rejected with HTTP 400; oversized fields with HTTP 413. "
+                "Set `role` here to the job description you drafted for the hire -- "
+                "it no longer has to match the template slot's default role."
             ),
             "additionalProperties": {
                 "type": "object",
@@ -76,6 +78,7 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
                     "soul": {"type": "string"},
                     "heartbeat": {"type": "string"},
                     "interface": {"type": "string"},
+                    "role": {"type": "string"},
                 },
                 "additionalProperties": False,
             },

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import logging
 import os
@@ -20,7 +21,7 @@ import yaml
 from src.shared.limits import THINKING_LEVELS
 from src.shared.operator_playbooks import _OPERATOR_CORE
 from src.shared.types import RESERVED_AGENT_IDS
-from src.shared.utils import truncate
+from src.shared.utils import atomic_write_text, truncate
 
 logger = logging.getLogger("cli")
 
@@ -218,20 +219,144 @@ def _load_config(mesh_path: Path | None = None) -> dict:
     return cfg
 
 
-# Guards individual reads/writes of permissions.json. Held internally by
-# _load_permissions and _save_permissions so a save never interleaves with a
-# read, and pairs with the atomic os.replace below so a reader never observes a
-# half-written file (the boot-crash / torn-read protection — finding M14).
+# ── Cross-thread / cross-process config lock (B-pre #2) ────────
 #
-# NOTE: this does NOT by itself prevent the lost-update race. Callers do
-# ``perms = _load_permissions(); ...mutate...; _save_permissions(perms)`` as
-# two separate lock acquisitions, so two concurrent writers (e.g. a template
-# apply touching agent B while the dashboard edits agent A) can both load the
-# same baseline and the second save clobbers the first. The lock is REENTRANT
-# precisely so a caller CAN close that gap by holding it across the whole
-# load→mutate→save (``with _PERMISSIONS_LOCK: ...``); today no caller does.
-# Low risk under the single-operator model; wrapping the hot call sites is a
-# tracked follow-up, not part of M14's torn-read/atomicity fix.
+# Recon widened B-pre #2: every ``config/agents.yaml`` writer was a bare
+# ``open(..., "w")`` truncate-and-write — no lock, no atomic rename — and
+# ``config/permissions.json``'s load->mutate->save was spread across
+# helpers that each independently re-read the file, so two concurrent
+# writers could both load the same baseline and the second save would
+# silently clobber the first (the lost-update race this module used to
+# just document below, unfixed). ``_config_lock()`` closes both gaps: ONE
+# sidecar lock file guards the FULL load->mutate->save critical section
+# for BOTH agents.yaml and permissions.json. A single shared lock (not one
+# per file) because several flows write both in one logical operation
+# (creating an agent touches agents.yaml, then permissions.json) — two
+# separate locks would need a fixed acquisition order to avoid deadlock;
+# one lock sidesteps that entirely.
+#
+# Built on ``fcntl.flock(LOCK_EX)`` (blocking), not a ``threading`` /
+# ``asyncio`` primitive, because the CLI REPL, the dashboard process, the
+# setup-wizard process, and the mesh host can all mutate these files from
+# DIFFERENT PROCESSES — a Python-level lock only ever serializes within
+# one process. Mirrors the flock context-manager precedent in
+# ``src/browser/profile_schema.py`` (``_LockHandle``), with two
+# deliberate differences: this lock BLOCKS (not ``LOCK_NB`` — callers need
+# the critical section to eventually run, not to skip it under
+# contention), and it is REENTRANT within a single thread via a
+# ``threading.local`` depth counter. Reentrancy is required because
+# several of the locked helpers below call each other synchronously
+# (e.g. ``_remove_agent`` calls ``_remove_team_blackboard_permissions``,
+# ``_ensure_all_agent_permissions`` calls ``_add_agent_permissions``) —
+# flock is scoped to the OPEN FILE DESCRIPTION, so acquiring a second,
+# independent fd for the same path from the same thread would
+# self-deadlock without the depth guard. Only the OUTERMOST
+# ``with _config_lock():`` in a thread's call stack opens an fd and
+# flocks it; nested acquisitions from that same thread reuse it and are
+# free. A different thread (or process) entering concurrently still opens
+# its OWN fresh fd and genuinely blocks on the OS-level lock until the
+# outermost holder's fd is unlocked — so cross-thread and cross-process
+# mutual exclusion is real (enforced by the kernel), not just Python-level
+# bookkeeping.
+#
+# The lock path is derived from ``AGENTS_FILE.parent`` at ACQUISITION time
+# (not frozen into a module-level constant at import time) so it always
+# sits next to whichever agents.yaml/permissions.json pair is actually in
+# play — tests redirect ``AGENTS_FILE``/``PERMISSIONS_FILE`` to a temp
+# ``config/`` dir per-test, and a frozen constant would silently keep
+# locking the real repo's config dir instead of following that redirect.
+
+
+def _config_lock_path() -> Path:
+    """Return the sidecar lock file path, next to the live agents.yaml."""
+    return AGENTS_FILE.parent / ".config.lock"
+
+
+_config_lock_state = threading.local()
+
+
+class _ConfigLock:
+    """Context manager for the shared agents.yaml + permissions.json lock.
+
+    Obtain via the ``_config_lock()`` factory: ``with _config_lock(): ...``.
+    See the module comment above for the full design rationale (blocking +
+    reentrant fcntl.flock on a fresh fd per outermost acquisition).
+    """
+
+    def __enter__(self) -> "_ConfigLock":
+        depth = getattr(_config_lock_state, "depth", 0)
+        if depth == 0:
+            lock_path = _config_lock_path()
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            fcntl.flock(fd, fcntl.LOCK_EX)  # blocks until any holder releases
+            _config_lock_state.fd = fd
+        _config_lock_state.depth = depth + 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        depth = _config_lock_state.depth - 1
+        _config_lock_state.depth = depth
+        if depth == 0:
+            fd = _config_lock_state.fd
+            _config_lock_state.fd = None
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+
+def _config_lock() -> _ConfigLock:
+    """Return the shared agents.yaml/permissions.json lock as a context manager.
+
+    Every load->mutate->save helper for either file acquires this for its
+    full critical section — see the module comment above ``_config_lock_path``.
+    """
+    return _ConfigLock()
+
+
+def _load_agents_yaml() -> dict:
+    """Load the raw agents.yaml document (``{"agents": {...}, ...}``).
+
+    Read-only I/O helper — does NOT itself acquire ``_config_lock()``.
+    Callers doing load->mutate->save MUST wrap the whole sequence in
+    ``with _config_lock(): ...`` (locking only the read half wouldn't
+    close the lost-update race — mirrors why ``_load_permissions``
+    alone was never sufficient either).
+    """
+    if not AGENTS_FILE.exists():
+        return {"agents": {}}
+    with open(AGENTS_FILE) as f:
+        return yaml.safe_load(f) or {"agents": {}}
+
+
+def _save_agents_yaml(agents_cfg: dict) -> None:
+    """Persist agents.yaml atomically (tempfile in the same dir + fsync +
+    os.replace, via the shared ``atomic_write_text`` helper) — a concurrent
+    reader always sees the old or the new complete file, never a torn one.
+
+    Does NOT itself acquire ``_config_lock()`` — callers doing
+    load->mutate->save MUST hold it across the whole sequence; this
+    function alone only protects against torn reads, not lost updates.
+    """
+    AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    content = yaml.dump(agents_cfg, default_flow_style=False, sort_keys=False)
+    atomic_write_text(AGENTS_FILE, content)
+
+
+# Guards individual reads/writes of permissions.json against torn reads —
+# held internally by _load_permissions and _save_permissions so a save
+# never interleaves with a read, pairing with the atomic os.replace below
+# so a reader never observes a half-written file (finding M14).
+#
+# This is now belt-and-suspenders: the real lost-update fix is the shared
+# ``_config_lock()`` above, which every load->mutate->save call site holds
+# across its FULL critical section (e.g. ``with _config_lock(): perms =
+# _load_permissions(); ...mutate...; _save_permissions(perms)``) — and,
+# being fcntl-based, also serializes across PROCESSES, which this
+# in-process-only ``RLock`` never could. ``_PERMISSIONS_LOCK`` stays
+# in place rather than being removed (B-pre #2's ratified decision keeps
+# it as harmless belt-and-suspenders for this unit).
 _PERMISSIONS_LOCK = threading.RLock()
 
 
@@ -470,7 +595,6 @@ def _add_agent_to_config(
     initial_interface: str = "",
     thinking: str = "",
     budget: dict | None = None,
-    resources: dict | None = None,
     capabilities: list[str] | None = None,
     preferred_inputs: list[str] | None = None,
     expected_outputs: list[str] | None = None,
@@ -486,13 +610,6 @@ def _add_agent_to_config(
     only persisted when non-empty so untouched yaml entries don't grow
     noisy default keys.
     """
-    agents_cfg: dict = {"agents": {}}
-    if AGENTS_FILE.exists():
-        with open(AGENTS_FILE) as f:
-            agents_cfg = yaml.safe_load(f) or {"agents": {}}
-    if "agents" not in agents_cfg:
-        agents_cfg["agents"] = {}
-
     entry: dict = {
         "role": role,
         "model": model,
@@ -510,8 +627,6 @@ def _add_agent_to_config(
         entry["thinking"] = thinking
     if budget:
         entry["budget"] = budget
-    if resources:
-        entry["resources"] = resources
     # Task 8 — structured routing fields. Persist only when non-empty
     # so existing minimal yaml entries don't grow empty default keys.
     if capabilities:
@@ -524,10 +639,13 @@ def _add_agent_to_config(
         entry["escalation_to"] = escalation_to
     if forbidden:
         entry["forbidden"] = list(forbidden)
-    agents_cfg["agents"][name] = entry
-    AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(AGENTS_FILE, "w") as f:
-        yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+
+    with _config_lock():
+        agents_cfg = _load_agents_yaml()
+        if "agents" not in agents_cfg:
+            agents_cfg["agents"] = {}
+        agents_cfg["agents"][name] = entry
+        _save_agents_yaml(agents_cfg)
 
 
 # Coordination grants layered on top of the base defaults for a fully-fledged
@@ -566,176 +684,179 @@ def _add_agent_permissions(name: str, permissions: dict | None = None, *, from_t
     ``blackboard_write``, ``can_publish``, and ``can_subscribe`` entries
     are merged into the defaults.
     """
-    cfg = _load_config()
-    collab = cfg.get("collaboration", True)
+    with _config_lock():
+        cfg = _load_config()
+        collab = cfg.get("collaboration", True)
 
-    perms = _load_permissions()
-    if collab:
-        other_agents = [a for a in cfg.get("agents", {}) if a != name]
-        can_message = ["*"] if other_agents else []
-    else:
-        can_message = []
+        perms = _load_permissions()
+        if collab:
+            other_agents = [a for a in cfg.get("agents", {}) if a != name]
+            can_message = ["*"] if other_agents else []
+        else:
+            can_message = []
 
-    # Self pattern: every WORKER always holds ``teams/{name}/*`` on both
-    # blackboard fields — its private team-of-one namespace (ratified #5).
-    # Invariant: "self always; team while member". The operator keeps its
-    # explicit ["*"] grants from _ensure_operator_agent instead.
-    self_patterns = [f"teams/{name}/*"] if name != _OPERATOR_AGENT_ID else []
+        # Self pattern: every WORKER always holds ``teams/{name}/*`` on both
+        # blackboard fields — its private team-of-one namespace (ratified #5).
+        # Invariant: "self always; team while member". The operator keeps its
+        # explicit ["*"] grants from _ensure_operator_agent instead.
+        self_patterns = [f"teams/{name}/*"] if name != _OPERATOR_AGENT_ID else []
 
-    agent_perms: dict = {
-        "can_message": can_message,
-        "can_publish": ["*"] if collab else [f"{name}_complete"],
-        "can_subscribe": ["*"] if collab else [],
-        "blackboard_read": list(self_patterns),
-        "blackboard_write": list(self_patterns),
-        "allowed_apis": ["llm", "image_gen"],
-        "allowed_credentials": ["*"],
-        # Default capability set for every new agent: browser + internet +
-        # schedules (cron) + ephemeral fleet-spawn ON; wallet OFF (the sole
-        # privileged grant — spending money requires explicit user setup).
-        # NOTE: ``can_spawn=True`` applies to NAMED agents created here. The
-        # ephemeral ``spawn-*`` agents they create resolve permissions via
-        # ``PermissionMatrix.get_permissions`` ("default" record / bare
-        # fallback → field default False), so a spawned agent CANNOT itself
-        # spawn — the recursion wall is bounded at one level. A template may
-        # flip any of these off via the merge below.
-        "can_use_browser": True,
-        "can_use_internet": True,
-        "can_manage_cron": True,
-        "can_spawn": True,
-        "can_use_wallet": False,
-    }
+        agent_perms: dict = {
+            "can_message": can_message,
+            "can_publish": ["*"] if collab else [f"{name}_complete"],
+            "can_subscribe": ["*"] if collab else [],
+            "blackboard_read": list(self_patterns),
+            "blackboard_write": list(self_patterns),
+            "allowed_apis": ["llm", "image_gen"],
+            "allowed_credentials": ["*"],
+            # Default capability set for every new agent: browser + internet +
+            # schedules (cron) + ephemeral fleet-spawn ON; wallet OFF (the sole
+            # privileged grant — spending money requires explicit user setup).
+            # NOTE: ``can_spawn=True`` applies to NAMED agents created here. The
+            # ephemeral ``spawn-*`` agents they create resolve permissions via
+            # ``PermissionMatrix.get_permissions`` ("default" record / bare
+            # fallback → field default False), so a spawned agent CANNOT itself
+            # spawn — the recursion wall is bounded at one level. A template may
+            # flip any of these off via the merge below.
+            "can_use_browser": True,
+            "can_use_internet": True,
+            "can_manage_cron": True,
+            "can_spawn": True,
+            "can_use_wallet": False,
+        }
 
-    # Merge template permissions into defaults
-    if permissions:
-        for key in ("blackboard_read", "blackboard_write", "can_publish", "can_subscribe"):
-            tpl_values = permissions.get(key)
-            if tpl_values and isinstance(tpl_values, list):
-                existing = set(agent_perms.get(key, []))
-                existing.update(tpl_values)
-                agent_perms[key] = sorted(existing)
-        # Defense in depth (ratified #5): no create path may hand a WORKER a
-        # blackboard wildcard — the host ACL is the read boundary now that
-        # the agent-side standalone guards are gone, and team joins strip
-        # ``*`` anyway (an agent must never start wider than a team member
-        # ends up). The operator's explicit ["*"] comes from
-        # _ensure_operator_agent, not this path.
-        if name != _OPERATOR_AGENT_ID:
-            for key in ("blackboard_read", "blackboard_write"):
-                agent_perms[key] = [p for p in agent_perms.get(key, []) if p != "*"]
-        # Boolean flags — template can override defaults. Includes the
-        # six control-plane permissions from Task 3 so the operator's
-        # explicit grants in ``_ensure_operator_agent`` get persisted to
-        # permissions.json instead of being silently dropped.
-        for key in (
-            "can_use_browser",
-            "can_use_internet",
-            "can_spawn",
-            "can_manage_cron",
-            "can_manage_fleet",
-            "can_manage_teams",
-            "can_edit_agent_config",
-            "can_view_fleet_metrics",
-            "can_request_user_credentials",
-            "can_use_wallet",
-        ):
-            if key in permissions:
-                value = bool(permissions[key])
-                # L4: clamp the irreversible-grant ceiling. A fleet template
-                # must never mint an agent that can spawn other agents or
-                # spend from the wallet — those are operator/user-only grants
-                # (mirrors _OPERATOR_PERMISSION_CEILING in operator_tools.py).
-                # None of the shipped templates set these true, so legitimate
-                # template application is unaffected.
-                if from_template and key in _TEMPLATE_PERMISSION_CEILING and value:
-                    logger.warning(
-                        "Template for agent '%s' tried to grant '%s'=true; "
-                        "clamping to false (irreversible-grant ceiling)",
-                        name,
-                        key,
-                    )
-                    value = False
-                agent_perms[key] = value
+        # Merge template permissions into defaults
+        if permissions:
+            for key in ("blackboard_read", "blackboard_write", "can_publish", "can_subscribe"):
+                tpl_values = permissions.get(key)
+                if tpl_values and isinstance(tpl_values, list):
+                    existing = set(agent_perms.get(key, []))
+                    existing.update(tpl_values)
+                    agent_perms[key] = sorted(existing)
+            # Defense in depth (ratified #5): no create path may hand a WORKER a
+            # blackboard wildcard — the host ACL is the read boundary now that
+            # the agent-side standalone guards are gone, and team joins strip
+            # ``*`` anyway (an agent must never start wider than a team member
+            # ends up). The operator's explicit ["*"] comes from
+            # _ensure_operator_agent, not this path.
+            if name != _OPERATOR_AGENT_ID:
+                for key in ("blackboard_read", "blackboard_write"):
+                    agent_perms[key] = [p for p in agent_perms.get(key, []) if p != "*"]
+            # Boolean flags — template can override defaults. Includes the
+            # six control-plane permissions from Task 3 so the operator's
+            # explicit grants in ``_ensure_operator_agent`` get persisted to
+            # permissions.json instead of being silently dropped.
+            for key in (
+                "can_use_browser",
+                "can_use_internet",
+                "can_spawn",
+                "can_manage_cron",
+                "can_manage_fleet",
+                "can_manage_teams",
+                "can_edit_agent_config",
+                "can_view_fleet_metrics",
+                "can_request_user_credentials",
+                "can_use_wallet",
+            ):
+                if key in permissions:
+                    value = bool(permissions[key])
+                    # L4: clamp the irreversible-grant ceiling. A fleet template
+                    # must never mint an agent that can spawn other agents or
+                    # spend from the wallet — those are operator/user-only grants
+                    # (mirrors _OPERATOR_PERMISSION_CEILING in operator_tools.py).
+                    # None of the shipped templates set these true, so legitimate
+                    # template application is unaffected.
+                    if from_template and key in _TEMPLATE_PERMISSION_CEILING and value:
+                        logger.warning(
+                            "Template for agent '%s' tried to grant '%s'=true; "
+                            "clamping to false (irreversible-grant ceiling)",
+                            name,
+                            key,
+                        )
+                        value = False
+                    agent_perms[key] = value
 
-    perms["permissions"][name] = agent_perms
-    _save_permissions(perms)
+        perms["permissions"][name] = agent_perms
+        _save_permissions(perms)
 
 
 def _ensure_all_agent_permissions() -> None:
     """Backfill permissions for agents missing from permissions.json, and
     forward-migrate any missing boolean capability flags for existing agents."""
-    cfg = _load_config()
-    perms = _load_permissions()
-    existing = set(perms.get("permissions", {}).keys())
-    for name in cfg.get("agents", {}):
-        if name not in existing:
-            _add_agent_permissions(name)
+    with _config_lock():
+        cfg = _load_config()
+        perms = _load_permissions()
+        existing = set(perms.get("permissions", {}).keys())
+        for name in cfg.get("agents", {}):
+            if name not in existing:
+                _add_agent_permissions(name)
 
-    # Reload after potentially writing new agents so the migration sees all
-    # agents, including ones just added above.
-    perms = _load_permissions()
+        # Reload after potentially writing new agents so the migration sees all
+        # agents, including ones just added above.
+        perms = _load_permissions()
 
-    # Forward-migrate: add any permission flags introduced after an agent's
-    # initial permissions entry was created (keyed in _AGENT_PERMISSION_DEFAULTS).
-    changed = False
-    for agent_id, agent_perms in perms.get("permissions", {}).items():
-        if agent_id == "default":
-            continue
-        for flag, default_val in _AGENT_PERMISSION_DEFAULTS.items():
-            if flag not in agent_perms:
-                agent_perms[flag] = default_val
+        # Forward-migrate: add any permission flags introduced after an agent's
+        # initial permissions entry was created (keyed in _AGENT_PERMISSION_DEFAULTS).
+        changed = False
+        for agent_id, agent_perms in perms.get("permissions", {}).items():
+            if agent_id == "default":
+                continue
+            for flag, default_val in _AGENT_PERMISSION_DEFAULTS.items():
+                if flag not in agent_perms:
+                    agent_perms[flag] = default_val
+                    changed = True
+
+        # Solo self-pattern default (ratified #5 — solo agent = team-of-one):
+        # every TEAMLESS worker holds its private ``teams/{agent_id}/*``
+        # pattern on both blackboard fields ("self always"). Additive only —
+        # existing patterns are never removed except the untouched pre-#5
+        # default read wildcard (below). The live enforcement is the
+        # resolution-time carve-out in PermissionMatrix._is_own_namespace;
+        # this keeps the FILE state matching the invariant.
+        try:
+            team_map = _open_teams_store().agent_team_map()
+        except Exception:
+            team_map = {}
+        for agent_id, agent_perms in perms.get("permissions", {}).items():
+            if agent_id in ("default", _OPERATOR_AGENT_ID):
+                continue
+            if team_map.get(agent_id):
+                continue
+            self_pattern = f"teams/{agent_id}/*"
+            # Narrow the pre-#5 default read wildcard: a teamless worker whose
+            # blackboard_read is exactly the untouched old default shape
+            # (["*"], or ["*"] + its own self pattern) drops the ``*`` — with
+            # the agent-side standalone guards gone, leaving it would grant
+            # fleet-wide reads no team member has. Any other (human-customized)
+            # pattern list is left alone.
+            reads = agent_perms.get("blackboard_read") or []
+            if set(reads) in ({"*"}, {"*", self_pattern}):
+                agent_perms["blackboard_read"] = [self_pattern]
                 changed = True
-
-    # Solo self-pattern default (ratified #5 — solo agent = team-of-one):
-    # every TEAMLESS worker holds its private ``teams/{agent_id}/*``
-    # pattern on both blackboard fields ("self always"). Additive only —
-    # existing patterns are never removed except the untouched pre-#5
-    # default read wildcard (below). The live enforcement is the
-    # resolution-time carve-out in PermissionMatrix._is_own_namespace;
-    # this keeps the FILE state matching the invariant.
-    try:
-        team_map = _open_teams_store().agent_team_map()
-    except Exception:
-        team_map = {}
-    for agent_id, agent_perms in perms.get("permissions", {}).items():
-        if agent_id in ("default", _OPERATOR_AGENT_ID):
-            continue
-        if team_map.get(agent_id):
-            continue
-        self_pattern = f"teams/{agent_id}/*"
-        # Narrow the pre-#5 default read wildcard: a teamless worker whose
-        # blackboard_read is exactly the untouched old default shape
-        # (["*"], or ["*"] + its own self pattern) drops the ``*`` — with
-        # the agent-side standalone guards gone, leaving it would grant
-        # fleet-wide reads no team member has. Any other (human-customized)
-        # pattern list is left alone.
-        reads = agent_perms.get("blackboard_read") or []
-        if set(reads) in ({"*"}, {"*", self_pattern}):
-            agent_perms["blackboard_read"] = [self_pattern]
-            changed = True
-        for field in ("blackboard_read", "blackboard_write"):
-            patterns = agent_perms.get(field) or []
-            if self_pattern not in patterns:
-                agent_perms[field] = [*patterns, self_pattern]
-                changed = True
-    if changed:
-        _save_permissions(perms)
+            for field in ("blackboard_read", "blackboard_write"):
+                patterns = agent_perms.get(field) or []
+                if self_pattern not in patterns:
+                    agent_perms[field] = [*patterns, self_pattern]
+                    changed = True
+        if changed:
+            _save_permissions(perms)
 
 
 def _set_collaborative_permissions() -> None:
     """Update all agent permissions to allow inter-agent messaging and pub/sub."""
-    perms = _load_permissions()
-    for name, p in perms.get("permissions", {}).items():
-        if name == "default":
-            continue
-        if "*" not in p.get("can_message", []):
-            p["can_message"] = list({*p.get("can_message", []), "*"})
-        if "*" not in p.get("can_publish", []):
-            p["can_publish"] = list({*p.get("can_publish", []), "*"})
-        if "*" not in p.get("can_subscribe", []):
-            p["can_subscribe"] = list({*p.get("can_subscribe", []), "*"})
-        p["allowed_credentials"] = ["*"]
-    _save_permissions(perms)
+    with _config_lock():
+        perms = _load_permissions()
+        for name, p in perms.get("permissions", {}).items():
+            if name == "default":
+                continue
+            if "*" not in p.get("can_message", []):
+                p["can_message"] = list({*p.get("can_message", []), "*"})
+            if "*" not in p.get("can_publish", []):
+                p["can_publish"] = list({*p.get("can_publish", []), "*"})
+            if "*" not in p.get("can_subscribe", []):
+                p["can_subscribe"] = list({*p.get("can_subscribe", []), "*"})
+            p["allowed_credentials"] = ["*"]
+        _save_permissions(perms)
 
 
 def _validate_agent_name(name: str) -> str:
@@ -886,62 +1007,62 @@ def _backfill_capabilities_for_existing_agents() -> None:
     """
     if not AGENTS_FILE.exists():
         return
-    try:
-        with open(AGENTS_FILE) as f:
-            agents_cfg = yaml.safe_load(f) or {"agents": {}}
-    except Exception:
-        return
-
-    agents = agents_cfg.get("agents", {})
-    if not isinstance(agents, dict) or not agents:
-        return
 
     from src.agent.workspace import _parse_interface_text
 
-    changed = False
-    for _agent_name, entry in agents.items():
-        if not isinstance(entry, dict):
-            continue
-        # Already declared — structured field wins, do nothing.
-        if entry.get("capabilities"):
-            continue
-        interface_text = entry.get("initial_interface") or ""
-        if not interface_text:
-            continue
-
+    with _config_lock():
         try:
-            derived = _parse_interface_text(interface_text)
+            agents_cfg = _load_agents_yaml()
         except Exception:
-            continue
+            return
 
-        # Only persist when the derivation produced something useful.
-        if not (
-            derived.get("capabilities")
-            or derived.get("preferred_inputs")
-            or derived.get("expected_outputs")
-            or derived.get("escalation_to")
-            or derived.get("forbidden")
-        ):
-            continue
+        agents = agents_cfg.get("agents", {})
+        if not isinstance(agents, dict) or not agents:
+            return
 
-        if derived.get("capabilities"):
-            entry["capabilities"] = list(derived["capabilities"])
-        if derived.get("preferred_inputs"):
-            entry["preferred_inputs"] = list(derived["preferred_inputs"])
-        if derived.get("expected_outputs"):
-            entry["expected_outputs"] = list(derived["expected_outputs"])
-        if derived.get("escalation_to"):
-            entry["escalation_to"] = derived["escalation_to"]
-        if derived.get("forbidden"):
-            entry["forbidden"] = list(derived["forbidden"])
-        changed = True
+        changed = False
+        for _agent_name, entry in agents.items():
+            if not isinstance(entry, dict):
+                continue
+            # Already declared — structured field wins, do nothing.
+            if entry.get("capabilities"):
+                continue
+            interface_text = entry.get("initial_interface") or ""
+            if not interface_text:
+                continue
 
-    if changed:
-        try:
-            with open(AGENTS_FILE, "w") as f:
-                yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
-        except Exception:
-            logger.exception("Failed to persist back-filled agent capabilities")
+            try:
+                derived = _parse_interface_text(interface_text)
+            except Exception:
+                continue
+
+            # Only persist when the derivation produced something useful.
+            if not (
+                derived.get("capabilities")
+                or derived.get("preferred_inputs")
+                or derived.get("expected_outputs")
+                or derived.get("escalation_to")
+                or derived.get("forbidden")
+            ):
+                continue
+
+            if derived.get("capabilities"):
+                entry["capabilities"] = list(derived["capabilities"])
+            if derived.get("preferred_inputs"):
+                entry["preferred_inputs"] = list(derived["preferred_inputs"])
+            if derived.get("expected_outputs"):
+                entry["expected_outputs"] = list(derived["expected_outputs"])
+            if derived.get("escalation_to"):
+                entry["escalation_to"] = derived["escalation_to"]
+            if derived.get("forbidden"):
+                entry["forbidden"] = list(derived["forbidden"])
+            changed = True
+
+        if changed:
+            try:
+                _save_agents_yaml(agents_cfg)
+            except Exception:
+                logger.exception("Failed to persist back-filled agent capabilities")
 
 
 def _set_agent_status(name: str, status: str) -> None:
@@ -952,16 +1073,15 @@ def _set_agent_status(name: str, status: str) -> None:
     operator tools that archive an agent should also stop the container
     via the runtime backend (the host endpoint handles that).
     """
-    if not AGENTS_FILE.exists():
-        raise ValueError("Agents config not found")
-    with open(AGENTS_FILE) as f:
-        agents_cfg = yaml.safe_load(f) or {"agents": {}}
-    agents = agents_cfg.get("agents", {})
-    if name not in agents:
-        raise ValueError(f"Agent '{name}' not found")
-    agents[name]["status"] = status
-    with open(AGENTS_FILE, "w") as f:
-        yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+    with _config_lock():
+        if not AGENTS_FILE.exists():
+            raise ValueError("Agents config not found")
+        agents_cfg = _load_agents_yaml()
+        agents = agents_cfg.get("agents", {})
+        if name not in agents:
+            raise ValueError(f"Agent '{name}' not found")
+        agents[name]["status"] = status
+        _save_agents_yaml(agents_cfg)
 
 
 def _archive_agent(name: str) -> None:
@@ -1002,27 +1122,28 @@ def _add_team_blackboard_permissions(agent: str, team: str) -> None:
     in-place ``*`` ACLs that haven't been touched stay intact until
     enforce mode tightens the read/write hot path.
     """
-    perms = _load_permissions()
-    agent_perms = perms.get("permissions", {}).get(agent)
-    if agent_perms is None:
-        return
-    team_pattern = f"teams/{team}/*"
-    self_pattern = f"teams/{agent}/*"
-    for field in ("blackboard_read", "blackboard_write"):
-        patterns = agent_perms.get(field, [])
-        # Strip any wildcard — replaced by the explicit team pattern
-        # below. This is the active narrowing for Task 5: an agent that
-        # previously had ``["*"]`` and is then added to a team ends
-        # up with its self + team patterns.
-        narrowed = [p for p in patterns if p != "*"]
-        if team_pattern not in narrowed:
-            narrowed.append(team_pattern)
-        # Invariant (ratified #5): "self always; team while member" — the
-        # private team-of-one pattern rides alongside the team pattern.
-        if self_pattern not in narrowed:
-            narrowed.append(self_pattern)
-        agent_perms[field] = narrowed
-    _save_permissions(perms)
+    with _config_lock():
+        perms = _load_permissions()
+        agent_perms = perms.get("permissions", {}).get(agent)
+        if agent_perms is None:
+            return
+        team_pattern = f"teams/{team}/*"
+        self_pattern = f"teams/{agent}/*"
+        for field in ("blackboard_read", "blackboard_write"):
+            patterns = agent_perms.get(field, [])
+            # Strip any wildcard — replaced by the explicit team pattern
+            # below. This is the active narrowing for Task 5: an agent that
+            # previously had ``["*"]`` and is then added to a team ends
+            # up with its self + team patterns.
+            narrowed = [p for p in patterns if p != "*"]
+            if team_pattern not in narrowed:
+                narrowed.append(team_pattern)
+            # Invariant (ratified #5): "self always; team while member" — the
+            # private team-of-one pattern rides alongside the team pattern.
+            if self_pattern not in narrowed:
+                narrowed.append(self_pattern)
+            agent_perms[field] = narrowed
+        _save_permissions(perms)
 
 
 def _remove_team_blackboard_permissions(agent: str, team: str) -> None:
@@ -1037,23 +1158,24 @@ def _remove_team_blackboard_permissions(agent: str, team: str) -> None:
     reacquire fleet-wide reach by being added to and then removed from
     a team (Task 5).
     """
-    perms = _load_permissions()
-    agent_perms = perms.get("permissions", {}).get(agent)
-    if agent_perms is None:
-        return
-    team_pattern = f"teams/{team}/*"
-    self_pattern = f"teams/{agent}/*"
-    for field in ("blackboard_read", "blackboard_write"):
-        patterns = agent_perms.get(field, [])
-        # Drop both the target team pattern and any surviving ``*``.
-        # The wildcard strip is the safety net for an agent whose ACL
-        # was never re-narrowed (e.g. config-edited directly): once the
-        # membership system touches it on remove, the wildcard goes.
-        remaining = [p for p in patterns if p != team_pattern and p != "*"]
-        if self_pattern not in remaining:
-            remaining.append(self_pattern)
-        agent_perms[field] = remaining
-    _save_permissions(perms)
+    with _config_lock():
+        perms = _load_permissions()
+        agent_perms = perms.get("permissions", {}).get(agent)
+        if agent_perms is None:
+            return
+        team_pattern = f"teams/{team}/*"
+        self_pattern = f"teams/{agent}/*"
+        for field in ("blackboard_read", "blackboard_write"):
+            patterns = agent_perms.get(field, [])
+            # Drop both the target team pattern and any surviving ``*``.
+            # The wildcard strip is the safety net for an agent whose ACL
+            # was never re-narrowed (e.g. config-edited directly): once the
+            # membership system touches it on remove, the wildcard goes.
+            remaining = [p for p in patterns if p != team_pattern and p != "*"]
+            if self_pattern not in remaining:
+                remaining.append(self_pattern)
+            agent_perms[field] = remaining
+        _save_permissions(perms)
 
 
 def _remove_agent(name: str, stop_container: bool = False) -> None:
@@ -1074,24 +1196,27 @@ def _remove_agent(name: str, stop_container: bool = False) -> None:
         except Exception as e:
             logger.warning("Failed to stop/remove container for '%s': %s", name, e)
 
-    # Remove from team if member (also clears standing goals)
-    with contextlib.suppress(Exception):
-        team = _open_teams_store().remove_agent(name)
-        if team:
-            _remove_team_blackboard_permissions(name, team)
+    # Remove from team if member (also clears standing goals). Wraps the
+    # blackboard-permission narrowing AND the agents.yaml/permissions.json
+    # removal below in ONE lock acquisition so a concurrent writer can't
+    # observe (or clobber) a half-removed agent — reentrant on
+    # ``_remove_team_blackboard_permissions``'s own inner acquisition.
+    with _config_lock():
+        with contextlib.suppress(Exception):
+            team = _open_teams_store().remove_agent(name)
+            if team:
+                _remove_team_blackboard_permissions(name, team)
 
-    # Remove from agents.yaml
-    if AGENTS_FILE.exists():
-        with open(AGENTS_FILE) as f:
-            agents_cfg = yaml.safe_load(f) or {}
-        agents_cfg.get("agents", {}).pop(name, None)
-        with open(AGENTS_FILE, "w") as f:
-            yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+        # Remove from agents.yaml
+        if AGENTS_FILE.exists():
+            agents_cfg = _load_agents_yaml()
+            agents_cfg.get("agents", {}).pop(name, None)
+            _save_agents_yaml(agents_cfg)
 
-    # Remove from permissions
-    perms = _load_permissions()
-    perms.get("permissions", {}).pop(name, None)
-    _save_permissions(perms)
+        # Remove from permissions
+        perms = _load_permissions()
+        perms.get("permissions", {}).pop(name, None)
+        _save_permissions(perms)
 
 
 def _pick_model_interactive(
@@ -1214,9 +1339,9 @@ def _apply_template(
 
     ``agent_overrides`` (PR-N) is an optional ``{agent_name: {field: value}}``
     map. v2 supports per-agent ``model``, ``instructions``, ``soul``,
-    ``heartbeat`` and ``interface`` overrides applied on top of the template's
-    defaults. The mesh route validates the shape and contents UPFRONT — by the
-    time we get here, the input is trusted.
+    ``heartbeat``, ``interface``, and ``role`` overrides applied on top of
+    the template's defaults. The mesh route validates the shape and
+    contents UPFRONT — by the time we get here, the input is trusted.
     """
     cfg = _load_config()
     default_model = cfg.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
@@ -1230,11 +1355,7 @@ def _apply_template(
         _reject_agent_team_collision(_validate_agent_name(slot_name))
 
     # Load existing agents to avoid silent overwrites
-    existing_agents: set[str] = set()
-    if AGENTS_FILE.exists():
-        with open(AGENTS_FILE) as f:
-            existing_cfg = yaml.safe_load(f) or {}
-        existing_agents = set(existing_cfg.get("agents", {}).keys())
+    existing_agents: set[str] = set(_load_agents_yaml().get("agents", {}).keys())
 
     # Lazy import — keeps the CLI-only path from pulling in shared/models
     # at module-import time (template loader runs from setup wizard too).
@@ -1271,14 +1392,16 @@ def _apply_template(
         interface = agent_def.get("initial_interface", "") or agent_def.get("interface", "")
         if "interface" in per_agent_override:
             interface = per_agent_override["interface"]
+        role = agent_def.get("role", agent_name)
+        if "role" in per_agent_override:
+            role = per_agent_override["role"]
         thinking = agent_def.get("thinking", "")
         budget = agent_def.get("budget")
         agent_permissions = agent_def.get("permissions")
-        resources = agent_def.get("resources")
 
         _add_agent_to_config(
             name=agent_name,
-            role=agent_def.get("role", agent_name),
+            role=role,
             model=model,
             initial_instructions=instructions,
             initial_soul=soul,
@@ -1286,7 +1409,6 @@ def _apply_template(
             initial_interface=interface,
             thinking=thinking,
             budget=budget,
-            resources=resources,
             capabilities=agent_def.get("capabilities") or [],
             preferred_inputs=agent_def.get("preferred_inputs") or [],
             expected_outputs=agent_def.get("expected_outputs") or [],
@@ -1402,7 +1524,6 @@ def _create_agent_from_template(
     interface = agent_def.get("initial_interface", "") or agent_def.get("interface", "")
     thinking = agent_def.get("thinking", "")
     budget = agent_def.get("budget")
-    resources = agent_def.get("resources")
     agent_permissions = agent_def.get("permissions")
 
     _add_agent_to_config(
@@ -1415,7 +1536,6 @@ def _create_agent_from_template(
         initial_interface=interface,
         thinking=thinking,
         budget=budget,
-        resources=resources,
         capabilities=agent_def.get("capabilities") or [],
         preferred_inputs=agent_def.get("preferred_inputs") or [],
         expected_outputs=agent_def.get("expected_outputs") or [],
@@ -1434,15 +1554,11 @@ def _default_description(name: str) -> str:
 
 def _update_agent_field(name: str, field: str, value) -> None:
     """Update a single field in agents.yaml for an agent."""
-    if AGENTS_FILE.exists():
-        with open(AGENTS_FILE) as f:
-            agents_cfg = yaml.safe_load(f) or {"agents": {}}
-    else:
-        agents_cfg = {"agents": {}}
-    if name in agents_cfg.get("agents", {}):
-        agents_cfg["agents"][name][field] = value
-        with open(AGENTS_FILE, "w") as f:
-            yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+    with _config_lock():
+        agents_cfg = _load_agents_yaml()
+        if name in agents_cfg.get("agents", {}):
+            agents_cfg["agents"][name][field] = value
+            _save_agents_yaml(agents_cfg)
 
 
 def _update_network_config(field: str, value) -> None:
@@ -1982,11 +2098,22 @@ to drop a goal.
 
 
 def _ensure_operator_agent(config_path: Path | None = None, default_model: str = "") -> None:
-    """Create the operator agent if it doesn't exist. Handles concierge->operator migration."""
-    agents_cfg: dict = {"agents": {}}
-    if AGENTS_FILE.exists():
-        with open(AGENTS_FILE) as f:
-            agents_cfg = yaml.safe_load(f) or {"agents": {}}
+    """Create the operator agent if it doesn't exist. Handles concierge->operator migration.
+
+    Thin locked wrapper: the whole function body (several load->mutate->save
+    sites across agents.yaml AND permissions.json, with multiple early
+    returns) runs inside ONE ``_config_lock()`` acquisition via
+    ``_ensure_operator_agent_locked`` — delegating rather than reindenting
+    every branch keeps this diff reviewable and avoids a mass-reindent of a
+    ~250-line function.
+    """
+    with _config_lock():
+        _ensure_operator_agent_locked(config_path, default_model)
+
+
+def _ensure_operator_agent_locked(config_path: Path | None, default_model: str) -> None:
+    """Body of ``_ensure_operator_agent`` — ONLY called with the lock held."""
+    agents_cfg: dict = _load_agents_yaml()
     if "agents" not in agents_cfg:
         agents_cfg["agents"] = {}
 
@@ -1996,9 +2123,7 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
     # Migration: rename concierge -> operator
     if has_concierge and not has_operator:
         agents_cfg["agents"][_OPERATOR_AGENT_ID] = agents_cfg["agents"].pop("concierge")
-        AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(AGENTS_FILE, "w") as f:
-            yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+        _save_agents_yaml(agents_cfg)
         # Also rename in permissions
         perms = _load_permissions()
         if "concierge" in perms.get("permissions", {}):
@@ -2008,8 +2133,7 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
     elif has_concierge and has_operator:
         # Both exist — keep operator, remove concierge
         del agents_cfg["agents"]["concierge"]
-        with open(AGENTS_FILE, "w") as f:
-            yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+        _save_agents_yaml(agents_cfg)
         return
 
     if has_operator:
@@ -2068,14 +2192,7 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
             op_entry["heartbeat"] = _OPERATOR_HEARTBEAT
             op_entry["initial_heartbeat"] = _OPERATOR_HEARTBEAT
             agents_cfg["agents"][_OPERATOR_AGENT_ID] = op_entry
-            AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-            with open(AGENTS_FILE, "w") as f:
-                yaml.dump(
-                    agents_cfg,
-                    f,
-                    default_flow_style=False,
-                    sort_keys=False,
-                )
+            _save_agents_yaml(agents_cfg)
             logger.info(
                 "Refreshed operator heartbeat to versioned template%s",
                 " (was empty — bootstrapped)" if existing_is_empty else "",
@@ -2113,14 +2230,7 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         if pb_new_has_latest and ((not pb_old_has_latest and pb_old_has_any) or pb_existing_empty):
             op_entry["initial_instructions"] = _OPERATOR_CORE
             agents_cfg["agents"][_OPERATOR_AGENT_ID] = op_entry
-            AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-            with open(AGENTS_FILE, "w") as f:
-                yaml.dump(
-                    agents_cfg,
-                    f,
-                    default_flow_style=False,
-                    sort_keys=False,
-                )
+            _save_agents_yaml(agents_cfg)
             logger.info(
                 "Refreshed operator instructions payload to versioned playbook%s",
                 " (was empty — bootstrapped)" if pb_existing_empty else "",

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2731,20 +2731,25 @@ def create_dashboard_router(
 
         # Remove from config and permissions (best-effort — don't fail if files are missing)
         try:
-            import yaml
+            from src.cli.config import (
+                _config_lock,
+                _load_agents_yaml,
+                _load_permissions,
+                _save_agents_yaml,
+                _save_permissions,
+            )
 
-            from src.cli.config import AGENTS_FILE, _load_permissions, _save_permissions
-
-            if AGENTS_FILE.exists():
-                with open(AGENTS_FILE) as f:
-                    agents_data = yaml.safe_load(f) or {}
+            # B-pre #2: both files' load->mutate->save happen under ONE
+            # lock acquisition — closes the lost-update race this used to
+            # run as two independent bare-``open(..., "w")`` writes.
+            with _config_lock():
+                agents_data = _load_agents_yaml()
                 agents_data.get("agents", {}).pop(agent_id, None)
-                with open(AGENTS_FILE, "w") as f:
-                    yaml.dump(agents_data, f, default_flow_style=False, sort_keys=False)
+                _save_agents_yaml(agents_data)
 
-            perms = _load_permissions()
-            perms.get("permissions", {}).pop(agent_id, None)
-            _save_permissions(perms)
+                perms = _load_permissions()
+                perms.get("permissions", {}).pop(agent_id, None)
+                _save_permissions(perms)
             if permissions is not None:
                 permissions.reload()
         except Exception as e:

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6598,6 +6598,24 @@ function dashboard() {
       } catch (e) { this.showToast(`Clear lead failed: ${e.message}`); }
     },
 
+    /** Hiring wizard v2 (Phase-4 §8 #16) — Team Hub "Hire teammate" entry
+     * point. This is a chat-seeding shortcut, NOT a new wizard state: it
+     * reuses the same sendChatTo('operator', …) pipeline the wizard v1
+     * chips use (wizardChipClicked above) and never calls a create API
+     * directly — the operator agent drives create_agent/apply_template
+     * itself, gated on the user's confirmation in chat. Wizard v1's
+     * idle|ask|confirming|building|first-output|build_failed state
+     * machine is untouched. */
+    hireForTeam(team) {
+      if (!team) return;
+      this.track('hire_teammate_clicked', { team: team });
+      const msg = `I want to hire for team ${team}. Review the team's goals (north_star / success criteria) and current members, ` +
+        `draft 1-3 job descriptions that close the biggest gaps, and propose the hires — pick a fitting template as each hire's starting resume, ` +
+        `set role from the job description, and wait for my confirmation before creating anyone.`;
+      this.switchTab('chat');
+      this.$nextTick(() => this.sendChatTo('operator', msg));
+    },
+
     /** Agents in the registry that are not in any team. Excludes operator (system agent, not team-assignable). */
     get soloAgents() {
       const assigned = new Set();

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2127,7 +2127,15 @@
 
               <!-- ── MEMBERS ── -->
               <div x-show="teamHubTab === 'members'" x-cloak class="px-4 py-3">
-                <p class="text-xs text-gray-500 mb-3">Agents assigned to this team. Members share context and can communicate through the team blackboard.</p>
+                <div class="flex items-start justify-between gap-3 mb-3">
+                  <p class="text-xs text-gray-500">Agents assigned to this team. Members share context and can communicate through the team blackboard.</p>
+                  <button @click="hireForTeam(activeTeam)"
+                    class="text-xs px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors flex-shrink-0 inline-flex items-center gap-1.5"
+                    title="Ask the operator to review this team's goals and members, draft job descriptions, and propose hires">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M19 8v6M22 11h-6"/></svg>
+                    <span>Hire teammate</span>
+                  </button>
+                </div>
                 <!-- Current members -->
                 <div class="space-y-1.5 mb-4">
                   <template x-for="m in (activeTeamData?.members || [])" :key="m">

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -622,7 +622,14 @@ class HealthMonitor:
                 )
                 await loop.run_in_executor(None, self.runtime.stop_agent, agent_id)
                 return
-            self.router.register_agent(agent_id, url)
+            # Pass the fresh role through — the container above already
+            # started with ``role=info.get("role", "")``, but re-registering
+            # without it left the mesh roster cache (``router.agent_roles``)
+            # stale after an auto-rebuild: register_agent only overwrites
+            # agent_roles when ``role`` is truthy, so an omitted role here
+            # silently kept whatever (possibly outdated, or absent) role was
+            # cached before the restart.
+            self.router.register_agent(agent_id, url, role=info.get("role", ""))
             health.consecutive_failures = 0
             health.restart_count += 1
             health.restart_timestamps.append(now)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4403,9 +4403,13 @@ def create_mesh_app(
         model_override = data.get("model", "")
 
         # Optional per-agent overrides (PR-N v2): allowed fields are
-        # {model, instructions, soul, heartbeat, interface}. `role` is
-        # intentionally NOT overrideable here — templates define role per slot
-        # and changing it post-creation is a different operation (rename).
+        # {model, instructions, soul, heartbeat, interface, role}. `role`
+        # was unfrozen in the hiring-wizard-v2 unit (§8 #16b) — role is
+        # descriptive/coordination text only (no tool gating reads it,
+        # SOFT_EDIT_FIELDS already lets edit_agent set it post-creation),
+        # so a per-slot override at creation time is zero extra permission
+        # surface; it just lets a hire's job-description-derived role land
+        # without a follow-up edit_agent round-trip.
         # Validated UPFRONT — no agent is created if any override is invalid.
         agent_overrides = data.get("agent_overrides") or {}
         if agent_overrides:
@@ -4417,15 +4421,19 @@ def create_mesh_app(
                 "soul",
                 "heartbeat",
                 "interface",
+                "role",
             }
             # Per-field length caps mirror src/agent/server.py _FILE_CAPS:
             #   INSTRUCTIONS.md: 12000, SOUL.md: 4000, INTERFACE.md: 4000,
-            #   HEARTBEAT.md: None (uncapped).
+            #   HEARTBEAT.md: None (uncapped). `role` has no cap anywhere
+            #   else in the config-edit surface (edit_agent's `role` field
+            #   is likewise uncapped) — mirrored here for consistency.
             _STRING_FIELD_CAPS: dict[str, int | None] = {
                 "instructions": 12000,
                 "soul": 4000,
                 "heartbeat": None,
                 "interface": 4000,
+                "role": None,
             }
 
             # 1. Unknown agent names
@@ -10047,9 +10055,7 @@ def create_mesh_app(
         old_value = change["old_value"]
         new_value = change["new_value"]
 
-        import yaml
-
-        from src.cli.config import AGENTS_FILE, _load_config
+        from src.cli.config import _load_config
 
         agent_cfg = _load_config()
         agents = agent_cfg.get("agents", {})
@@ -10057,30 +10063,35 @@ def create_mesh_app(
             raise HTTPException(404, f"Agent '{agent_id}' not found")
 
         if field == "permissions":
-            from src.cli.config import _load_permissions, _save_permissions
+            from src.cli.config import _config_lock, _load_permissions, _save_permissions
 
-            perms = _load_permissions()
-            # Apply semantics differ between forward and undo paths:
-            #   * Forward apply (caller passed partial dict): MERGE the
-            #     keys into the agent's existing perms so other granted
-            #     bits aren't clobbered. `setdefault` covers the rare
-            #     case of a never-backfilled agent.
-            #   * Undo (``is_undo=True``): REPLACE the agent's perms
-            #     dict with the stored old full state. A merge would
-            #     leave the granted keys in place — the original edit
-            #     only wrote keys that changed, so a merge of the old
-            #     full dict doesn't unset what was added. REPLACE
-            #     restores correctly. The dashboard already warns when
-            #     undoing an older receipt would discard newer edits.
-            if isinstance(new_value, dict):
-                if is_undo:
-                    perms.setdefault("permissions", {})[agent_id] = new_value
-                else:
-                    perms.setdefault("permissions", {}).setdefault(
-                        agent_id,
-                        {},
-                    ).update(new_value)
-                _save_permissions(perms)
+            # B-pre #2: hold the shared config lock across the full
+            # load->mutate->save so a concurrent writer (another edit,
+            # a template apply, a team-membership change) can't clobber
+            # this update — mirrors the agents.yaml branch below.
+            with _config_lock():
+                perms = _load_permissions()
+                # Apply semantics differ between forward and undo paths:
+                #   * Forward apply (caller passed partial dict): MERGE the
+                #     keys into the agent's existing perms so other granted
+                #     bits aren't clobbered. `setdefault` covers the rare
+                #     case of a never-backfilled agent.
+                #   * Undo (``is_undo=True``): REPLACE the agent's perms
+                #     dict with the stored old full state. A merge would
+                #     leave the granted keys in place — the original edit
+                #     only wrote keys that changed, so a merge of the old
+                #     full dict doesn't unset what was added. REPLACE
+                #     restores correctly. The dashboard already warns when
+                #     undoing an older receipt would discard newer edits.
+                if isinstance(new_value, dict):
+                    if is_undo:
+                        perms.setdefault("permissions", {})[agent_id] = new_value
+                    else:
+                        perms.setdefault("permissions", {}).setdefault(
+                            agent_id,
+                            {},
+                        ).update(new_value)
+                    _save_permissions(perms)
             # Hot-reload the in-memory permission matrix
             if permissions is not None:
                 permissions.reload()
@@ -10091,10 +10102,21 @@ def create_mesh_app(
             # both write paths converge on the same scheduler call).
             pass
         else:
+            from src.cli.config import _config_lock, _load_agents_yaml, _save_agents_yaml
+
             yaml_key = _CONFIG_FIELD_MAP.get(field, field)
-            agents[agent_id][yaml_key] = new_value
-            with open(AGENTS_FILE, "w") as f:
-                yaml.dump(agent_cfg, f, default_flow_style=False, sort_keys=False)
+            # B-pre #2: load->mutate->save under the shared lock, re-reading
+            # agents.yaml fresh (not the ``agent_cfg`` snapshot from above,
+            # which could already be stale by the time we get here) and
+            # writing it back atomically (tempfile + os.replace) instead of
+            # the old bare truncate-and-write.
+            with _config_lock():
+                fresh_cfg = _load_agents_yaml()
+                fresh_agents = fresh_cfg.get("agents", {})
+                if agent_id not in fresh_agents:
+                    raise HTTPException(404, f"Agent '{agent_id}' not found")
+                fresh_agents[agent_id][yaml_key] = new_value
+                _save_agents_yaml(fresh_cfg)
 
         # Budget sync: update the in-memory cost tracker immediately
         if field == "budget" and cost_tracker is not None and isinstance(new_value, dict):

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -276,22 +276,31 @@ class SetupWizard:
         if existing_agents:
             click.echo(f"  Existing agents: {', '.join(existing_agents)}")
 
-            from src.cli.config import AGENTS_FILE
+            from src.cli.config import AGENTS_FILE, _config_lock, _load_agents_yaml, _save_agents_yaml
             if AGENTS_FILE.exists():
-                with open(AGENTS_FILE) as f:
-                    agents_data = yaml.safe_load(f) or {}
+                with _config_lock():
+                    agents_data = _load_agents_yaml()
                 stale = [
                     n for n, a in agents_data.get("agents", {}).items()
                     if a.get("model") != selected_model
                 ]
                 if stale:
                     click.echo(f"\n  These agents use a different model: {', '.join(stale)}")
+                    # Interactive confirm runs OUTSIDE the lock (B-pre #2 —
+                    # the critical section must stay a short load->mutate->
+                    # save, not block other writers on a human answering a
+                    # prompt). Re-load fresh right before mutating in case
+                    # something else changed agents.yaml while we waited.
                     if click.confirm(f"  Update all agents to {selected_model}?", default=True):
-                        for n in stale:
-                            agents_data["agents"][n]["model"] = selected_model
-                        with open(AGENTS_FILE, "w") as f:
-                            yaml.dump(agents_data, f, default_flow_style=False, sort_keys=False)
-                        click.echo(f"  Updated {len(stale)} agent(s).")
+                        with _config_lock():
+                            agents_data = _load_agents_yaml()
+                            updated = 0
+                            for n in stale:
+                                if n in agents_data.get("agents", {}):
+                                    agents_data["agents"][n]["model"] = selected_model
+                                    updated += 1
+                            _save_agents_yaml(agents_data)
+                        click.echo(f"  Updated {updated} agent(s).")
 
             if not click.confirm("  Add another agent?", default=False):
                 click.echo("  Keeping existing agents.")

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -403,7 +403,43 @@ Tell the user who to talk to first and what to try: "Start by asking \
 with." Mention any blockers from missing credentials or pending logins.
 
 If any step fails, retry once. Don't block the entire setup on one failure — \
-continue and report issues at the end."""
+continue and report issues at the end.
+
+## Hiring into an existing team (v2)
+
+When the user asks to hire for a team that already has members — including \
+via the Team Hub "Hire teammate" button, which seeds a chat message like \
+"I want to hire for team X..." — this is a smaller, additive flow, not a \
+restart of Team Setup above:
+
+1. **Read the team's goals and roster first.** Call inspect_teams(team_name=X) \
+for north_star, success_criteria, and current members. The job descriptions \
+you draft should close the biggest gap between what the team is on the hook \
+for and what its current members already cover — don't propose a hire that \
+duplicates an existing agent's coverage.
+
+2. **Draft 1-3 job descriptions**, each a short paragraph: what this hire \
+owns, why the team needs it now, how it fits with existing members.
+
+3. **Templates are starting resumes, not identities.** Pick the closest \
+fleet template for each hire (list_templates) — its instructions/soul/ \
+interface become the new hire's starting point, not a fixed job title. Use \
+apply_template's `agent_overrides` to tune the slot: set `role` to the job \
+description you drafted (role is a per-slot override now, same as model/ \
+instructions/soul/heartbeat/interface), and adjust instructions/soul as \
+needed so the hire reads as built for THIS team, not the template's default \
+persona. If no template fits, create_agent works for a from-scratch hire.
+
+4. **Propose before creating.** Present the draft job description(s) and \
+which template backs each one, then wait for the user's confirmation in \
+chat — do not call create_agent/apply_template until they say go.
+
+5. **Join the team.** After creation, call add_agents_to_team(team_name, \
+[new_agent_id]) — a hire isn't done until it's actually on the roster the \
+goals belong to.
+
+Everything else about a hire (credentials, browser logins, verifying \
+health) follows the same steps 5-7 above."""
 
 _PLAYBOOK_EDIT = """\
 ## Active Playbook: Agent Configuration Edit

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -712,7 +712,6 @@ class AgentConfig(BaseModel):
     thinking: str = ""
     status: str = "active"
     budget: dict[str, Any] | None = None
-    resources: dict[str, Any] | None = None
 
     # Task 8 — structured routing metadata.
     capabilities: list[str] = Field(default_factory=list)

--- a/src/templates/competitive-intel.yaml
+++ b/src/templates/competitive-intel.yaml
@@ -225,10 +225,6 @@ agents:
       # to ask the user for a service credential.
       can_request_user_credentials: true
 
-    resources:
-      memory_limit: "768m"
-      cpu_limit: 0.5
-
     budget:
       daily_usd: 10.0
       monthly_usd: 200.0

--- a/src/templates/content.yaml
+++ b/src/templates/content.yaml
@@ -53,9 +53,6 @@ agents:
       blackboard_write: ["sources/*", "tasks/*", "status/*"]
       can_publish: ["research_complete"]
       can_subscribe: ["content_requested"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0
@@ -120,9 +117,6 @@ agents:
       blackboard_write: ["drafts/*", "tasks/*", "status/*"]
       can_publish: ["draft_ready"]
       can_subscribe: ["research_complete", "revision_requested"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0
@@ -185,9 +179,6 @@ agents:
       blackboard_write: ["feedback/*", "tasks/*", "status/*"]
       can_publish: ["edit_complete", "revision_requested"]
       can_subscribe: ["draft_ready"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 3.0
       monthly_usd: 60.0

--- a/src/templates/deep-research.yaml
+++ b/src/templates/deep-research.yaml
@@ -68,9 +68,6 @@ agents:
       blackboard_write: ["sources/*", "tasks/*", "status/*"]
       can_publish: ["sources_ready"]
       can_subscribe: ["research_requested", "more_sources_needed"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0
@@ -134,9 +131,6 @@ agents:
       blackboard_write: ["analysis/*", "tasks/*", "status/*"]
       can_publish: ["analysis_ready", "more_sources_needed"]
       can_subscribe: ["sources_ready"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 8.0
       monthly_usd: 160.0
@@ -198,9 +192,6 @@ agents:
       blackboard_write: ["reports/*", "tasks/*", "status/*"]
       can_publish: ["report_ready"]
       can_subscribe: ["analysis_ready"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0

--- a/src/templates/devteam.yaml
+++ b/src/templates/devteam.yaml
@@ -75,9 +75,6 @@ agents:
       blackboard_write: ["tasks/*", "status/*"]
       can_publish: ["tasks_ready", "review_requested"]
       can_subscribe: ["task_complete", "review_complete"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0
@@ -156,9 +153,6 @@ agents:
       blackboard_write: ["tasks/*", "status/*"]
       can_publish: ["task_complete"]
       can_subscribe: ["tasks_ready"]
-    resources:
-      memory_limit: "1g"
-      cpu_limit: 1.0
     budget:
       daily_usd: 10.0
       monthly_usd: 200.0
@@ -237,9 +231,6 @@ agents:
       blackboard_write: ["reviews/*", "tasks/*", "status/*"]
       can_publish: ["review_complete"]
       can_subscribe: ["task_complete"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0

--- a/src/templates/lead-enrichment.yaml
+++ b/src/templates/lead-enrichment.yaml
@@ -175,9 +175,6 @@ agents:
       # Navigates login-gated sources (e.g. LinkedIn) — may need to ask
       # the user for a service credential via request_credential().
       can_request_user_credentials: true
-    resources:
-      memory_limit: "768m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 15.0
       monthly_usd: 300.0
@@ -276,9 +273,6 @@ agents:
       blackboard_write: ["leads/exports/*", "tasks/*", "status/*"]
       can_publish: ["export_ready"]
       can_subscribe: ["lead_enriched", "batch_complete"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 2.0
       monthly_usd: 40.0

--- a/src/templates/monitor.yaml
+++ b/src/templates/monitor.yaml
@@ -74,9 +74,6 @@ agents:
       # Checks login-gated sources via browser — may need to ask the user
       # for a service credential.
       can_request_user_credentials: true
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 3.0
       monthly_usd: 60.0
@@ -137,9 +134,6 @@ agents:
       blackboard_write: ["analysis/*", "tasks/*", "status/*"]
       can_publish: ["analysis_complete"]
       can_subscribe: ["alert_triggered"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0

--- a/src/templates/opportunity-finder.yaml
+++ b/src/templates/opportunity-finder.yaml
@@ -146,9 +146,6 @@ agents:
       blackboard_write: ["gaps/raw/*", "tasks/*", "status/*"]
       can_publish: ["gaps_ready", "new_gap_found"]
       can_subscribe: ["research_requested", "evaluation_complete"]
-    resources:
-      memory_limit: "768m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 8.0
       monthly_usd: 160.0
@@ -299,9 +296,6 @@ agents:
       blackboard_write: ["evaluations/*", "tasks/*", "status/*"]
       can_publish: ["evaluation_complete", "more_evidence_needed"]
       can_subscribe: ["gaps_ready", "new_gap_found"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 8.0
       monthly_usd: 160.0
@@ -511,9 +505,6 @@ agents:
       blackboard_write: ["models/*", "tasks/*", "status/*"]
       can_publish: ["model_complete"]
       can_subscribe: ["evaluation_complete"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 10.0
       monthly_usd: 200.0

--- a/src/templates/price-intelligence.yaml
+++ b/src/templates/price-intelligence.yaml
@@ -169,9 +169,6 @@ agents:
       # Crawls login-gated supplier/competitor pricing pages via browser —
       # may need to ask the user for a service credential.
       can_request_user_credentials: true
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0
@@ -296,9 +293,6 @@ agents:
       blackboard_write: ["prices/*/analysis", "tasks/*", "status/*"]
       can_publish: ["price_report_ready"]
       can_subscribe: ["price_change"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 3.0
       monthly_usd: 60.0

--- a/src/templates/research.yaml
+++ b/src/templates/research.yaml
@@ -112,9 +112,6 @@ agents:
       blackboard_write: ["research/*", "sources/*", "tasks/*", "status/*"]
       can_publish: ["research_complete"]
       can_subscribe: ["research_requested"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 8.0
       monthly_usd: 160.0

--- a/src/templates/review-ops.yaml
+++ b/src/templates/review-ops.yaml
@@ -154,9 +154,6 @@ agents:
       # Scrapes login-gated review platforms via browser — may need to ask
       # the user for a service credential.
       can_request_user_credentials: true
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 4.0
       monthly_usd: 80.0
@@ -341,9 +338,6 @@ agents:
       blackboard_write: ["reviews/*/draft", "tasks/*", "status/*"]
       can_publish: ["response_drafted"]
       can_subscribe: ["negative_review"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 4.0
       monthly_usd: 80.0

--- a/src/templates/sales.yaml
+++ b/src/templates/sales.yaml
@@ -63,9 +63,6 @@ agents:
       # Researches login-gated company/contact sources (e.g. LinkedIn) —
       # may need to ask the user for a service credential.
       can_request_user_credentials: true
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 5.0
       monthly_usd: 100.0
@@ -130,9 +127,6 @@ agents:
       blackboard_write: ["leads/*/qualification", "tasks/*", "status/*"]
       can_publish: ["qualified", "disqualified"]
       can_subscribe: ["research_complete"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 3.0
       monthly_usd: 60.0
@@ -198,9 +192,6 @@ agents:
       blackboard_write: ["leads/*/outreach", "tasks/*", "status/*"]
       can_publish: ["outreach_ready"]
       can_subscribe: ["qualified"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 3.0
       monthly_usd: 60.0

--- a/src/templates/social-listening.yaml
+++ b/src/templates/social-listening.yaml
@@ -151,9 +151,6 @@ agents:
       # Reads login-gated social platforms via browser — may need to ask
       # the user for a service credential.
       can_request_user_credentials: true
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 4.0
       monthly_usd: 80.0
@@ -300,9 +297,6 @@ agents:
       blackboard_write: ["drafts/*", "tasks/*", "status/*"]
       can_publish: ["draft_complete"]
       can_subscribe: ["signal_found"]
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5
     budget:
       daily_usd: 6.0
       monthly_usd: 120.0

--- a/src/templates/starter.yaml
+++ b/src/templates/starter.yaml
@@ -101,6 +101,3 @@ agents:
       daily_usd: 5.0
       monthly_usd: 100.0
 
-    resources:
-      memory_limit: "512m"
-      cpu_limit: 0.5

--- a/tests/test_config_lock.py
+++ b/tests/test_config_lock.py
@@ -1,0 +1,284 @@
+"""Tests for the B-pre #2 config file-lock + atomic-write posture.
+
+Covers three things the ratified decision calls out explicitly:
+  1. Concurrent-writer lost-update prevention — threads racing add-agent /
+     update-field must not clobber each other (the real exposure recon
+     found: every agents.yaml writer used to be a bare truncate-and-write
+     with no lock at all).
+  2. Atomic-write mechanics for agents.yaml — tempfile in the same dir +
+     os.replace, mirroring ``_save_permissions``; a failed write must never
+     leave a torn file at the real path.
+  3. Cross-helper composition under ONE shared lock — a multi-step flow
+     that calls another locked helper from inside an already-locked
+     critical section must not deadlock (the reentrancy the shared
+     ``_config_lock()`` is built for) and must not lose updates when two
+     such flows run concurrently for different agents.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.cli.config import (
+    AGENTS_FILE,
+    PERMISSIONS_FILE,
+    PROJECT_ROOT,
+    _add_agent_permissions,
+    _add_agent_to_config,
+    _add_team_blackboard_permissions,
+    _config_lock,
+    _load_agents_yaml,
+    _load_permissions,
+    _remove_agent,
+    _save_agents_yaml,
+    _update_agent_field,
+)
+
+
+class _TempConfigMixin:
+    """Mixin that redirects config files to a temp directory (mirrors the
+    equivalent mixin in test_templates.py)."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._orig_agents = AGENTS_FILE
+        self._orig_perms = PERMISSIONS_FILE
+        self._orig_root = PROJECT_ROOT
+
+        import src.cli.config as cfg_mod
+
+        self._agents_path = Path(self._tmpdir) / "config" / "agents.yaml"
+        self._perms_path = Path(self._tmpdir) / "config" / "permissions.json"
+        self._agents_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_mod.AGENTS_FILE = self._agents_path
+        cfg_mod.PERMISSIONS_FILE = self._perms_path
+        cfg_mod.PROJECT_ROOT = Path(self._tmpdir)
+        self._perms_path.write_text(json.dumps({"permissions": {}}, indent=2))
+
+    def teardown_method(self):
+        import src.cli.config as cfg_mod
+
+        cfg_mod.AGENTS_FILE = self._orig_agents
+        cfg_mod.PERMISSIONS_FILE = self._orig_perms
+        cfg_mod.PROJECT_ROOT = self._orig_root
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _mock_config(self, *, collab=True, agents=None):
+        """Patch ``_load_config`` — needed only by helpers (e.g.
+        ``_add_agent_permissions``) that read mesh.yaml/collaboration
+        settings; ``CONFIG_FILE`` itself isn't redirected by this mixin."""
+        return patch(
+            "src.cli.config._load_config",
+            return_value={
+                "llm": {"default_model": "openai/gpt-4o-mini"},
+                "agents": agents or {},
+                "collaboration": collab,
+            },
+        )
+
+
+class TestConcurrentWriterLostUpdate(_TempConfigMixin):
+    """The lost-update race B-pre #2 closes: two threads independently
+    doing load->mutate->save against the SAME file used to be able to both
+    load the same baseline, and the later save would silently clobber the
+    earlier one's write."""
+
+    def test_concurrent_add_agent_all_survive(self):
+        """20 threads each add a DIFFERENT agent concurrently — every
+        write must land in the final agents.yaml."""
+        names = [f"agent-{i}" for i in range(20)]
+
+        def _add(name):
+            _add_agent_to_config(name, f"role-{name}", "openai/gpt-4o")
+
+        threads = [threading.Thread(target=_add, args=(n,)) for n in names]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+            assert not t.is_alive(), "thread did not complete — possible deadlock"
+
+        cfg = _load_agents_yaml()
+        assert set(cfg["agents"].keys()) == set(names)
+
+    def test_concurrent_update_agent_field_all_survive(self):
+        """20 threads each set a distinct field on the SAME pre-existing
+        agent concurrently — all 20 field writes must be present after,
+        none dropped by an interleaved load->mutate->save."""
+        _add_agent_to_config("shared", "worker", "openai/gpt-4o")
+
+        def _update(i):
+            _update_agent_field("shared", f"field_{i}", i)
+
+        threads = [threading.Thread(target=_update, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+            assert not t.is_alive(), "thread did not complete — possible deadlock"
+
+        cfg = _load_agents_yaml()
+        entry = cfg["agents"]["shared"]
+        for i in range(20):
+            assert entry.get(f"field_{i}") == i
+
+    def test_lock_actually_serializes_across_threads(self):
+        """Direct proof the lock blocks a second thread rather than just
+        bookkeeping in Python: thread A holds the lock across a sleep and
+        records a timestamp just before releasing; thread B can only
+        record ITS timestamp after acquiring, which must be no earlier
+        than A's — impossible unless the OS-level flock actually blocked
+        B's acquisition."""
+        order: list[str] = []
+        stamps: dict[str, float] = {}
+
+        def _holder():
+            with _config_lock():
+                order.append("A-enter")
+                time.sleep(0.3)
+                stamps["A"] = time.monotonic()
+                order.append("A-exit")
+
+        def _waiter():
+            time.sleep(0.05)  # let A acquire first
+            with _config_lock():
+                stamps["B"] = time.monotonic()
+                order.append("B-enter")
+
+        t1 = threading.Thread(target=_holder)
+        t2 = threading.Thread(target=_waiter)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert order[0] == "A-enter"
+        assert order[-1] == "B-enter"
+        assert stamps["B"] >= stamps["A"]
+
+
+class TestAtomicWrite(_TempConfigMixin):
+    """agents.yaml must be written tempfile-then-os.replace, never a bare
+    truncate-in-place — a concurrent reader must always see the old OR the
+    new complete file, never a torn one."""
+
+    def test_save_agents_yaml_uses_tempfile_and_replace(self):
+        import os as _os
+
+        calls: list[tuple[str, str]] = []
+        orig_replace = _os.replace
+
+        def _spy_replace(src, dst):
+            calls.append((str(src), str(dst)))
+            return orig_replace(src, dst)
+
+        with patch("os.replace", side_effect=_spy_replace):
+            _save_agents_yaml({"agents": {"x": {"role": "r", "model": "m"}}})
+
+        assert len(calls) == 1
+        src, dst = calls[0]
+        assert Path(dst) == self._agents_path
+        # The temp file must live in the SAME directory as the target —
+        # required for os.replace to be atomic on POSIX (a cross-filesystem
+        # rename is not atomic).
+        assert Path(src).parent == self._agents_path.parent
+        assert Path(src) != self._agents_path
+
+    def test_no_torn_file_on_write_failure(self):
+        """A failure while writing the tempfile must leave the REAL
+        agents.yaml completely untouched — readers never observe a
+        half-written file."""
+        _save_agents_yaml({"agents": {"orig": {"role": "r", "model": "m"}}})
+        original_bytes = self._agents_path.read_bytes()
+
+        with patch("os.fdopen", side_effect=OSError("disk full (simulated)")):
+            with pytest.raises(OSError):
+                _save_agents_yaml({"agents": {"new": {"role": "r2", "model": "m2"}}})
+
+        assert self._agents_path.read_bytes() == original_bytes
+        cfg = _load_agents_yaml()
+        assert cfg["agents"] == {"orig": {"role": "r", "model": "m"}}
+
+    def test_torn_write_leaves_no_orphan_tempfile(self):
+        """A failed write cleans up its own tempfile instead of littering
+        config/ with a stray .tmp file."""
+        with patch("os.fdopen", side_effect=OSError("disk full (simulated)")):
+            with pytest.raises(OSError):
+                _save_agents_yaml({"agents": {"x": {}}})
+
+        leftovers = list(self._agents_path.parent.glob("*.tmp"))
+        assert leftovers == []
+
+
+class TestCrossHelperUnderOneLock(_TempConfigMixin):
+    """Several helpers call each other synchronously while already holding
+    the lock (e.g. ``_remove_agent`` -> ``_remove_team_blackboard_permissions``).
+    The shared lock is reentrant within one thread specifically so this
+    doesn't deadlock; concurrent multi-step flows for DIFFERENT agents must
+    still each land completely."""
+
+    def test_remove_agent_reentrant_no_deadlock(self):
+        _add_agent_to_config("teammate", "worker", "openai/gpt-4o")
+        with self._mock_config():
+            _add_agent_permissions("teammate")
+
+        class _FakeTeamStore:
+            def remove_agent(self, name):
+                return "eng-team"
+
+        with patch("src.cli.config._open_teams_store", return_value=_FakeTeamStore()):
+            done = threading.Event()
+
+            def _run():
+                _remove_agent("teammate")
+                done.set()
+
+            t = threading.Thread(target=_run)
+            t.start()
+            t.join(timeout=10)
+            assert done.is_set(), "_remove_agent hung — reentrant lock deadlocked"
+
+        cfg = _load_agents_yaml()
+        assert "teammate" not in cfg.get("agents", {})
+        perms = _load_permissions()
+        assert "teammate" not in perms.get("permissions", {})
+
+    def test_concurrent_multi_step_permission_flows_survive(self):
+        """Two threads each run a two-step flow (join a team's blackboard
+        perms, then tag the agent's yaml entry) for DIFFERENT agents at the
+        same time — both flows must fully land, exercising exactly the
+        interleaving risk that motivated ONE shared lock across both files
+        instead of two independent per-file locks."""
+        _add_agent_to_config("alpha", "worker", "openai/gpt-4o")
+        _add_agent_to_config("beta", "worker", "openai/gpt-4o")
+        with self._mock_config():
+            _add_agent_permissions("alpha")
+            _add_agent_permissions("beta")
+
+        def _flow(agent, team):
+            _add_team_blackboard_permissions(agent, team)
+            _update_agent_field(agent, "note", f"joined-{team}")
+
+        t1 = threading.Thread(target=_flow, args=("alpha", "red"))
+        t2 = threading.Thread(target=_flow, args=("beta", "blue"))
+        t1.start()
+        t2.start()
+        t1.join(timeout=30)
+        t2.join(timeout=30)
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+
+        perms = _load_permissions()
+        assert "teams/red/*" in perms["permissions"]["alpha"]["blackboard_read"]
+        assert "teams/blue/*" in perms["permissions"]["beta"]["blackboard_read"]
+        cfg = _load_agents_yaml()
+        assert cfg["agents"]["alpha"]["note"] == "joined-red"
+        assert cfg["agents"]["beta"]["note"] == "joined-blue"

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2698,3 +2698,54 @@ class TestChatDeliverables:
         # (PR #1037) rather than inventing a new download route.
         assert "downloadAgentFile('operator', f.path)" in _INDEX_HTML
         assert "downloadAgentFile(activeChatId, f.path)" in _INDEX_HTML
+
+
+class TestHireTeammateEntryPoint:
+    """Hiring wizard v2 (Phase-4 §8 #16) — Team Hub "Hire teammate" button.
+
+    This is a chat-seeding shortcut, not a new wizard state machine: it
+    must reuse the existing sendChatTo('operator', …) pipeline exactly
+    like the wizard v1 chips do, and must never call a create API
+    (create_agent / apply_template) directly from the UI — the operator
+    agent drives creation itself, gated on the user's chat confirmation."""
+
+    def test_button_present_in_team_members_tab(self):
+        assert "hireForTeam(activeTeam)" in _INDEX_HTML
+        assert "Hire teammate" in _INDEX_HTML
+
+    def test_handler_declared_in_app_js(self):
+        assert "hireForTeam(team)" in _APP_JS_TEXT
+
+    def test_handler_reuses_send_chat_to_pipeline(self):
+        idx = _APP_JS_TEXT.index("hireForTeam(team)")
+        block = _APP_JS_TEXT[idx:idx + 900]
+        assert "this.sendChatTo('operator'" in block
+
+    def test_handler_never_calls_a_create_api_directly(self):
+        """The wizard UI must never call create_agent/apply_template itself
+        — only the operator agent (via its own tools) creates anything."""
+        idx = _APP_JS_TEXT.index("hireForTeam(team)")
+        block = _APP_JS_TEXT[idx:idx + 900]
+        assert "/agents" not in block
+        assert "apply_template" not in block
+        assert "fetch(" not in block
+
+    def test_seeded_message_names_the_team_and_hiring_flow(self):
+        """Pins the substance of the seeded prompt: review team goals +
+        members, draft job descriptions, template as starting resume, role
+        from the job description, wait for confirmation before creating."""
+        idx = _APP_JS_TEXT.index("hireForTeam(team)")
+        block = _APP_JS_TEXT[idx:idx + 900]
+        assert "I want to hire for team ${team}" in block
+        assert "north_star / success criteria" in block
+        assert "job" in block and "descriptions" in block
+        assert "starting resume" in block
+        assert "set role from the job description" in block
+        assert "wait for my confirmation before" in block
+
+    def test_button_lives_in_team_hub_members_tab(self):
+        """The button must render inside the members sub-tab (team
+        selected), not as a fleet-wide/global action."""
+        idx = _INDEX_HTML.index("teamHubTab === 'members'\" x-cloak")
+        block = _INDEX_HTML[idx:idx + 600]
+        assert "hireForTeam(activeTeam)" in block

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -220,6 +220,34 @@ class TestHealthRestartMissingConfig:
         _, kwargs = monitor.runtime.start_agent.call_args
         assert kwargs["env_overrides"].get("LLM_MAX_TOKENS") == "32000"
 
+    @pytest.mark.asyncio
+    async def test_restart_refreshes_stale_role_in_router_roster(self):
+        """Regression: the rebuilt container starts with the FRESH role
+        (``info.get("role", "")``), but re-registering with the router
+        used to omit ``role=`` entirely — ``MessageRouter.register_agent``
+        only overwrites ``agent_roles`` when ``role`` is truthy, so the
+        mesh roster cache kept whatever (stale) role was cached before the
+        restart even though the container itself got the new one."""
+        from src.host.mesh import MessageRouter
+
+        real_router = MessageRouter(permissions=MagicMock(), agent_registry={})
+        real_router.agent_roles["good-agent"] = "stale-role"
+
+        monitor = _make_monitor({
+            "good-agent": {"role": "fresh-role", "tools_dir": "/tools"},
+        })
+        monitor.router = real_router
+        monitor.register("good-agent")
+        health = monitor.agents["good-agent"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+        monitor.runtime.start_agent.return_value = "http://localhost:8401"
+        monitor.runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        await monitor._try_restart("good-agent")
+
+        assert real_router.agent_roles["good-agent"] == "fresh-role"
+
 
 class TestParallelHealthChecks:
     @pytest.mark.asyncio

--- a/tests/test_operator_fleet.py
+++ b/tests/test_operator_fleet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yaml
 
 
 @pytest.fixture(autouse=True)
@@ -648,8 +649,54 @@ class TestMeshFleetApplyEndpoint:
         cm.start_agent.assert_not_called()
 
     @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
-    def test_apply_role_override_field_rejected(self):
-        """`role` is intentionally NOT in the allowed fields → 400."""
+    def test_apply_role_override_field_accepted(self, tmp_path, monkeypatch):
+        """`role` is a hiring-wizard-v2 unfreeze (§8 #16b): a per-slot
+        override lands in agents.yaml AND the started container's env
+        (AGENT_ROLE), letting a hire's job-description-derived role win
+        over the template slot's default role."""
+        from fastapi.testclient import TestClient
+
+        # Isolate agents.yaml/permissions.json for this test — other tests
+        # in this class share the real repo config (gitignored, tolerated
+        # because they never assert on `created` contents), but this test
+        # DOES assert on-disk content, so it needs a clean slate rather
+        # than depending on whether a prior test run already created
+        # (and thus template-skipped) the "assistant" slot.
+        import src.cli.config as cli_config
+
+        monkeypatch.setattr(cli_config, "AGENTS_FILE", tmp_path / "agents.yaml")
+        monkeypatch.setattr(cli_config, "PERMISSIONS_FILE", tmp_path / "permissions.json")
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"role": "Senior support specialist"}},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        created_ids = [c["agent_id"] for c in data["created"]]
+        assert "assistant" in created_ids
+        assert next(c for c in data["created"] if c["agent_id"] == "assistant")["role"] == (
+            "Senior support specialist"
+        )
+
+        cm.start_agent.assert_called_once()
+        _, kwargs = cm.start_agent.call_args
+        assert kwargs["role"] == "Senior support specialist"
+
+        with open(cli_config.AGENTS_FILE) as f:
+            agents_cfg = yaml.safe_load(f)
+        assert agents_cfg["agents"]["assistant"]["role"] == "Senior support specialist"
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_still_unknown_override_field_rejected(self):
+        """A field that was never allowed (and still isn't) stays a 400 —
+        `role` moving to the allowed set doesn't loosen the unknown-field
+        gate for everything else."""
         from fastapi.testclient import TestClient
 
         app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
@@ -658,14 +705,13 @@ class TestMeshFleetApplyEndpoint:
             "/mesh/fleet/apply",
             json={
                 "template": "starter",
-                "agent_overrides": {"assistant": {"role": "renamed-role"}},
+                "agent_overrides": {"assistant": {"nickname": "renamed"}},
             },
         )
         assert resp.status_code == 400
         detail = resp.json()["detail"]
-        assert "role" in detail
-        # Allowed list should be present in the error
-        assert "soul" in detail or "instructions" in detail
+        assert "nickname" in detail
+        assert "role" in detail  # allowed list is echoed in the error
         cm.start_agent.assert_not_called()
 
     @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -127,13 +127,6 @@ class TestAddAgentToConfig(_TempConfigMixin):
             cfg = yaml.safe_load(f)
         assert cfg["agents"]["frank"]["budget"]["daily_usd"] == 5.0
 
-    def test_resources(self):
-        _add_agent_to_config("greg", "helper", "openai/gpt-4o", resources={"memory_limit": "1g", "cpu_limit": 1.0})
-        with open(self._agents_path) as f:
-            cfg = yaml.safe_load(f)
-        assert cfg["agents"]["greg"]["resources"]["memory_limit"] == "1g"
-        assert cfg["agents"]["greg"]["resources"]["cpu_limit"] == 1.0
-
     def test_empty_fields_not_written(self):
         """Empty optional fields should not appear in agents.yaml."""
         _add_agent_to_config("hank", "helper", "openai/gpt-4o")
@@ -146,7 +139,6 @@ class TestAddAgentToConfig(_TempConfigMixin):
         assert "initial_interface" not in agent
         assert "thinking" not in agent
         assert "budget" not in agent
-        assert "resources" not in agent
 
     def test_all_fields_together(self):
         """All optional fields can be set simultaneously."""
@@ -160,7 +152,6 @@ class TestAddAgentToConfig(_TempConfigMixin):
             initial_interface="Accepts X, produces Y.",
             thinking="high",
             budget={"daily_usd": 10.0},
-            resources={"memory_limit": "512m"},
         )
         with open(self._agents_path) as f:
             cfg = yaml.safe_load(f)
@@ -171,7 +162,6 @@ class TestAddAgentToConfig(_TempConfigMixin):
         assert agent["initial_interface"] == "Accepts X, produces Y."
         assert agent["thinking"] == "high"
         assert agent["budget"]["daily_usd"] == 10.0
-        assert agent["resources"]["memory_limit"] == "512m"
 
     def test_structured_routing_fields_persisted(self):
         """Task 8 — structured fields round-trip through agents.yaml."""
@@ -551,25 +541,6 @@ class TestApplyTemplate(_TempConfigMixin):
         with open(self._agents_path) as f:
             cfg = yaml.safe_load(f)
         assert cfg["agents"][agent_id]["initial_interface"] == expected_interface
-
-    def test_resources_written_in_single_pass(self):
-        """Resources are included in the same agents.yaml write, not a separate re-read."""
-        tpl = {
-            "agents": {
-                "worker": {
-                    "role": "worker",
-                    "model": "{default_model}",
-                    "resources": {"memory_limit": "1g", "cpu_limit": 1.0},
-                },
-            },
-        }
-        with self._mock_config():
-            _apply_template("test-tpl", tpl)
-
-        with open(self._agents_path) as f:
-            cfg = yaml.safe_load(f)
-        assert cfg["agents"]["worker"]["resources"]["memory_limit"] == "1g"
-        assert cfg["agents"]["worker"]["resources"]["cpu_limit"] == 1.0
 
     def test_sets_permissions_from_template(self):
         tpl = {
@@ -1260,16 +1231,6 @@ class TestCreateAgentFromTemplate(_TempConfigMixin):
         with self._mock_config():
             with pytest.raises(ValueError, match="Invalid agent name"):
                 _create_agent_from_template("../evil", "devteam/engineer", "openai/gpt-4o")
-
-    def test_applies_resources_from_template(self):
-        with self._mock_config():
-            _create_agent_from_template("my_eng", "devteam/engineer", "openai/gpt-4o")
-
-        with open(self._agents_path) as f:
-            cfg = yaml.safe_load(f)
-        resources = cfg["agents"]["my_eng"].get("resources", {})
-        assert resources.get("memory_limit") == "1g"
-        assert resources.get("cpu_limit") == 1.0
 
     def test_applies_budget_from_template(self):
         with self._mock_config():


### PR DESCRIPTION
Phase 4 unit 2 of docs/plans/2026-07-04-agent-employee-platform-architecture.md, implementing §8 #16 in its ratified order: the B-pre #2 config file-lock FIRST, then the hiring surface that depends on it.

## What changed

**B-pre #2 — config file-lock + atomic writes (recon-widened target).** A sidecar `config/.config.lock` acquired with blocking `fcntl.flock(LOCK_EX)` on a fresh fd per outermost acquisition (same-thread reentrant via a threading.local depth counter — nested helpers like `_remove_agent` → `_remove_team_blackboard_permissions` would otherwise self-deadlock; cross-thread/cross-process exclusion is kernel-enforced). EVERY `config/agents.yaml` and `config/permissions.json` load→mutate→save now runs under it — the eleven cli/config.py helpers plus the writers in host/server.py (`_apply_pending_change`), dashboard/server.py (agent delete), and setup_wizard.py (interactive prompt kept outside the lock). agents.yaml writes are now atomic (shared `atomic_write_text`: tempfile+fsync+os.replace) — previously every writer was a bare truncate-and-write. New tests/test_config_lock.py (8 tests incl. a 20-thread lost-update test) verified against negative controls.

**Role unfrozen (plan correction: surgical).** `role` added to `_ALLOWED_OVERRIDE_FIELDS` so `apply_template` agent_overrides can set it per slot (`role` was already operator-editable everywhere else); the pinned rejection test becomes a positive end-to-end test + a still-unknown-field negative; fleet_tool docstrings/schema updated. Also fixes the recon-found roster staleness bug: `health.py _try_restart` now passes `role=` on re-register, with a regression test.

**Dead `resources` template key deleted (§8 #16d).** Round-trip sites in cli/config.py, all 13 template YAMLs, `AgentConfig`; grep-zero for the config key.

**Hiring wizard v2 (operator-tier, wizard-v1 shape).** Team Hub "Hire teammate" button seeds the operator chat with a goals-driven hiring prompt via the existing `sendChatTo` pipeline — no new wizard states, no create API called from the UI. The team_build operator playbook gains a "hiring into an existing team" section: derive job descriptions from team goals, templates as starting resumes via `apply_template(agent_overrides={"role": ...})`, propose-then-confirm, `add_agents_to_team` after creation.

## Tests

ruff clean. Targeted 1143 passed / 3 skipped / 0 failed. Full local suite 8462 passed / 26 skipped / 0 failed (baseline 8449). One pre-existing xdist-only isolation flake in test_dashboard (browser settings) was confirmed unrelated via serial + repeated parallel runs and did not fire in the final run.