### PR TITLE
test(cron): harden set_cron schema security pin against tool-registry pollution

### DIFF
--- a/tests/test_cron_standup.py
+++ b/tests/test_cron_standup.py
@@ -261,7 +261,16 @@ class TestPostToChannelNotAgentSettable:
     def test_set_cron_tool_schema_has_no_post_to_channel_param(self):
         """The LLM-facing tool schema must not even expose the
         parameter — the agent can't ask for it, let alone set it."""
-        import src.agent.builtins.mesh_tool  # noqa: F401  (registers into _tool_staging)
+        import importlib
+
+        import src.agent.builtins.mesh_tool as mesh_tool
+        # Reload so registration re-runs even when another test file in
+        # this worker cleared the module-global ``_tool_staging`` (e.g.
+        # test_grouped_tools/test_mcp_e2e setup) — a bare re-import is a
+        # no-op and this security pin would KeyError on registry state
+        # instead of testing the schema. Same idiom as test_builtins'
+        # set_cron copy test.
+        importlib.reload(mesh_tool)
         from src.agent.tools import _tool_staging
 
         params = _tool_staging["set_cron"]["parameters"]


### PR DESCRIPTION
The unit-1 security pin (`post_to_channel` must not appear in the set_cron tool schema) read the module-global `_tool_staging` after a bare import. Once mesh_tool is already imported in a worker, that import is a no-op — so when a same-worker test file clears the staging registry (`test_grouped_tools`/`test_mcp_e2e` setups), the key is absent and the pin KeyErrors on registry state instead of testing the schema. Surfaced as an order-dependent full-suite failure after #1224's new tests reshuffled the xdist file→worker mapping; reproduced interpreter-level (import → clear → re-import leaves `set_cron` absent) and with a two-file pytest recipe.

Fix: `importlib.reload` before reading — registration re-runs deterministically. This is the exact idiom `test_builtins`' set_cron copy test already uses for the same reason.

Test-only change. Verified green under the repro recipe; full local suite result recorded before merge.