### PR TITLE
fix(host,cli,dashboard,channels): Phase-5 U0 hardening — archived-boot skip, probe repoint, sentinel/error-string leaks, CLI confirm auth

### DIFF
--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.channels import AT_MENTION_RE
 from src.host.credentials import is_system_credential
-from src.shared.utils import sanitize_for_prompt, setup_logging
+from src.shared.utils import sanitize_for_prompt, setup_logging, usable_agent_reply
 
 if TYPE_CHECKING:
     from src.shared.types import MessageOrigin
@@ -270,8 +270,14 @@ class Channel(abc.ABC):
                 user=str(user_id),
             )
         response = await self.dispatch(target, message, origin=origin)
-        if not response or not response.strip():
-            return ""  # Suppress silent/empty responses
+        # Plan §8 #24 recon minor item: a bare ``response.strip()`` truthy
+        # check let the ``__SILENT__`` sentinel (a stopped/unresponsive
+        # agent) and the "(no response)"/``dispatch_error:`` lane-dispatch
+        # shapes through as if they were real agent text — a channel user
+        # would see the literal token. ``usable_agent_reply`` is the shared
+        # gate every other consumer of these non-success shapes uses.
+        if not usable_agent_reply(response):
+            return ""  # Suppress silent/unusable responses
         return f"[{target}] {response}"
 
     #: Commands gated to the channel owner only. Non-owner allowed users

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -931,7 +931,12 @@ def pending_cmd(port: int, as_json: bool):
 def confirm_cmd(nonce: str, port: int, as_json: bool):
     """Confirm a pending action by nonce (Task 9)."""
     as_json = as_json or _json_mode
-    result = _mesh_post(port, f"/mesh/pending/{nonce}/confirm")
+    # Route through the dashboard proxy (plan §8 #24 recon minor item),
+    # like the sibling ``pending`` command — the raw mesh endpoint requires
+    # a bearer/internal header AND a human-origin stamp that a bare CLI
+    # POST can't provide, so it 401s/403s. The dashboard proxy injects both
+    # server-side.
+    result = _mesh_post(port, f"/dashboard/api/workplace/pending/{nonce}/confirm")
     if as_json:
         click.echo(dumps_safe(result))
     else:
@@ -945,7 +950,8 @@ def confirm_cmd(nonce: str, port: int, as_json: bool):
 def cancel_cmd(nonce: str, port: int, as_json: bool):
     """Cancel a pending action by nonce (Task 9)."""
     as_json = as_json or _json_mode
-    result = _mesh_post(port, f"/mesh/pending/{nonce}/cancel")
+    # See confirm_cmd above — same dashboard-proxy auth fix.
+    result = _mesh_post(port, f"/dashboard/api/workplace/pending/{nonce}/cancel")
     if as_json:
         click.echo(dumps_safe(result))
     else:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -792,6 +792,16 @@ class RuntimeContext:
                 pass
 
         for agent_id, agent_cfg in agents_cfg.items():
+            # Plan §8 #24 prereq (i): an archived agent was deliberately torn
+            # down by ``_archive_agent_core`` (container stopped, health
+            # deregistered) — without this filter every mesh restart
+            # resurrected the container and re-registered health, fighting
+            # the archive. Mirrors the ``status`` check the sibling boot
+            # reconciles (``_reconcile_work_summary_jobs`` /
+            # ``_reconcile_standup_jobs``) already apply.
+            if (agent_cfg.get("status") or "active") == "archived":
+                logger.info("Skipping boot for archived agent '%s' (no container, no health registration)", agent_id)
+                continue
             if agent_id in RESERVED_AGENT_IDS and agent_id != _OPERATOR_AGENT_ID:
                 raise click.ClickException(f"Agent ID '{agent_id}' is reserved for internal use")
             budget = agent_cfg.get("budget", {})
@@ -1917,9 +1927,12 @@ class RuntimeContext:
 
         from src.dashboard.server import create_dashboard_router, create_spa_catchall_router
 
-        # Task 9 — pass the mesh's pending-action and tasks stores into
-        # the dashboard so the new ``/api/workplace/*`` endpoints can
-        # render the Board tab without a second HTTP hop.
+        # Task 9 — pass the mesh's tasks store into the dashboard so the
+        # ``/api/workplace/*`` endpoints can render the Board tab without a
+        # second HTTP hop. Pending actions are read via the dashboard's
+        # ``/api/workplace/pending*`` loopback proxy to ``/mesh/pending*``
+        # instead (the permission tier is enforced mesh-side); no store is
+        # injected for that surface.
         dashboard_router = create_dashboard_router(
             blackboard=self.blackboard,
             health_monitor=self.health_monitor,
@@ -1940,7 +1953,6 @@ class RuntimeContext:
             channel_manager=self.channel_manager,
             wallet_service_ref=wallet_ref,
             api_key_manager=self._api_key_manager,
-            pending_actions=getattr(app, "pending_actions", None),
             tasks_store=getattr(app, "tasks_store", None),
             help_requests_store=getattr(app, "help_requests_store", None),
             summaries_store=getattr(app, "summaries_store", None),
@@ -1951,8 +1963,7 @@ class RuntimeContext:
             thread_store=self.thread_store,
             # Offboarding-with-handover + onboarding wake (plan §8 #15):
             # cross-router seams into the mesh app's own closures, same
-            # ``getattr(app, ...)`` injection pattern as pending_actions/
-            # tasks_store above.
+            # ``getattr(app, ...)`` injection pattern as tasks_store above.
             offboard_agent=getattr(app, "_offboard_agent", None),
             onboarding_wake=getattr(app, "_schedule_onboarding_wake", None),
         )
