### PR TITLE
fix(browser): verify the full selected set in select_option

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -9610,27 +9610,43 @@ class BrowserManager:
                         )
                     raise
 
-                landed = None
+                # Verify the FULL selected set actually landed. A <select>
+                # whose change handler reverts (some of) the value makes
+                # Playwright return the requested options in ``selected`` even
+                # though the DOM snapped back — a contradictory success. The
+                # scalar ``input_value()`` reports only the FIRST selected
+                # option, so a multi-select revert of options 2..N is invisible
+                # to it; read EVERY currently-selected value straight off the
+                # element instead.
                 try:
-                    landed = await locator.input_value()
-                except Exception:
-                    pass
+                    landed_values = await locator.evaluate(
+                        "el => Array.from(el.selectedOptions, o => o.value)",
+                    )
+                except Exception as e:
+                    # A failed read-back is NOT a success. Classify: a
+                    # detached/stale element → ref_stale (re-snapshot); anything
+                    # else is an infrastructure failure, not a landed selection.
+                    msg_l = str(e).lower()
+                    if "not attached" in msg_l or "detached" in msg_l:
+                        return _err("ref_stale", str(e))
+                    return _err("service_unavailable", str(e))
 
-                # A <select> whose change handler reverts the value makes Playwright
-                # return the requested option in ``selected`` while ``input_value()``
-                # shows the OLD value — a contradictory success. Verify it stuck.
-                if landed is not None and selected and landed not in selected:
+                # Compare multiplicity-preserving (duplicate option values are
+                # legal — do NOT collapse to a set) and order-insensitively.
+                # An empty landed set means nothing is selected — a full revert.
+                if not landed_values or sorted(landed_values) != sorted(selected):
                     return _err(
                         "selection_reverted",
-                        f"The <select> value did not change to the requested option "
-                        f"(page script may have reset it). Current value: {landed!r}.",
+                        f"The <select> did not settle on the requested option(s) "
+                        f"(page script may have reset it). Current value(s): "
+                        f"{landed_values!r}.",
                     )
 
                 result = {
                     "success": True,
                     "data": {
                         "selected": selected,
-                        "value": landed,
+                        "value": landed_values,
                         "ref": ref or selector,
                     },
                 }

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -9618,23 +9618,36 @@ class BrowserManager:
                 # option, so a multi-select revert of options 2..N is invisible
                 # to it; read EVERY currently-selected value straight off the
                 # element instead.
+                #
+                # ``select_option`` may redirect through a ``<label>`` to its
+                # associated control, so the located element here isn't
+                # guaranteed to BE the ``<select>``. Guard the read: an element
+                # with no ``selectedOptions`` yields ``null`` (INCONCLUSIVE —
+                # trust Playwright's ``selected``), never a thrown
+                # ``Array.from(undefined)`` that would masquerade as a failure.
                 try:
                     landed_values = await locator.evaluate(
-                        "el => Array.from(el.selectedOptions, o => o.value)",
+                        "el => el && el.selectedOptions "
+                        "? Array.from(el.selectedOptions, o => o.value) : null",
                     )
                 except Exception as e:
-                    # A failed read-back is NOT a success. Classify: a
-                    # detached/stale element → ref_stale (re-snapshot); anything
-                    # else is an infrastructure failure, not a landed selection.
+                    # Only an ACTUAL raise from the read-back is a non-success.
+                    # Classify: a detached/stale element → ref_stale
+                    # (re-snapshot); anything else is an infrastructure failure,
+                    # not a landed selection.
                     msg_l = str(e).lower()
                     if "not attached" in msg_l or "detached" in msg_l:
                         return _err("ref_stale", str(e))
                     return _err("service_unavailable", str(e))
 
