### PR TITLE
feat(host): Phase-5 U1 — durable per-agent track record ledger (§8 #18)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1956,6 +1956,10 @@ class RuntimeContext:
             tasks_store=getattr(app, "tasks_store", None),
             help_requests_store=getattr(app, "help_requests_store", None),
             summaries_store=getattr(app, "summaries_store", None),
+            # Durable per-agent track record (plan §8 #18) — same
+            # getattr(app, ...) injection pattern as summaries_store
+            # above (the store is constructed inside create_mesh_app).
+            track_record_store=getattr(app, "track_record_store", None),
             connector_store=self.connector_store,
             mcp_gateway=self.mcp_gateway,
             intent_store=self.intent_store,

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -720,6 +720,13 @@ def create_dashboard_router(
     # team_id) -> None`` — fire-and-forget (schedules its own background
     # task; never awaited here). Optional for the same reason.
     onboarding_wake: Any = None,
+    # Durable per-agent track record (plan §8 #18). The runtime passes
+    # the same instance the mesh app holds (``getattr(app,
+    # "track_record_store", None)``, mirroring ``summaries_store``
+    # above). Optional so existing dashboard tests keep working — the
+    # human-path write points below no-op (via ``record_best_effort``)
+    # when absent.
+    track_record_store: Any = None,
 ) -> APIRouter:
     """Create the dashboard FastAPI router."""
     if teams_store is None:
@@ -8621,7 +8628,7 @@ def create_dashboard_router(
                 "feedback is required for rating='rework'",
             )
         try:
-            return summaries_store.set_rating(
+            result = summaries_store.set_rating(
                 summary_id,
                 rating,
                 feedback or None,
@@ -8633,6 +8640,23 @@ def create_dashboard_router(
             raise HTTPException(409, str(e))
         except ValueError as e:
             raise HTTPException(400, str(e))
+        # Durable track record (plan §8 #18) — this is the HUMAN path
+        # (dashboard rating UI), so rater_kind is "human": counts at full
+        # weight in earned-autonomy scoring. solo scope maps to a single
+        # agent_id; team scope has no single rated agent.
+        from src.host.track_record import record_best_effort
+
+        record_best_effort(
+            track_record_store,
+            source="summary_rating",
+            ref_id=summary_id,
+            outcome=rating,
+            rater_kind="human",
+            agent_id=result["scope_id"] if result.get("scope_kind") == "solo" else None,
+            team_id=result["scope_id"] if result.get("scope_kind") == "team" else None,
+            rated_by="operator",
+        )
+        return result
 
     @api_router.get("/api/workplace/goals")
     async def api_workplace_goals() -> dict:
@@ -9256,6 +9280,21 @@ def create_dashboard_router(
         )
         if push_status:
             result["feedback_push"] = push_status
+        # Durable track record (plan §8 #18) — this is the HUMAN path
+        # (dashboard outcome UI), so rater_kind is "human": counts at
+        # full weight in earned-autonomy scoring.
+        from src.host.track_record import record_best_effort
+
+        record_best_effort(
+            track_record_store,
+            source="task_outcome",
+            ref_id=task_id,
+            outcome=outcome,
+            rater_kind="human",
+            agent_id=updated.get("assignee"),
+            team_id=updated.get("team_id"),
+            rated_by="operator",
+        )
         if outcome == "rework":
             try:
                 rework = tasks_store.create_rework_task(

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -841,6 +841,21 @@ def create_mesh_app(
     )
     app.summaries_store = summaries_store  # exposed for tests/dashboard
 
+    # Durable per-agent track record (plan §8 #18) — an append-only
+    # ledger of task-outcome / summary-rating / drive-review events,
+    # written host-side at rating time so history survives the 90d/30d
+    # reap on the two sources it's assembled from. NEVER reaped itself
+    # (see src/host/track_record.py). ``record_best_effort`` is the
+    # shared best-effort writer every write point below calls.
+    from src.host.track_record import AUTONOMY_RATER_KINDS, TrackRecordStore, record_best_effort
+
+    _track_record_db_path = os.environ.get(
+        "OPENLEGION_TRACK_RECORD_DB",
+        "data/track_record.db",
+    )
+    track_record_store = TrackRecordStore(db_path=_track_record_db_path)
+    app.track_record_store = track_record_store  # exposed for tests/dashboard
+
     # Durable verbatim-intent store (Phase 2, session observability).
     # Instantiated in cli/runtime and passed in; attached here so the
     # Phase 3 read endpoints / reader can reach it off the app.
@@ -6598,6 +6613,42 @@ def create_mesh_app(
             raise HTTPException(404, f"Review '{review_id}' not found for team '{team_id}'")
         return review
 
+    def _record_drive_review_outcome(
+        team_id: str, review_id: str, resolved: dict, resolution: str, resolver: str,
+    ) -> None:
+        """Durable track record write (plan §8 #18) for a merge/reject.
+
+        agent_id is the review AUTHOR (submitter); rater_kind is
+        "human" — today's only path to merge/reject is operator-or-
+        internal (``_require_operator_or_internal``), so every
+        resolution here is a human-executed or internally-confirmed
+        action. details_json carries the lead's advisory verdict
+        alongside the resolution so ``pair_trust`` can later measure
+        (lead, submitter) trust for kernel-executed auto-merge (§8 #20).
+        """
+        try:
+            team = teams_store.get_team(team_id) or {}
+        except Exception:
+            team = {}
+        record_best_effort(
+            track_record_store,
+            source="drive_review",
+            ref_id=review_id,
+            outcome=resolution,
+            rater_kind="human",
+            agent_id=resolved.get("author"),
+            team_id=team_id,
+            rated_by=resolver,
+            details={
+                "branch": resolved.get("branch"),
+                "lead_agent_id": team.get("lead_agent_id"),
+                "lead_verdict": resolved.get("lead_verdict"),
+                "lead_verdict_at": resolved.get("lead_verdict_at"),
+                "resolution": resolution,
+                "resolved_by": resolver,
+            },
+        )
+
     @app.post("/mesh/teams/{team_id}/drive/reviews/{review_id}/merge")
     async def drive_merge_review(team_id: str, review_id: str, request: Request) -> dict:
         """Integrate a reviewed branch into main (operator-or-internal).
@@ -6681,6 +6732,7 @@ def create_mesh_app(
             after_value=commit,
             provenance="user",
         )
+        _record_drive_review_outcome(team_id, review_id, resolved, "merged", caller)
         return {"merged": True, "review": resolved, "merge_commit": commit}
 
     @app.post("/mesh/teams/{team_id}/drive/reviews/{review_id}/reject")
@@ -6704,6 +6756,7 @@ def create_mesh_app(
             after_value=review_id,
             provenance="user",
         )
+        _record_drive_review_outcome(team_id, review_id, resolved, "rejected", caller)
         return {"rejected": True, "review": resolved}
 
     @app.post("/mesh/teams/{team_id}/drive/reviews/{review_id}/verdict")
@@ -8584,7 +8637,7 @@ def create_mesh_app(
                 SummaryNotFound,
             )
 
-            return summaries_store.set_rating(
+            result = summaries_store.set_rating(
                 summary_id,
                 rating,
                 feedback=sanitize_for_prompt(feedback) if feedback else None,
@@ -8596,6 +8649,21 @@ def create_mesh_app(
             raise HTTPException(409, str(e))
         except ValueError as e:
             raise HTTPException(400, str(e))
+        # Durable track record (plan §8 #18) — this is the operator-AGENT
+        # path (mesh-reachable), so rater_kind is "operator_agent" (the
+        # rating-trust rule excludes it from autonomy scoring). solo scope
+        # maps to a single agent_id; team scope has no single rated agent.
+        record_best_effort(
+            track_record_store,
+            source="summary_rating",
+            ref_id=summary_id,
+            outcome=rating,
+            rater_kind="operator_agent",
+            agent_id=result["scope_id"] if result.get("scope_kind") == "solo" else None,
+            team_id=result["scope_id"] if result.get("scope_kind") == "team" else None,
+            rated_by=caller,
+        )
+        return result
 
     # === Operator product surface (Task 7) — read tools ===
     #
@@ -9166,6 +9234,22 @@ def create_mesh_app(
                 logger.debug("agent bundle: workspace fetch for %s failed: %s", agent_id, e)
                 workspace = None
 
+        # Durable track record (plan §8 #18) — the ledger the two reaped
+        # sources (tasks/work_summaries) feed at rating time. None-guarded
+        # best-effort like ``workspace`` above: the store is always wired
+        # in normal boot, but a standalone/test construction may omit it,
+        # and a bundle build must never fail because of it.
+        track_record: dict | None = None
+        if track_record_store is not None:
+            try:
+                track_record = {
+                    "counts": track_record_store.counts_for_agent(agent_id),
+                    "recent": track_record_store.recent_events(agent_id, limit=20),
+                }
+            except Exception as e:
+                logger.warning("agent bundle: track record read for %s failed: %s", agent_id, e)
+                track_record = None
+
         return {
             "bundle_version": 1,
             "agent_id": agent_id,
@@ -9177,6 +9261,7 @@ def create_mesh_app(
             # C.3-b) — ``None`` when unset, matching ``workspace``'s
             # optional-section style.
             "goals": teams_store.get_agent_goals(agent_id),
+            "track_record": track_record,
         }
 
     @app.get("/mesh/agents/{agent_id}/export")
@@ -9197,6 +9282,44 @@ def create_mesh_app(
         if agent_cfg is None:
             raise HTTPException(404, f"Agent '{agent_id}' not found")
         return await _build_agent_bundle(agent_id, agent_cfg)
+
+    @app.get("/mesh/agents/{agent_id}/track-record")
+    async def get_agent_track_record(agent_id: str, request: Request) -> dict:
+        """Read an agent's durable track record (plan §8 #18).
+
+        Self-or-operator-or-internal — mirrors the standing-goals read
+        gate (``get_agent_goals_endpoint``). ``counts`` covers every
+        rater kind; ``autonomy_counts`` is restricted to
+        ``rater_kinds=("human", "system")`` — the rating-trust rule:
+        operator-agent ratings must never inflate the autonomy ladder
+        even though they're visible in ``counts`` and still feed
+        ``feedback_push`` learning.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != agent_id and not _caller_is_operator(caller, request) and not _is_internal_caller(request):
+            _record_denial(
+                "permission",
+                caller=caller,
+                target=agent_id,
+                gate="track_record:read",
+            )
+            raise HTTPException(
+                403,
+                "Track record is readable by the agent itself or the operator only",
+            )
+        from src.cli.config import _load_config
+
+        cfg = _load_config()
+        if cfg.get("agents", {}).get(agent_id) is None:
+            raise HTTPException(404, f"Agent '{agent_id}' not found")
+        return {
+            "agent_id": agent_id,
+            "counts": track_record_store.counts_for_agent(agent_id),
+            "autonomy_counts": track_record_store.counts_for_agent(
+                agent_id, rater_kinds=AUTONOMY_RATER_KINDS,
+            ),
+            "recent": track_record_store.recent_events(agent_id, limit=20),
+        }
 
     # ── Offboarding-with-handover (plan §8 #15) ───────────────────
     #
@@ -10087,6 +10210,20 @@ def create_mesh_app(
         )
         if push_status:
             result["feedback_push"] = push_status
+        # Durable track record (plan §8 #18) — this is the operator-AGENT
+        # path (mesh-reachable), so rater_kind is "operator_agent": the
+        # rating-trust rule excludes it from autonomy scoring even though
+        # it's counted here and still feeds feedback_push above.
+        record_best_effort(
+            track_record_store,
+            source="task_outcome",
+            ref_id=task_id,
+            outcome=outcome,
+            rater_kind="operator_agent",
+            agent_id=updated.get("assignee"),
+            team_id=updated.get("team_id"),
+            rated_by="operator",
+        )
         if outcome == "rework":
             try:
                 rework = tasks_store.create_rework_task(

--- a/src/host/track_record.py
+++ b/src/host/track_record.py
@@ -1,0 +1,335 @@
+"""TrackRecordStore — durable, append-only per-agent outcome ledger.
+
+Plan §8 #18 (docs/plans/2026-07-04-agent-employee-platform-architecture.md):
+a recon correction on §6's "raw material already collected, just
+composed" — that claim is wrong on DURABILITY. Rated ``tasks`` rows
+reap at 90 days (``orchestration.py``) and ``work_summaries`` at 30
+(``summaries.py``); a live-query composition over either source would
+silently lose history the moment a row ages out. This store is the
+durable Layer-3 ledger those two (and Team-Drive-review resolution)
+feed AT RATING TIME: one ``outcome_events`` row appended host-side, in
+the same code paths that already call ``feedback_push`` (task
+``set_outcome``, summary ``set_rating``) plus the drive-review
+merge/reject paths. APPEND-ONLY, NEVER REAPED — no ``retention_until``
+column, no reap method — that durability is precisely what tells it
+apart from the two reaped sources it's assembled from.
+
+Rating-trust rule (load-bearing, pinned by test): earned-autonomy
+scoring (plan §8 #19) must use only HUMAN ratings (plus objective
+``system`` signals) at full weight. Operator-*agent* ratings — the
+internal mesh paths an agent's own heartbeat/tool call can reach —
+are EXCLUDED from autonomy scoring (agents grading agents must not
+feed the trust ladder) while still counted here and still feeding
+``feedback_push`` learning. Callers that need the autonomy-safe view
+pass ``rater_kinds=AUTONOMY_RATER_KINDS`` to :meth:`counts_for_agent`.
+
+Enum values are NEVER unified across sources — task outcomes
+(accepted/rework/rejected/acknowledged), summary ratings
+(accepted/acknowledged/rework), and drive-review resolutions
+(merged/rejected) each keep their own raw vocabulary. Counts are
+reported keyed by ``(source, outcome)`` — no invented numeric score
+(none exists anywhere else in the codebase either).
+
+Storage follows the canonical-v1 pattern (mirrors ``ThreadStore``): one
+``executescript``, no lazy ``ALTER`` chains, ``PRAGMA user_version = 1``,
+WAL + ``busy_timeout``, env override ``OPENLEGION_TRACK_RECORD_DB``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from src.shared.utils import dumps_safe, setup_logging
+
+logger = setup_logging("host.track_record")
+
+VALID_SOURCES: frozenset[str] = frozenset({"task_outcome", "summary_rating", "drive_review"})
+
+# Rater-kind vocabulary. ``human`` = a real user, via the dashboard's
+# human-driven surfaces; ``operator_agent`` = the same rating recorded
+# through a mesh-reachable (agent-callable) path — the operator trust
+# tier is still an agent identity that can act from its own heartbeat;
+# ``system`` = a deterministic mesh-computed signal (reserved for a
+# future objective-signal writer). See the module docstring's
+# rating-trust rule for why the split exists and matters.
+VALID_RATER_KINDS: frozenset[str] = frozenset({"human", "operator_agent", "system"})
+
+# The rating-trust rule, pinned: only these rater kinds count toward
+# earned-autonomy scoring (plan §8 #19 reads counts filtered to this).
+AUTONOMY_RATER_KINDS: tuple[str, ...] = ("human", "system")
+
+# Hard cap on details_json size so a runaway payload can't bloat the
+# durable ledger (mirrors the summaries/threads store caps).
+MAX_DETAILS_BYTES = 8192
+
+
+class TrackRecordStore:
+    """SQLite-backed, append-only outcome ledger. Never reaped.
+
+    Disk-backed access opens a fresh WAL connection per operation;
+    ``:memory:`` keeps a single shared connection behind a lock
+    (mirrors ``ThreadStore``).
+    """
+
+    _EVENT_COLS = (
+        "id, agent_id, team_id, source, ref_id, outcome, "
+        "rater_kind, rated_by, details_json, created_at"
+    )
+
+    def __init__(self, db_path: str = "data/track_record.db") -> None:
+        self.db_path = db_path
+        self._shared_conn: sqlite3.Connection | None = None
+        self._mem_lock = threading.Lock()
+        if db_path == ":memory:":
+            self._shared_conn = sqlite3.connect(":memory:", isolation_level=None, check_same_thread=False)
+            self._shared_conn.execute("PRAGMA busy_timeout=30000")
+        else:
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def close(self) -> None:
+        if self._shared_conn is not None:
+            self._shared_conn.close()
+            self._shared_conn = None
+
+    @contextmanager
+    def _conn(self):
+        if self._shared_conn is not None:
+            with self._mem_lock:
+                yield self._shared_conn
+            return
+        conn = sqlite3.connect(self.db_path, isolation_level=None)
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            conn.execute("PRAGMA journal_mode=WAL")
+            yield conn
+        finally:
+            conn.close()
+
+    def _init_schema(self) -> None:
+        # Canonical schema v1 — exactly one shape, no lazy ALTER chains.
+        # Deliberately NO retention_until column and NO reap method: this
+        # table is append-only for the life of the deployment (see module
+        # docstring — that durability is the whole reason this store
+        # exists alongside the two reaped sources it's assembled from).
+        with self._conn() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS outcome_events (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    agent_id     TEXT,
+                    team_id      TEXT,
+                    source       TEXT NOT NULL,
+                    ref_id       TEXT NOT NULL,
+                    outcome      TEXT NOT NULL,
+                    rater_kind   TEXT NOT NULL,
+                    rated_by     TEXT,
+                    details_json TEXT,
+                    created_at   REAL NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_outcome_events_agent
+                    ON outcome_events(agent_id, created_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_outcome_events_ref
+                    ON outcome_events(source, ref_id);
+
+                PRAGMA user_version = 1;
+                """
+            )
+
+    @staticmethod
+    def _row_to_dict(row: tuple) -> dict:
+        details = None
+        if row[8]:
+            try:
+                details = json.loads(row[8])
+            except (ValueError, TypeError):
+                details = {"_decode_error": True}
+        return {
+            "id": row[0],
+            "agent_id": row[1],
+            "team_id": row[2],
+            "source": row[3],
+            "ref_id": row[4],
+            "outcome": row[5],
+            "rater_kind": row[6],
+            "rated_by": row[7],
+            "details": details,
+            "created_at": row[9],
+        }
+
+    # ── append ───────────────────────────────────────────────────
+
+    def record(
+        self,
+        *,
+        source: str,
+        ref_id: str,
+        outcome: str,
+        rater_kind: str,
+        agent_id: str | None = None,
+        team_id: str | None = None,
+        rated_by: str | None = None,
+        details: dict | None = None,
+    ) -> dict:
+        """Append one outcome event and return it.
+
+        Raises ``ValueError`` on a malformed call — write-site callers
+        are expected to go through :func:`record_best_effort` (or an
+        equivalent broad try/except) since a ledger write must NEVER
+        fail the source operation (task outcome / summary rating /
+        drive resolution) that triggered it.
+        """
+        if source not in VALID_SOURCES:
+            raise ValueError(f"source must be one of {sorted(VALID_SOURCES)}, got {source!r}")
+        if rater_kind not in VALID_RATER_KINDS:
+            raise ValueError(f"rater_kind must be one of {sorted(VALID_RATER_KINDS)}, got {rater_kind!r}")
+        if not ref_id:
+            raise ValueError("ref_id is required")
+        if not outcome:
+            raise ValueError("outcome is required")
+        if agent_id is None and team_id is None:
+            raise ValueError("at least one of agent_id/team_id is required")
+        details_json = None
+        if details is not None:
+            details_json = dumps_safe(details)
+            if len(details_json.encode("utf-8", errors="replace")) > MAX_DETAILS_BYTES:
+                # A truncated JSON document is worse than no document —
+                # replace the whole payload with a marker (mirrors
+                # ThreadStore.post_message's oversized-payload handling).
+                details_json = dumps_safe({"truncated": True})
+        now = time.time()
+        with self._conn() as conn:
+            cur = conn.execute(
+                "INSERT INTO outcome_events "
+                "(agent_id, team_id, source, ref_id, outcome, rater_kind, rated_by, details_json, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (agent_id, team_id, source, ref_id, outcome, rater_kind, rated_by, details_json, now),
+            )
+            event_id = cur.lastrowid
+        return self.get(event_id)  # type: ignore[return-value]
+
+    # ── reads ────────────────────────────────────────────────────
+
+    def get(self, event_id: int) -> dict | None:
+        with self._conn() as conn:
+            row = conn.execute(
+                f"SELECT {self._EVENT_COLS} FROM outcome_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def counts_for_agent(
+        self,
+        agent_id: str,
+        *,
+        rater_kinds: tuple[str, ...] | None = None,
+    ) -> dict[str, dict[str, int]]:
+        """Counts keyed ``source -> outcome -> count`` for one agent.
+
+        ``rater_kinds`` restricts to those rater kinds when given — the
+        rating-trust rule: pass :data:`AUTONOMY_RATER_KINDS` for the
+        autonomy-safe view. ``None`` (default) counts every rater kind.
+        """
+        clauses = ["agent_id = ?"]
+        params: list[Any] = [agent_id]
+        if rater_kinds is not None:
+            placeholders = ",".join("?" for _ in rater_kinds)
+            clauses.append(f"rater_kind IN ({placeholders})")
+            params.extend(rater_kinds)
+        where = " AND ".join(clauses)
+        with self._conn() as conn:
+            rows = conn.execute(
+                f"SELECT source, outcome, COUNT(*) FROM outcome_events "
+                f"WHERE {where} GROUP BY source, outcome",
+                params,
+            ).fetchall()
+        counts: dict[str, dict[str, int]] = {}
+        for source, outcome, n in rows:
+            counts.setdefault(source, {})[outcome] = n
+        return counts
+
+    def recent_events(self, agent_id: str, limit: int = 20) -> list[dict]:
+        """Newest-first events for one agent, hard-capped at 200."""
+        limit = max(1, min(int(limit), 200))
+        with self._conn() as conn:
+            rows = conn.execute(
+                f"SELECT {self._EVENT_COLS} FROM outcome_events "
+                "WHERE agent_id = ? ORDER BY created_at DESC, id DESC LIMIT ?",
+                (agent_id, limit),
+            ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
+    def pair_trust(self, lead_agent_id: str, submitter_agent_id: str) -> dict:
+        """Auto-merge trust signal for a (lead, submitter) pair (§8 #20).
+
+        Scans this agent's ``drive_review`` events for ones whose
+        ``details_json`` carries ``lead_agent_id`` == ``lead_agent_id``
+        and ``lead_verdict == "approve"`` — i.e. reviews this lead
+        advisory-approved, authored by ``submitter_agent_id``. Returns
+        the count of human-executed merges of lead-approved reviews,
+        the count of rejects-after-approve, and the qualifying set's
+        most recent event timestamp — the raw inputs the earned-
+        autonomy trust floor / decay policy (§8 #19/#20) reads to decide
+        whether the kernel may auto-merge for this pair.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                f"SELECT {self._EVENT_COLS} FROM outcome_events "
+                "WHERE source = 'drive_review' AND agent_id = ? "
+                "ORDER BY created_at DESC, id DESC",
+                (submitter_agent_id,),
+            ).fetchall()
+        merged = 0
+        rejected_after_approve = 0
+        last_event_at: float | None = None
+        for r in rows:
+            event = self._row_to_dict(r)
+            details = event.get("details") or {}
+            if details.get("lead_agent_id") != lead_agent_id:
+                continue
+            if details.get("lead_verdict") != "approve":
+                continue
+            if last_event_at is None:
+                # Rows are newest-first — the first qualifying row IS
+                # the most recent one for this pair.
+                last_event_at = event["created_at"]
+            if event["outcome"] == "merged":
+                merged += 1
+            elif event["outcome"] == "rejected":
+                rejected_after_approve += 1
+        return {
+            "lead_agent_id": lead_agent_id,
+            "submitter_agent_id": submitter_agent_id,
+            "merged": merged,
+            "rejected_after_approve": rejected_after_approve,
+            "last_event_at": last_event_at,
+        }
+
+
+def record_best_effort(store: "TrackRecordStore | None", **kwargs: Any) -> None:
+    """Append an outcome event, swallowing every error.
+
+    Call-site contract (plan §8 #18): a ledger write failure must NEVER
+    fail the source operation (task outcome / summary rating / drive
+    resolution) that triggered it. Every write point in ``server.py`` /
+    ``dashboard/server.py`` calls this instead of ``store.record`` so
+    that contract holds without repeating a try/except at each site.
+    A ``None`` store (standalone constructions that didn't wire one) is
+    silently a no-op — the ledger is best-effort infrastructure, not a
+    hard dependency of the operations it observes.
+    """
+    if store is None:
+        return
+    try:
+        store.record(**kwargs)
+    except Exception as e:
+        logger.warning(
+            "track record event write failed (source=%s ref_id=%s): %s",
+            kwargs.get("source"), kwargs.get("ref_id"), e,
+        )

--- a/tests/test_agent_export.py
+++ b/tests/test_agent_export.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
 
 
-def _build_app(tmp_path, monkeypatch, *, transport=None, cron_scheduler=None):
+def _build_app(tmp_path, monkeypatch, *, transport=None, cron_scheduler=None, auth_tokens=None):
     import src.cli.config as cli_config
     from src.host.mesh import Blackboard, MessageRouter, PubSub
     from src.host.permissions import PermissionMatrix
@@ -22,6 +22,10 @@ def _build_app(tmp_path, monkeypatch, *, transport=None, cron_scheduler=None):
         "_load_config",
         lambda: {"agents": {"scout": {"role": "researcher", "model": "openai/gpt-4o-mini"}}},
     )
+    # Isolate the track-record ledger DB into tmp_path — otherwise every
+    # test file that doesn't override it shares one on-disk
+    # data/track_record.db and count assertions get flaky.
+    monkeypatch.setenv("OPENLEGION_TRACK_RECORD_DB", str(tmp_path / "track_record.db"))
 
     perms = PermissionMatrix()
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
@@ -33,7 +37,7 @@ def _build_app(tmp_path, monkeypatch, *, transport=None, cron_scheduler=None):
         pubsub=pubsub,
         router=router,
         permissions=perms,
-        auth_tokens={"operator": "tok-op"},
+        auth_tokens=auth_tokens or {"operator": "tok-op"},
         cron_scheduler=cron_scheduler,
         transport=transport,
     )
@@ -65,6 +69,8 @@ def test_export_bundles_config_permissions_cron(tmp_path, monkeypatch):
         assert body["workspace"] is None
         # no standing goals set → null, matching the optional-section style
         assert body["goals"] is None
+        # no track record events → empty (but present) section (§8 #18)
+        assert body["track_record"] == {"counts": {}, "recent": []}
     finally:
         bb.close()
 
@@ -141,5 +147,129 @@ def test_export_requires_operator(tmp_path, monkeypatch):
             headers={"Authorization": "Bearer tok-worker"},
         )
         assert resp.status_code in (401, 403), resp.text
+    finally:
+        bb.close()
+
+
+# =============================================================================
+# Durable track record (plan §8 #18) — Personnel-File section
+# =============================================================================
+
+
+def test_export_includes_track_record_counts_and_recent(tmp_path, monkeypatch):
+    app, bb = _build_app(tmp_path, monkeypatch)
+    try:
+        app.track_record_store.record(
+            source="task_outcome", ref_id="task_1", outcome="accepted",
+            rater_kind="human", agent_id="scout", rated_by="operator",
+        )
+        app.track_record_store.record(
+            source="task_outcome", ref_id="task_2", outcome="rework",
+            rater_kind="operator_agent", agent_id="scout", rated_by="operator",
+        )
+        resp = TestClient(app).get("/mesh/agents/scout/export", headers=_OP)
+        assert resp.status_code == 200, resp.text
+        tr = resp.json()["track_record"]
+        assert tr["counts"] == {"task_outcome": {"accepted": 1, "rework": 1}}
+        assert len(tr["recent"]) == 2
+        assert tr["recent"][0]["ref_id"] == "task_2"  # newest first
+    finally:
+        bb.close()
+
+
+def test_export_track_record_absent_when_read_fails(tmp_path, monkeypatch):
+    """Bundle build must not fail when the store is unreachable — the
+    ``track_record`` section degrades to None (mirrors ``workspace``)."""
+    app, bb = _build_app(tmp_path, monkeypatch)
+    try:
+        monkeypatch.setattr(
+            app.track_record_store, "counts_for_agent",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("db gone")),
+        )
+        resp = TestClient(app).get("/mesh/agents/scout/export", headers=_OP)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["track_record"] is None
+    finally:
+        bb.close()
+
+
+# =============================================================================
+# GET /mesh/agents/{id}/track-record (plan §8 #18 read surface)
+# =============================================================================
+
+
+_SCOUT = {"Authorization": "Bearer tok-scout"}
+
+
+def test_track_record_endpoint_self_read_allowed(tmp_path, monkeypatch):
+    app, bb = _build_app(
+        tmp_path, monkeypatch, auth_tokens={"operator": "tok-op", "scout": "tok-scout"},
+    )
+    try:
+        app.track_record_store.record(
+            source="task_outcome", ref_id="task_1", outcome="accepted",
+            rater_kind="human", agent_id="scout", rated_by="operator",
+        )
+        resp = TestClient(app).get("/mesh/agents/scout/track-record", headers=_SCOUT)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["agent_id"] == "scout"
+        assert body["counts"] == {"task_outcome": {"accepted": 1}}
+        assert len(body["recent"]) == 1
+    finally:
+        bb.close()
+
+
+def test_track_record_endpoint_other_agent_403(tmp_path, monkeypatch):
+    app, bb = _build_app(
+        tmp_path, monkeypatch,
+        auth_tokens={"operator": "tok-op", "scout": "tok-scout", "writer": "tok-writer"},
+    )
+    try:
+        resp = TestClient(app).get(
+            "/mesh/agents/scout/track-record",
+            headers={"Authorization": "Bearer tok-writer"},
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        bb.close()
+
+
+def test_track_record_endpoint_operator_allowed(tmp_path, monkeypatch):
+    app, bb = _build_app(tmp_path, monkeypatch)
+    try:
+        resp = TestClient(app).get("/mesh/agents/scout/track-record", headers=_OP)
+        assert resp.status_code == 200, resp.text
+    finally:
+        bb.close()
+
+
+def test_track_record_endpoint_unknown_agent_404(tmp_path, monkeypatch):
+    app, bb = _build_app(tmp_path, monkeypatch)
+    try:
+        resp = TestClient(app).get("/mesh/agents/ghost/track-record", headers=_OP)
+        assert resp.status_code == 404, resp.text
+    finally:
+        bb.close()
+
+
+def test_track_record_endpoint_autonomy_counts_exclude_operator_agent(tmp_path, monkeypatch):
+    """Pins the rating-trust rule (plan §8 #18): an operator-agent-rated
+    event shows up in ``counts`` but never in ``autonomy_counts``."""
+    app, bb = _build_app(tmp_path, monkeypatch)
+    try:
+        app.track_record_store.record(
+            source="task_outcome", ref_id="task_1", outcome="accepted",
+            rater_kind="human", agent_id="scout", rated_by="operator",
+        )
+        app.track_record_store.record(
+            source="task_outcome", ref_id="task_2", outcome="accepted",
+            rater_kind="operator_agent", agent_id="scout", rated_by="operator",
+        )
+        resp = TestClient(app).get("/mesh/agents/scout/track-record", headers=_OP)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["counts"] == {"task_outcome": {"accepted": 2}}
+        assert body["autonomy_counts"] == {"task_outcome": {"accepted": 1}}
     finally:
         bb.close()

--- a/tests/test_dashboard_summaries_api.py
+++ b/tests/test_dashboard_summaries_api.py
@@ -18,6 +18,7 @@ from src.host.costs import CostTracker
 from src.host.mesh import Blackboard
 from src.host.summaries import WorkSummariesStore
 from src.host.traces import TraceStore
+from src.host.track_record import TrackRecordStore
 
 
 class _CSRFTestClient(TestClient):
@@ -55,6 +56,39 @@ def client(tmp_path):
     costs.close()
     traces.close()
     summaries.close()
+
+
+@pytest.fixture
+def client_with_track_record(tmp_path):
+    """Same wiring as ``client`` plus a real ``TrackRecordStore`` — a
+    separate fixture (rather than changing ``client``'s shape) so the
+    9 existing ``c, store = client`` call sites stay untouched."""
+    from src.dashboard.server import create_dashboard_router
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    summaries = WorkSummariesStore(":memory:")
+    track_record = TrackRecordStore(":memory:")
+
+    router = create_dashboard_router(
+        blackboard=bb,
+        health_monitor=None,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=None,
+        agent_registry={},
+        summaries_store=summaries,
+        track_record_store=track_record,
+    )
+    app = FastAPI()
+    app.include_router(router)
+    yield _CSRFTestClient(app), summaries, track_record
+    bb.close()
+    costs.close()
+    traces.close()
+    summaries.close()
+    track_record.close()
 
 
 def _seed(store, *, scope_id="content-seo", scope_kind="team", offset=0):
@@ -162,6 +196,37 @@ def test_rate_accepted_persists(client):
     rated = resp.json()
     assert rated["rating"] == "accepted"
     assert rated["rated_by"] == "operator"  # dashboard persona
+
+
+def test_rate_writes_track_record_event_as_human(client_with_track_record):
+    """Plan §8 #18: the dashboard rating endpoint is the HUMAN path —
+    its track-record write must be tagged ``rater_kind="human"``."""
+    c, store, track_record = client_with_track_record
+    row = _seed(store, scope_id="content-seo", scope_kind="team")
+    resp = c.post(
+        f"/dashboard/api/workplace/summaries/{row['id']}/rating",
+        json={"rating": "accepted"},
+    )
+    assert resp.status_code == 200, resp.text
+    with track_record._conn() as conn:
+        row_db = conn.execute(
+            "SELECT agent_id, team_id, source, outcome, rater_kind FROM outcome_events"
+        ).fetchone()
+    assert row_db == (None, "content-seo", "summary_rating", "accepted", "human")
+
+
+def test_rate_solo_scope_writes_agent_scoped_track_record_event(client_with_track_record):
+    c, store, track_record = client_with_track_record
+    row = _seed(store, scope_id="writer", scope_kind="solo")
+    resp = c.post(
+        f"/dashboard/api/workplace/summaries/{row['id']}/rating",
+        json={"rating": "accepted"},
+    )
+    assert resp.status_code == 200, resp.text
+    events = track_record.recent_events("writer")
+    assert len(events) == 1
+    assert events[0]["rater_kind"] == "human"
+    assert events[0]["team_id"] is None
 
 
 def test_rate_rework_with_feedback(client):

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -61,6 +61,11 @@ def v2_app(tmp_path, monkeypatch):
     server_module = _reload_server(
         monkeypatch, tasks_db=str(tmp_path / "tasks.db"),
     )
+    # Pin the track-record ledger DB into tmp_path too — otherwise every
+    # test in this module (and every OTHER test file that doesn't
+    # override it) shares one on-disk data/track_record.db and accrues
+    # rows across the whole test session, making count assertions flaky.
+    monkeypatch.setenv("OPENLEGION_TRACK_RECORD_DB", str(tmp_path / "track_record.db"))
     perms_map = {
         "operator": {"can_route_tasks": True},
         "scout":    {"can_route_tasks": True, "can_message": ["analyst", "operator"]},
@@ -80,6 +85,7 @@ def v2_app(tmp_path, monkeypatch):
     yield app, server_module, tmp_path
     bb.close()
     monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    monkeypatch.delenv("OPENLEGION_TRACK_RECORD_DB", raising=False)
     importlib.reload(server_module)
 
 
@@ -1106,6 +1112,45 @@ async def test_outcome_endpoint_operator_accepts(v2_app):
         body = r.json()
         assert body["ok"] is True
         assert body["task"]["outcome"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_writes_track_record_event_as_operator_agent(v2_app):
+    """The mesh ``/mesh/tasks/{id}/outcome`` path is agent-reachable (plan
+    §8 #17's ``_require_operator_or_internal``) — its track-record write
+    (§8 #18) must be tagged ``rater_kind="operator_agent"`` so the
+    rating-trust rule can exclude it from autonomy scoring."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        tid = await _create_and_complete(c)
+        r = await c.post(
+            f"/mesh/tasks/{tid}/outcome",
+            json={"outcome": "accepted"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+    events = app.track_record_store.recent_events("analyst")
+    assert len(events) == 1
+    event = events[0]
+    assert event["source"] == "task_outcome"
+    assert event["ref_id"] == tid
+    assert event["outcome"] == "accepted"
+    assert event["rater_kind"] == "operator_agent"
+    # _create_and_complete's task creation doesn't set team_id explicitly
+    # (a bare create call), so the recorded event carries whatever the
+    # task row carries — None here, mirroring "assignee"'s team-agnostic
+    # source of truth (the task row, not team membership).
+    assert event["team_id"] is None
+    counts = app.track_record_store.counts_for_agent("analyst")
+    assert counts == {"task_outcome": {"accepted": 1}}
+    # Rating-trust rule: an operator-agent-rated event is excluded from
+    # the autonomy-safe view even though it's present in plain counts.
+    autonomy_counts = app.track_record_store.counts_for_agent(
+        "analyst", rater_kinds=("human", "system"),
+    )
+    assert autonomy_counts == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_summaries_api.py
+++ b/tests/test_summaries_api.py
@@ -41,6 +41,12 @@ def mesh_setup(tmp_path, monkeypatch):
     monkeypatch.setenv(
         "OPENLEGION_WORK_SUMMARIES_DB", str(tmp_path / "summaries.db"),
     )
+    # Pin the track-record ledger DB too (plan §8 #18) — otherwise this
+    # module's app shares data/track_record.db with every other test
+    # file that doesn't override it, making count assertions flaky.
+    monkeypatch.setenv(
+        "OPENLEGION_TRACK_RECORD_DB", str(tmp_path / "track_record.db"),
+    )
     server = _reload_server()
 
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
@@ -87,9 +93,11 @@ def mesh_setup(tmp_path, monkeypatch):
     costs.close()
     traces.close()
     app.summaries_store.close()
+    app.track_record_store.close()
     monkeypatch.delenv("OPENLEGION_TEAM_SCOPE_MODE", raising=False)
     monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
     monkeypatch.delenv("OPENLEGION_WORK_SUMMARIES_DB", raising=False)
+    monkeypatch.delenv("OPENLEGION_TRACK_RECORD_DB", raising=False)
     _reload_server()
 
 
@@ -363,6 +371,69 @@ async def test_operator_can_rate_summary(mesh_setup):
     assert rated["rating"] == "accepted"
     assert rated["feedback"] == "good"
     assert rated["rated_by"] == "operator"
+
+
+@pytest.mark.asyncio
+async def test_rate_team_summary_writes_track_record_event_team_scoped(mesh_setup):
+    """Plan §8 #18: a team-scoped rating has no single rated agent —
+    ``agent_id`` is None, ``team_id`` carries the scope. This is the
+    mesh (agent-reachable) path, so ``rater_kind`` is "operator_agent"."""
+    store = mesh_setup["store"]
+    now = time.time()
+    row = store.create(
+        scope_kind="team", scope_id="content-seo",
+        period_start=now - 100, period_end=now,
+        narrative_md="x", metrics={}, generated_by="operator",
+    )
+    app = mesh_setup["app"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            f"/mesh/work-summaries/{row['id']}/rating",
+            json={"rating": "accepted", "feedback": "good"},
+            headers=_hdr(mesh_setup["tokens"]["operator"]),
+        )
+    assert resp.status_code == 200, resp.text
+    events = app.track_record_store.recent_events("content-seo")
+    assert events == []  # team scope: nothing under the team's own "agent" bucket
+    counts = app.track_record_store.counts_for_agent("content-seo")
+    assert counts == {}
+    # Query by team_id directly via a raw event since counts_for_agent
+    # is agent-keyed; confirm the row landed with team_id set instead.
+    with app.track_record_store._conn() as conn:
+        row_db = conn.execute(
+            "SELECT agent_id, team_id, rater_kind FROM outcome_events WHERE source='summary_rating'"
+        ).fetchone()
+    assert row_db == (None, "content-seo", "operator_agent")
+
+
+@pytest.mark.asyncio
+async def test_rate_solo_summary_writes_track_record_event_agent_scoped(mesh_setup):
+    """Plan §8 #18: a solo-scoped rating's scope_id IS the agent id."""
+    store = mesh_setup["store"]
+    now = time.time()
+    row = store.create(
+        scope_kind="solo", scope_id="writer",
+        period_start=now - 100, period_end=now,
+        narrative_md="solo work", metrics={}, generated_by="operator",
+    )
+    app = mesh_setup["app"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            f"/mesh/work-summaries/{row['id']}/rating",
+            json={"rating": "accepted"},
+            headers=_hdr(mesh_setup["tokens"]["operator"]),
+        )
+    assert resp.status_code == 200, resp.text
+    events = app.track_record_store.recent_events("writer")
+    assert len(events) == 1
+    assert events[0]["source"] == "summary_rating"
+    assert events[0]["outcome"] == "accepted"
+    assert events[0]["rater_kind"] == "operator_agent"
+    assert events[0]["team_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_drive.py
+++ b/tests/test_team_drive.py
@@ -1349,6 +1349,81 @@ class TestReviewFlow:
             live_server, f"/mesh/teams/team-x/drive/reviews/{review['id']}/reject", "operator",
         ).status_code == 409
 
+    @_requires_merge_tree
+    def test_merge_writes_track_record_event_with_lead_verdict_details(
+        self, live_server, drive_env, tmp_path,
+    ):
+        """Plan §8 #18: a merge is a HUMAN-executed resolution (today's
+        only path to merge is operator-or-internal) — the durable event
+        carries the review author as agent_id and the lead's advisory
+        verdict in details_json so ``pair_trust`` (§8 #20) can later
+        measure (lead, submitter) trust for kernel-executed auto-merge."""
+        store = drive_env["store"]
+        store.set_lead("team-x", "member2")
+        self._push_branch(live_server, tmp_path, "feat-tr", "tr.md", "content\n")
+        review = self._post(
+            live_server, "/mesh/teams/team-x/drive/reviews", "member1",
+            {"branch": "feat-tr", "title": "tr"},
+        ).json()["review"]
+        verdict_resp = self._post(
+            live_server, f"/mesh/teams/team-x/drive/reviews/{review['id']}/verdict", "member2",
+            {"verdict": "approve", "note": "lgtm"},
+        )
+        assert verdict_resp.status_code == 200, verdict_resp.text
+        merge = self._post(
+            live_server, f"/mesh/teams/team-x/drive/reviews/{review['id']}/merge", "operator",
+        )
+        assert merge.status_code == 200, merge.text
+
+        events = drive_env["app"].track_record_store.recent_events("member1")
+        assert len(events) == 1
+        event = events[0]
+        assert event["source"] == "drive_review"
+        assert event["ref_id"] == review["id"]
+        assert event["outcome"] == "merged"
+        assert event["rater_kind"] == "human"
+        assert event["team_id"] == "team-x"
+        assert event["rated_by"] == "operator"
+        details = event["details"]
+        assert details["branch"] == "feat-tr"
+        assert details["lead_agent_id"] == "member2"
+        assert details["lead_verdict"] == "approve"
+        assert details["lead_verdict_at"] is not None
+        assert details["resolution"] == "merged"
+        assert details["resolved_by"] == "operator"
+
+        # pair_trust reads exactly this shape for the auto-merge trust floor.
+        pair = drive_env["app"].track_record_store.pair_trust("member2", "member1")
+        assert pair["merged"] == 1
+        assert pair["rejected_after_approve"] == 0
+
+    def test_reject_writes_track_record_event_without_lead_verdict(
+        self, live_server, drive_env, tmp_path,
+    ):
+        """A reject with no lead verdict recorded still writes a durable
+        event — lead_agent_id/lead_verdict are simply None."""
+        self._push_branch(live_server, tmp_path, "feat-nope2", "n2.md", "no\n")
+        review = self._post(
+            live_server, "/mesh/teams/team-x/drive/reviews", "member1",
+            {"branch": "feat-nope2", "title": "nope2"},
+        ).json()["review"]
+        rej = self._post(
+            live_server, f"/mesh/teams/team-x/drive/reviews/{review['id']}/reject", "operator",
+        )
+        assert rej.status_code == 200
+
+        events = drive_env["app"].track_record_store.recent_events("member1")
+        assert len(events) == 1
+        event = events[0]
+        assert event["source"] == "drive_review"
+        assert event["outcome"] == "rejected"
+        assert event["rater_kind"] == "human"
+        assert event["team_id"] == "team-x"
+        details = event["details"]
+        assert details["lead_agent_id"] is None
+        assert details["lead_verdict"] is None
+        assert details["resolution"] == "rejected"
+
 
 # ── Agent-side team_drive tool ───────────────────────────────────────
 

--- a/tests/test_track_record.py
+++ b/tests/test_track_record.py
@@ -1,0 +1,369 @@
+"""Tests for ``TrackRecordStore`` (src/host/track_record.py).
+
+Covers append/counts/rater-filtering/pair_trust/persistence-across-
+reopen and the append-only invariant (no reap method, no
+``retention_until`` column) — plan §8 #18's durability property, the
+whole reason this store exists alongside the reaped tasks/summaries
+tables it's assembled from.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from src.host.track_record import (
+    AUTONOMY_RATER_KINDS,
+    TrackRecordStore,
+    record_best_effort,
+)
+
+
+@pytest.fixture
+def store():
+    s = TrackRecordStore(":memory:")
+    yield s
+    s.close()
+
+
+# =============================================================================
+# append / basic shape
+# =============================================================================
+
+
+def test_record_returns_full_event(store):
+    event = store.record(
+        source="task_outcome",
+        ref_id="task_1",
+        outcome="accepted",
+        rater_kind="human",
+        agent_id="writer",
+        team_id="content-seo",
+        rated_by="operator",
+    )
+    assert event["id"] is not None
+    assert event["source"] == "task_outcome"
+    assert event["ref_id"] == "task_1"
+    assert event["outcome"] == "accepted"
+    assert event["rater_kind"] == "human"
+    assert event["agent_id"] == "writer"
+    assert event["team_id"] == "content-seo"
+    assert event["rated_by"] == "operator"
+    assert event["details"] is None
+    assert event["created_at"] <= time.time()
+
+
+def test_record_stores_details_json(store):
+    event = store.record(
+        source="drive_review",
+        ref_id="rev_1",
+        outcome="merged",
+        rater_kind="human",
+        agent_id="writer",
+        team_id="content-seo",
+        rated_by="operator",
+        details={"branch": "feat-x", "lead_agent_id": "lead1", "lead_verdict": "approve"},
+    )
+    assert event["details"] == {"branch": "feat-x", "lead_agent_id": "lead1", "lead_verdict": "approve"}
+
+
+def test_record_team_scoped_summary_has_no_agent_id(store):
+    """Team-scoped summary ratings have no single rated agent (spec)."""
+    event = store.record(
+        source="summary_rating",
+        ref_id="ws_1",
+        outcome="accepted",
+        rater_kind="human",
+        team_id="content-seo",
+        rated_by="operator",
+    )
+    assert event["agent_id"] is None
+    assert event["team_id"] == "content-seo"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"source": "bogus", "ref_id": "x", "outcome": "accepted", "rater_kind": "human", "agent_id": "a"},
+        {"source": "task_outcome", "ref_id": "x", "outcome": "accepted", "rater_kind": "bogus", "agent_id": "a"},
+        {"source": "task_outcome", "ref_id": "", "outcome": "accepted", "rater_kind": "human", "agent_id": "a"},
+        {"source": "task_outcome", "ref_id": "x", "outcome": "", "rater_kind": "human", "agent_id": "a"},
+        {"source": "task_outcome", "ref_id": "x", "outcome": "accepted", "rater_kind": "human"},
+    ],
+)
+def test_record_rejects_invalid_input(store, kwargs):
+    with pytest.raises(ValueError):
+        store.record(**kwargs)
+
+
+def test_record_oversized_details_replaced_with_marker(store):
+    huge = {"blob": "x" * 20_000}
+    event = store.record(
+        source="task_outcome",
+        ref_id="task_big",
+        outcome="accepted",
+        rater_kind="human",
+        agent_id="writer",
+        details=huge,
+    )
+    assert event["details"] == {"truncated": True}
+
+
+# =============================================================================
+# counts_for_agent + rater filtering (rating-trust rule)
+# =============================================================================
+
+
+def test_counts_for_agent_keyed_by_source_and_outcome(store):
+    store.record(source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="task_outcome", ref_id="t2", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="task_outcome", ref_id="t3", outcome="rework", rater_kind="human", agent_id="a")
+    store.record(source="summary_rating", ref_id="s1", outcome="accepted", rater_kind="human", agent_id="a")
+    # A different agent's events must not bleed into "a"'s counts.
+    store.record(source="task_outcome", ref_id="t4", outcome="accepted", rater_kind="human", agent_id="b")
+
+    counts = store.counts_for_agent("a")
+    assert counts == {
+        "task_outcome": {"accepted": 2, "rework": 1},
+        "summary_rating": {"accepted": 1},
+    }
+
+
+def test_counts_for_agent_never_double_unifies_enum_values(store):
+    """Drive-review outcomes (merged/rejected) never collide with task
+    outcomes (accepted/rework/rejected/acknowledged) — keyed by source
+    first, so the raw per-source vocabulary is preserved verbatim."""
+    store.record(source="task_outcome", ref_id="t1", outcome="rejected", rater_kind="human", agent_id="a")
+    store.record(source="drive_review", ref_id="r1", outcome="rejected", rater_kind="human", agent_id="a")
+    counts = store.counts_for_agent("a")
+    assert counts["task_outcome"]["rejected"] == 1
+    assert counts["drive_review"]["rejected"] == 1
+
+
+def test_rater_kinds_filter_restricts_counts(store):
+    store.record(source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="task_outcome", ref_id="t2", outcome="accepted", rater_kind="operator_agent", agent_id="a")
+    store.record(source="task_outcome", ref_id="t3", outcome="accepted", rater_kind="system", agent_id="a")
+
+    all_counts = store.counts_for_agent("a")
+    assert all_counts["task_outcome"]["accepted"] == 3
+
+    autonomy_counts = store.counts_for_agent("a", rater_kinds=AUTONOMY_RATER_KINDS)
+    assert autonomy_counts["task_outcome"]["accepted"] == 2  # human + system, operator_agent excluded
+
+
+def test_operator_agent_rated_events_absent_from_autonomy_counts_present_in_counts(store):
+    """Pins the rating-trust rule (§8 #18): an operator-agent-rated
+    event is counted in ``counts`` but excluded from the autonomy-safe
+    view — agents grading agents must not feed the trust ladder."""
+    store.record(
+        source="task_outcome", ref_id="t1", outcome="accepted",
+        rater_kind="operator_agent", agent_id="a", rated_by="operator",
+    )
+    counts = store.counts_for_agent("a")
+    autonomy_counts = store.counts_for_agent("a", rater_kinds=AUTONOMY_RATER_KINDS)
+    assert counts.get("task_outcome", {}).get("accepted") == 1
+    assert autonomy_counts.get("task_outcome", {}).get("accepted", 0) == 0
+
+
+def test_counts_for_agent_unknown_agent_is_empty(store):
+    assert store.counts_for_agent("nobody") == {}
+
+
+# =============================================================================
+# recent_events
+# =============================================================================
+
+
+def test_recent_events_newest_first_and_limit_clamped(store):
+    for i in range(5):
+        store.record(source="task_outcome", ref_id=f"t{i}", outcome="accepted", rater_kind="human", agent_id="a")
+    recent = store.recent_events("a", limit=3)
+    assert len(recent) == 3
+    assert [e["ref_id"] for e in recent] == ["t4", "t3", "t2"]
+
+
+def test_recent_events_scoped_to_agent(store):
+    store.record(source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="task_outcome", ref_id="t2", outcome="accepted", rater_kind="human", agent_id="b")
+    recent = store.recent_events("a", limit=20)
+    assert [e["ref_id"] for e in recent] == ["t1"]
+
+
+# =============================================================================
+# pair_trust (§8 #20 auto-merge trust signal)
+# =============================================================================
+
+
+def _drive_event(store, *, submitter, lead, verdict, resolution, ts_offset=0.0):
+    store.record(
+        source="drive_review",
+        ref_id=f"rev_{submitter}_{resolution}_{ts_offset}",
+        outcome=resolution,
+        rater_kind="human",
+        agent_id=submitter,
+        team_id="team-x",
+        rated_by="operator",
+        details={
+            "branch": "feat",
+            "lead_agent_id": lead,
+            "lead_verdict": verdict,
+            "lead_verdict_at": "2026-07-11T00:00:00Z",
+            "resolution": resolution,
+            "resolved_by": "operator",
+        },
+    )
+
+
+def test_pair_trust_counts_merged_and_rejected_after_approve(store):
+    _drive_event(store, submitter="writer", lead="lead1", verdict="approve", resolution="merged")
+    _drive_event(store, submitter="writer", lead="lead1", verdict="approve", resolution="merged")
+    _drive_event(store, submitter="writer", lead="lead1", verdict="approve", resolution="rejected")
+
+    result = store.pair_trust("lead1", "writer")
+    assert result["merged"] == 2
+    assert result["rejected_after_approve"] == 1
+    assert result["last_event_at"] is not None
+
+
+def test_pair_trust_ignores_non_approve_verdicts(store):
+    _drive_event(store, submitter="writer", lead="lead1", verdict="reject", resolution="rejected")
+    _drive_event(store, submitter="writer", lead="lead1", verdict=None, resolution="merged")
+
+    result = store.pair_trust("lead1", "writer")
+    assert result["merged"] == 0
+    assert result["rejected_after_approve"] == 0
+    assert result["last_event_at"] is None
+
+
+def test_pair_trust_scoped_to_exact_lead_submitter_pair(store):
+    # Same submitter, different lead — must not count toward lead1's trust.
+    _drive_event(store, submitter="writer", lead="lead2", verdict="approve", resolution="merged")
+    # Same lead, different submitter — must not count toward writer's trust.
+    _drive_event(store, submitter="other", lead="lead1", verdict="approve", resolution="merged")
+
+    result = store.pair_trust("lead1", "writer")
+    assert result["merged"] == 0
+    assert result["rejected_after_approve"] == 0
+
+
+def test_pair_trust_last_event_at_is_most_recent_qualifying_event(store):
+    older = store.record(
+        source="drive_review", ref_id="rev_a", outcome="merged", rater_kind="human",
+        agent_id="writer", team_id="team-x",
+        details={"lead_agent_id": "lead1", "lead_verdict": "approve"},
+    )
+    newer = store.record(
+        source="drive_review", ref_id="rev_b", outcome="merged", rater_kind="human",
+        agent_id="writer", team_id="team-x",
+        details={"lead_agent_id": "lead1", "lead_verdict": "approve"},
+    )
+    assert newer["created_at"] >= older["created_at"]
+    result = store.pair_trust("lead1", "writer")
+    assert result["last_event_at"] == newer["created_at"]
+
+
+def test_pair_trust_no_events_returns_zeroed_result(store):
+    result = store.pair_trust("lead1", "nobody")
+    assert result == {
+        "lead_agent_id": "lead1",
+        "submitter_agent_id": "nobody",
+        "merged": 0,
+        "rejected_after_approve": 0,
+        "last_event_at": None,
+    }
+
+
+# =============================================================================
+# persistence across reopen (disk-backed)
+# =============================================================================
+
+
+def test_persists_across_reopen(tmp_path):
+    db_path = str(tmp_path / "track_record.db")
+    s1 = TrackRecordStore(db_path)
+    s1.record(source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human", agent_id="a")
+    s1.close()
+
+    s2 = TrackRecordStore(db_path)
+    try:
+        counts = s2.counts_for_agent("a")
+        assert counts == {"task_outcome": {"accepted": 1}}
+        recent = s2.recent_events("a")
+        assert len(recent) == 1
+        assert recent[0]["ref_id"] == "t1"
+    finally:
+        s2.close()
+
+
+def test_disk_backed_creates_parent_dir(tmp_path):
+    db_path = tmp_path / "nested" / "dir" / "track_record.db"
+    s = TrackRecordStore(str(db_path))
+    try:
+        assert db_path.parent.exists()
+    finally:
+        s.close()
+
+
+# =============================================================================
+# append-only invariant (§8 #18: NEVER reaped)
+# =============================================================================
+
+
+def test_store_has_no_reap_method(store):
+    """The whole point of this store vs. tasks/work_summaries is that it
+    is NEVER reaped — pin the absence of any reap-shaped method so a
+    future edit can't quietly reintroduce one."""
+    assert not hasattr(store, "reap_expired")
+    assert not hasattr(store, "_safe_reap")
+
+
+def test_schema_has_no_retention_column(tmp_path):
+    db_path = str(tmp_path / "track_record.db")
+    s = TrackRecordStore(db_path)
+    try:
+        conn = sqlite3.connect(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(outcome_events)").fetchall()}
+        conn.close()
+        assert "retention_until" not in cols
+    finally:
+        s.close()
+
+
+def test_schema_user_version_is_1(tmp_path):
+    db_path = str(tmp_path / "track_record.db")
+    s = TrackRecordStore(db_path)
+    try:
+        conn = sqlite3.connect(db_path)
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        conn.close()
+        assert version == 1
+    finally:
+        s.close()
+
+
+# =============================================================================
+# record_best_effort — never raises, never fails the caller
+# =============================================================================
+
+
+def test_record_best_effort_noop_when_store_is_none():
+    # Must not raise even though there's nothing to write to.
+    record_best_effort(None, source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human", agent_id="a")
+
+
+def test_record_best_effort_swallows_store_errors(store, caplog):
+    # Missing agent_id/team_id raises ValueError inside store.record —
+    # record_best_effort must swallow it, not propagate.
+    record_best_effort(store, source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human")
+    assert store.counts_for_agent("t1") == {}
+
+
+def test_record_best_effort_writes_through_on_success(store):
+    record_best_effort(
+        store, source="task_outcome", ref_id="t1", outcome="accepted",
+        rater_kind="human", agent_id="a", rated_by="operator",
+    )
+    assert store.counts_for_agent("a") == {"task_outcome": {"accepted": 1}}

--- a/tests/test_workplace_outcome.py
+++ b/tests/test_workplace_outcome.py
@@ -24,6 +24,7 @@ from src.host.health import HealthMonitor
 from src.host.mesh import Blackboard
 from src.host.orchestration import Tasks
 from src.host.traces import TraceStore
+from src.host.track_record import TrackRecordStore
 
 
 def _make_components(tmp_path: str) -> dict:
@@ -60,10 +61,13 @@ class _CSRFTestClient(TestClient):
         return super().request(method, url, **kwargs)
 
 
-def _make_client(components: dict, tasks_store) -> TestClient:
+def _make_client(components: dict, tasks_store, track_record_store=None) -> TestClient:
     from src.dashboard.server import create_dashboard_router
     router = create_dashboard_router(
-        **components, mesh_port=8420, tasks_store=tasks_store,
+        **components,
+        mesh_port=8420,
+        tasks_store=tasks_store,
+        track_record_store=track_record_store,
     )
     app = FastAPI()
     app.include_router(router)
@@ -83,13 +87,17 @@ class TestWorkplaceOutcome:
         self._tmp = tempfile.mkdtemp()
         self.components = _make_components(self._tmp)
         self.tasks = Tasks(db_path=os.path.join(self._tmp, "tasks.db"))
-        self.client = _make_client(self.components, self.tasks)
+        self.track_record = TrackRecordStore(":memory:")
+        self.client = _make_client(
+            self.components, self.tasks, track_record_store=self.track_record,
+        )
 
     def teardown_method(self):
         try:
             self.tasks.close()
         except Exception:
             pass
+        self.track_record.close()
         self.components["cost_tracker"].close()
         self.components["trace_store"].close()
         self.components["blackboard"].close()
@@ -315,3 +323,59 @@ class TestWorkplaceOutcome:
             json=["accepted"],
         )
         assert resp.status_code == 400
+
+    # ── plan §8 #18 — durable track record write ──────────────────
+
+    def test_outcome_writes_track_record_event_as_human(self):
+        """The dashboard outcome endpoint is the HUMAN-driven path (plan
+        §8 #18) — its track-record write must be tagged
+        ``rater_kind="human"`` so it counts at full weight toward
+        earned-autonomy scoring."""
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst",
+            title="t", team_id="research",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert resp.status_code == 200
+        events = self.track_record.recent_events("analyst")
+        assert len(events) == 1
+        event = events[0]
+        assert event["source"] == "task_outcome"
+        assert event["ref_id"] == rec["id"]
+        assert event["outcome"] == "accepted"
+        assert event["rater_kind"] == "human"
+        assert event["team_id"] == "research"
+        autonomy_counts = self.track_record.counts_for_agent(
+            "analyst", rater_kinds=("human", "system"),
+        )
+        assert autonomy_counts == {"task_outcome": {"accepted": 1}}
+
+    def test_outcome_track_record_write_failure_does_not_fail_request(self):
+        """A ledger write failure must NEVER fail the source operation
+        (plan §8 #18's best-effort contract)."""
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        self.track_record.close()  # subsequent .record() calls now raise
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["task"]["outcome"] == "accepted"
+
+    def test_outcome_absent_track_record_store_is_a_noop(self):
+        """Existing dashboard test constructions that don't wire a
+        track_record_store (the default) keep working unchanged."""
+        client = _make_client(self.components, self.tasks)  # no track_record_store
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="writer2", title="t",
+        )
+        resp = client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
New `TrackRecordStore` (`data/track_record.db`, WAL, canonical v1, env `OPENLEGION_TRACK_RECORD_DB`) — an append-only `outcome_events` ledger written host-side at rating time, because the two sources it composes reap out from under a live query (tasks 90d, work_summaries 30d). No retention column, no reap method — pinned.

- Write points (all `record_best_effort` — a ledger failure never fails the source op): task outcomes on BOTH paths (mesh = `operator_agent`, dashboard = `human` — the §8 #18 rating-trust rule's raw material), summary ratings on both paths (solo→agent, team→team), drive-review merge/reject with lead-verdict details for §8 #20 pair trust.
- Reads: `GET /mesh/agents/{id}/track-record` (self-or-operator-or-internal, goals-gate mirror; `autonomy_counts` excludes operator-agent raters — pinned) + Personnel-File bundle `track_record` section (None-guarded).
- `pair_trust(lead, submitter)` query ready for the U4 auto-merge trust floor.

29 store unit tests + 17 integration tests across 6 suites; touched suites all green (0 failures); ruff clean. Full local suite gate before merge.

Recorded approximation: drive-review events attribute the lead via the team's current `lead_agent_id` at resolution time (the verdict row doesn't record its author) — U4 adds `lead_verdict_by` for exact pair attribution.