@@ -2051,6 +2062,20 @@ class RuntimeContext:
             reviews = store.list_reviews(team_id, status="open")
             return {"team_id": team_id, "count": len(reviews)} if reviews else None
 
+        def agent_pending_tasks(agent: str) -> int:
+            """Durable-tasks probe input (plan §8 #24 prereq iii): the
+            durable tasks table is what ``hand_off``/``create_task``
+            actually write to (never the legacy blackboard ``tasks/{agent}``
+            prefix), so this is the authoritative count of un-started work
+            waiting for ``agent``. Lazy — resolves ``self._tasks_store_ref``
+            at call time (set after ``create_mesh_app`` in ``start()``);
+            missing store ⇒ 0 (conservative, mirrors ``agent_standing_goals``
+            above)."""
+            store = getattr(self, "_tasks_store_ref", None)
+            if store is None:
+                return 0
+            return store.count_pending_for_assignee(agent)
+
         def deployment_utility_model() -> str:
             """Deployment ``llm.utility_model`` for the cron plate gate.
 
@@ -2120,7 +2145,16 @@ class RuntimeContext:
                 )
             except Exception as e:
                 logger.warning("Heartbeat dispatch failed for '%s': %s", agent_name, e)
-                return {"response": f"Error: {e}", "outcome": "error", "skipped": False}
+                # Plan §8 #24 recon minor item: ``usable_agent_reply`` (the
+                # shared gate every "is this real agent-authored text"
+                # consumer shares) only rejects ``__SILENT__``, "(no
+                # response)", and a ``"dispatch_error:"`` prefix — a bare
+                # ``f"Error: {e}"`` string passed the gate and a stopped
+                # lead's standup cron could post it into the team channel
+                # as the lead's own words (see ``_post_to_channel`` gating
+                # in ``_execute_job`` above). Match the prefix the gate
+                # already expects instead of inventing a new one.
+                return {"response": f"dispatch_error: {e}", "outcome": "error", "skipped": False}
 
         self.cron_scheduler = CronScheduler(
             dispatch_fn=cron_dispatch,
@@ -2148,12 +2182,20 @@ class RuntimeContext:
             # only a handful of attrs, mirroring the ``health_monitor``
             # note above) from needing to know about every new seam.
             lead_reviews_fn=lead_pending_reviews,
+            pending_tasks_fn=agent_pending_tasks,
             thread_store=getattr(self, "thread_store", None),
         )
         self._cron_job_count = len(self.cron_scheduler.jobs)
 
     def _reconcile_heartbeats(self) -> None:
-        """Ensure every agent in config has a heartbeat cron job."""
+        """Ensure every agent in config has a heartbeat cron job.
+
+        Skips archived agents (plan §8 #24 prereq ii) — unlike this
+        reconcile, its siblings ``_reconcile_work_summary_jobs`` and
+        ``_reconcile_standup_jobs`` already excluded archived rows; without
+        the same filter here, a boot recreated a heartbeat cron job for an
+        agent that was deliberately torn down and never re-woken.
+        """
         if not self.cron_scheduler:
             return
         from src.cli.config import _OPERATOR_AGENT_ID
@@ -2164,7 +2206,9 @@ class RuntimeContext:
             "heartbeat_schedule",
             CronScheduler.DEFAULT_HEARTBEAT_SCHEDULE,
         )
-        for agent_id in agents_cfg:
+        for agent_id, agent_cfg in agents_cfg.items():
+            if (agent_cfg or {}).get("status", "active") == "archived":
+                continue
             # Operator heartbeat is faster than the fleet default so
             # fleet-health regressions surface within minutes rather
             # than hours. The previous 1h cadence was set when the

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -57,6 +57,7 @@ from src.shared.utils import (
     sanitize_for_prompt,
     set_llm_max_tokens_env,
     setup_logging,
+    usable_agent_reply,
 )
 
 if TYPE_CHECKING:
@@ -655,11 +656,14 @@ def create_dashboard_router(
     channel_manager: Any = None,
     wallet_service_ref: list | None = None,
     api_key_manager: Any = None,
-    # Task 9 — Workplace tab + pending action review surface. Both are
-    # optional so existing dashboard tests that don't construct them
-    # keep working; the new endpoints fall back to empty/disabled when
-    # the relevant store is absent.
-    pending_actions: Any = None,
+    # Task 9 — Workplace tab pending-action review surface. The dashboard
+    # never reads a ``PendingActions`` store directly — ``/api/workplace/
+    # pending*`` proxies to the mesh's ``/mesh/pending*`` endpoints over
+    # loopback so the operator-or-internal permission tier is enforced
+    # (reading the store here would bypass that gate). A prior revision
+    # accepted an unused ``pending_actions`` kwarg for this surface; it has
+    # been removed (plan §8 #24 recon minor item — dead parameter, grep
+    # confirmed no body reference).
     tasks_store: Any = None,
     # Open help-requests registry (credential / browser-login / captcha asks)
     # backing the "Needs you" feed. Optional so existing tests keep working;
@@ -706,8 +710,8 @@ def create_dashboard_router(
     thread_store: Any = None,
     # Offboarding-with-handover (plan §8 #15). Cross-router seam into the
     # mesh app's internal ``_offboard_agent`` helper — injected the same
-    # way ``pending_actions``/``tasks_store`` are (``getattr(app, ...)``
-    # in ``cli/runtime.py``). ``async def offboard_agent(agent_id, *,
+    # way ``tasks_store`` is (``getattr(app, ...)`` in ``cli/runtime.py``).
+    # ``async def offboard_agent(agent_id, *,
     # reason) -> dict``; optional so dashboard-only test constructions
     # keep working — the delete endpoint skips the offboard attempt when
     # absent (no manifest to run).
@@ -3782,6 +3786,13 @@ def create_dashboard_router(
             response = await lane_manager.deliver_chat(
                 agent_id, message, trace_id=trace_id, origin=origin,
             )
+            # Plan §8 #24 recon minor item: a stopped/unresponsive agent's
+            # ``__SILENT__`` sentinel (or the "(no response)"/
+            # ``dispatch_error:`` lane-dispatch shapes) must never reach the
+            # operator raw — substitute a human-readable fallback so the
+            # dashboard chat never shows a literal internal token.
+            if not usable_agent_reply(response):
+                response = "The agent did not produce a reply."
             if event_bus:
                 event_bus.emit("chat_done", agent=agent_id, data={"response": response, "session": chat_session})
             return {"response": response}
@@ -8766,7 +8777,8 @@ def create_dashboard_router(
 
     @api_router.get("/api/workplace/pending")
     async def api_workplace_pending() -> dict:
-        """List open pending actions for inline + System>Operator review.
+        """List open pending actions for the Work tab "Needs you" panel
+        and the inline operator-chat ``pending_action_card`` review.
 
         Proxies to the mesh's ``GET /mesh/pending`` over loopback with
         the ``x-mesh-internal`` + ``X-Agent-ID: operator`` headers so the

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -118,6 +118,7 @@ class CronScheduler:
         utility_model_fn: Callable | None = None,
         goals_fn: Callable | None = None,
         lead_reviews_fn: Callable | None = None,
+        pending_tasks_fn: Callable | None = None,
         thread_store: Any = None,
     ):
         self.config_path = Path(config_path)
@@ -144,6 +145,19 @@ class CronScheduler:
         # with no open reviews — the probe below stays free for everyone
         # who isn't a lead sitting on a nonempty review queue.
         self.lead_reviews_fn = lead_reviews_fn
+        # Durable-tasks probe input (plan §8 #24 prereq iii): ``pending_
+        # tasks_fn(agent) -> int`` counts non-terminal (``pending``) tasks
+        # assigned to ``agent`` in the mesh-side durable tasks table (a
+        # cheap SQLite COUNT). ``hand_off``/``create_task`` write ONLY to
+        # this table, never to the legacy blackboard ``tasks/{agent}``
+        # prefix the probe below still scans — without this, a pending
+        # handoff to a stopped/unreachable agent could never trip the
+        # heartbeat safety net. Kept ALONGSIDE the blackboard scan rather
+        # than replacing it: template flows (``claim_task`` / the shared
+        # ``tasks/*`` work-queue pattern) still populate that namespace and
+        # a regression test pins it — the durable count is the primary,
+        # authoritative source; the blackboard scan is additional coverage.
+        self.pending_tasks_fn = pending_tasks_fn
         # Host-published channel post (§8 #14): wired so ``_execute_job``
         # can post a standup (or any ``post_to_channel``-tagged) job's
         # dispatch response into the team's channel thread. None in
@@ -1015,6 +1029,25 @@ class CronScheduler:
                 ))
             except Exception as e:
                 logger.debug("Pending tasks probe failed for '%s': %s", agent, e)
+
+        # Probe 3b: pending tasks in the DURABLE tasks store (plan §8 #24
+        # prereq iii). This is the authoritative source — ``hand_off``/
+        # ``create_task`` write only here, never to the blackboard prefix
+        # probe 3 scans — so a queued handoff to a stopped/unreachable
+        # agent trips the safety net even though probe 3 never sees it.
+        # Mesh-side only (cheap COUNT query); a read failure degrades to
+        # "no probe" rather than raising into the tick.
+        if self.pending_tasks_fn is not None:
+            try:
+                pending_count = self.pending_tasks_fn(agent)
+            except Exception as e:
+                logger.debug("Pending durable tasks probe failed for '%s': %s", agent, e)
+                pending_count = 0
+            results.append(HeartbeatProbeResult(
+                name="pending_durable_tasks",
+                triggered=bool(pending_count),
+                detail=f"{pending_count} pending task(s) in the durable tasks store",
+            ))
 
         # Probe 4: lead-duty pending drive-review verdicts (plan §8 #13/
         # #14). Mesh-side Team-store data only — no container hop. Non-

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -11507,8 +11507,10 @@ def create_mesh_app(
 
     # === Task 9 — Pending action review surface ===
     #
-    # The dashboard's System > Operator panel and the inline chat
-    # bubble both call these endpoints. Confirm wraps the existing
+    # The dashboard's Work tab "Needs you" panel and the inline operator-
+    # chat ``pending_action_card`` both call these endpoints (the System >
+    # Operator panel that used to render this queue was removed in PR
+    # #1044). Confirm wraps the existing
     # ``/mesh/config/confirm`` path; cancel is the additive escape
     # hatch (delete-without-apply) backed by ``PendingActions.cancel``.
     # Both inherit CSRF protection (X-Requested-With) from the

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -929,8 +929,10 @@ class DashboardEvent(BaseModel):
         # store) on create / status_change / reroute / cancel.
         # ``pending_action_*`` are emitted from ``host/pending_actions.py``
         # on store / consume(success) / reap_expired so the dashboard's
-        # System > Operator panel and inline chat bubbles render the
-        # operator's review queue without polling.
+        # Work tab "Needs you" panel and inline operator-chat
+        # ``pending_action_card`` bubbles render the operator's review
+        # queue without polling (the System > Operator panel that used to
+        # render this queue was removed in PR #1044).
         "task_created",
         "task_status_changed",
         # ``task_completed_without_handoff`` is emitted by

--- a/tests/test_boot_archived_skip.py
+++ b/tests/test_boot_archived_skip.py
@@ -1,0 +1,100 @@
+"""Boot must not resurrect archived agents.
+
+Regression guard (plan §8 #24 prereq i): ``RuntimeContext._start_agents``
+iterated ``agents_cfg`` with NO status filter — an archived agent (torn
+down intentionally by ``_archive_agent_core``: container stopped, health
+deregistered) got its container restarted and health re-registered on
+every mesh boot, fighting the archive. Mirrors the archive-endpoint
+regression guard in ``test_archive_health_dereg.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+from src.cli.runtime import RuntimeContext
+from src.host.transport import HttpTransport
+
+
+class _StubRuntimeBackend:
+    """Cheap stand-in for DockerBackend/SandboxBackend — tracks which
+    agent ids actually got a ``start_agent`` call."""
+
+    def __init__(self):
+        self.extra_env: dict[str, str] = {}
+        self.started: list[str] = []
+
+    def start_agent(self, *, agent_id, role, tools_dir, model, thinking, env_overrides):
+        self.started.append(agent_id)
+        return f"http://agent-{agent_id}"
+
+
+def _build_ctx(fake_cfg: dict) -> RuntimeContext:
+    ctx = RuntimeContext.__new__(RuntimeContext)
+    ctx.cfg = fake_cfg
+    ctx.cost_tracker = MagicMock()
+    ctx.runtime = _StubRuntimeBackend()
+    ctx.router = MagicMock()
+    ctx.transport = HttpTransport()
+    ctx.health_monitor = MagicMock()
+    ctx.permissions = MagicMock()
+    ctx.credential_vault = MagicMock()
+    ctx.connector_store = MagicMock()
+    return ctx
+
+
+def test_start_agents_skips_archived(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_config
+    import src.cli.runtime as runtime_mod
+
+    fake_cfg = {
+        "agents": {
+            "worker-active": {"role": "worker", "status": "active"},
+            "worker-archived": {"role": "worker", "status": "archived"},
+        },
+        "llm": {},
+        "mesh": {"port": 8400},
+        "network": {},
+    }
+    monkeypatch.setattr(runtime_mod, "_load_config", lambda: fake_cfg)
+    monkeypatch.setattr(cli_config, "_ensure_operator_agent", lambda **k: None)
+
+    ctx = _build_ctx(fake_cfg)
+
+    with caplog.at_level(logging.INFO):
+        RuntimeContext._start_agents(ctx)
+
+    # No container start for the archived agent — only the active one.
+    assert ctx.runtime.started == ["worker-active"]
+    # No router registration for the archived agent.
+    registered_ids = [c.args[0] for c in ctx.router.register_agent.call_args_list]
+    assert registered_ids == ["worker-active"]
+    # No transport registration (HttpTransport.register) either.
+    assert "worker-active" in ctx.transport._urls
+    assert "worker-archived" not in ctx.transport._urls
+    # No health monitor registration.
+    health_registered = [c.args[0] for c in ctx.health_monitor.register.call_args_list]
+    assert health_registered == ["worker-active"]
+    # One info line logged for the skipped agent.
+    assert any("worker-archived" in r.message for r in caplog.records)
+
+
+def test_start_agents_missing_status_defaults_active(tmp_path, monkeypatch):
+    """Legacy rows with no ``status`` field must still boot (default active)."""
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_config
+    import src.cli.runtime as runtime_mod
+
+    fake_cfg = {
+        "agents": {"worker-legacy": {"role": "worker"}},
+        "llm": {}, "mesh": {"port": 8400}, "network": {},
+    }
+    monkeypatch.setattr(runtime_mod, "_load_config", lambda: fake_cfg)
+    monkeypatch.setattr(cli_config, "_ensure_operator_agent", lambda **k: None)
+
+    ctx = _build_ctx(fake_cfg)
+    RuntimeContext._start_agents(ctx)
+
+    assert ctx.runtime.started == ["worker-legacy"]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -490,6 +490,42 @@ class TestSilentResponseSuppression:
         assert "[alpha]" in result
         assert "reply from alpha" in result
 
+    @pytest.mark.asyncio
+    async def test_silent_token_suppressed(self):
+        """Plan §8 #24 recon minor item: a stopped/unresponsive agent's
+        ``__SILENT__`` sentinel must never leak raw to a channel user —
+        it must be suppressed exactly like an empty response."""
+        from src.shared.types import SILENT_REPLY_TOKEN
+
+        async def silent_token_dispatch(agent: str, message: str, **_kwargs) -> str:
+            return SILENT_REPLY_TOKEN
+
+        ch = _make_channel(dispatch_fn=silent_token_dispatch)
+        result = await ch.handle_message("u1", "hi")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_no_response_marker_suppressed(self):
+        """The lane dispatcher's "(no response)" unreachable-agent success
+        marker must also be suppressed, not echoed as real text."""
+        async def no_response_dispatch(agent: str, message: str, **_kwargs) -> str:
+            return "(no response)"
+
+        ch = _make_channel(dispatch_fn=no_response_dispatch)
+        result = await ch.handle_message("u1", "hi")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_error_prefix_suppressed(self):
+        """A ``dispatch_error:``-prefixed string (the except-branch note)
+        must be suppressed, never shown as the agent's words."""
+        async def dispatch_error_dispatch(agent: str, message: str, **_kwargs) -> str:
+            return "dispatch_error: connection reset"
+
+        ch = _make_channel(dispatch_fn=dispatch_error_dispatch)
+        result = await ch.handle_message("u1", "hi")
+        assert result == ""
+
 
 # ── /steer command ────────────────────────────────────────────
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1556,9 +1556,11 @@ class TestWorkplaceCLICommands:
         assert result.exit_code == 0
         assert "Confirmed" in result.output
         assert "abc-nonce" in result.output
-        # URL should be the mesh confirm endpoint
+        # URL must be the dashboard proxy, not the raw mesh endpoint — the
+        # mesh endpoint requires bearer/internal + human-origin headers a
+        # bare CLI POST can't provide and 401s/403s (plan §8 #24).
         called_url = m.call_args.args[0]
-        assert "/mesh/pending/abc-nonce/confirm" in called_url
+        assert "/dashboard/api/workplace/pending/abc-nonce/confirm" in called_url
 
     def test_confirm_command_propagates_error(self):
         runner = CliRunner()
@@ -1573,7 +1575,7 @@ class TestWorkplaceCLICommands:
         assert result.exit_code == 0
         assert "Cancelled" in result.output
         called_url = m.call_args.args[0]
-        assert "/mesh/pending/abc/cancel" in called_url
+        assert "/dashboard/api/workplace/pending/abc/cancel" in called_url
 
     def test_cancel_command_includes_csrf_header(self):
         """The CLI commands must inject X-Requested-With so the dashboard

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -252,6 +252,85 @@ class TestCronDispatch:
         assert origin.channel == "cron"
         assert origin.user == ""
 
+    # ── Plan §8 #24 recon minor item: heartbeat dispatch errors must be
+    # rejected by the shared ``usable_agent_reply`` gate ─────────────────
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_dispatch_error_response_rejected_by_usable_gate(self):
+        """``RuntimeContext._create_cron_scheduler``'s ``heartbeat_dispatch``
+        used to return ``f"Error: {e}"`` on a transport failure — a string
+        ``usable_agent_reply`` does NOT reject, so a stopped lead's standup
+        cron could post the raw error into the team channel as its own
+        words. The producer must emit the ``dispatch_error:`` prefix the
+        gate already expects."""
+        from src.cli.runtime import RuntimeContext
+        from src.shared.utils import usable_agent_reply
+
+        ctx = RuntimeContext.__new__(RuntimeContext)
+        ctx.async_dispatch = AsyncMock(return_value="ok")
+        ctx.transport = MagicMock()
+        ctx.transport.request = AsyncMock(side_effect=RuntimeError("connection reset"))
+        ctx.blackboard = None
+        ctx.trace_store = None
+        ctx.event_bus = None
+        ctx.cfg = {}
+        ctx.health_monitor = None
+
+        ctx._create_cron_scheduler()
+        result = await ctx.cron_scheduler.heartbeat_dispatch_fn("agent1", "check in")
+
+        assert result["outcome"] == "error"
+        assert result["response"].startswith("dispatch_error:")
+        assert "connection reset" in result["response"]
+        assert usable_agent_reply(result["response"]) is False
+
+    # ── ``agent_pending_tasks`` wiring (plan §8 #24 prereq iii) ─────────
+
+    @pytest.mark.asyncio
+    async def test_pending_tasks_fn_reads_durable_tasks_store(self):
+        """``RuntimeContext._create_cron_scheduler`` wires a
+        ``pending_tasks_fn`` that counts non-terminal ``pending`` tasks
+        for ``agent`` from ``self._tasks_store_ref`` — the same durable
+        table ``hand_off``/``create_task`` write to."""
+        from src.cli.runtime import RuntimeContext
+        from src.host.orchestration import Tasks
+
+        ctx = RuntimeContext.__new__(RuntimeContext)
+        ctx.async_dispatch = AsyncMock(return_value="ok")
+        ctx.transport = MagicMock()
+        ctx.blackboard = None
+        ctx.trace_store = None
+        ctx.event_bus = None
+        ctx.cfg = {}
+        ctx.health_monitor = None
+
+        tasks_store = Tasks(db_path=":memory:")
+        tasks_store.create(creator="op", assignee="worker-1", title="do the thing")
+        ctx._tasks_store_ref = tasks_store
+
+        ctx._create_cron_scheduler()
+        assert ctx.cron_scheduler.pending_tasks_fn("worker-1") == 1
+        assert ctx.cron_scheduler.pending_tasks_fn("worker-2") == 0
+
+    @pytest.mark.asyncio
+    async def test_pending_tasks_fn_no_store_returns_zero(self):
+        """Missing ``_tasks_store_ref`` (store not yet wired) degrades to
+        0 — conservative, mirrors ``agent_standing_goals``."""
+        from src.cli.runtime import RuntimeContext
+
+        ctx = RuntimeContext.__new__(RuntimeContext)
+        ctx.async_dispatch = AsyncMock(return_value="ok")
+        ctx.transport = MagicMock()
+        ctx.blackboard = None
+        ctx.trace_store = None
+        ctx.event_bus = None
+        ctx.cfg = {}
+        ctx.health_monitor = None
+        # No ``_tasks_store_ref`` attribute at all.
+
+        ctx._create_cron_scheduler()
+        assert ctx.cron_scheduler.pending_tasks_fn("worker-1") == 0
+
 
 class TestHeartbeat:
     def setup_method(self):
@@ -296,6 +375,84 @@ class TestHeartbeat:
         signal_probes = [r for r in results if r.name == "pending_signals"]
         assert len(signal_probes) == 1
         assert signal_probes[0].triggered is False
+
+    # ── pending_durable_tasks probe (plan §8 #24 prereq iii) ────────────
+    #
+    # The legacy blackboard ``tasks/{agent}`` scan (probe 3, above) never
+    # sees a task ``hand_off``/``create_task`` write — those land only in
+    # the durable SQLite tasks table. ``pending_tasks_fn`` is the mesh-side
+    # seam (mirroring ``lead_reviews_fn``) that reads that table instead.
+
+    def test_pending_durable_tasks_probe_absent_when_unwired(self):
+        """No ``pending_tasks_fn`` configured → no probe entry at all
+        (back-compat: deployments that haven't wired the seam yet)."""
+        sched = CronScheduler(config_path=self.config_path)
+        results = sched._run_heartbeat_probes("test")
+        assert not any(r.name == "pending_durable_tasks" for r in results)
+
+    def test_pending_durable_tasks_probe_fires_on_pending_count(self):
+        sched = CronScheduler(
+            config_path=self.config_path,
+            pending_tasks_fn=lambda agent: 3,
+        )
+        results = sched._run_heartbeat_probes("test")
+        durable_probes = [r for r in results if r.name == "pending_durable_tasks"]
+        assert len(durable_probes) == 1
+        assert durable_probes[0].triggered is True
+        assert "3" in durable_probes[0].detail
+
+    def test_pending_durable_tasks_probe_quiet_when_zero(self):
+        sched = CronScheduler(
+            config_path=self.config_path,
+            pending_tasks_fn=lambda agent: 0,
+        )
+        results = sched._run_heartbeat_probes("test")
+        durable_probes = [r for r in results if r.name == "pending_durable_tasks"]
+        assert len(durable_probes) == 1
+        assert durable_probes[0].triggered is False
+
+    def test_pending_durable_tasks_probe_failure_degrades_quietly(self):
+        def _boom(agent):
+            raise RuntimeError("db locked")
+
+        sched = CronScheduler(config_path=self.config_path, pending_tasks_fn=_boom)
+        results = sched._run_heartbeat_probes("test")  # must not raise
+        durable_probes = [r for r in results if r.name == "pending_durable_tasks"]
+        assert durable_probes[0].triggered is False
+
+    def test_pending_durable_tasks_probe_coexists_with_blackboard_scan(self):
+        """Both sources stay wired: the legacy blackboard probe (still
+        exercised by template ``claim_task`` flows) and the durable-store
+        probe fire independently off the same tick."""
+        mock_bb = MagicMock()
+        mock_bb.list_by_prefix.side_effect = (
+            lambda prefix: [MagicMock(key="tasks/test/legacy", value={})]
+            if "tasks" in prefix else []
+        )
+        sched = CronScheduler(
+            config_path=self.config_path,
+            blackboard=mock_bb,
+            pending_tasks_fn=lambda agent: 1,
+        )
+        results = sched._run_heartbeat_probes("test")
+        names = {r.name for r in results if r.triggered}
+        assert "pending_tasks" in names
+        assert "pending_durable_tasks" in names
+
+    @pytest.mark.asyncio
+    async def test_pending_durable_tasks_probe_makes_tick_actionable(self):
+        """A durable-store hit alone (no blackboard, no activity) must
+        escalate the heartbeat to a real dispatch — the whole point of the
+        fix (a hand_off to a stopped agent trips the safety net)."""
+        dispatch = AsyncMock(return_value="handling the queued task")
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=dispatch,
+            pending_tasks_fn=lambda agent: 1,
+        )
+        job = sched.add_job(agent="test", schedule="every 15m", message="heartbeat", heartbeat=True)
+        result = await sched._execute_job(job)
+        dispatch.assert_called_once()
+        assert result == "handling the queued task"
 
     @pytest.mark.asyncio
     async def test_heartbeat_skips_when_clean_no_context(self):

--- a/tests/test_cron_heartbeats_reconcile.py
+++ b/tests/test_cron_heartbeats_reconcile.py
@@ -1,0 +1,73 @@
+"""Tests for ``RuntimeContext._reconcile_heartbeats`` (plan §8 #24 prereq
+ii).
+
+Regression guard: unlike its siblings ``_reconcile_work_summary_jobs``
+and ``_reconcile_standup_jobs`` (both already skip archived rows), this
+reconcile recreated a heartbeat cron job for an archived agent on every
+mesh boot — the archive endpoint (``_archive_agent_core``) already
+removed that job via ``cron_scheduler.remove_agent_jobs``, so recreating
+it fought the archive. Mirrors the ``TestReconcileStandupJobs`` pattern
+in ``tests/test_cron_standup.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+
+from src.cli.runtime import RuntimeContext
+from src.host.cron import CronScheduler
+
+
+class TestReconcileHeartbeats:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _stub(self, scheduler, cfg):
+        class _Stub:
+            cron_scheduler = scheduler
+
+        stub = _Stub()
+        stub.cfg = cfg
+        return stub
+
+    def test_creates_heartbeat_for_active_agent(self):
+        scheduler = CronScheduler(config_path=self.config_path)
+        cfg = {"agents": {"worker-1": {"role": "worker", "status": "active"}}}
+        RuntimeContext._reconcile_heartbeats(self._stub(scheduler, cfg))
+        assert scheduler.find_heartbeat_job("worker-1") is not None
+
+    def test_skips_archived_agent(self):
+        scheduler = CronScheduler(config_path=self.config_path)
+        cfg = {"agents": {"worker-archived": {"role": "worker", "status": "archived"}}}
+        RuntimeContext._reconcile_heartbeats(self._stub(scheduler, cfg))
+        assert scheduler.find_heartbeat_job("worker-archived") is None
+
+    def test_mixed_roster_only_active_gets_job(self):
+        scheduler = CronScheduler(config_path=self.config_path)
+        cfg = {
+            "agents": {
+                "worker-active": {"role": "worker", "status": "active"},
+                "worker-archived": {"role": "worker", "status": "archived"},
+            },
+        }
+        RuntimeContext._reconcile_heartbeats(self._stub(scheduler, cfg))
+        assert scheduler.find_heartbeat_job("worker-active") is not None
+        assert scheduler.find_heartbeat_job("worker-archived") is None
+
+    def test_legacy_row_missing_status_defaults_active(self):
+        scheduler = CronScheduler(config_path=self.config_path)
+        cfg = {"agents": {"worker-legacy": {"role": "worker"}}}
+        RuntimeContext._reconcile_heartbeats(self._stub(scheduler, cfg))
+        assert scheduler.find_heartbeat_job("worker-legacy") is not None
+
+    def test_no_cron_scheduler_is_a_noop(self):
+        class _Stub:
+            cron_scheduler = None
+            cfg = {"agents": {"worker-1": {"status": "active"}}}
+
+        RuntimeContext._reconcile_heartbeats(_Stub())  # must not raise

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5223,6 +5223,21 @@ class TestDashboardOriginStamp:
 # === Task 9 — Workplace tab + pending action review ===
 
 
+class TestPendingActionsDeadKwargRemoved:
+    """Plan §8 #24 recon minor item: ``create_dashboard_router`` accepted a
+    ``pending_actions`` kwarg that was never read in the router body — the
+    dashboard proxies to the mesh's ``/mesh/pending*`` endpoints instead
+    (enforcing the operator-or-internal gate mesh-side). Regression guard
+    against the dead parameter reappearing."""
+
+    def test_signature_has_no_pending_actions_param(self):
+        import inspect
+
+        from src.dashboard.server import create_dashboard_router
+
+        assert "pending_actions" not in inspect.signature(create_dashboard_router).parameters
+
+
 class TestWorkplaceTabRoutes:
     """Verify the new /api/workplace/* endpoints respond with the right
     shape for both the empty-state path and the store-attached path
@@ -5236,11 +5251,14 @@ class TestWorkplaceTabRoutes:
         from src.host.orchestration import Tasks
         from src.host.pending_actions import PendingActions
         self.tasks_store = Tasks(db_path=os.path.join(self._tmpdir, "tasks.db"))
+        # NOT passed into ``create_dashboard_router`` — the router never
+        # accepted a ``pending_actions`` kwarg for reading (removed as a
+        # dead parameter, plan §8 #24); it's used directly by
+        # ``_patch_pending_proxy`` below to stub the loopback proxy calls.
         self.pending_actions = PendingActions(
             db_path=os.path.join(self._tmpdir, "pa.db"),
         )
         self.components["tasks_store"] = self.tasks_store
-        self.components["pending_actions"] = self.pending_actions
 
     def teardown_method(self):
         try:
@@ -6708,6 +6726,44 @@ class TestDashboardChatPrioritySteerLane:
             "/dashboard/api/agents/alpha/chat", json={"message": "hi"},
         )
         assert resp.status_code == 502
+
+    def test_chat_silent_sentinel_becomes_human_readable(self):
+        """Plan §8 #24 recon minor item: a stopped/unresponsive agent's
+        ``__SILENT__`` sentinel must never leak raw into the dashboard
+        chat response — the operator would see a literal internal token."""
+        from src.shared.types import SILENT_REPLY_TOKEN
+
+        self.components["lane_manager"].deliver_chat = AsyncMock(
+            return_value=SILENT_REPLY_TOKEN,
+        )
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "hi"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()["response"]
+        assert body != SILENT_REPLY_TOKEN
+        assert SILENT_REPLY_TOKEN not in body
+
+    def test_chat_no_response_marker_becomes_human_readable(self):
+        self.components["lane_manager"].deliver_chat = AsyncMock(
+            return_value="(no response)",
+        )
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "hi"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response"] != "(no response)"
+
+    def test_chat_dispatch_error_prefix_becomes_human_readable(self):
+        self.components["lane_manager"].deliver_chat = AsyncMock(
+            return_value="dispatch_error: connection reset",
+        )
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat", json={"message": "hi"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()["response"]
+        assert not body.startswith("dispatch_error:")
 
 
 class TestDashboardChatStreamBusyAwareFork:


### PR DESCRIPTION
Phase-5 Unit 0 (plan §8 #24 prereqs i–iii + the U0 recon minor items; see the Phase-5 landed entry in docs/plans/2026-07-04-agent-employee-platform-architecture.md):

1. Boot no longer resurrects archived agents — `_start_agents()` skips `status=archived` (no container start, no router/transport/health registration); mirrors the sibling reconciles.
2. `_reconcile_heartbeats()` gains the archived filter its siblings already have.
3. Heartbeat pending-tasks probe now reads the DURABLE tasks store (new `pending_tasks_fn` seam wired to `Tasks.count_pending_for_assignee`) — `hand_off`/`create_task` never write the legacy blackboard `tasks/{agent}` prefix the old probe scanned, so a queued handoff to a stopped agent could never trip the safety net. Blackboard scan KEPT alongside (template `tasks/*` work-queue flows still populate it; pinned by test).
4. `__SILENT__`/"(no response)"/`dispatch_error:` shapes no longer leak to humans: channels suppress them (empty reply), dashboard chat substitutes a readable fallback — both via the shared `usable_agent_reply` gate.
5. `heartbeat_dispatch` failure strings now carry the `dispatch_error:` prefix the reply gate already rejects (stops a stopped lead's standup posting raw errors into the team channel).
6. CLI `openlegion confirm`/`cancel` route through the dashboard pending proxy (the bare mesh POST could never pass the operator-or-internal + human-origin gates).
7. Stale approvals-UI comments corrected (queue lives in the Work-tab Needs-you panel + inline chat card; the System>Operator card was removed in #1044).
8. Dead `pending_actions` kwarg removed from `create_dashboard_router`.

13 files, +559/−30, incl. 2 new test files + regression tests per fix. Touched suites: 1143 passed, 1 failed = the known pre-existing TelegramStop ordering flake (reproduced on clean main). Full local suite gate runs before merge.