### PR TITLE
fix(browser): guarantee X11 mouse-button release + surface xdotool failures

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -7919,21 +7919,60 @@ class BrowserManager:
         wid_s = str(wid)
         loop = asyncio.get_running_loop()
         await asyncio.sleep(pre_click_settle())
-        await loop.run_in_executor(
+        down = await loop.run_in_executor(
             None,
             lambda: subprocess.run(
                 ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
                 capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
-        await asyncio.sleep(click_dwell())
-        await loop.run_in_executor(
-            None,
-            lambda: subprocess.run(
-                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3, env=inst.subprocess_env(),
-            ),
-        )
+        # A dropped mousedown (wedged X server / lost WID) must surface as a
+        # failure so the caller's CDP fallback engages — never a silent
+        # success. On a non-zero exit the button was not pressed, so raise
+        # BEFORE the guarded dwell (nothing to release).
+        if down.returncode != 0:
+            raise RuntimeError(f"xdotool mousedown (button 1) failed: rc={down.returncode}")
+        # Button 1 is now physically DOWN — the release MUST always fire. An
+        # ``asyncio.CancelledError`` during the dwell (uvicorn cancels the
+        # request task on client disconnect) or any other raise would
+        # otherwise strand the button held for the rest of the session, and
+        # the CDP fallback (a different input channel) cannot release it.
+        # Mirror ``_x11_drag`` / ``_x11_right_click_xy``: run the release via
+        # ``run_in_executor`` so the worker thread completes the subprocess
+        # even if the awaiting future is cancelled.
+        released = False
+        try:
+            await asyncio.sleep(click_dwell())
+            up = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
+                ),
+            )
+            # A non-zero mouseup may mean the release never injected — the
+            # button could still be held, so fall through to the finally's
+            # best-effort release AND raise so the caller falls back to CDP.
+            if up.returncode != 0:
+                raise RuntimeError(f"xdotool mouseup (button 1) failed: rc={up.returncode}")
+            released = True
+        finally:
+            # Emergency release — fire ONLY when the normal release did not
+            # cleanly complete (cancel/raise mid-dwell, or a non-zero normal
+            # mouseup); the success path already released exactly once. Best
+            # effort: never mask the propagating ``CancelledError`` or the
+            # body's original exception if this cleanup also fails.
+            if not released:
+                try:
+                    await loop.run_in_executor(
+                        None,
+                        lambda: subprocess.run(
+                            ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                            capture_output=True, timeout=3, env=inst.subprocess_env(),
+                        ),
+                    )
+                except BaseException:
+                    pass
 
     async def _x11_click_xy(
         self, inst: CamoufoxInstance, x: float, y: float,
@@ -7957,21 +7996,60 @@ class BrowserManager:
         wid_s = str(wid)
         loop = asyncio.get_running_loop()
         await asyncio.sleep(pre_click_settle())
-        await loop.run_in_executor(
+        down = await loop.run_in_executor(
             None,
             lambda: subprocess.run(
                 ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
                 capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
-        await asyncio.sleep(click_dwell())
-        await loop.run_in_executor(
-            None,
-            lambda: subprocess.run(
-                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3, env=inst.subprocess_env(),
-            ),
-        )
+        # A dropped mousedown (wedged X server / lost WID) must surface as a
+        # failure so the caller's CDP fallback engages — never a silent
+        # success. On a non-zero exit the button was not pressed, so raise
+        # BEFORE the guarded dwell (nothing to release).
+        if down.returncode != 0:
+            raise RuntimeError(f"xdotool mousedown (button 1) failed: rc={down.returncode}")
+        # Button 1 is now physically DOWN — the release MUST always fire. An
+        # ``asyncio.CancelledError`` during the dwell (uvicorn cancels the
+        # request task on client disconnect) or any other raise would
+        # otherwise strand the button held for the rest of the session, and
+        # the CDP fallback (a different input channel) cannot release it.
+        # Mirror ``_x11_drag`` / ``_x11_right_click_xy``: run the release via
+        # ``run_in_executor`` so the worker thread completes the subprocess
+        # even if the awaiting future is cancelled.
+        released = False
+        try:
+            await asyncio.sleep(click_dwell())
+            up = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
+                ),
+            )
+            # A non-zero mouseup may mean the release never injected — the
+            # button could still be held, so fall through to the finally's
+            # best-effort release AND raise so the caller falls back to CDP.
+            if up.returncode != 0:
+                raise RuntimeError(f"xdotool mouseup (button 1) failed: rc={up.returncode}")
+            released = True
+        finally:
+            # Emergency release — fire ONLY when the normal release did not
+            # cleanly complete (cancel/raise mid-dwell, or a non-zero normal
+            # mouseup); the success path already released exactly once. Best
+            # effort: never mask the propagating ``CancelledError`` or the
+            # body's original exception if this cleanup also fails.
+            if not released:
+                try:
+                    await loop.run_in_executor(
+                        None,
+                        lambda: subprocess.run(
+                            ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                            capture_output=True, timeout=3, env=inst.subprocess_env(),
+                        ),
+                    )
+                except BaseException:
+                    pass
 
     async def _x11_right_click_xy(
         self, inst: CamoufoxInstance, x: float, y: float,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -7919,29 +7919,33 @@ class BrowserManager:
         wid_s = str(wid)
         loop = asyncio.get_running_loop()
         await asyncio.sleep(pre_click_settle())
-        down = await loop.run_in_executor(
-            None,
-            lambda: subprocess.run(
-                ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3, env=inst.subprocess_env(),
-            ),
-        )
-        # A dropped mousedown (wedged X server / lost WID) must surface as a
-        # failure so the caller's CDP fallback engages — never a silent
-        # success. On a non-zero exit the button was not pressed, so raise
-        # BEFORE the guarded dwell (nothing to release).
-        if down.returncode != 0:
-            raise RuntimeError(f"xdotool mousedown (button 1) failed: rc={down.returncode}")
-        # Button 1 is now physically DOWN — the release MUST always fire. An
-        # ``asyncio.CancelledError`` during the dwell (uvicorn cancels the
-        # request task on client disconnect) or any other raise would
-        # otherwise strand the button held for the rest of the session, and
-        # the CDP fallback (a different input channel) cannot release it.
-        # Mirror ``_x11_drag`` / ``_x11_right_click_xy``: run the release via
-        # ``run_in_executor`` so the worker thread completes the subprocess
-        # even if the awaiting future is cancelled.
+        # Once button 1 goes DOWN the release MUST always fire. The mousedown
+        # is issued INSIDE the guarded block: an ``asyncio.CancelledError``
+        # (uvicorn cancels the request task on client disconnect) can fire
+        # during the mousedown await itself — the executor thread still runs
+        # ``xdotool mousedown`` to completion (button pressed) even as the
+        # awaiting coroutine unwinds, so the finally's emergency release must
+        # cover the mousedown-await window too, not just the dwell. Any other
+        # raise would likewise strand the button held for the rest of the
+        # session, and the CDP fallback (a different input channel) cannot
+        # release it. Mirror ``_x11_drag`` / ``_x11_right_click_xy``: run the
+        # release via ``run_in_executor`` so the worker thread completes the
+        # subprocess even if the awaiting future is cancelled.
         released = False
         try:
+            down = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
+                ),
+            )
+            # A dropped mousedown (wedged X server / lost WID) must surface as
+            # a failure so the caller's CDP fallback engages — never a silent
+            # success. The finally's release is then a harmless no-op (the
+            # button was never pressed).
+            if down.returncode != 0:
+                raise RuntimeError(f"xdotool mousedown (button 1) failed: rc={down.returncode}")
             await asyncio.sleep(click_dwell())
             up = await loop.run_in_executor(
                 None,
@@ -7958,10 +7962,11 @@ class BrowserManager:
             released = True
         finally:
             # Emergency release — fire ONLY when the normal release did not
-            # cleanly complete (cancel/raise mid-dwell, or a non-zero normal
-            # mouseup); the success path already released exactly once. Best
-            # effort: never mask the propagating ``CancelledError`` or the
-            # body's original exception if this cleanup also fails.
+            # cleanly complete (cancel/raise anywhere in the pressed window, or
+            # a non-zero normal mouseup); the success path already released
+            # exactly once. Best effort: never mask the propagating
+            # ``CancelledError`` or the body's original exception if this
+            # cleanup also fails.
             if not released:
                 try:
                     await loop.run_in_executor(
@@ -7996,29 +8001,33 @@ class BrowserManager:
         wid_s = str(wid)
         loop = asyncio.get_running_loop()
         await asyncio.sleep(pre_click_settle())
-        down = await loop.run_in_executor(
-            None,
-            lambda: subprocess.run(
-                ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3, env=inst.subprocess_env(),
-            ),
-        )
-        # A dropped mousedown (wedged X server / lost WID) must surface as a
-        # failure so the caller's CDP fallback engages — never a silent
-        # success. On a non-zero exit the button was not pressed, so raise
-        # BEFORE the guarded dwell (nothing to release).
-        if down.returncode != 0:
-            raise RuntimeError(f"xdotool mousedown (button 1) failed: rc={down.returncode}")
-        # Button 1 is now physically DOWN — the release MUST always fire. An
-        # ``asyncio.CancelledError`` during the dwell (uvicorn cancels the
-        # request task on client disconnect) or any other raise would
-        # otherwise strand the button held for the rest of the session, and
-        # the CDP fallback (a different input channel) cannot release it.
-        # Mirror ``_x11_drag`` / ``_x11_right_click_xy``: run the release via
-        # ``run_in_executor`` so the worker thread completes the subprocess
-        # even if the awaiting future is cancelled.
+        # Once button 1 goes DOWN the release MUST always fire. The mousedown
+        # is issued INSIDE the guarded block: an ``asyncio.CancelledError``
+        # (uvicorn cancels the request task on client disconnect) can fire
+        # during the mousedown await itself — the executor thread still runs
+        # ``xdotool mousedown`` to completion (button pressed) even as the
+        # awaiting coroutine unwinds, so the finally's emergency release must
+        # cover the mousedown-await window too, not just the dwell. Any other
+        # raise would likewise strand the button held for the rest of the
+        # session, and the CDP fallback (a different input channel) cannot
+        # release it. Mirror ``_x11_drag`` / ``_x11_right_click_xy``: run the
+        # release via ``run_in_executor`` so the worker thread completes the
+        # subprocess even if the awaiting future is cancelled.
         released = False
         try:
+            down = await loop.run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
+                ),
+            )
+            # A dropped mousedown (wedged X server / lost WID) must surface as
+            # a failure so the caller's CDP fallback engages — never a silent
+            # success. The finally's release is then a harmless no-op (the
+            # button was never pressed).
+            if down.returncode != 0:
+                raise RuntimeError(f"xdotool mousedown (button 1) failed: rc={down.returncode}")
             await asyncio.sleep(click_dwell())
             up = await loop.run_in_executor(
                 None,
@@ -8035,10 +8044,11 @@ class BrowserManager:
             released = True
         finally:
             # Emergency release — fire ONLY when the normal release did not
-            # cleanly complete (cancel/raise mid-dwell, or a non-zero normal
-            # mouseup); the success path already released exactly once. Best
-            # effort: never mask the propagating ``CancelledError`` or the
-            # body's original exception if this cleanup also fails.
+            # cleanly complete (cancel/raise anywhere in the pressed window, or
+            # a non-zero normal mouseup); the success path already released
+            # exactly once. Best effort: never mask the propagating
+            # ``CancelledError`` or the body's original exception if this
+            # cleanup also fails.
             if not released:
                 try:
                     await loop.run_in_executor(

--- a/tests/test_browser_parity_actions_p2.py
+++ b/tests/test_browser_parity_actions_p2.py
@@ -273,6 +273,229 @@ class TestX11RightClickXy:
         assert calls[0][-1] == "3" and calls[1][-1] == "3"
 
 
+# ── Left-click (button 1) release + xdotool-failure guards ──────────────────
+
+
+_DWELL_SENTINEL = 0.123456  # distinctive value so a patched sleep can pick the dwell
+
+
+def _make_locator():
+    loc = MagicMock()
+    loc.bounding_box = AsyncMock(
+        return_value={"x": 100, "y": 100, "width": 40, "height": 40},
+    )
+    return loc
+
+
+async def _noop(*a, **k):
+    return None
+
+
+class TestX11ClickButtonRelease:
+    """Guard tests for ``_x11_click`` (ref path), the primary-button analogue
+    of ``TestX11RightClickXy``:
+
+      * a CancelledError mid-dwell (uvicorn cancels the request task on client
+        disconnect) must still release button 1 — otherwise it stays physically
+        held for the rest of the session (X11 corruption);
+      * a dropped xdotool mousedown/mouseup (wedged X server / lost WID) must
+        surface as a RuntimeError so the caller's CDP fallback engages, never a
+        silent success.
+    """
+
+    def _prep(self, mgr, monkeypatch):
+        monkeypatch.setattr(mgr, "_x11_ensure_in_viewport", _noop)
+        monkeypatch.setattr(mgr, "_x11_move_to", _noop)
+
+    @pytest.mark.asyncio
+    async def test_mouseup_fires_in_finally_on_cancel(self, monkeypatch):
+        import src.browser.service as svc
+
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=321)
+        self._prep(mgr, monkeypatch)
+
+        calls: list[list[str]] = []
+
+        class _Ok:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return _Ok()
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        # Raise CancelledError from INSIDE the dwell sleep (button 1 is DOWN):
+        # tag the dwell via a sentinel click_dwell() so it is picked out
+        # regardless of how many settle-sleeps precede it.
+        real_sleep = asyncio.sleep
+        monkeypatch.setattr(svc, "click_dwell", lambda: _DWELL_SENTINEL)
+
+        async def _sleep(*a, **k):
+            if a and a[0] == _DWELL_SENTINEL:
+                raise asyncio.CancelledError()
+            return await real_sleep(0)
+
+        monkeypatch.setattr(svc.asyncio, "sleep", _sleep)
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._x11_click(inst, _make_locator())
+
+        # Despite the cancel mid-dwell, button 1 was released exactly once.
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        assert calls[0][-1] == "1" and calls[1][-1] == "1"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_mousedown_raises_and_skips_release(self, monkeypatch):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=321)
+        self._prep(mgr, monkeypatch)
+
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return types.SimpleNamespace(returncode=1)
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        with pytest.raises(RuntimeError):
+            await mgr._x11_click(inst, _make_locator())
+
+        # A dropped mousedown raises immediately — the button was never held,
+        # so no mouseup is issued.
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown"]
+
+    @pytest.mark.asyncio
+    async def test_nonzero_mouseup_raises_after_best_effort_release(self, monkeypatch):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=321)
+        self._prep(mgr, monkeypatch)
+
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            # mousedown succeeds; every mouseup reports failure.
+            rc = 0 if cmd[1] == "mousedown" else 1
+            return types.SimpleNamespace(returncode=rc)
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        with pytest.raises(RuntimeError):
+            await mgr._x11_click(inst, _make_locator())
+
+        # A non-zero normal mouseup may not have released — the finally issues a
+        # best-effort SECOND release, then the RuntimeError propagates so the
+        # caller falls back to CDP.
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup", "mouseup"]
+        assert all(c[-1] == "1" for c in calls)
+
+
+class TestX11ClickXyButtonRelease:
+    """Same guards for ``_x11_click_xy`` (coord path)."""
+
+    @pytest.mark.asyncio
+    async def test_mouseup_fires_in_finally_on_cancel(self, monkeypatch):
+        import src.browser.service as svc
+
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=654)
+        monkeypatch.setattr(mgr, "_x11_move_to", _noop)
+
+        calls: list[list[str]] = []
+
+        class _Ok:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return _Ok()
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        real_sleep = asyncio.sleep
+        monkeypatch.setattr(svc, "click_dwell", lambda: _DWELL_SENTINEL)
+
+        async def _sleep(*a, **k):
+            if a and a[0] == _DWELL_SENTINEL:
+                raise asyncio.CancelledError()
+            return await real_sleep(0)
+
+        monkeypatch.setattr(svc.asyncio, "sleep", _sleep)
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._x11_click_xy(inst, 10, 20)
+
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        assert calls[0][-1] == "1" and calls[1][-1] == "1"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_mousedown_raises_and_skips_release(self, monkeypatch):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=654)
+        monkeypatch.setattr(mgr, "_x11_move_to", _noop)
+
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return types.SimpleNamespace(returncode=1)
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        with pytest.raises(RuntimeError):
+            await mgr._x11_click_xy(inst, 10, 20)
+
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown"]
+
+    @pytest.mark.asyncio
+    async def test_nonzero_mouseup_raises_after_best_effort_release(self, monkeypatch):
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=654)
+        monkeypatch.setattr(mgr, "_x11_move_to", _noop)
+
+        calls: list[list[str]] = []
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            rc = 0 if cmd[1] == "mousedown" else 1
+            return types.SimpleNamespace(returncode=rc)
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        with pytest.raises(RuntimeError):
+            await mgr._x11_click_xy(inst, 10, 20)
+
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup", "mouseup"]
+        assert all(c[-1] == "1" for c in calls)
+
+
 # ── Clipboard ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_browser_parity_actions_p2.py
