### PR TITLE
fix(host,cli,dashboard): Phase-5 end-of-phase review findings (6 MAJOR)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -2738,15 +2738,26 @@ class RuntimeContext:
                     logger.warning("ladder nudge dispatch failed: %s", e)
 
             def _ladder_send_assignee(agent: str, message: str) -> None:
-                # Rung 1 — fire-and-forget onto the dispatch loop: the
-                # ladder sweep must never block on a full agent turn.
-                # ``deliver_chat`` forks busy→steer / idle→followup and the
-                # turn bills the nudged agent's normal WORK ledger (no
-                # coordination-exempt path).
+                # Rung 1 — a followup turn on the assignee. System-composed
+                # (no human typed it), so it MUST carry the system-note flag
+                # exactly like rung 2 below: without it the nudge lands in the
+                # assignee's transcript as a role=user message (indistinguishable
+                # from a real operator message) and runs through
+                # ``looks_like_correction`` — a host-authored escalation must
+                # never be able to write itself into the agent's corrections
+                # learnings. (Phase-5 review finding: the prior ``deliver_chat``
+                # path had no ``system_note`` parameter to thread the flag
+                # through, so the busy→steer fork silently bypassed the marker;
+                # a queued followup is the correct posture for a not-time-
+                # critical blocked-task nudge anyway.) Fire-and-forget onto the
+                # dispatch loop so the sweep never blocks; bills the nudged
+                # agent's normal WORK ledger.
                 if self.lane_manager is None or self._dispatch_loop is None:
                     return
                 fut = asyncio.run_coroutine_threadsafe(
-                    self.lane_manager.deliver_chat(agent, message),
+                    self.lane_manager.enqueue(
+                        agent, message, mode="followup", system_note=True,
+                    ),
                     self._dispatch_loop,
                 )
                 fut.add_done_callback(_log_ladder_send)

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -149,6 +149,7 @@ function dashboard() {
       // Task 9 — Workplace tab + pending action review
       'task_created', 'task_status_changed', 'task_outcome',
       'pending_action_created', 'pending_action_resolved', 'pending_action_expired',
+      'pending_action_updated',
       // PR 1 — soft-edit receipts + undo
       'operator_action_receipt', 'operator_action_receipt_undone',
       'operator_action_receipt_superseded',
@@ -4068,7 +4069,17 @@ function dashboard() {
       const existing = this.chatHistories[target].find(
         m => m.role === 'pending_action_card' && m.event_id === data.nonce,
       );
-      if (existing) return;
+      if (existing) {
+        // Card already rendered — refresh the advisory recommendation fields
+        // in place (plan §8 #19; Phase-5 review finding) so a lead's later
+        // recommendation shows on the existing card instead of being dropped.
+        // Everything else about a held action is immutable once proposed.
+        if (data.lead_recommendation !== undefined) {
+          existing.lead_recommendation = data.lead_recommendation || null;
+          existing.lead_recommendation_note = data.lead_recommendation_note || null;
+        }
+        return;
+      }
       const isDestructive = (
         data.action_kind === 'delete'
         && (data.target_kind === 'team' || data.target_kind === 'agent')
@@ -4424,6 +4435,16 @@ function dashboard() {
         // Also surface as an inline chat card in the operator chat —
         // the new single visual language for "operator wants the human
         // to act." Idempotent on event_id.
+        this._injectPendingActionCard(data);
+      } else if (evt.type === 'pending_action_updated') {
+        // A lead recorded an advisory recommendation (plan §8 #19). Patch the
+        // Needs-you row and the already-rendered inline card live, in place —
+        // the held action itself is unchanged (Phase-5 review finding).
+        const row = this.workplacePending.find(p => p.nonce === data.nonce);
+        if (row) {
+          row.lead_recommendation = data.lead_recommendation || null;
+          row.lead_recommendation_note = data.lead_recommendation_note || null;
+        }
         this._injectPendingActionCard(data);
       } else if (evt.type === 'pending_action_resolved') {
         this.workplacePending = this.workplacePending.filter(p => p.nonce !== data.nonce);

--- a/src/host/auto_merge.py
+++ b/src/host/auto_merge.py
@@ -64,6 +64,29 @@ logger = setup_logging("host.auto_merge")
 # unambiguously as kernel-executed in every listing/audit trail.
 AUTO_MERGE_RATER = "policy_engine"
 
+# Per-event-loop serialization lock for the daily-cap window (Phase-5
+# review finding). The consumer is fired fire-and-forget, once per
+# ``approve`` verdict; a lead clearing a backlog of approvals in one turn
+# spawns several consumers concurrently. Each claims a DIFFERENT review, so
+# the claim-first merge machinery does not serialize them — and the daily
+# cap is a read-decide-then-record-later window, so without this lock every
+# consumer reads the same pre-merge count and all proceed, blowing past the
+# operator's ``auto_merge_daily_cap``. Holding one lock from the cap read
+# through the ``auto_merged`` record makes count→merge→record atomic across
+# consumers (auto-merges are rare and the cap is small, so serializing them
+# is free and arguably correct — the kernel merges one at a time). Keyed by
+# running loop so a fresh test loop never reuses a lock bound to another.
+_cap_locks: dict[Any, asyncio.Lock] = {}
+
+
+def _cap_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _cap_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _cap_locks[loop] = lock
+    return lock
+
 
 def midnight_utc_ts(now: float | None = None) -> float:
     """Epoch seconds for the most recent UTC midnight at or before ``now``."""
@@ -145,10 +168,22 @@ async def consider_auto_merge(
     def _skip(reason: str) -> None:
         logger.info("auto-merge skipped for review %s (team %s): %s", review_id, team_id, reason)
 
+    lock: asyncio.Lock | None = None
+    lock_held = False
     try:
         if track_record_store is None:
             _skip("no track record store wired")
             return
+
+        # Serialize the daily-cap window (Phase-5 review finding): held from
+        # the cap read through the ``auto_merged`` record so concurrent
+        # consumers (a lead approving a backlog in one turn) can't all read the
+        # same pre-merge count and each proceed past ``auto_merge_daily_cap``.
+        # Released before the best-effort notify below (which need not be
+        # serialized) and, on any early return/exception, by the ``finally``.
+        lock = _cap_lock()
+        await lock.acquire()
+        lock_held = True
 
         # Step 1: kill switch / daily rate cap.
         cap = limits_mod.resolve("auto_merge_daily_cap")
@@ -291,6 +326,12 @@ async def consider_auto_merge(
             review_id, team_id, branch, commit, lead_verdict_by, author, sampled,
         )
 
+        # The cap slot is now durably recorded — release before the notify so
+        # a slow operator-chat post doesn't serialize the next consumer.
+        if lock_held:
+            lock.release()
+            lock_held = False
+
         # Step 5: notify (best-effort — never blocks/fails the pipeline
         # outcome, the merge already landed).
         if notify_fn is not None:
@@ -310,3 +351,8 @@ async def consider_auto_merge(
         # Outermost net: the verdict endpoint's response must never block
         # on, or fail because of, this consumer.
         logger.exception("auto-merge consumer raised for review %s (team %s)", review_id, team_id)
+    finally:
+        # Release the cap lock on any early return (cap reached, trust floor,
+        # lost claim, git failure) or exception before the pre-notify release.
+        if lock_held and lock is not None:
+            lock.release()

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -742,6 +742,7 @@ class HibernationSweeper:
         ask_broker: Any,
         config_fn: Callable[[], dict],
         operator_agent_id: str = "operator",
+        wake_available_fn: Callable[[], bool] | None = None,
     ):
         self._hibernate_fn = hibernate_fn
         self._lane_manager = lane_manager
@@ -749,6 +750,11 @@ class HibernationSweeper:
         self._ask_broker = ask_broker
         self._config_fn = config_fn
         self._operator_agent_id = operator_agent_id
+        # Fail-closed gate (Phase-5 review finding): the idle sweep must not
+        # hibernate anyone when the cold-wake seam isn't wired (sandbox
+        # backend), or agents would stop and never auto-wake. None ⇒ assume
+        # available (test/legacy construction).
+        self._wake_available_fn = wake_available_fn
         self._running = False
 
     async def start(self) -> None:
@@ -767,6 +773,8 @@ class HibernationSweeper:
         idle_minutes = shared_limits.resolve("hibernate_idle_minutes")
         if idle_minutes <= 0:
             return  # sweep disabled — B4-style 0-valid default-off
+        if self._wake_available_fn is not None and not self._wake_available_fn():
+            return  # cold-wake seam unavailable (sandbox backend) — never strand
         if self._lane_manager is None:
             return
         try:
@@ -9948,6 +9956,35 @@ def create_mesh_app(
         new_daily = daily_req if daily_req is not None else old_daily
         new_monthly = monthly_req if monthly_req is not None else old_monthly
 
+        # Phase-5 review finding: a FIRST-EVER partial allocation (a period
+        # unnamed AND with no prior explicit value) leaves ``new_*`` None, and
+        # ``set_budget`` then materializes the GLOBAL deployment default for it
+        # ($50/$200 by default) — unvalidated against the envelope, so a
+        # daily-only allocation to a fresh member could silently materialize a
+        # $200 monthly cap against a $50 monthly envelope (Σ blown 4×, locking
+        # every other teammate out of monthly headroom). Validate the
+        # would-be-materialized default against the SAME Σ headroom check and
+        # reject on breach, directing the lead to name that period explicitly.
+        from src.host.costs import _default_budget as _default_member_budget
+
+        _defaults = _default_member_budget()
+        for _period, _env, _new, _label in (
+            ("daily_usd", daily_env, new_daily, "DAILY"),
+            ("monthly_usd", monthly_env, new_monthly, "MONTHLY"),
+        ):
+            if _new is None and _env > 0:
+                materialized = _defaults.get(_period, 0.0)
+                others = _others_explicit_sum(_period)
+                if others + materialized > _env + 1e-9:
+                    headroom = round(max(_env - others, 0.0), 4)
+                    raise HTTPException(
+                        409,
+                        f"Allocating to '{agent_id}' with no {_label} budget yet would "
+                        f"materialize the deployment default (${materialized:.2f}), which "
+                        f"exceeds the team's {_label} envelope headroom (${headroom:.2f}). "
+                        f"Specify {_period} explicitly (≤ ${headroom:.2f}) to allocate safely.",
+                    )
+
         cost_tracker.set_budget(agent_id, daily_usd=new_daily, monthly_usd=new_monthly)
 
         # Re-read the persisted row for the audit's ``after_value`` (rather
@@ -10147,6 +10184,14 @@ def create_mesh_app(
             raise HTTPException(403, "Only the operator can hibernate agents")
         if agent_id == "operator":
             raise HTTPException(400, "The operator agent cannot be hibernated")
+        if not _hibernation_wake_available():
+            raise HTTPException(
+                409,
+                "Hibernation is unavailable on this deployment: the wake-on-demand seam "
+                "is wired only for the HTTP transport (Docker backend). Under the sandbox "
+                "backend a hibernated agent would never auto-wake, so hibernation is "
+                "refused rather than silently stranding the agent.",
+            )
         from src.cli.config import _agent_status, _load_config
 
         cfg_now = _load_config()
@@ -10570,6 +10615,18 @@ def create_mesh_app(
                 logger.debug("agent_archived emit failed: %s", e)
         return {"archived": True, "agent_id": agent_id}
 
+    def _hibernation_wake_available() -> bool:
+        """True iff the cold-wake seam is actually wired for this deployment
+        (Phase-5 review finding). The seam lives on ``HttpTransport`` and is
+        installed by ``cli/runtime.py`` only ``if isinstance(transport,
+        HttpTransport)`` — the sandbox backend's ``SandboxTransport`` never
+        calls ``ensure_running``, so a hibernated agent under ``--sandbox``
+        would stop and never auto-wake. Hibernation fails closed there (the
+        manual endpoint 409s and the idle sweep skips) rather than stranding
+        agents, mirroring how Team Drive is scoped Docker-only (§8 #9)."""
+        from src.host.transport import HttpTransport as _HttpTransportForGate
+        return isinstance(transport, _HttpTransportForGate)
+
     async def _hibernate_agent_core(agent_id: str, *, caller: str = "operator") -> dict:
         """Hibernate-agent side effects (plan §8 #24). Mirrors
         ``_archive_agent_core``'s shape with ONE deliberate difference:
@@ -10711,15 +10768,39 @@ def create_mesh_app(
         if health_monitor is not None:
             health_monitor.register(agent_id)
 
+        def _wake_teardown() -> None:
+            """Restore a CLEAN hibernated state after a failed wake (Phase-5
+            review finding). ``start_agent`` already ran (container up) and
+            transport/router/health are re-registered; a bare ``return False``
+            here would leave a container running AND health-registered while
+            the status stays ``hibernated`` — the exact inverse of the
+            hibernate invariant, so the health monitor would fight it with
+            restarts and every later dispatch would force-recreate the
+            container. Undo the registration + container so the next dispatch
+            retries a genuinely-asleep agent instead of a health-monitored
+            zombie. Status is deliberately LEFT ``hibernated``."""
+            if health_monitor is not None:
+                try:
+                    health_monitor.unregister(agent_id)
+                except Exception as e:
+                    logger.warning("wake_teardown: health dereg for %s failed: %s", agent_id, e)
+            if container_manager is not None:
+                try:
+                    container_manager.stop_agent(agent_id, remove_data=False)
+                except Exception as e:
+                    logger.warning("wake_teardown: container stop for %s failed: %s", agent_id, e)
+
         ready = await container_manager.wait_for_agent(agent_id, timeout=60)
         if not ready:
             logger.error("wake_agent: '%s' did not become ready after cold-wake", agent_id)
+            _wake_teardown()
             return False
 
         try:
             _wake_agent_status(agent_id)
         except ValueError as e:
             logger.error("wake_agent: status flip failed for '%s': %s", agent_id, e)
+            _wake_teardown()
             return False
         _status_overrides.pop(agent_id, None)
         if lane_manager is not None:
@@ -10812,6 +10893,7 @@ def create_mesh_app(
         tasks_store=tasks_store,
         ask_broker=ask_broker,
         config_fn=_load_config_for_sweep,
+        wake_available_fn=_hibernation_wake_available,
     )
 
     @app.post("/mesh/agents/{agent_id}/offboard")
@@ -13105,6 +13187,24 @@ def create_mesh_app(
             after_value=recommendation,
             provenance="agent",
         )
+        # Push the advisory live (Phase-5 review finding): without this, an
+        # already-rendered inline pending_action_card never shows the lead's
+        # recommendation (the card injector is create-once and chat history is
+        # client-persisted) — the operator would only see it on a full reload.
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "pending_action_updated",
+                    agent="operator",
+                    data={
+                        "nonce": nonce,
+                        "lead_recommendation": record.get("lead_recommendation"),
+                        "lead_recommendation_note": record.get("lead_recommendation_note"),
+                        "lead_recommendation_by": record.get("lead_recommendation_by"),
+                    },
+                )
+            except Exception as e:
+                logger.debug("pending_action_updated emit failed for %s: %s", nonce, e)
         return {"recorded": True, "pending": record}
 
     @app.post("/mesh/audit/archive")

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -964,6 +964,11 @@ class DashboardEvent(BaseModel):
         "pending_action_created",
         "pending_action_resolved",
         "pending_action_expired",
+        # A lead recorded an advisory approve/reject recommendation on a held
+        # action (plan §8 #19). Additive display update — carries the nonce +
+        # recommendation fields so the Needs-you row and the already-rendered
+        # inline card refresh live instead of only on a full reload.
+        "pending_action_updated",
         # PR — close EventBus coverage gaps. Without these literals,
         # ``EventBus.emit`` raises a Pydantic ValidationError that the
         # debug-level ``except Exception`` swallows and the dashboard

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -257,6 +257,45 @@ class TestDailyCap:
 
         assert repo_env["store"].get_review(review["id"])["status"] == "open"
 
+    async def test_concurrent_burst_respects_cap_no_toctou(self, repo_env, monkeypatch):
+        """Phase-5 review finding: a lead approving a backlog fires several
+        consumers at once, each claiming a DIFFERENT review. The daily-cap
+        window (read count → merge → record) must be serialized so they can't
+        all read the same pre-merge count and blow past ``auto_merge_daily_cap``.
+        Git is stubbed (a slow, awaiting merge) to force interleaving and isolate
+        the cap logic from real CAS timing."""
+        monkeypatch.setenv("OPENLEGION_AUTO_MERGE_DAILY_CAP", "1")
+        store, track = repo_env["store"], repo_env["track"]
+        _seed_events(track, submitter="member1", lead="member2", outcome="merged", count=5)
+        r1 = _make_review(repo_env, "feat-burst-1")
+        r2 = _make_review(repo_env, "feat-burst-2")
+
+        # Map each branch to its pinned head_sha so the live==recorded check
+        # passes and the (stubbed, slow) merge proceeds for both consumers.
+        head_by_branch = {r1["branch"]: r1["head_sha"], r2["branch"]: r2["head_sha"]}
+
+        async def _slow_merge(repo, sha, *, message):
+            await asyncio.sleep(0.02)  # yield so the sibling consumer interleaves
+            return "deadbeef" * 5
+
+        def _stub_head(repo, branch):
+            return head_by_branch.get(branch, "")
+
+        stub = {"merge_branch_fn": _slow_merge, "branch_head_sha_fn": _stub_head}
+
+        results = await asyncio.gather(
+            _run(repo_env, r1, **stub),
+            _run(repo_env, r2, **stub),
+            return_exceptions=True,
+        )
+        assert all(not isinstance(x, Exception) for x in results), results
+        merged = track.count_events(
+            source="drive_review", outcome="auto_merged", rater_kind="system",
+        )
+        assert merged == 1, f"cap=1 but {merged} auto-merges recorded (TOCTOU)"
+        statuses = {store.get_review(r1["id"])["status"], store.get_review(r2["id"])["status"]}
+        assert statuses == {"merged", "open"}, statuses
+
 
 class TestConcurrencyAndSampling:
     @_requires_merge_tree

--- a/tests/test_hibernation.py
+++ b/tests/test_hibernation.py
@@ -169,6 +169,22 @@ class TestHibernateEndpoint:
         assert cm.stopped == [("scout", False)]
         bb.close()
 
+    def test_hibernate_endpoint_409_when_wake_seam_unavailable(self, tmp_path, monkeypatch):
+        """Phase-5 review finding: the manual endpoint must refuse (409) under a
+        transport without the cold-wake seam (sandbox), rather than stopping an
+        agent that could never auto-wake."""
+        from src.host.transport import SandboxTransport
+        app, bb, cm, tr, hm, eb, cfg = _build_app(
+            tmp_path, monkeypatch, transport=SandboxTransport(),
+        )
+        resp = TestClient(app).post("/mesh/agents/scout/hibernate", headers=_OP)
+        assert resp.status_code == 409, resp.text
+        assert "wake" in resp.json()["detail"].lower()
+        # Nothing was stopped — the agent stays running/active.
+        assert cm.stopped == []
+        assert cfg["agents"]["scout"]["status"] == "active"
+        bb.close()
+
     def test_hibernate_keeps_cron_jobs(self, tmp_path, monkeypatch):
         sched = CronScheduler(config_path=str(tmp_path / "cron.json"))
         sched.ensure_heartbeat("scout")
@@ -396,6 +412,32 @@ class TestWake:
         assert ok is False
         # Status stays hibernated — never falsely flips to active.
         assert cfg["agents"]["scout"]["status"] == "hibernated"
+        # Phase-5 review finding: a failed wake must NOT leave a running,
+        # health-registered container labelled "hibernated" (the health
+        # monitor would fight it with restarts). Teardown restores a clean
+        # hibernated state: the started container is stopped WITHOUT data
+        # removal, and health is deregistered again.
+        assert ("scout", False) in cm.stopped
+        assert not any(remove for _a, remove in cm.stopped), cm.stopped
+        # register happened during the wake attempt, unregister undid it.
+        hm.register.assert_called_with("scout")
+        hm.unregister.assert_called_with("scout")
+        bb.close()
+
+    async def test_wake_teardown_on_status_flip_failure(self, tmp_path, monkeypatch):
+        """The second failure branch (status write raises after the container
+        is up + registered) must also tear down to a clean hibernated state."""
+        cm = _FakeContainerManager()
+        cm.wait_result = True
+        app, bb, _cm, tr, hm, eb, cfg = _build_app(
+            tmp_path, monkeypatch, agent_status="hibernated", container_manager=cm,
+        )
+        with patch("src.cli.config._wake_agent_status", side_effect=ValueError("boom")):
+            ok = await app.ensure_agent_running("scout")
+        assert ok is False
+        assert cfg["agents"]["scout"]["status"] == "hibernated"
+        assert ("scout", False) in cm.stopped
+        hm.unregister.assert_called_with("scout")
         bb.close()
 
 
@@ -681,7 +723,8 @@ class TestCronHibernatedTicks:
 # ── Idle sweep ────────────────────────────────────────────────────────
 
 
-def _sweeper(tmp_path, *, agents_cfg, lane_manager=None, tasks_store=None, ask_broker=None):
+def _sweeper(tmp_path, *, agents_cfg, lane_manager=None, tasks_store=None,
+             ask_broker=None, wake_available_fn=None):
     hibernate_calls: list[tuple[str, str]] = []
 
     async def hibernate_fn(agent_id, *, caller="sweep"):
@@ -694,6 +737,7 @@ def _sweeper(tmp_path, *, agents_cfg, lane_manager=None, tasks_store=None, ask_b
         tasks_store=tasks_store,
         ask_broker=ask_broker,
         config_fn=lambda: {"agents": agents_cfg},
+        wake_available_fn=wake_available_fn,
     )
     return sweeper, hibernate_calls
 
@@ -707,6 +751,22 @@ class TestHibernationSweeper:
         )
         await sweeper._tick()
         assert calls == []
+
+    async def test_wake_seam_unavailable_skips_sweep_fail_closed(self, tmp_path, monkeypatch):
+        """Phase-5 review finding: under a backend whose transport lacks the
+        cold-wake seam (sandbox), the idle sweep must hibernate NOBODY — an
+        agent stopped there would never auto-wake and would strand forever."""
+        monkeypatch.setenv("OPENLEGION_HIBERNATE_IDLE_MINUTES", "10")
+        lm = LaneManager(dispatch_fn=AsyncMock())
+        lm._activity["scout"] = time.time() - 20 * 60  # idle, would otherwise hibernate
+        tasks = Tasks(db_path=str(tmp_path / "tasks.db"))
+        broker = AskBroker()
+        sweeper, calls = _sweeper(
+            tmp_path, agents_cfg={"scout": {"status": "active"}}, lane_manager=lm,
+            tasks_store=tasks, ask_broker=broker, wake_available_fn=lambda: False,
+        )
+        await sweeper._tick()
+        assert calls == []  # fail-closed: nobody hibernated without a wake path
 
     async def test_all_conditions_met_hibernates(self, tmp_path, monkeypatch):
         monkeypatch.setenv("OPENLEGION_HIBERNATE_IDLE_MINUTES", "10")

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -901,6 +901,46 @@ async def test_recommend_lead_records_and_surfaces(v2_app):
 
 
 @pytest.mark.asyncio
+async def test_recommend_emits_pending_action_updated_event(tmp_path, monkeypatch):
+    """Phase-5 review finding: recording a recommendation must push a
+    ``pending_action_updated`` WS event so an already-rendered inline card
+    refreshes live instead of only on a full dashboard reload."""
+    from src.dashboard.events import EventBus
+
+    server_module = _reload_server(monkeypatch, tasks_db=str(tmp_path / "tasks.db"))
+    monkeypatch.setenv("OPENLEGION_TRACK_RECORD_DB", str(tmp_path / "track_record.db"))
+    monkeypatch.setenv("OPENLEGION_PENDING_ACTIONS_DB", str(tmp_path / "pending_actions.db"))
+    bus = EventBus()
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    permissions = PermissionMatrix()
+    for aid in ("scout", "analyst"):
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, can_route_tasks=True)
+    router = MessageRouter(permissions, {"scout": "http://s:8400", "analyst": "http://a:8400"})
+    app = server_module.create_mesh_app(
+        blackboard=blackboard, pubsub=PubSub(), router=router,
+        permissions=permissions, event_bus=bus,
+    )
+    _seed_teams(app)
+    app.teams_store.set_lead("research", "scout")
+    _store_wallet_hold(app, "n1", "analyst")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/pending/n1/recommend",
+            json={"recommendation": "reject", "note": "hold off"},
+            headers={"X-Agent-ID": "scout", "X-Mesh-Internal": "1"},
+        )
+    assert r.status_code == 200, r.text
+    updates = [e for e in bus._buffer if e["type"] == "pending_action_updated"]
+    assert len(updates) == 1, bus._buffer
+    data = updates[0]["data"]
+    assert data["nonce"] == "n1"
+    assert data["lead_recommendation"] == "reject"
+    assert data["lead_recommendation_note"] == "hold off"
+    assert data["lead_recommendation_by"] == "scout"
+
+
+@pytest.mark.asyncio
 async def test_recommend_non_lead_teammate_403(v2_app):
     """The proposer itself is NOT the lead — recommending is still
     denied (analyst proposed this hold and is not research's lead)."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3025,9 +3025,14 @@ class TestSystemNoteCallSites:
     def test_runtime_sites_flagged(self):
         src = self._src("src/cli/runtime.py")
         # cron_dispatch + verification wake + the blocked-task ladder's
-        # rung-2 creator followup (``_ladder_send_creator``, plan §8 #22
-        # — mesh-composed, no human typed it).
-        assert src.count("system_note=True") == 3
+        # rung-1 assignee followup AND rung-2 creator followup
+        # (``_ladder_send_assignee`` / ``_ladder_send_creator``, plan §8 #22
+        # — both mesh-composed, no human typed them; rung 1 was corrected
+        # from a ``deliver_chat`` call that could not carry the flag,
+        # Phase-5 review finding).
+        assert src.count("system_note=True") == 4
+        # Rung 1 must NOT regress to the flag-less deliver_chat path.
+        assert "self.lane_manager.deliver_chat(agent, message)" not in src
 
     def test_webhooks_flagged(self):
         src = self._src("src/host/webhooks.py")

--- a/tests/test_team_budget.py
+++ b/tests/test_team_budget.py
@@ -498,6 +498,39 @@ class TestAllocateMemberBudgetEnvelope:
             bb.close()
             tracker.close()
 
+    def test_first_partial_allocation_rejects_default_materialization_blowout(self, tmp_path):
+        """Phase-5 review finding: a first-ever DAILY-only allocation to a
+        member with no prior explicit budget must NOT let ``set_budget``
+        silently materialize the global default monthly cap ($200) against a
+        tight monthly envelope — that blows Σ ≤ envelope and locks other
+        members out. The endpoint rejects it, directing the lead to name the
+        monthly period explicitly; nothing is written."""
+        app, bb, store, tracker = _setup_lead_teams(tmp_path)
+        try:
+            # Generous daily, tight $1 monthly envelope (below any plausible
+            # deployment default, so the default-materialization always breaches).
+            store.set_budget("alpha", 100.0, 1.0)
+            resp = TestClient(app).post(
+                "/mesh/teams/alpha/members/member2/budget",
+                headers=_hdr(_LEAD_TOKENS["lead1"]),
+                json={"daily_usd": 10.0},
+            )
+            assert resp.status_code == 409, resp.text
+            assert "monthly" in resp.json()["detail"].lower()
+            # Nothing persisted — no silent blowout.
+            assert tracker.budgets.get("member2") is None
+            # Naming both periods within headroom succeeds and writes exactly that.
+            resp2 = TestClient(app).post(
+                "/mesh/teams/alpha/members/member2/budget",
+                headers=_hdr(_LEAD_TOKENS["lead1"]),
+                json={"daily_usd": 10.0, "monthly_usd": 0.5},
+            )
+            assert resp2.status_code == 200, resp2.text
+            assert tracker.budgets["member2"] == {"daily_usd": 10.0, "monthly_usd": 0.5}
+        finally:
+            bb.close()
+            tracker.close()
+
     def test_sigma_boundary_exactly_equal_passes(self, tmp_path):
         app, bb, store, tracker = _setup_lead_teams(tmp_path)
         try:


### PR DESCRIPTION
Consolidated 3-lane adversarial review of merged Phase-5 (deep opus + breadth/integration + invariant sweep). Invariant sweep passed all ten families with zero findings; six confirmed defects fixed, each with a negative-control-verified regression test.

1. **auto-merge daily-cap TOCTOU** (`auto_merge.py`) — a backlog of approvals fires N consumers that all pass the cap; serialized the cap-read→record window with a per-loop lock.
2. **hibernation wake-failure zombie** (`server.py`) — failed wake left a running, health-registered container labelled `hibernated`; both failure branches now tear down.
3. **lead recommendation not live on the card** (`server.py`/`app.js`/`types.py`) — added `pending_action_updated` WS event; injector patches existing card + handler refreshes row/card.
4. **ladder rung-1 bypassed system_note** (`runtime.py`) — rung 1 used `deliver_chat` (no `system_note` param); now uses the followup + `system_note=True` path.
5. **U7 partial-allocation Σ blowout** (`server.py`) — first-ever daily-only allocation materialized the $200 default monthly cap unvalidated; now validated against Σ headroom + 409.
6. **hibernation never auto-wakes under SandboxBackend** (`server.py`) — wake seam is HttpTransport-only; hibernation now fails closed under sandbox (endpoint 409 + sweep skip).

10 files, +371/−11; touched suites green; ruff clean. Full local suite gate before merge.
