### PR TITLE
fix(browser): retry bound-cookie coherence when the drop fails

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -4802,9 +4802,17 @@ class BrowserManager:
 
         Flow: compute the current ``(UA, proxy)`` signature; compare against
         the per-agent signature persisted last launch. On a mismatch, drop
-        only the bound vendor cookies (never generic session cookies). Then
-        persist the current signature as the new baseline — including on the
-        first launch, when nothing is dropped. Best-effort throughout: any
+        only the bound vendor cookies (never generic session cookies). The
+        current signature is persisted as the new baseline ONLY when it is
+        SAFE to do so: on the first launch (nothing to drop), when the
+        signature is unchanged (idempotent), or when a mismatch's drop was
+        verified — enumeration succeeded and either found no bound cookie or
+        the drop was confirmed to have removed every bound family. If
+        enumeration FAILED (``cookies is None``) or the drop could not be
+        verified, we RETAIN the old baseline so the NEXT launch retries the
+        drop; otherwise a silently-failed drop would advance the baseline and
+        leave poisoned anti-bot cookies replaying under the new identity —
+        a guaranteed 403 + trust hit (BC-4). Best-effort throughout: any
         failure is logged and the browser starts anyway.
         """
         from src.browser import session_persistence as _sp
@@ -4825,10 +4833,18 @@ class BrowserManager:
         async with _get_fingerprint_lock():
             persisted_sig = _binding_signatures.get(agent_id)
 
-        # Only drop when we have a prior signature AND it changed. First
-        # launch (no prior signature) drops nothing but still records the
-        # baseline below.
+        # Whether it is SAFE to advance the persisted baseline to ``current_sig``.
+        # First launch (no prior signature) and an unchanged signature are both
+        # safe — nothing to drop / idempotent. A mismatch is safe ONLY once we
+        # have verified the drop actually happened (or there was nothing bound
+        # to drop). If enumeration or the drop could not be verified we leave the
+        # OLD baseline so the NEXT launch retries — never advance over a failed
+        # drop, or poisoned bound cookies replay under the new identity (BC-4).
+        baseline_safe = True
+
         if persisted_sig is not None and persisted_sig != current_sig:
+            # Mismatch: assume unsafe until we prove the drop succeeded.
+            baseline_safe = False
             try:
                 cookies = await context.cookies()
             except Exception as e:
@@ -4837,7 +4853,18 @@ class BrowserManager:
                     agent_id, e,
                 )
                 cookies = None
-            if cookies:
+            if cookies is None:
+                # Enumeration FAILED — we cannot know what to drop. Retain the
+                # old baseline (do NOT advance) so the next launch retries.
+                logger.warning(
+                    "binding-coherence: cookie enumeration failed for '%s'; "
+                    "retaining old baseline to retry drop next launch",
+                    agent_id,
+                )
+            else:
+                # Enumeration SUCCEEDED. ``cookies == []`` (empty) is a genuine
+                # "nothing to drop" and is distinct from the ``None`` failure
+                # above.
                 bound_names: list[str] = []
                 vendors: list[str] = []
                 for cookie in cookies:
@@ -4849,7 +4876,11 @@ class BrowserManager:
                         bound_names.append(name)
                         if family not in vendors:
                             vendors.append(family)
-                if bound_names:
+                if not bound_names:
+                    # Enumeration succeeded and nothing was bound — safe to
+                    # advance the baseline.
+                    baseline_safe = True
+                else:
                     dropped = await self._clear_bound_cookies(
                         context, bound_names, cookies,
                     )
@@ -4861,9 +4892,33 @@ class BrowserManager:
                             agent_id, persisted_sig, current_sig, dropped,
                             ",".join(vendors) or "(none)",
                         )
+                        # Verified drop (count > 0). Best-effort readback for
+                        # extra safety: confirm no bound family survived. A
+                        # readback failure — or a surviving bound cookie —
+                        # leaves the old baseline for a retry.
+                        baseline_safe = await self._bound_cookies_gone(
+                            context, agent_id,
+                        )
+                    else:
+                        # Drop returned 0 while bound cookies existed: it
+                        # FAILED. Retain the old baseline so the next launch
+                        # retries rather than replaying poisoned cookies.
+                        logger.warning(
+                            "binding-coherence: bound-cookie drop failed for "
+                            "'%s' (%d bound cookie(s) still present); retaining "
+                            "old baseline to retry drop next launch",
+                            agent_id, len(bound_names),
+                        )
 
-        # Record the current signature as the new baseline (first-run
-        # included) and durably persist it next to the burn state.
+        if not baseline_safe:
+            # Leave the previously persisted signature untouched — the next
+            # launch will see a mismatch again and retry the drop. Never blocks
+            # startup; the browser proceeds with the profile as-is.
+            return
+
+        # Record the current signature as the new baseline (first-run, unchanged
+        # signature, and verified drop) and durably persist it next to the burn
+        # state.
         async with _get_fingerprint_lock():
             _binding_signatures[agent_id] = current_sig
             try:
@@ -4873,6 +4928,42 @@ class BrowserManager:
                     "binding-coherence: state snapshot failed for '%s': %s",
                     agent_id, e,
                 )
+
+    async def _bound_cookies_gone(self, context, agent_id: str) -> bool:
+        """Best-effort readback: ``True`` iff no bound vendor family remains.
+
+        Called after a drop that reported success (count > 0) as a stronger
+        confirmation than the count alone. Re-reads ``context.cookies()`` and
+        checks that none of the anti-bot bound families
+        (``cf_clearance``/``datadome``/``_abck`` …) survived.
+
+        Returns ``False`` on ANY readback failure — an exception OR a surviving
+        bound cookie — so the caller retains the old binding baseline and
+        retries the drop on the next launch. Fully guarded: never raises, so it
+        can never block browser startup.
+        """
+        from src.browser import session_persistence as _sp
+
+        try:
+            remaining = await context.cookies()
+        except Exception as e:
+            logger.warning(
+                "binding-coherence: post-drop cookie readback failed for "
+                "'%s': %s; retaining old baseline to retry next launch",
+                agent_id, e,
+            )
+            return False
+        for cookie in remaining or []:
+            if not isinstance(cookie, dict):
+                continue
+            if _sp.cookie_binding_vendor(cookie.get("name")) is not None:
+                logger.warning(
+                    "binding-coherence: bound cookie survived the drop for "
+                    "'%s'; retaining old baseline to retry next launch",
+                    agent_id,
+                )
+                return False
+        return True
 
     async def _clear_bound_cookies(
         self, context, bound_names: list[str], all_cookies: list,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -4953,7 +4953,17 @@ class BrowserManager:
                 agent_id, e,
             )
             return False
-        for cookie in remaining or []:
+        if remaining is None:
+            # A ``None`` readback means we couldn't confirm the jar — treat it
+            # exactly like the exception path (unverified), NOT as an empty jar
+            # (which would falsely "verify" the drop and advance the baseline).
+            logger.warning(
+                "binding-coherence: post-drop cookie readback returned None "
+                "for '%s'; retaining old baseline to retry next launch",
+                agent_id,
+            )
+            return False
+        for cookie in remaining:
             if not isinstance(cookie, dict):
                 continue
             if _sp.cookie_binding_vendor(cookie.get("name")) is not None:

--- a/tests/test_binding_cookie_coherence.py
+++ b/tests/test_binding_cookie_coherence.py
@@ -392,3 +392,18 @@ class TestRetrySafetyBC4:
         assert ctx.cookies_calls == 2  # enumeration + post-drop readback
         assert _binding_signatures[agent] == stale
         assert _binding_signatures[agent] != _current_sig(mgr, agent)
+
+    @pytest.mark.asyncio
+    async def test_readback_returning_none_is_unverified(self):
+        """A ``None`` readback means the jar couldn't be confirmed — it must be
+        treated like the exception path (unverified), NOT as an empty jar that
+        falsely verifies the drop."""
+
+        class _NoneReadbackContext:
+            async def cookies(self):
+                return None
+
+        mgr = _make_manager()
+        # Directly exercise the readback helper: None → False (unverified) so
+        # the caller retains the old baseline and retries next launch.
+        assert await mgr._bound_cookies_gone(_NoneReadbackContext(), "agent-x") is False

--- a/tests/test_binding_cookie_coherence.py
+++ b/tests/test_binding_cookie_coherence.py
@@ -16,6 +16,18 @@ Covers:
     persisted so the NEXT identity change is detectable.
   * legacy Playwright without ``clear_cookies(name=...)`` → clear-all +
     re-add of the non-bound subset (same end state).
+
+BC-4 retry safety — the baseline is advanced ONLY when the drop is verified,
+otherwise the OLD signature is retained so the NEXT launch retries (never
+advance over a failed drop, or poisoned cookies replay under the new identity):
+  * mismatch + ``context.cookies()`` raises (enumeration failed) → baseline NOT
+    advanced.
+  * mismatch + drop returns 0 while bound cookies present → baseline NOT
+    advanced.
+  * mismatch + enumeration returns ``[]`` (no bound cookies) → baseline
+    advanced.
+  * mismatch + drop reports success but a bound cookie survives the post-drop
+    readback → baseline NOT advanced.
 """
 
 from __future__ import annotations