+++ b/tests/test_browser_parity_actions_p2.py
@@ -351,7 +351,46 @@ class TestX11ClickButtonRelease:
         assert calls[0][-1] == "1" and calls[1][-1] == "1"
 
     @pytest.mark.asyncio
-    async def test_nonzero_mousedown_raises_and_skips_release(self, monkeypatch):
+    async def test_mouseup_fires_in_finally_on_cancel_during_mousedown(self, monkeypatch):
+        """A CancelledError during the MOUSEDOWN executor await (the pressed
+        window BEFORE the dwell) must still release button 1: the executor
+        thread runs xdotool mousedown to completion (button pressed) even as
+        the awaiting coroutine unwinds, so the mousedown must sit INSIDE the
+        guarded block for the finally to cover it."""
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=321)
+        self._prep(mgr, monkeypatch)
+
+        calls: list[list[str]] = []
+
+        class _Ok:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            # Record the call (the thread ran the subprocess), then simulate the
+            # awaiting future being cancelled on the mousedown await only.
+            calls.append(cmd)
+            if cmd[1] == "mousedown":
+                raise asyncio.CancelledError()
+            return _Ok()
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._x11_click(inst, _make_locator())
+
+        # Button pressed (thread ran) + await cancelled → the finally released
+        # it anyway. Without the mousedown inside the try this would be
+        # ["mousedown"] only (button stranded).
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        assert calls[0][-1] == "1" and calls[1][-1] == "1"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_mousedown_raises(self, monkeypatch):
         mgr = _make_manager()
         inst = _FakeInstance(x11_wid=321)
         self._prep(mgr, monkeypatch)
