### PR TITLE
perf(browser): only persist fingerprint-burn state on a real transition

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -940,6 +940,14 @@ _fingerprint_hard_burn_reason: dict[str, tuple[str, str]] = {}
 # a new module-level global, but lock-protected identity state consistent
 # with the surrounding fingerprint globals). Guarded by ``_fingerprint_lock``.
 _binding_signatures: dict[str, str] = {}
+# Retry-on-failure flag for the hard-burn dedupe path. ``snapshot`` persists
+# the WHOLE fingerprint state, so one global bool suffices. Set True when a
+# ``_force_fingerprint_burn`` transition FAILED to persist (the snapshot
+# returned False), so the next signal re-attempts even if it would otherwise
+# dedupe as an unchanged repeat — matching the original unconditional-snapshot
+# resilience. Guarded by ``_fingerprint_lock`` like the surrounding state
+# (Constraint #8: lock-protected module global).
+_fingerprint_snapshot_dirty: bool = False
 
 
 def _get_fingerprint_lock() -> asyncio.Lock:
@@ -1127,6 +1135,7 @@ async def _force_fingerprint_burn(
     agent_id: str, vendor: str, reason: str,
 ) -> bool:
     """Mark agent as hard-burned. Returns True iff state transitioned."""
+    global _fingerprint_snapshot_dirty
     async with _get_fingerprint_lock():
         already = agent_id in _fingerprint_hard_burned
         prev_reason = _fingerprint_hard_burn_reason.get(agent_id)
