### PR TITLE
feat(host,agent): Phase-5 U2 — positive feedback push to learnings/wins.md (§8 #23)

### DIFF
--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -829,9 +829,13 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         A1 (rating → learning loop): the mesh pushes the operator's /
         user's ``rework`` / ``rejected`` feedback here; it lands in the
         corrections learnings file and rides ``get_learnings_context``
-        into every future prompt. Mesh-internal only — same gate as
-        ``PUT /team`` so agents can't forge corrections into their own
-        (or via SSRF, a peer's) learnings.
+        into every future prompt. Phase-5 U2 (§8 #23): an ``accepted``
+        outcome routes to the SEPARATE wins file instead, so praise
+        never dilutes the corrections signal. Any other/unknown outcome
+        is treated as a correction — the safe default, unchanged from
+        before U2. Mesh-internal only — same gate as ``PUT /team`` so
+        agents can't forge corrections into their own (or via SSRF, a
+        peer's) learnings.
         """
         if not request.headers.get("x-mesh-internal"):
             raise HTTPException(
@@ -848,10 +852,16 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         title = str(body.get("title", ""))[:200]
         outcome = str(body.get("outcome", ""))[:32] or "rework"
         original = f"Task {task_id}: {title}" if title else f"Task {task_id}"
-        loop.workspace.record_correction(
-            original=sanitize_for_prompt(original),
-            correction=f"[{outcome}] {sanitize_for_prompt(feedback)}",
-        )
+        if outcome == "accepted":
+            loop.workspace.record_win(
+                original=sanitize_for_prompt(original),
+                feedback=sanitize_for_prompt(feedback),
+            )
+        else:
+            loop.workspace.record_correction(
+                original=sanitize_for_prompt(original),
+                correction=f"[{outcome}] {sanitize_for_prompt(feedback)}",
+            )
         return {"recorded": True}
 
     @app.post("/config")

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -275,6 +275,7 @@ class WorkspaceManager:
     LEARNINGS_DIR = "learnings"
     ERRORS_FILE = "learnings/errors.md"
     CORRECTIONS_FILE = "learnings/corrections.md"
+    WINS_FILE = "learnings/wins.md"
     CHAT_TRANSCRIPT = "chat_transcript.jsonl"
     CHAT_ARCHIVE_DIR = "chat_archive"
     ACTIVITY_LOG = "activity.jsonl"
@@ -994,16 +995,42 @@ class WorkspaceManager:
             f.write(entry)
         self._learnings_cache = None
 
+    def record_win(self, original: str, feedback: str) -> None:
+        """Record positive feedback (praise) for learning.
+
+        Mirrors ``record_correction`` — same truncation caps, same
+        timestamped append, same size-based rotation — but writes to
+        the separate wins file so praise never dilutes the corrections
+        signal (§8 #23).
+        """
+        path = self.root / self.WINS_FILE
+        self._rotate_if_large(path)
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+        entry = (
+            f"- [{timestamp}] Original: {original[:200]}\n"
+            f"  What worked: {feedback[:500]}\n"
+        )
+        with path.open("a") as f:
+            f.write(entry)
+        self._learnings_cache = None
+
     @staticmethod
     def looks_like_correction(message: str) -> bool:
         """Heuristic: does this user message look like a correction?"""
         lower = message.lower().strip()
         return any(lower.startswith(s) for s in _CORRECTION_SIGNALS)
 
-    _LEARNINGS_FILES = (ERRORS_FILE, CORRECTIONS_FILE)
+    _LEARNINGS_FILES = (ERRORS_FILE, CORRECTIONS_FILE, WINS_FILE)
 
     def get_learnings_context(self, max_chars: int = 3000) -> str:
-        """Load recent errors and corrections for system prompt injection.
+        """Load recent errors, corrections, and wins for system prompt injection.
+
+        Sections are assembled in a fixed order — errors, then
+        corrections, then wins (§8 #23) — and the combined string is
+        capped at ``max_chars`` from the front. Because wins is always
+        LAST, errors/corrections keep exactly the space they had before
+        wins existed; wins only gets whatever room is left over under
+        the shared cap, and drops out entirely once that room is gone.
 
         Results are cached with mtime-based invalidation and pre-sanitized.
         """
@@ -1016,6 +1043,7 @@ class WorkspaceManager:
         for relpath, heading in [
             (self.ERRORS_FILE, "## Recent Errors (avoid repeating)"),
             (self.CORRECTIONS_FILE, "## User Corrections (follow these)"),
+            (self.WINS_FILE, "## What worked (keep doing)"),
         ]:
             content = self._read_file(relpath)
             if content and content.strip():

--- a/src/host/feedback_push.py
+++ b/src/host/feedback_push.py
@@ -10,9 +10,12 @@ which appends it to the agent's corrections file — from there it rides
 ``get_learnings_context`` into every future task / chat / heartbeat
 prompt automatically.
 
-``accepted`` / ``acknowledged`` are deliberately NOT pushed: they are
-rating signals, not corrections, and stuffing praise into the
-corrections file would dilute the signal the LLM is told to follow.
+Phase-5 U2 (§8 #23): an ``accepted`` outcome WITH non-empty feedback
+text is pushed the same way, but lands in a SEPARATE
+``learnings/wins.md`` file instead of the corrections file — praise is
+pushed to a separate wins file so it never dilutes the corrections
+signal. ``accepted`` without feedback and ``acknowledged`` are still
+deliberately NOT pushed: there is no comment to record either way.
 
 Best-effort by design: the rated agent's container may be stopped or
 archived. A failed push is logged and surfaced as
@@ -29,6 +32,7 @@ from src.shared.utils import setup_logging
 logger = setup_logging("host.feedback_push")
 
 _ACTIONABLE_OUTCOMES = ("rework", "rejected")
+_WIN_OUTCOMES = ("accepted",)
 
 
 async def push_outcome_feedback(
@@ -38,9 +42,18 @@ async def push_outcome_feedback(
 
     Returns ``"recorded"`` on success, ``"failed"`` on a push error, or
     ``None`` when the outcome carries nothing actionable (wrong outcome
-    kind, empty feedback, no assignee, no transport).
+    kind, empty feedback, no assignee, no transport). ``rework`` /
+    ``rejected`` push corrections; ``accepted`` pushes a win, but only
+    when the feedback is non-empty after stripping whitespace — an
+    empty-comment accept is a rating signal with nothing to record.
     """
-    if outcome not in _ACTIONABLE_OUTCOMES or not feedback:
+    if outcome in _ACTIONABLE_OUTCOMES:
+        if not feedback:
+            return None
+    elif outcome in _WIN_OUTCOMES:
+        if not feedback or not feedback.strip():
+            return None
+    else:
         return None
     if transport is None:
         return None

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -929,7 +929,12 @@ class TestHeartbeatEndpointNoForceLlm:
 
 
 class TestLearningsFeedbackEndpoint:
-    """A1: mesh-pushed rating feedback lands in the corrections file."""
+    """A1: mesh-pushed rating feedback lands in the corrections file.
+
+    §8 #23 (Phase-5 U2): an ``accepted`` outcome routes to the SEPARATE
+    wins file instead; every other outcome (including unknown ones)
+    keeps routing to corrections, unchanged.
+    """
 
     @pytest.mark.asyncio
     async def test_feedback_recorded_to_corrections(self, tmp_workspace):
@@ -954,9 +959,85 @@ class TestLearningsFeedbackEndpoint:
         ).read_text()
         assert "Task task_1: SEO audit" in corrections
         assert "[rework] Too shallow" in corrections
+        assert not (Path(tmp_workspace) / "learnings" / "wins.md").exists()
         # ...and it reaches the prompt-injection surface.
         ctx = loop.workspace.get_learnings_context()
         assert "Too shallow" in ctx
+
+    @pytest.mark.asyncio
+    async def test_rejected_outcome_recorded_to_corrections(self, tmp_workspace):
+        """Regression: ``rejected`` keeps routing to corrections too."""
+        app, _ = _make_app(tmp_workspace)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/learnings/feedback",
+                json={
+                    "task_id": "task_2",
+                    "outcome": "rejected",
+                    "feedback": "Wrong data source entirely",
+                },
+                headers={"x-mesh-internal": "1"},
+            )
+        assert r.status_code == 200
+        corrections = (
+            Path(tmp_workspace) / "learnings" / "corrections.md"
+        ).read_text()
+        assert "[rejected] Wrong data source entirely" in corrections
+
+    @pytest.mark.asyncio
+    async def test_accepted_feedback_recorded_to_wins(self, tmp_workspace):
+        """§8 #23: accepted + feedback lands in the SEPARATE wins file,
+        never in corrections, and surfaces under its own heading."""
+        app, loop = _make_app(tmp_workspace)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/learnings/feedback",
+                json={
+                    "task_id": "task_3",
+                    "title": "SEO audit",
+                    "outcome": "accepted",
+                    "feedback": "Great per-keyword breakdown, keep doing this",
+                },
+                headers={"x-mesh-internal": "1"},
+            )
+        assert r.status_code == 200
+        assert r.json()["recorded"] is True
+        wins = (Path(tmp_workspace) / "learnings" / "wins.md").read_text()
+        assert "Task task_3: SEO audit" in wins
+        assert "Great per-keyword breakdown" in wins
+        assert not (Path(tmp_workspace) / "learnings" / "corrections.md").exists()
+        # ...and it reaches the prompt-injection surface under its own heading.
+        ctx = loop.workspace.get_learnings_context()
+        assert "## What worked (keep doing)" in ctx
+        assert "Great per-keyword breakdown" in ctx
+
+    @pytest.mark.asyncio
+    async def test_unknown_outcome_falls_back_to_correction(self, tmp_workspace):
+        """Unknown outcomes are treated as corrections — the safe
+        default, unchanged from before §8 #23."""
+        app, _ = _make_app(tmp_workspace)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/learnings/feedback",
+                json={
+                    "task_id": "task_4",
+                    "outcome": "somethingweird",
+                    "feedback": "unclear signal",
+                },
+                headers={"x-mesh-internal": "1"},
+            )
+        assert r.status_code == 200
+        corrections = (
+            Path(tmp_workspace) / "learnings" / "corrections.md"
+        ).read_text()
+        assert "[somethingweird] unclear signal" in corrections
+        assert not (Path(tmp_workspace) / "learnings" / "wins.md").exists()
 
     @pytest.mark.asyncio
     async def test_requires_mesh_internal_header(self, tmp_workspace):

--- a/tests/test_feedback_loop.py
+++ b/tests/test_feedback_loop.py
@@ -2,11 +2,13 @@
 
 Covers:
 * A1 — ``push_outcome_feedback`` helper + agent ``POST /learnings/feedback``
-  endpoint + the mesh outcome endpoint pushing on rework/rejected.
+  endpoint + the mesh outcome endpoint pushing on rework/rejected/accepted.
 * A3 — rework briefs carry the original description; retry briefs carry
   the previous attempt's blocker_note.
 * A4 — ``_format_fleet_health`` digest rendering.
 * A6 — task-level failed/blocked closes write the learnings errors file.
+* §8 #23 (Phase-5 U2) — an ``accepted`` outcome with non-empty feedback
+  pushes a WIN to the assignee's separate wins learnings file.
 """
 
 from __future__ import annotations
@@ -52,11 +54,32 @@ async def test_push_feedback_on_rework():
 
 
 @pytest.mark.asyncio
+async def test_push_win_on_accepted_with_feedback():
+    """§8 #23: accepted + non-empty feedback pushes a WIN, same endpoint."""
+    transport = _FakeTransport()
+    record = {"id": "task_1", "title": "SEO audit", "assignee": "analyst"}
+
+    status = await push_outcome_feedback(
+        transport, record, "accepted", "Great catch on the schema markup",
+    )
+
+    assert status == "recorded"
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    assert call["agent_id"] == "analyst"
+    assert call["path"] == "/learnings/feedback"
+    assert call["json"]["outcome"] == "accepted"
+    assert call["json"]["feedback"] == "Great catch on the schema markup"
+
+
+@pytest.mark.asyncio
 async def test_push_skipped_for_non_actionable_outcomes():
     transport = _FakeTransport()
     record = {"id": "task_1", "assignee": "analyst"}
 
-    assert await push_outcome_feedback(transport, record, "accepted", "nice") is None
+    # accepted with no comment (or only whitespace) has nothing to record.
+    assert await push_outcome_feedback(transport, record, "accepted", "") is None
+    assert await push_outcome_feedback(transport, record, "accepted", "   ") is None
     assert await push_outcome_feedback(transport, record, "acknowledged", "ok") is None
     assert await push_outcome_feedback(transport, record, "rework", "") is None
     assert transport.calls == []
@@ -275,6 +298,27 @@ async def test_outcome_endpoint_pushes_feedback_to_assignee(tmp_path, monkeypatc
         assert r2.status_code == 200
         assert "feedback_push" not in r2.json()
         assert len(fake_transport.calls) == 1
+
+        # accepted WITH feedback → pushes a win (§8 #23), same endpoint.
+        rec3 = app.tasks_store.create(
+            creator="operator", assignee="analyst", title="great work",
+        )
+        app.tasks_store.update_status(rec3["id"], "working", actor="analyst")
+        app.tasks_store.update_status(rec3["id"], "done", actor="analyst")
+        async with AsyncClient(
+            transport=HTTPXASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r3 = await c.post(
+                f"/mesh/tasks/{rec3['id']}/outcome",
+                json={"outcome": "accepted", "feedback": "Nice structure, keep it up"},
+                headers={"X-Agent-ID": "operator"},
+            )
+        assert r3.status_code == 200
+        assert r3.json()["feedback_push"] == "recorded"
+        assert len(fake_transport.calls) == 2
+        win_call = fake_transport.calls[-1]
+        assert win_call["json"]["outcome"] == "accepted"
+        assert win_call["json"]["feedback"] == "Nice structure, keep it up"
     finally:
         blackboard.close()
         monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -602,6 +602,24 @@ class TestLearnings:
         assert "JSON format" in content
         assert "YAML instead" in content
 
+    def test_record_win_creates_file(self):
+        self.ws.record_win("Good report", "Loved the structure and depth")
+        path = Path(self._tmpdir) / "learnings" / "wins.md"
+        assert path.exists()
+        content = path.read_text()
+        assert "Good report" in content
+        assert "Loved the structure and depth" in content
+
+    def test_record_win_rotates_large_file(self):
+        path = Path(self._tmpdir) / "learnings" / "wins.md"
+        with path.open("w") as f:
+            for i in range(5000):
+                f.write(f"- Win {i}: did something great\n")
+        original_lines = len(path.read_text().splitlines())
+        self.ws.record_win("new win", "even better this time")
+        new_lines = len(path.read_text().splitlines())
+        assert new_lines < original_lines
+
     def test_get_learnings_context_empty_when_no_learnings(self):
         context = self.ws.get_learnings_context()
         assert context == ""
@@ -616,6 +634,65 @@ class TestLearnings:
         self.ws.record_correction("Said hello", "Actually say 'hi'")
         context = self.ws.get_learnings_context()
         assert "Corrections" in context
+
+    def test_get_learnings_context_includes_wins(self):
+        self.ws.record_win("Nice catch", "Great attention to detail")
+        context = self.ws.get_learnings_context()
+        assert "## What worked (keep doing)" in context
+        assert "Great attention to detail" in context
+
+    def test_get_learnings_context_no_wins_heading_when_absent(self):
+        self.ws.record_error("exec", "boom")
+        self.ws.record_correction("said x", "say y")
+        context = self.ws.get_learnings_context()
+        assert "What worked" not in context
+
+    def test_get_learnings_context_section_order(self):
+        self.ws.record_error("exec", "boom")
+        self.ws.record_correction("said x", "say y")
+        self.ws.record_win("nice", "great structure")
+        context = self.ws.get_learnings_context()
+        assert (
+            context.index("Recent Errors")
+            < context.index("User Corrections")
+            < context.index("What worked")
+        )
+
+    def test_get_learnings_context_wins_windowed_to_last_20_lines(self):
+        path = Path(self._tmpdir) / "learnings" / "wins.md"
+        path.write_text("\n".join(f"line {i}" for i in range(30)) + "\n")
+        context = self.ws.get_learnings_context(max_chars=100_000)
+        assert "line 29" in context
+        assert "line 10" in context
+        assert "line 9" not in context  # dropped: only the last 20 lines survive
+
+    def test_get_learnings_context_wins_get_remainder(self):
+        """Wins fill whatever room is left under the cap, without
+        displacing errors/corrections that already fit (§8 #23)."""
+        self.ws.record_correction("short original", "short fix")
+        before = self.ws.get_learnings_context(max_chars=1000)
+
+        self.ws.record_win("nice work", "very thorough coverage")
+        after = self.ws.get_learnings_context(max_chars=1000)
+
+        assert after.startswith(before)
+        assert "What worked" in after
+        assert "very thorough coverage" in after
+
+    def test_get_learnings_context_corrections_priority_under_cap(self):
+        """When errors+corrections already exceed the shared cap, wins
+        must NOT steal any of the space they already had (§8 #23) —
+        the output is byte-identical with or without a wins file."""
+        self.ws.record_error("exec", "x" * 100)
+        self.ws.record_correction("y" * 100, "z" * 100)
+        before = self.ws.get_learnings_context(max_chars=50)
+        assert len(before) == 50
+
+        self.ws.record_win("great job", "keep doing this " * 20)
+        after = self.ws.get_learnings_context(max_chars=50)
+
+        assert after == before
+        assert "What worked" not in after
 
     def test_looks_like_correction(self):
         assert self.ws.looks_like_correction("No, I meant something else")


### PR DESCRIPTION
`accepted` outcomes with non-empty feedback now push to a NEW `learnings/wins.md` — never the corrections file, whose praise-exclusion design intent survives verbatim (docstring updated to say why). Agent endpoint routes by outcome (unknown → correction, the pre-U2 safe default, pinned); `record_win` mirrors `record_correction` (caps, rotation); `get_learnings_context` appends a `## What worked (keep doing)` section LAST so errors/corrections keep byte-identical priority under the shared cap (pinned by exact-equality test). `acknowledged` and empty-feedback accepts still push nothing; rework/rejected unchanged.

Touched suites 505 passed / 0 failed; ruff clean. Full local suite gate before merge.

Recorded residual: the read-only `GET /workspace-learnings` dashboard endpoint doesn't surface wins.md — cosmetic parity gap, candidate for the end-of-phase fix PR.