-                # Compare multiplicity-preserving (duplicate option values are
-                # legal — do NOT collapse to a set) and order-insensitively.
-                # An empty landed set means nothing is selected — a full revert.
-                if not landed_values or sorted(landed_values) != sorted(selected):
+                # ``None`` = the located element has no ``selectedOptions`` (a
+                # label wrapper / redirect target, not the <select> itself). The
+                # read is inconclusive, so trust Playwright's ``selected`` rather
+                # than fabricate a revert. When we DID read the <select>, compare
+                # multiplicity-preserving (duplicate option values are legal — do
+                # NOT collapse to a set) and order-insensitively; a legitimate
+                # clear (both empty) is equal and stays a success.
+                if landed_values is not None and sorted(landed_values) != sorted(selected):
                     return _err(
                         "selection_reverted",
                         f"The <select> did not settle on the requested option(s) "
@@ -9646,7 +9659,7 @@ class BrowserManager:
                     "success": True,
                     "data": {
                         "selected": selected,
-                        "value": landed_values,
+                        "value": landed_values if landed_values is not None else selected,
                         "ref": ref or selector,
                     },
                 }

--- a/tests/test_browser_select_option.py
+++ b/tests/test_browser_select_option.py
@@ -21,9 +21,13 @@ Covers:
     scalar ``input_value()`` that only reports the FIRST). When it does
     not match the requested selection multiplicity-preservingly (a change
     handler reverted one or more options, single OR multi-select) the
-    result is ``selection_reverted``, not a false success. A read-back
-    that RAISES is never a success either — a detached element →
-    ``ref_stale``, anything else → ``service_unavailable``.
+    result is ``selection_reverted``, not a false success. A guarded read
+    off a non-select element (``select_option`` redirected through a
+    ``<label>``) yields ``null`` — INCONCLUSIVE, so it trusts Playwright's
+    ``selected`` and succeeds rather than fabricating a failure. A
+    legitimate clear (empty ``selected`` AND empty landed set) is a
+    success too. A read-back that RAISES is never a success — a detached
+    element → ``ref_stale``, anything else → ``service_unavailable``.
 
 Mirrors ``tests/test_browser_parity_actions.py`` / ``tests/test_browser_captcha_redetect.py``:
 every test drives ``BrowserManager`` handler methods directly against a
@@ -68,11 +72,14 @@ def _patch_get_or_start(mgr: BrowserManager, inst: CamoufoxInstance) -> None:
     mgr.get_or_start = AsyncMock(return_value=inst)  # type: ignore[assignment]
 
 
+_UNSET = object()
+
+
 def _mk_locator(
     *,
     select_option_result=None,
     select_option_error=None,
-    landed_values=None,
+    landed_values=_UNSET,
     evaluate_error=None,
 ):
     """Playwright ``Locator`` mock.
@@ -83,6 +90,9 @@ def _mk_locator(
     ``landed_values`` (or raise ``evaluate_error``). When ``landed_values``
     is left unset it MIRRORS ``select_option_result`` — i.e. the value stuck,
     the common success case — so callers only pass it to model a revert.
+    Pass ``landed_values=None`` EXPLICITLY to model the located element having
+    no ``selectedOptions`` (a label-redirect target — the read is inconclusive
+    and the guard returns ``null``).
     """
     loc = MagicMock()
     if select_option_error is not None:
@@ -92,7 +102,7 @@ def _mk_locator(
     if evaluate_error is not None:
         loc.evaluate = AsyncMock(side_effect=evaluate_error)
     else:
-        if landed_values is None:
+        if landed_values is _UNSET:
             landed_values = list(select_option_result or [])
         loc.evaluate = AsyncMock(return_value=landed_values)
     return loc
@@ -435,6 +445,57 @@ class TestSelectOptionReadBackRaises:
 
         assert result["success"] is False
         assert result["error"]["code"] == "service_unavailable"
+
+
+class TestSelectOptionInconclusiveReadBack:
+    """``select_option`` can redirect through a ``<label>`` to its associated
+    control, so the located element isn't guaranteed to BE the ``<select>``. A
+    read-back off a non-select element has no ``selectedOptions`` — the guarded
+    evaluate returns ``None``. That is INCONCLUSIVE, not a failure: trust
+    Playwright's ``selected`` rather than fabricate a revert."""
+
+    @pytest.mark.asyncio
+    async def test_null_read_back_is_success_not_service_unavailable(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        # Playwright reports the option selected; the located element has no
+        # selectedOptions (label wrapper) so the read-back is None.
+        loc = _mk_locator(select_option_result=["red"], landed_values=None)
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="red")
+
+        assert result["success"] is True
+        assert result["data"]["selected"] == ["red"]
+        # An inconclusive read falls back to Playwright's returned selection.
+        assert result["data"]["value"] == ["red"]
+
+
+class TestSelectOptionLegitimateClear:
+    """A legitimate clear — deselect everything — returns an EMPTY ``selected``
+    AND an empty landed set. The two are equal, so it is a success; the guard
+    must NOT misflag ``landed_values == []`` as a revert on its own."""
+
+    @pytest.mark.asyncio
+    async def test_empty_selection_matching_empty_landed_is_success(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        # select_option([]) deselects all in a multi-select — nothing requested
+        # to stick, nothing landed.
+        loc = _mk_locator(select_option_result=[], landed_values=[])
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value=[])
+
+        assert result["success"] is True
+        assert result["data"]["selected"] == []
+        assert result["data"]["value"] == []
 
 
 class TestSelectOptionUnclassifiedErrorPropagates:

--- a/tests/test_browser_select_option.py
+++ b/tests/test_browser_select_option.py
@@ -6,7 +6,8 @@ Covers:
     ``select_option`` mesh action with the right params.
   * Manager primary path — ``locator.select_option`` is called with
     exactly the supplied kwarg (value/label/index) and the response
-    echoes the returned selection + the landed ``input_value()``.
+    echoes the returned selection + the FULL landed value set read back
+    off the element (``el.selectedOptions``).
   * Manager error classification — an "is not a <select>" Playwright
     error is classified as ``not_a_select``; an explicit no-matching-
     option error is ``option_not_found``; a detached/not-attached
@@ -15,9 +16,14 @@ Covers:
     hidden/disabled/loading); missing value/label/index is rejected as
     ``invalid_input`` before any locator resolution; supplying more than
     one of value/label/index is also ``invalid_input``.
-  * Post-select verification — when the returned selection and the
-    landed ``input_value()`` disagree (a change handler reverted the
-    value), the result is ``selection_reverted``, not a false success.
+  * Post-select verification — the landed set is read via
+    ``locator.evaluate`` (every currently-selected option value, not the
+    scalar ``input_value()`` that only reports the FIRST). When it does
+    not match the requested selection multiplicity-preservingly (a change
+    handler reverted one or more options, single OR multi-select) the
+    result is ``selection_reverted``, not a false success. A read-back
+    that RAISES is never a success either — a detached element →
+    ``ref_stale``, anything else → ``service_unavailable``.
 
 Mirrors ``tests/test_browser_parity_actions.py`` / ``tests/test_browser_captcha_redetect.py``:
 every test drives ``BrowserManager`` handler methods directly against a
@@ -62,13 +68,33 @@ def _patch_get_or_start(mgr: BrowserManager, inst: CamoufoxInstance) -> None:
     mgr.get_or_start = AsyncMock(return_value=inst)  # type: ignore[assignment]
 
 
-def _mk_locator(*, select_option_result=None, select_option_error=None, input_value=""):
+def _mk_locator(
+    *,
+    select_option_result=None,
+    select_option_error=None,
+    landed_values=None,
+    evaluate_error=None,
+):
+    """Playwright ``Locator`` mock.
+
+    ``select_option`` returns the requested option *values* (or raises
+    ``select_option_error``). The post-select verification then reads the
+    landed set via ``locator.evaluate`` — mocked here to return
+    ``landed_values`` (or raise ``evaluate_error``). When ``landed_values``
+    is left unset it MIRRORS ``select_option_result`` — i.e. the value stuck,
+    the common success case — so callers only pass it to model a revert.
+    """
     loc = MagicMock()
     if select_option_error is not None:
         loc.select_option = AsyncMock(side_effect=select_option_error)
     else:
         loc.select_option = AsyncMock(return_value=select_option_result or [])
-    loc.input_value = AsyncMock(return_value=input_value)
+    if evaluate_error is not None:
+        loc.evaluate = AsyncMock(side_effect=evaluate_error)
+    else:
+        if landed_values is None:
+            landed_values = list(select_option_result or [])
+        loc.evaluate = AsyncMock(return_value=landed_values)
     return loc
 
 