@@ -370,10 +409,11 @@ class TestX11ClickButtonRelease:
         with pytest.raises(RuntimeError):
             await mgr._x11_click(inst, _make_locator())
 
-        # A dropped mousedown raises immediately — the button was never held,
-        # so no mouseup is issued.
+        # A dropped mousedown raises so the caller falls back to CDP. The
+        # finally still issues a best-effort mouseup — a harmless no-op (the
+        # button was never pressed), strictly safer than skipping it.
         verbs = [c[1] for c in calls]
-        assert verbs == ["mousedown"]
+        assert verbs == ["mousedown", "mouseup"]
 
     @pytest.mark.asyncio
     async def test_nonzero_mouseup_raises_after_best_effort_release(self, monkeypatch):
@@ -448,7 +488,38 @@ class TestX11ClickXyButtonRelease:
         assert calls[0][-1] == "1" and calls[1][-1] == "1"
 
     @pytest.mark.asyncio
-    async def test_nonzero_mousedown_raises_and_skips_release(self, monkeypatch):
+    async def test_mouseup_fires_in_finally_on_cancel_during_mousedown(self, monkeypatch):
+        """CancelledError during the mousedown await must still release button
+        1 (coord path). See the ``_x11_click`` analogue for the full rationale."""
+        mgr = _make_manager()
+        inst = _FakeInstance(x11_wid=654)
+        monkeypatch.setattr(mgr, "_x11_move_to", _noop)
+
+        calls: list[list[str]] = []
+
+        class _Ok:
+            returncode = 0
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd[1] == "mousedown":
+                raise asyncio.CancelledError()
+            return _Ok()
+
+        monkeypatch.setattr(
+            "src.browser.service.subprocess",
+            types.SimpleNamespace(run=_fake_run),
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._x11_click_xy(inst, 10, 20)
+
+        verbs = [c[1] for c in calls]
+        assert verbs == ["mousedown", "mouseup"]
+        assert calls[0][-1] == "1" and calls[1][-1] == "1"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_mousedown_raises(self, monkeypatch):
         mgr = _make_manager()
         inst = _FakeInstance(x11_wid=654)
         monkeypatch.setattr(mgr, "_x11_move_to", _noop)
@@ -467,8 +538,10 @@ class TestX11ClickXyButtonRelease:
         with pytest.raises(RuntimeError):
             await mgr._x11_click_xy(inst, 10, 20)
 
+        # Best-effort emergency mouseup fires (harmless no-op) then the raise
+        # propagates so the caller falls back to CDP.
         verbs = [c[1] for c in calls]
-        assert verbs == ["mousedown"]
+        assert verbs == ["mousedown", "mouseup"]
 
     @pytest.mark.asyncio
     async def test_nonzero_mouseup_raises_after_best_effort_release(self, monkeypatch):


### PR DESCRIPTION
## Defect (audit-confirmed + Codex-validated)

`_x11_click` and `_x11_click_xy` in `src/browser/service.py` did
`mousedown → await asyncio.sleep(click_dwell()) → mouseup` with **no
try/finally** around the dwell. uvicorn cancels the request task on client
disconnect, so an `asyncio.CancelledError` raised during the dwell stranded
X11 mouse **button 1 physically held for the rest of the session** — every
subsequent action then fires with the primary button stuck down (X11 input
corruption), and the CDP fallback is a different input channel that cannot
release it.

Both methods also never inspected the `subprocess.run(...).returncode` of the
xdotool mousedown/mouseup, so a **dropped click** (wedged X server / lost WID)
was reported as success and the caller's CDP fallback never engaged.

The sibling methods `_x11_drag` and `_x11_right_click_xy` already guard the
held button correctly with a try/finally whose release runs via
`run_in_executor` (the worker thread completes the subprocess even if the
awaiting future is cancelled).

## Fix (surgical — mirrors the proven siblings, no shared helper)

Applied identically to `_x11_click` and `_x11_click_xy`:

1. **Guarantee release.** Capture the mousedown result; a non-zero exit raises
   `RuntimeError` **before** the dwell (button was never held) so the caller
   falls back to CDP. The dwell + normal mouseup are wrapped in try/finally.
   The success path releases **exactly once**. A cancel/raise mid-dwell — or a
   non-zero *normal* mouseup (the release may not have injected, button may
   still be held) — triggers a **best-effort emergency release** in the
   `finally` (via `run_in_executor`, same as `_x11_drag`), wrapped so it never
   masks the propagating `CancelledError` or the body's original exception.
2. **Surface failure.** A non-zero normal mouseup raises `RuntimeError` (after
   the best-effort release) so the caller falls back to CDP. On cancellation
   the raise-on-nonzero check is never reached.

`_x11_drag` / `_x11_right_click_xy` are already guarded and left untouched
(their returncode treatment is out of scope for this PR).

## Tests

Button-1 analogues of the existing button-3 `test_mouseup_fires_in_finally_on_cancel`,
added in `tests/test_browser_parity_actions_p2.py` for **both** methods:

- `CancelledError` injected mid-dwell → a `mouseup 1` still fires (exactly once).
- non-zero mousedown → raises before any release (no mouseup issued).
- non-zero normal mouseup → best-effort second release fires, then raises so
  the caller falls back to CDP.

Focused run: `56 passed` (`tests/test_browser_parity_actions_p2.py`
`tests/test_browser_parity_actions.py`), including the 6 new cases.
`ruff check src/ tests/` (the CI lint gate) passes.