@@ -58,10 +70,14 @@ _GENERIC = ["session", "csrftoken"]
 
 
 class _FakeContext:
-    """Playwright BrowserContext duck-type supporting name-filtered clear."""
+    """Playwright BrowserContext duck-type supporting name-filtered clear.
+
+    Faithfully mutates its cookie jar on clear/add so the post-drop readback
+    (``_bound_cookies_gone``) reflects the real end state.
+    """
 
     def __init__(self, cookies: list[dict]):
-        self._cookies = cookies
+        self._cookies = list(cookies)
         self.cookies_calls = 0
         self.cleared_names: list[str] = []
         self.cleared_all = 0
@@ -74,22 +90,26 @@ class _FakeContext:
     async def clear_cookies(self, name: str | None = None) -> None:
         if name is None:
             self.cleared_all += 1
+            self._cookies = []
         else:
             self.cleared_names.append(name)
+            self._cookies = [c for c in self._cookies if c.get("name") != name]
 
     async def add_cookies(self, cookies: list[dict]) -> None:
         self.readded = list(cookies)
+        self._cookies = self._cookies + list(cookies)
 
 
 class _LegacyContext:
     """Older Playwright: ``clear_cookies`` has NO ``name`` kwarg.
 
     Calling ``clear_cookies(name=...)`` therefore raises ``TypeError`` —
-    the exact signal the coherence helper falls back on.
+    the exact signal the coherence helper falls back on. Faithfully mutates
+    its jar so the post-drop readback reflects the clear-all + re-add end state.
     """
 
     def __init__(self, cookies: list[dict]):