@@ -83,14 +109,15 @@ class TestSelectOptionPrimaryPath:
         _patch_get_or_start(mgr, inst)
         inst.refs["e1"] = object()
 
-        loc = _mk_locator(select_option_result=["red"], input_value="red")
+        loc = _mk_locator(select_option_result=["red"])
         mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
 
         result = await mgr.select_option("agent-select", ref="e1", value="red")
 
         assert result["success"] is True
         assert result["data"]["selected"] == ["red"]
-        assert result["data"]["value"] == "red"
+        # ``value`` now carries the FULL landed set read off the element.
+        assert result["data"]["value"] == ["red"]
         assert result["data"]["ref"] == "e1"
         loc.select_option.assert_awaited_once_with(value="red")
 
@@ -101,10 +128,11 @@ class TestSelectOptionPrimaryPath:
         _patch_get_or_start(mgr, inst)
         inst.refs["e1"] = object()
 
-        # Playwright's select_option returns option *values*; input_value()
-        # reports the same value — keep the mock self-consistent so the
-        # post-select verification (Fix 3) sees the value stuck.
-        loc = _mk_locator(select_option_result=["blue"], input_value="blue")
+        # Playwright's select_option returns option *values*; the element's
+        # selectedOptions report the same value — keep the mock self-consistent
+        # (landed_values mirrors select_option_result) so the post-select
+        # verification sees the value stuck.
+        loc = _mk_locator(select_option_result=["blue"])
         mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
 
         result = await mgr.select_option("agent-select", ref="e1", label="Blue")
@@ -119,7 +147,7 @@ class TestSelectOptionPrimaryPath:
         _patch_get_or_start(mgr, inst)
         inst.refs["e1"] = object()
 
-        loc = _mk_locator(select_option_result=["opt3"], input_value="opt3")
+        loc = _mk_locator(select_option_result=["opt3"])
         mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
 
         result = await mgr.select_option("agent-select", ref="e1", index=2)
@@ -131,7 +159,7 @@ class TestSelectOptionPrimaryPath:
     async def test_selector_path_used_when_no_ref(self):
         mgr = _make_manager()
         page = _mk_page()
-        loc = _mk_locator(select_option_result=["blue"], input_value="blue")
+        loc = _mk_locator(select_option_result=["blue"])
         locator_chain = MagicMock()
         locator_chain.first = loc
         page.locator = MagicMock(return_value=locator_chain)