@@ -1135,16 +1144,21 @@ async def _force_fingerprint_burn(
         _fingerprint_hard_burned.add(agent_id)
         _fingerprint_hard_burn_reason[agent_id] = (vendor, reason)
         _fingerprint_last_signal[agent_id] = time.time()
-        # Persist ONLY on a real transition: a new burn, or a changed
-        # (vendor, reason). A burned agent repeatedly hitting the same
-        # walled site fires this listener per block-response; fsyncing an
-        # identical state each time micro-stalls the shared event loop for
-        # the whole fleet. The durable facts (burn set + reason) haven't
-        # changed on a repeat — last_signal is a best-effort timestamp we
-        # deliberately don't fsync on an identical hit.
+        # Persist on a real transition (a new burn, or a changed
+        # (vendor, reason)) — OR when a prior transition's snapshot FAILED
+        # and left the dirty flag set. A burned agent repeatedly hitting
+        # the same walled site fires this listener per block-response;
+        # fsyncing an identical state each time micro-stalls the shared
+        # event loop for the whole fleet. The durable facts (burn set +
+        # reason) haven't changed on a repeat — last_signal is a best-effort
+        # timestamp we deliberately don't fsync on an identical hit. But if
+        # the genuine transition never made it to disk, dedupe would lose
+        # it on restart; the dirty flag forces a retry on the next signal,
+        # matching the original unconditional-snapshot resilience.
         changed = (not already) or (prev_reason != (vendor, reason))
-        if changed:
-            _snapshot_fingerprint_state_locked()
+        if changed or _fingerprint_snapshot_dirty:
+            ok = _snapshot_fingerprint_state_locked()
+            _fingerprint_snapshot_dirty = not ok
     return not already
 
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1129,11 +1129,22 @@ async def _force_fingerprint_burn(
     """Mark agent as hard-burned. Returns True iff state transitioned."""
     async with _get_fingerprint_lock():
         already = agent_id in _fingerprint_hard_burned
+        prev_reason = _fingerprint_hard_burn_reason.get(agent_id)
+        # Always refresh the in-memory state — the last-signal timestamp
+        # and reason must track every block hit even on a repeat.
         _fingerprint_hard_burned.add(agent_id)
         _fingerprint_hard_burn_reason[agent_id] = (vendor, reason)
         _fingerprint_last_signal[agent_id] = time.time()
-        # Persist so a vendor-confirmed hard block survives a restart.
-        _snapshot_fingerprint_state_locked()
+        # Persist ONLY on a real transition: a new burn, or a changed
+        # (vendor, reason). A burned agent repeatedly hitting the same
+        # walled site fires this listener per block-response; fsyncing an
+        # identical state each time micro-stalls the shared event loop for
+        # the whole fleet. The durable facts (burn set + reason) haven't
+        # changed on a repeat — last_signal is a best-effort timestamp we
+        # deliberately don't fsync on an identical hit.
+        changed = (not already) or (prev_reason != (vendor, reason))
+        if changed:
+            _snapshot_fingerprint_state_locked()
     return not already
 
 

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -51,6 +51,7 @@ atexit.register(shutil.rmtree, _PROFILES_ROOT, ignore_errors=True)
 @pytest.fixture(autouse=True)
 def _reset_fingerprint_state():
     """Each test starts with empty module-level fingerprint state."""
+    import src.browser.service as service
     from src.browser.service import (
         _binding_signatures,
         _fingerprint_audit_buckets,
@@ -65,6 +66,7 @@ def _reset_fingerprint_state():
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
     _binding_signatures.clear()
+    service._fingerprint_snapshot_dirty = False
     yield
     _fingerprint_window.clear()
     _fingerprint_last_signal.clear()
@@ -72,6 +74,7 @@ def _reset_fingerprint_state():
     _fingerprint_hard_burned.clear()
     _fingerprint_hard_burn_reason.clear()
     _binding_signatures.clear()
+    service._fingerprint_snapshot_dirty = False
 
 
 class TestRollingWindow:
@@ -337,6 +340,39 @@ class TestForceFingerprintBurn:
         assert len(calls) == 1
         # Different vendor/signal — a genuinely new durable fact.
         await service._force_fingerprint_burn(agent, "perimeterx", "x-px-block-type=1")
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_snapshot_retries_on_next_signal(self, monkeypatch):
+        """If a GENUINE transition's snapshot FAILS (returns False), the
+        dedupe must NOT swallow the retry — the next identical signal has to
+        re-attempt the snapshot so the transition survives a restart. The
+        original code snapshotted every call; the dirty flag preserves that
+        resilience through the dedupe."""
+        import src.browser.service as service
+
+        results = iter([False, True])  # first snapshot fails, second succeeds
+        calls = []
+
+        def _snap():
+            calls.append(1)
+            return next(results)
+
+        monkeypatch.setattr(
+            service, "_snapshot_fingerprint_state_locked", _snap,
+        )
+        agent = "agent-retry"
+        # First burn — a real transition whose snapshot FAILS.
+        await service._force_fingerprint_burn(agent, "cloudflare", "cf-mitigated=block")
+        assert len(calls) == 1
+        assert service._fingerprint_snapshot_dirty is True
+        # Identical signal — normally deduped, but the dirty flag forces a
+        # retry. This time the snapshot succeeds and clears the flag.
+        await service._force_fingerprint_burn(agent, "cloudflare", "cf-mitigated=block")
+        assert len(calls) == 2
+        assert service._fingerprint_snapshot_dirty is False
+        # Now that it's durably persisted, a further identical signal dedupes.
+        await service._force_fingerprint_burn(agent, "cloudflare", "cf-mitigated=block")
         assert len(calls) == 2
 
     @pytest.mark.asyncio

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -287,6 +287,79 @@ class TestForceFingerprintBurn:
         assert second is False  # state already transitioned
 
     @pytest.mark.asyncio
+    async def test_first_burn_persists_exactly_once(self, monkeypatch):
+        """A first burn for an agent fsyncs the snapshot exactly once."""
+        import src.browser.service as service
+
+        calls = []
+        monkeypatch.setattr(
+            service, "_snapshot_fingerprint_state_locked",
+            lambda: calls.append(1) or True,
+        )
+        await service._force_fingerprint_burn(
+            "agent-persist-once", "cloudflare", "cf-mitigated=block",
+        )
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_repeat_same_reason_does_not_persist_again(self, monkeypatch):
+        """A repeat burn with the SAME (vendor, reason) must NOT re-fsync —
+        the loop-blocking snapshot is deduped on an unchanged durable state."""
+        import src.browser.service as service
+
+        calls = []
+        monkeypatch.setattr(
+            service, "_snapshot_fingerprint_state_locked",
+            lambda: calls.append(1) or True,
+        )
+        agent = "agent-persist-dedup"
+        await service._force_fingerprint_burn(agent, "datadome", "x-datadome=protected")
+        assert len(calls) == 1
+        # Same walled site, same block signal — repeated block-responses.
+        await service._force_fingerprint_burn(agent, "datadome", "x-datadome=protected")
+        await service._force_fingerprint_burn(agent, "datadome", "x-datadome=protected")
+        # Still exactly one persist — no per-block fsync stall.
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_changed_reason_persists_again(self, monkeypatch):
+        """A burn whose (vendor, reason) changed IS a real transition and
+        must re-snapshot so the new durable reason survives a restart."""
+        import src.browser.service as service
+
+        calls = []
+        monkeypatch.setattr(
+            service, "_snapshot_fingerprint_state_locked",
+            lambda: calls.append(1) or True,
+        )
+        agent = "agent-persist-changed"
+        await service._force_fingerprint_burn(agent, "cloudflare", "cf-mitigated=block")
+        assert len(calls) == 1
+        # Different vendor/signal — a genuinely new durable fact.
+        await service._force_fingerprint_burn(agent, "perimeterx", "x-px-block-type=1")
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_repeat_still_refreshes_in_memory_state(self, monkeypatch):
+        """Even when the snapshot is deduped, the in-memory last_signal +
+        reason must still be refreshed on every repeat block hit."""
+        import src.browser.service as service
+
+        monkeypatch.setattr(
+            service, "_snapshot_fingerprint_state_locked", lambda: True,
+        )
+        agent = "agent-inmem-refresh"
+        await service._force_fingerprint_burn(agent, "datadome", "x-datadome=protected")
+        first_signal = service._fingerprint_last_signal[agent]
+        # A later repeat hit with the SAME reason.
+        monkeypatch.setattr(service.time, "time", lambda: first_signal + 100.0)
+        await service._force_fingerprint_burn(agent, "datadome", "x-datadome=protected")
+        assert service._fingerprint_last_signal[agent] == first_signal + 100.0
+        assert service._fingerprint_hard_burn_reason[agent] == (
+            "datadome", "x-datadome=protected",
+        )
+
+    @pytest.mark.asyncio
     async def test_health_payload_surfaces_hard_burn(self):
         from src.browser.service import (
             _force_fingerprint_burn,


### PR DESCRIPTION
## Problem (PF-2, Codex-confirmed)

`_force_fingerprint_burn` (`src/browser/service.py`) is driven by `_record_response_for_burn`, a context-level `response` listener that fires for **every** response carrying a recognized hard-block signal. It called `_snapshot_fingerprint_state_locked()` **unconditionally** on every invocation.

That snapshot (via `fingerprint_state.snapshot`) does a synchronous JSON-serialize + flush + `os.fsync` + `os.replace` + `chmod` **on the event loop** while holding the fingerprint asyncio lock. So a burned agent repeatedly loading the same walled site issues a fresh loop-blocking fsync **per block-response, indefinitely** — micro-stalling the single shared event loop for the whole fleet.

## Fix (surgical — dedupe the fsync)

Keep the write **synchronous and durable** (no `asyncio.to_thread` — that would risk out-of-order writes / `.tmp` races / a durability regression), but only fire it on a **real persistable change**:

- Capture `prev_reason` before overwriting.
- Still refresh the in-memory state on **every** call (burn set, `hard_burn_reason`, `last_signal`).
- Persist only when `changed = (not already) or (prev_reason != (vendor, reason))`.

Rationale: `last_signal` is a best-effort timestamp; not fsyncing it on an identical repeat hit is fine — the burn set + reason are the durable facts and they haven't changed on a repeat.

`_reset_fingerprint_window` / `persist_fingerprint_state` are genuinely low-frequency and left untouched.

## Tests

Extends `tests/test_fingerprint_health.py::TestForceFingerprintBurn`:
- first burn snapshots **exactly once**;
- a repeat with the **same** `(vendor, reason)` does **not** re-snapshot;
- a **changed** reason **does** re-snapshot;
- in-memory `last_signal` / reason are still refreshed on a repeat.

`69 passed` (full `test_fingerprint_health.py`). `ruff check` clean on both changed files.