### PR TITLE
fix(host): validate /mesh/browser/command body, action, and params types

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -11988,28 +11988,31 @@ def create_mesh_app(
         """
         caller_id = _extract_verified_agent_id(request)
         body = await request.json()
-        # Reject malformed bodies (null, list, string, number) with a clean 400
-        # before any target resolution or permission work — otherwise
-        # ``body.get(...)`` raises AttributeError → opaque 500.
+        # Validate the request SHAPE before target resolution or any permission
+        # work. Otherwise ``body.get(...)`` raises AttributeError on a non-dict
+        # body (→ opaque 500), and — more subtly — delegation resolution would
+        # run on structurally-invalid input, so a shape error (e.g. a list
+        # ``action``) combined with an unauthorized target could surface as a
+        # 403 instead of the intended 400. Hoist the ``action``/``params`` reads
+        # here so both are validated up front (read once, no later re-read).
         if not isinstance(body, dict):
             raise HTTPException(400, "request body must be a JSON object")
+        action = body.get("action", "")
+        # A non-string ``action`` (e.g. a list) is unhashable and would raise at
+        # the ``action not in _ALLOWED_BROWSER_ACTIONS`` membership check → 500.
+        if not isinstance(action, str):
+            raise HTTPException(400, "action must be a string")
+        params = body.get("params", {})
+        # A non-dict ``params`` fails later at ``params.get("url")`` or ships
+        # invalid JSON downstream — reject it up front.
+        if not isinstance(params, dict):
+            raise HTTPException(400, "params must be a JSON object")
+
         req_agent_id = _resolve_browser_target(
             caller_id,
             body.get("target_agent_id") or "",
             request,
         )
-
-        action = body.get("action", "")
-        params = body.get("params", {})
-
-        # A non-string ``action`` (e.g. a list) is unhashable and would raise at
-        # the ``action not in _ALLOWED_BROWSER_ACTIONS`` membership check → 500.
-        if not isinstance(action, str):
-            raise HTTPException(400, "action must be a string")
-        # A non-dict ``params`` fails later at ``params.get("url")`` or ships
-        # invalid JSON downstream — reject it up front.
-        if not isinstance(params, dict):
-            raise HTTPException(400, "params must be a JSON object")
 
         if not action:
             raise HTTPException(400, "action is required")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -11988,6 +11988,11 @@ def create_mesh_app(
         """
         caller_id = _extract_verified_agent_id(request)
         body = await request.json()
+        # Reject malformed bodies (null, list, string, number) with a clean 400
+        # before any target resolution or permission work — otherwise
+        # ``body.get(...)`` raises AttributeError → opaque 500.
+        if not isinstance(body, dict):
+            raise HTTPException(400, "request body must be a JSON object")
         req_agent_id = _resolve_browser_target(
             caller_id,
             body.get("target_agent_id") or "",
@@ -11996,6 +12001,15 @@ def create_mesh_app(
 
         action = body.get("action", "")
         params = body.get("params", {})
+
+        # A non-string ``action`` (e.g. a list) is unhashable and would raise at
+        # the ``action not in _ALLOWED_BROWSER_ACTIONS`` membership check → 500.
+        if not isinstance(action, str):
+            raise HTTPException(400, "action must be a string")
+        # A non-dict ``params`` fails later at ``params.get("url")`` or ships
+        # invalid JSON downstream — reject it up front.
+        if not isinstance(params, dict):
+            raise HTTPException(400, "params must be a JSON object")
 
         if not action:
             raise HTTPException(400, "action is required")

--- a/tests/test_browser_delegation.py
+++ b/tests/test_browser_delegation.py
@@ -687,6 +687,87 @@ class TestBrowserCommandEndpoint:
                 assert resp.status_code == 400, (bad, resp.text)
                 assert "must be a string" in resp.text
 
+    @pytest.mark.asyncio
+    async def test_non_dict_body_rejected(self, tmp_path):
+        """A well-formed JSON body that decodes to null / a list / a string
+        must yield a clean 400, not an opaque 500 from ``body.get(...)``
+        raising AttributeError."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "worker": {"can_use_browser": True},
+            },
+        )
+
+        # Send raw JSON documents (not httpx ``json=`` — ``json=None`` would
+        # send an empty body, a different decode-error path). Each decodes to
+        # a non-dict: null → None, a list, a string.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            for raw in ("null", "[1, 2, 3]", '"just a string"'):
+                resp = await client.post(
+                    "/mesh/browser/command",
+                    content=raw,
+                    headers={
+                        "X-Agent-ID": "worker",
+                        "Content-Type": "application/json",
+                    },
+                )
+                assert resp.status_code == 400, (raw, resp.text)
+                assert "must be a JSON object" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_non_dict_params_rejected(self, tmp_path):
+        """A non-dict ``params`` must yield 400 up front rather than failing
+        later at ``params.get("url")`` or shipping invalid JSON downstream."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "worker": {"can_use_browser": True},
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={"action": "snapshot", "params": "not-a-dict"},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 400, resp.text
+        assert "params must be a JSON object" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_non_string_action_rejected(self, tmp_path):
+        """A list ``action`` is unhashable and would blow up at the
+        ``action not in _ALLOWED_BROWSER_ACTIONS`` membership check → 500.
+        It must be rejected with a clean 400 instead."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "worker": {"can_use_browser": True},
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={"action": ["snapshot"], "params": {}},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 400, resp.text
+        assert "action must be a string" in resp.text
+
 
 class TestBrowserLoginRequestEndpoint:
     """POST /mesh/browser-login-request delegation matrix."""

--- a/tests/test_browser_delegation.py
+++ b/tests/test_browser_delegation.py
@@ -768,6 +768,42 @@ class TestBrowserCommandEndpoint:
         assert resp.status_code == 400, resp.text
         assert "action must be a string" in resp.text
 
+    @pytest.mark.asyncio
+    async def test_shape_validation_precedes_delegation(self, tmp_path):
+        """A structurally-invalid request must fail shape validation (400)
+        BEFORE delegation/permission resolution runs — even when the target is
+        one the caller can't message. Otherwise malformed input would drive
+        delegation work and surface as a 403 (auth) instead of a 400 (shape).
+        """
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "worker1": {
+                    "can_use_browser": False,
+                    "can_message": ["worker1"],  # self only — can't reach worker2
+                },
+                "worker2": {"can_use_browser": True},
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={
+                    "action": ["snapshot"],  # non-string: shape error
+                    "params": {},
+                    "target_agent_id": "worker2",  # caller can't message this
+                },
+                headers={"X-Agent-ID": "worker1"},
+            )
+        # Shape wins: 400, not the 403 delegation would raise.
+        assert resp.status_code == 400, resp.text
+        assert "action must be a string" in resp.text
+
 
 class TestBrowserLoginRequestEndpoint:
     """POST /mesh/browser-login-request delegation matrix."""


### PR DESCRIPTION
## Problem (CH-2)

The `POST /mesh/browser/command` handler in `src/host/server.py` did `body = await request.json()` and then read `body.get("target_agent_id")`, `body.get("action", "")`, and `body.get("params", {})` with no type validation:

- A JSON body that decodes to `null`, a list, or a string raises `AttributeError` on `body.get(...)` → uncaught → opaque **HTTP 500**, instead of the clean 400 the endpoint emits for other bad input.
- A **list** `action` is unhashable and blows up at the `action not in _ALLOWED_BROWSER_ACTIONS` membership check → 500.
- A non-dict `params` slips through and fails later at `params.get("url")` (navigate/open_tab) or ships invalid JSON downstream to the browser service.

## Fix (surgical)

Three type guards, in the endpoint's existing `HTTPException` style, with no change to valid-request behavior:

1. Reject a non-dict `body` with `400 "request body must be a JSON object"` — placed **before** `_resolve_browser_target` and any permission work, so malformed input is rejected before target resolution.
2. Reject a non-string `action` with `400 "action must be a string"` (before the membership check).
3. Reject a non-dict `params` with `400 "params must be a JSON object"` (before it is used).

The existing "action is required" and unknown-action checks are unchanged.

## Tests

Added to `tests/test_browser_delegation.py::TestBrowserCommandEndpoint`:

- `test_non_dict_body_rejected` — raw JSON bodies `null` / `[1, 2, 3]` / `"just a string"` each → 400.
- `test_non_dict_params_rejected` — `params: "not-a-dict"` → 400.
- `test_non_string_action_rejected` — `action: ["snapshot"]` → 400.

The existing `test_self_path_success` (valid dict body) continues to pass as the regression guard.

Full file green: `34 passed`. `ruff check` clean on both changed files.