@@ -279,21 +307,134 @@ class TestSelectOptionRevertedValue:
     @pytest.mark.asyncio
     async def test_reverted_value_classified_as_selection_reverted(self):
         """Playwright returns the requested option in ``selected`` but a page
-        change-handler reset the DOM value, so ``input_value()`` shows the OLD
-        value. A contradictory selected/value must NOT report success."""
+        change-handler reset the DOM value, so the read-back set shows the OLD
+        value. A contradictory selected/landed pair must NOT report success
+        (single-select regression)."""
         mgr = _make_manager()
         inst = _mk_inst()
         _patch_get_or_start(mgr, inst)
         inst.refs["e1"] = object()
 
         # select_option returns ["US"] but the select snapped back to "CA".
-        loc = _mk_locator(select_option_result=["US"], input_value="CA")
+        loc = _mk_locator(select_option_result=["US"], landed_values=["CA"])
         mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
 
         result = await mgr.select_option("agent-select", ref="e1", value="US")
 
         assert result["success"] is False
         assert result["error"]["code"] == "selection_reverted"
+
+    @pytest.mark.asyncio
+    async def test_empty_landed_set_classified_as_selection_reverted(self):
+        """A change handler that clears the selection entirely leaves nothing
+        selected — an empty read-back set is a full revert, never a success."""
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(select_option_result=["US"], landed_values=[])
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="US")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "selection_reverted"
+
+
+class TestSelectOptionMultiSelect:
+    """The bug the OLD scalar ``input_value()`` check missed: a multi-select
+    whose change handler reverts option 2..N. ``input_value()`` reports only
+    the FIRST selected value, so it saw the (still-present) first option and
+    reported a false success; the full-set read-back catches the drop."""
+
+    @pytest.mark.asyncio
+    async def test_multiselect_partial_revert_is_selection_reverted(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        # Requested US+CA+MX; the page's change handler dropped CA and MX,
+        # leaving only US selected. The old scalar guard (first value == "US",
+        # which IS in ``selected``) would have reported success.
+        loc = _mk_locator(
+            select_option_result=["US", "CA", "MX"], landed_values=["US"],
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option(
+            "agent-select", ref="e1", value=["US", "CA", "MX"],
+        )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "selection_reverted"
+        # The honest current state is surfaced (only US survived).
+        assert "'US'" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_multiselect_fully_applied_is_success(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        # Landed set matches the requested set regardless of order — the
+        # comparison is order-insensitive and multiplicity-preserving.
+        loc = _mk_locator(
+            select_option_result=["US", "CA", "MX"],
+            landed_values=["MX", "US", "CA"],
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option(
+            "agent-select", ref="e1", value=["US", "CA", "MX"],
+        )
+
+        assert result["success"] is True
+        assert result["data"]["selected"] == ["US", "CA", "MX"]
+        assert sorted(result["data"]["value"]) == ["CA", "MX", "US"]
+
+
+class TestSelectOptionReadBackRaises:
+    """A read-back that RAISES is never a success — the old ``except: pass``
+    silently skipped verification and returned success. Now it is classified."""
+
+    @pytest.mark.asyncio
+    async def test_read_back_not_attached_is_ref_stale(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(
+            select_option_result=["US"],
+            evaluate_error=Exception("Element is not attached to the DOM"),
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="US")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ref_stale"
+
+    @pytest.mark.asyncio
+    async def test_read_back_generic_error_is_service_unavailable(self):
+        mgr = _make_manager()
+        inst = _mk_inst()
+        _patch_get_or_start(mgr, inst)
+        inst.refs["e1"] = object()
+
+        loc = _mk_locator(
+            select_option_result=["US"],
+            evaluate_error=RuntimeError("evaluate blew up"),
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=loc)  # type: ignore[assignment]
+
+        result = await mgr.select_option("agent-select", ref="e1", value="US")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
 
 
 class TestSelectOptionUnclassifiedErrorPropagates:


### PR DESCRIPTION
## Defect (CT-3, Codex-confirmed)

`select_option` (`src/browser/service.py`) verified that a selection landed by reading a **scalar** `landed = await locator.input_value()` and checking `landed not in selected`. Two gaps:

1. **Multi-select** — `input_value()` returns only the **first** selected option's value. A page change-handler that reverts options 2..N leaves the first option in place, so the guard was trivially satisfied and the action returned `success: True` with the full requested `selected` list, hiding the drop.
2. **Swallowed read-back** — `except Exception: pass` silently **skipped** verification when `input_value()` raised, still returning success.

## Fix (surgical)

Replace the scalar read with a **full-set** read straight off the element:

```python
landed_values = await locator.evaluate("el => Array.from(el.selectedOptions, o => o.value)")
```

- Compare **multiplicity-preserving and order-insensitively**: `sorted(landed_values) != sorted(selected)` → `selection_reverted`. Duplicate option values are legal, so the set is **not** collapsed.
- An **empty** landed set (`[]`) is treated as a full revert.
- A read-back that **raises** is never a success — it is classified: a detached/not-attached element → `ref_stale`; anything else → `service_unavailable`.
- The `select_option()` call's own exception classification (`not_a_select` / `option_not_found` / `not_interactable` / `ref_stale`), the input validation (exactly one of value/label/index), and the captcha-redetect wrapper are **unchanged**.
- The `success` data shape (`selected`, `value`, `ref`) is kept; `value` now carries the **full landed list** (was the scalar first value).

## Tests

Extends `tests/test_browser_select_option.py`:

- Multi-select where the page reverts option 2..N → `selection_reverted` (the bug the old scalar check missed).
- Multi-select fully applied (landed set matches requested, any order) → success.
- Empty landed set → `selection_reverted`.
- Read-back raises "not attached" → `ref_stale` (not success).
- Read-back raises a generic error → `service_unavailable` (not success).
- Single-select success + single-select reverted regressions still classify correctly.

`24 passed` (`tests/test_browser_select_option.py`). `ruff check` clean (the CI gate).