-        self._cookies = cookies
+        self._cookies = list(cookies)
         self.cleared_all = 0
         self.readded: list[dict] | None = None
 
@@ -98,9 +118,82 @@ class _LegacyContext:
 
     async def clear_cookies(self) -> None:  # no ``name`` param on purpose
         self.cleared_all += 1
+        self._cookies = []
 
     async def add_cookies(self, cookies: list[dict]) -> None:
         self.readded = list(cookies)
+        self._cookies = self._cookies + list(cookies)
+
+
+class _RaisingCookiesContext:
+    """``context.cookies()`` raises → enumeration fails (``cookies is None``)."""
+
+    def __init__(self):
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+
+    async def cookies(self) -> list[dict]:
+        raise RuntimeError("cookies() boom")
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:  # pragma: no cover
+        pass
+
+
+class _BrokenClearContext:
+    """Both clear paths raise → ``_clear_bound_cookies`` returns 0 (drop failed).
+
+    ``clear_cookies(name=...)`` raises a non-``TypeError`` (so the helper takes
+    the clear-all fallback), and the fallback ``clear_cookies()`` raises too, so
+    the final count is 0 while bound cookies are still present.
+    """
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = list(cookies)
+        self.cookies_calls = 0
+
+    async def cookies(self) -> list[dict]:
+        self.cookies_calls += 1
+        return list(self._cookies)
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        raise RuntimeError("clear-all boom" if name is None else "targeted boom")
+
+    async def add_cookies(self, cookies: list[dict]) -> None:  # pragma: no cover
+        pass
+
+
+class _NoOpClearContext:
+    """``clear_cookies(name=...)`` SUCCEEDS but removes nothing.
+
+    The silent-no-op drop the post-drop readback guards against: the drop
+    reports success (count > 0) yet the jar never shrinks, so a re-read still
+    finds the bound cookies.
+    """
+
+    def __init__(self, cookies: list[dict]):
+        self._cookies = list(cookies)
+        self.cookies_calls = 0
+        self.cleared_names: list[str] = []
+        self.cleared_all = 0
+
+    async def cookies(self) -> list[dict]:
+        self.cookies_calls += 1
+        return list(self._cookies)  # never shrinks
+
+    async def clear_cookies(self, name: str | None = None) -> None:
+        if name is None:
+            self.cleared_all += 1
+        else:
+            self.cleared_names.append(name)
+
+    async def add_cookies(self, cookies: list[dict]) -> None:  # pragma: no cover
+        pass
 
 
 def _make_manager() -> BrowserManager:
@@ -201,3 +294,101 @@ class TestLegacyPlaywrightFallback:
         assert readded_names == set(_GENERIC)
         assert all(b not in readded_names for b in _BOUND)
         assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+
+class TestRetrySafetyBC4:
+    """BC-4: a mismatch that could not verify the drop must NOT advance the
+    persisted baseline — the OLD signature stays so the next launch retries."""
+
+    @pytest.mark.asyncio
+    async def test_enumeration_failure_keeps_old_baseline(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-enum-fail"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-enum:8080"})
+        stale = "deadbeefdeadbeef"
+        _binding_signatures[agent] = stale  # force mismatch
+
+        ctx = _RaisingCookiesContext()
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Enumeration raised → nothing dropped, and the OLD baseline is kept so
+        # the next launch sees a mismatch again and retries.
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        assert _binding_signatures[agent] == stale
+        assert _binding_signatures[agent] != _current_sig(mgr, agent)
+
+    @pytest.mark.asyncio
+    async def test_drop_failure_keeps_old_baseline(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-drop-fail"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-drop:8080"})
+        stale = "cafecafecafecafe"
+        _binding_signatures[agent] = stale  # force mismatch
+
+        ctx = _BrokenClearContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Both clear paths raised → drop returned 0 while bound cookies remain,
+        # so the baseline is NOT advanced (retry next launch).
+        assert _binding_signatures[agent] == stale
+        assert _binding_signatures[agent] != _current_sig(mgr, agent)
+
+    @pytest.mark.asyncio
+    async def test_successful_drop_advances_baseline(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-drop-ok"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-ok:8080"})
+        _binding_signatures[agent] = "1111111111111111"  # force mismatch
+
+        ctx = _FakeContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        # Verified drop (readback finds no bound family left) → baseline advances.
+        assert set(ctx.cleared_names) == set(_BOUND)
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+    @pytest.mark.asyncio
+    async def test_no_bound_cookies_advances_baseline(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-empty"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-empty:8080"})
+        _binding_signatures[agent] = "2222222222222222"  # force mismatch
+
+        # Enumeration SUCCEEDS but returns an empty jar (distinct from a None
+        # failure) — nothing bound to drop → safe to advance.
+        ctx = _FakeContext([])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert ctx.cookies_calls == 1  # enumerated once; no drop, no readback
+        assert ctx.cleared_names == []
+        assert ctx.cleared_all == 0
+        assert _binding_signatures[agent] == _current_sig(mgr, agent)
+
+    @pytest.mark.asyncio
+    async def test_readback_detecting_surviving_bound_keeps_old_baseline(self):
+        from src.browser.service import _binding_signatures
+
+        mgr = _make_manager()
+        agent = "agent-noop-drop"
+        mgr.set_proxy_config(agent, {"server": "http://proxy-noop:8080"})
+        stale = "3333333333333333"
+        _binding_signatures[agent] = stale  # force mismatch
+
+        # Drop reports success by name, but the jar never shrinks — the post-drop
+        # readback still sees bound cookies → treat as NOT verified.
+        ctx = _NoOpClearContext([_cookie(n) for n in _BOUND + _GENERIC])
+        await mgr._enforce_binding_cookie_coherence(_inst(agent, ctx))
+
+        assert set(ctx.cleared_names) == set(_BOUND)
+        assert ctx.cookies_calls == 2  # enumeration + post-drop readback
+        assert _binding_signatures[agent] == stale
+        assert _binding_signatures[agent] != _current_sig(mgr, agent)


### PR DESCRIPTION
## Defect (BC-4, Codex-confirmed)

`_enforce_binding_cookie_coherence` (`src/browser/service.py`) drops anti-bot bound cookies (`cf_clearance`/`datadome`/`_abck`…) when the per-agent `(UA, proxy[, egress-IP])` binding signature changes. On the mismatch path it turned a `context.cookies()` failure into `cookies = None` and a `_clear_bound_cookies()` failure into a return of `0`, then **unconditionally** advanced the persisted baseline `_binding_signatures[agent_id] = current_sig` and snapshotted it.

So when enumeration or the drop **failed**, the next launch saw a matching signature and **never retried** — poisoned bound cookies persisted in the profile and got replayed under the new identity (guaranteed 403 + trust-score hit).

## Fix (surgical)

Advance the persisted baseline **only when it is safe** — exactly one of:

- **(a)** first launch (no prior signature) — nothing to drop;
- **(b)** signature unchanged — idempotent no-op;
- **(c)** mismatch **and** enumeration succeeded **and** there were genuinely no bound cookies (`cookies == []`, distinguished from the `cookies is None` enumeration failure);
- **(d)** mismatch **and** the drop was verified.

A `baseline_safe` flag tracks this. A nonempty bound set cleared with a nonzero `_clear_bound_cookies` count is a verified drop; a new best-effort `_bound_cookies_gone` readback then re-reads the jar and confirms no bound family survived (a readback exception **or** a surviving bound cookie is treated as not-verified). When the mismatch path cannot verify, the **old** signature is left untouched so the **next** launch retries the drop.

Everything stays best-effort / `try`/`except`-guarded — a failure never blocks browser startup (retaining the old baseline only causes a retry on a future launch; it does not loop or block within one launch).

## Tests

Extended `tests/test_binding_cookie_coherence.py`:

1. mismatch + `context.cookies()` raises → baseline **not** advanced (old value retained, retries next launch);
2. mismatch + drop returns 0 while bound cookies present → baseline **not** advanced;
3. mismatch + successful drop → baseline advanced to `current_sig`;
4. mismatch + enumeration returns `[]` → baseline advanced;
5. mismatch + drop reports success but a bound cookie survives the readback → baseline **not** advanced;
6. first-launch / unchanged-signature regression coverage retained.

The fake contexts now faithfully mutate their cookie jar on clear/add so the post-drop readback reflects the real end state.

`ruff check` clean on both changed files; `9 passed` for `tests/test_binding_cookie_coherence.py`.