### PR TITLE
Phase 0–5 integration: make the whole teams feature work seamlessly

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1073,8 +1073,17 @@ class AgentLoop:
         (exactly-once delivery, answered right after the heartbeat). Plain
         2-tuple entries (wakes/asks — answered via tools, not turn text) keep
         the by-design agenda-prompt injection.
+
+        M17: if the reply future is ALREADY done (the caller's
+        ``asyncio.wait_for`` timed out and cancelled it, so it got
+        ``(True, None)`` and will NOT dispatch a followup), the entry is
+        REQUEUED instead of consumed — otherwise its message text is lost
+        entirely. Its done future is never folded, so the next real turn's
+        catch-all drain delivers the text without any cross-turn answer
+        bleed.
         """
         messages: list[tuple[str, bool]] = []
+        requeue: list[tuple] = []
         while not self._steer_queue.empty():
             try:
                 entry = self._steer_queue.get_nowait()
@@ -1082,16 +1091,23 @@ class AgentLoop:
                 break
             reply_future = entry[2] if len(entry) > 2 else None
             if heartbeat and reply_future is not None:
-                # Wait-reply chat steer drained by an agenda turn: consume it
-                # without injecting its text or folding its future. Resolving
-                # the live future None routes the caller to a dedicated
-                # followup turn instead of the agenda prompt.
-                if not reply_future.done():
+                if reply_future.done():
+                    # Caller already timed out (future cancelled) — requeue so
+                    # the next real turn delivers the text (M17). Collected and
+                    # re-put AFTER the drain loop so we don't spin forever.
+                    requeue.append(entry)
+                else:
+                    # Wait-reply chat steer drained by an agenda turn while the
+                    # caller is still waiting: consume it without injecting its
+                    # text or folding its future. Resolving the live future
+                    # None routes the caller to a dedicated followup turn.
                     reply_future.set_result(None)
                 continue
             messages.append((entry[0], entry[1]))
             if reply_future is not None and not reply_future.done():
                 self._turn_steer_futures.append(reply_future)
+        for entry in requeue:
+            self._steer_queue.put_nowait(entry)
         return messages
 
     def _sweep_heartbeat_steer_futures(self) -> None:
@@ -1108,10 +1124,15 @@ class AgentLoop:
         to ``idle``, so no chat can interleave the queue between here and the
         lock release.
 
-        Live reply futures resolve to ``None`` (caller falls back to a fresh
+        LIVE reply futures resolve to ``None`` (caller falls back to a fresh
         followup turn — ``(False, None)``) and their entries are consumed;
-        plain 2-tuple entries (wakes/asks/REPL) are left on the queue for the
-        normal next-turn catch-all drain — never dropped, never mis-answered.
+        a future that is ALREADY done (the caller's ``asyncio.wait_for``
+        timed out and cancelled it, so it got ``(True, None)`` and will NOT
+        dispatch a followup) has its entry REQUEUED so the next real turn's
+        catch-all drain delivers the text — otherwise the message is lost
+        (M17). Plain 2-tuple entries (wakes/asks/REPL) are left on the queue
+        for the normal next-turn catch-all drain — never dropped, never
+        mis-answered.
         """
         # Defensive: a heartbeat drain never folds, but never let a stray
         # future ride into an unrelated later turn's resolve.
@@ -1132,8 +1153,15 @@ class AgentLoop:
             reply_future = entry[2] if len(entry) > 2 else None
             if reply_future is not None:
                 if not reply_future.done():
+                    # Live caller still waiting — resolve None, consume (it
+                    # falls back to its own followup turn).
                     reply_future.set_result(None)
-                # Consumed — a chat message is never answered by an agenda turn.
+                else:
+                    # Caller already timed out (future cancelled) and won't
+                    # dispatch a followup — requeue so the next real turn's
+                    # catch-all drain delivers the text (M17). The done future
+                    # is never folded, so no cross-turn answer bleed.
+                    self._steer_queue.put_nowait(entry)
             else:
                 self._steer_queue.put_nowait(entry)
 

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -1464,6 +1464,7 @@ class REPLSession:
 
     def _cmd_remove(self, arg: str) -> None:
         """Remove an agent from config and stop its container."""
+        from src.cli.config import _OPERATOR_AGENT_ID
         from src.host.transport import HttpTransport
 
         if not self.ctx.agents:
@@ -1472,8 +1473,13 @@ class REPLSession:
 
         name = arg.strip() or None
         if name is None:
-            # Interactive picker
-            names = sorted(self.ctx.agents.keys())
+            # Interactive picker — the operator agent (the human's front
+            # door) is never a removal candidate, matching the mesh (403/
+            # 400) and dashboard ("system agent") delete guards.
+            names = [n for n in sorted(self.ctx.agents.keys()) if n != _OPERATOR_AGENT_ID]
+            if not names:
+                click.echo("No removable agents (the operator agent cannot be removed).")
+                return
             if len(names) == 1:
                 name = names[0]
             else:
@@ -1485,6 +1491,12 @@ class REPLSession:
 
         if name not in self.ctx.agents:
             click.echo(f"Agent '{name}' not found.")
+            return
+
+        # Operator guard (M12) — parity with the mesh + dashboard delete
+        # surfaces, which both refuse to destroy the operator agent.
+        if name == _OPERATOR_AGENT_ID:
+            click.echo("The operator agent cannot be removed.")
             return
 
         if not click.confirm(f"Remove agent '{name}'?"):
@@ -1559,6 +1571,25 @@ class REPLSession:
         from src.cli.config import _remove_agent
 
         _remove_agent(name)
+
+        # Per-agent store teardown (M11) — parity with the mesh + dashboard
+        # delete paths. ``cleanup_agent`` (the mesh app's helper, wired onto
+        # the runtime context in ``_start_mesh_server``) clears the stores
+        # the ad-hoc block above misses — vault, private blackboard
+        # namespace, cost/trace rows, wallet — and runs ``permissions.reload()``
+        # (called AFTER ``_remove_agent`` dropped the id from permissions.json,
+        # so the reload actually takes). Without it a same-name recreated
+        # agent silently inherits the deleted agent's wallet + private
+        # namespace. Overlapping calls (pubsub/cron/lane/connector) are
+        # idempotent. The seam is ``None`` only when the mesh app is not
+        # wired (not a live REPL); the ad-hoc block already ran the partial
+        # cleanup in that degraded case.
+        cleanup_agent = getattr(self.ctx, "cleanup_agent", None)
+        if cleanup_agent is not None:
+            try:
+                cleanup_agent(name)
+            except Exception as e:
+                click.echo(f"  Warning: per-agent cleanup failed: {e}")
 
         click.echo(f"Removed agent '{name}'.")
         if self.ctx.event_bus:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -328,6 +328,12 @@ class RuntimeContext:
         # ``None`` until then (mirrors every other subsystem attribute
         # above).
         self.offboard_agent = None
+        # Per-agent runtime-state teardown helper (M11 parity, plan §8 #15):
+        # the mesh app's ``cleanup_agent`` (vault/blackboard/costs/traces/
+        # wallet + ``permissions.reload()``). Wired from the mesh app once
+        # ``_start_mesh_server`` runs; the CLI ``/remove`` runs it so it
+        # clears the SAME per-agent stores the mesh + dashboard delete paths do.
+        self.cleanup_agent = None
         self.agent_urls: dict[str, str] = {}
         self._dispatch_loop = None
         # Post-completion verification wakes (success path) — sliding
@@ -2123,6 +2129,11 @@ class RuntimeContext:
         # offboard_agent`` (mirrors how the REPL already reads
         # ``self.ctx.lane_manager`` / ``self.ctx.teams_store``).
         self.offboard_agent = getattr(app, "_offboard_agent", None)
+        # CLI REPL access to the mesh app's per-agent teardown (M11) — the
+        # same helper the mesh + dashboard delete paths call, so ``/remove``
+        # clears the agent's vault/blackboard/costs/traces/wallet + reloads
+        # permissions instead of leaking them for a same-name recreate.
+        self.cleanup_agent = getattr(app, "cleanup_agent", None)
 
         server_config = uvicorn.Config(app, host="0.0.0.0", port=mesh_port, log_level="warning")
         self._server = uvicorn.Server(server_config)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -320,6 +320,15 @@ _BUSY_CHAT_STATUS_NOTE = (
     # paragraph. This is content, not the SSE frame terminator.
 )
 
+# M15b: the busy /chat/stream path awaits ``deliver_chat`` for the running
+# turn's own final text, which can take up to the steer reply timeout
+# (~150s) — well past the SPA's 120s no-data abort. While that await is
+# pending the generator emits a ``: keepalive`` SSE comment every this-many
+# seconds (mirrors the idle branch's upstream-keepalive forwarding) so the
+# browser's idle-abort timer resets and a delivered reply isn't dropped
+# client-side. Module-level so tests can shrink it.
+_BUSY_KEEPALIVE_INTERVAL_SECONDS = 30
+
 
 def _is_ip_literal_domain(domain: str) -> bool:
     """True when ``domain`` is a literal IPv4 or IPv6 address."""
@@ -3900,12 +3909,36 @@ def create_dashboard_router(
         if _is_busy and lane_manager is not None:
 
             async def busy_event_generator():
+                import asyncio
+
                 final_response = ""
                 try:
                     yield f"data: {dumps_safe({'type': 'text_delta', 'content': _BUSY_CHAT_STATUS_NOTE})}\n\n"
-                    final_response = await lane_manager.deliver_chat(
-                        agent_id, message, trace_id=_trace_id_val, origin=_origin,
+                    # M15b: the steered reply is the running turn's own final
+                    # text and can take up to the steer reply timeout (~150s)
+                    # to resolve — past the SPA's 120s no-data abort. Keepalive
+                    # comments (SSE ``:`` lines, no UI state) reset the browser's
+                    # idle-abort timer while the await is pending, matching the
+                    # idle branch's keepalive contract.
+                    _deliver = asyncio.ensure_future(
+                        lane_manager.deliver_chat(
+                            agent_id, message, trace_id=_trace_id_val, origin=_origin,
+                        )
                     )
+                    while True:
+                        done, _pending = await asyncio.wait(
+                            {_deliver}, timeout=_BUSY_KEEPALIVE_INTERVAL_SECONDS,
+                        )
+                        if done:
+                            break
+                        yield ": keepalive\n\n"
+                    final_response = _deliver.result()
+                    # M15a: gate the lane sentinels (``__SILENT__`` / "(no
+                    # response)" / ``dispatch_error:``) exactly as the sibling
+                    # non-streaming ``/chat`` does, so a stopped/unreachable
+                    # agent's internal token never renders as the agent's reply.
+                    if not usable_agent_reply(final_response):
+                        final_response = "The agent did not produce a reply."
                     # Single chunk — the turn's own final text arrives all at
                     # once (there is no token stream to relay), then `done`.
                     yield f"data: {dumps_safe({'type': 'text_delta', 'content': final_response})}\n\n"
@@ -4020,7 +4053,12 @@ def create_dashboard_router(
                 response = await lane_manager.deliver_chat(
                     aid, message, trace_id=bc_trace_id, origin=bc_origin,
                 )
-                return aid, response or "(no response)"
+                # M15a: gate lane sentinels (``__SILENT__`` / "(no response)" /
+                # ``dispatch_error:``) so a stopped/unreachable recipient's
+                # internal token never renders as its reply (matches /chat).
+                if not usable_agent_reply(response):
+                    response = "The agent did not produce a reply."
+                return aid, response
             except Exception as e:
                 return aid, f"Error: {e}"
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -9171,6 +9171,12 @@
                               x-text="'Expires in ' + workplaceFormatExpiry(msg.expires_at)"></span>
                           </div>
                           <p class="text-xs text-gray-200 mb-2" x-text="msg.summary || (msg.action_kind + ' on ' + (msg.target_kind || '?') + ' ' + (msg.target_id || '?'))"></p>
+                          <!-- Lead advisory recommendation (plan §8 #19)
+                               — additive, read-only. Zero effect on
+                               Confirm/Cancel below. Mirrors the Chat-tab
+                               operator-panel card (M18 parity). -->
+                          <p x-show="msg.lead_recommendation" class="text-[11px] text-indigo-300 mb-2"
+                            x-text="'Lead recommends: ' + msg.lead_recommendation + (msg.lead_recommendation_note ? ' — ' + msg.lead_recommendation_note : '')"></p>
                           <template x-if="msg.preview_diff">
                             <div class="mb-3">
                               <button @click="diffOpen = !diffOpen"

--- a/src/host/asks.py
+++ b/src/host/asks.py
@@ -94,8 +94,8 @@ class AskBroker:
         # skips thread posting silently. Wired post-construction via
         # ``set_thread_store`` — never imported statically so this module
         # stays green without threads.py in the tree. Agreed unit-2 API:
-        #   ensure_dm_thread(scope_id, agent_a, agent_b) -> thread_id
-        #   post_message(thread_id, sender, body, kind="message",
+        #   ensure_dm_thread(scope_id, agent_a, agent_b) -> {"id": ...}
+        #   post_message(thread_id, sender, *, body=None, kind="message",
         #                recipient=None, payload=None)
         self._thread_store = thread_store
         # ``None`` → resolve ``limits.ask_bill_cap_usd()`` per accrual so
@@ -370,9 +370,9 @@ class AskBroker:
             if record.thread_id is None:
                 record.thread_id = store.ensure_dm_thread(
                     record.scope_id, record.asker, record.recipient,
-                )
+                )["id"]
             store.post_message(
-                record.thread_id, sender, body,
+                record.thread_id, sender, body=body,
                 kind="message", recipient=recipient,
                 payload={"ask_id": record.ask_id},
             )

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -167,6 +167,13 @@ class BlockedTaskLadder:
         except Exception as e:
             logger.warning("ladder: listing blocked tasks failed: %s", e)
             return
+        # C5: clear stale Needs-you rows for tasks that have left `blocked`.
+        # ``ladder_reset_unblocked`` above drops the per-episode ladder
+        # state, but the durable rung-4 ``help_requests`` row (M9-exempt
+        # from age reap) would otherwise keep the authoritative Needs-you
+        # feed asserting "human action required" long after the task
+        # unblocked/completed. The once-ever claim is deliberately kept.
+        self._reconcile_resolved_escalations(blocked)
         for task in blocked:
             task_id = task.get("id")
             if not task_id:
@@ -177,6 +184,27 @@ class BlockedTaskLadder:
                 await self._process_blocked(task, task_id, now, interval_s, fallback_s)
             except Exception as e:
                 logger.warning("ladder: escalating task %s failed: %s", task_id, e)
+
+    def _reconcile_resolved_escalations(self, blocked: list[dict]) -> None:
+        """Resolve open rung-4 Needs-you rows whose task is no longer blocked (C5)."""
+        if self._help_requests is None:
+            return
+        try:
+            open_ids = self._help_requests.open_escalation_task_ids()
+        except Exception as e:
+            logger.debug("ladder: reading open escalations failed: %s", e)
+            return
+        if not open_ids:
+            return
+        blocked_ids = {t.get("id") for t in blocked if t.get("id")}
+        for task_id in open_ids - blocked_ids:
+            try:
+                self._help_requests.resolve_for_task(task_id)
+            except Exception as e:
+                logger.debug(
+                    "ladder: resolving stale escalation for task %s failed: %s",
+                    task_id, e,
+                )
 
     async def _process_blocked(
         self, task: dict, task_id: str, now: float,
@@ -265,15 +293,17 @@ class BlockedTaskLadder:
     def _escalate_human(self, task: dict, task_id: str, note: str, reason: str) -> bool:
         """File the ONE durable Needs-you entry for this task (claim-gated).
 
-        Claim-then-deliver, same at-most-once posture as the stall nudge:
-        the claim is only consumed when a registry is wired, and a record
-        failure after the claim is logged (never retried — the operator's
-        recourse is the audit row + the task list, both durable).
+        RECORD-then-claim (C6): the once-ever ``blocked_human_notices``
+        claim is consumed only AFTER the durable Needs-you row is filed, so
+        a transient ``help_requests.db`` failure leaves the forever-claim
+        intact and a future re-block can still surface the task (instead of
+        the claim being permanently burned with no row). A read-only peek
+        preserves at-most-once-per-task-ever without consuming the claim.
         """
         if self._help_requests is None:
             return False
-        if not self._tasks.claim_blocked_human_notice(task_id):
-            return False  # already surfaced once for this task — never re-file
+        if self._tasks.blocked_human_notice_claimed(task_id):
+            return False  # already surfaced once for this task ever — never re-file
         title = sanitize_for_prompt(task.get("title") or "")[:120]
         description = (
             f"Task '{title}' ({task_id}) is blocked and the escalation "
@@ -292,10 +322,14 @@ class BlockedTaskLadder:
                     "team_id": task.get("team_id"),
                 },
             )
-            return True
         except Exception as e:
+            # Claim NOT consumed — a later re-block re-enters this path and
+            # retries the durable file (the escalation is never lost).
             logger.warning("ladder: human escalation for task %s failed: %s", task_id, e)
             return False
+        # Durable row landed — now consume the forever-claim.
+        self._tasks.claim_blocked_human_notice(task_id)
+        return True
 
     def _audit(self, task_id: str, rung: int, detail: dict) -> None:
         if self._audit_fn is None:

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -4083,18 +4083,60 @@ class CredentialVault:
             _bare_model(requested_model) == _bare_model(_utility_model)
         )
 
+        # Phase 2 unit 3 (ask_teammate) asker-billing on the STREAMING path
+        # (M2). Resolve the bill-to identity ONCE per call, keyed on the
+        # VERIFIED caller, exactly like ``execute_api_call`` (1453-1461):
+        # while an ask window is open, preflight, the team envelope, usage
+        # rows and the per-ask cap accrual all target the ASKER. Skipped
+        # for coordination (B2 precedence: the recipient's own coordination
+        # ledger absorbs utility-model churn, preserving the asker's cap).
+        # Without this, an ask delivered to an IDLE recipient runs as a
+        # streaming followup-lane work turn and the RECIPIENT silently pays.
+        bill_agent = agent_id
+        if (
+            agent_id
+            and request.service == "llm"
+            and not _is_coordination
+            and self._bill_resolver is not None
+        ):
+            try:
+                _asker = self._bill_resolver.active_billing_for(agent_id)
+            except Exception as _bill_err:  # pragma: no cover - defensive
+                logger.warning("ask bill resolver failed: %s", _bill_err)
+                _asker = None
+            if _asker:
+                bill_agent = _asker
+
         if self.cost_tracker and agent_id and request.service == "llm":
             if _is_coordination:
                 c_pre = self.cost_tracker.coordination_preflight_check(
-                    agent_id, requested_model,
+                    bill_agent, requested_model,
                 )
                 if not c_pre["allowed"]:
                     yield f"data: {json.dumps({'error': 'Coordination budget exceeded'})}\n\n"
                     return
             else:
-                preflight = self.cost_tracker.preflight_check(agent_id, requested_model)
+                preflight = self.cost_tracker.preflight_check(bill_agent, requested_model)
                 if not preflight["allowed"]:
                     yield f"data: {json.dumps({'error': 'Budget exceeded'})}\n\n"
+                    return
+                # Team envelope (plan B4 / §8 #11) — the DEFAULT production
+                # work transport STREAMS, so the envelope must be enforced
+                # here too (M1), not only on the sync ``execute_api_call``
+                # fork. Unset/0 envelope = unlimited (B4). Same message
+                # shape the sync fork yields at 1546-1562.
+                envelope = self.cost_tracker.team_envelope_check(bill_agent, requested_model)
+                if not envelope["allowed"]:
+                    _d = envelope.get("daily_limit")
+                    _m = envelope.get("monthly_limit")
+                    _msg = (
+                        f"Team budget exceeded for team '{envelope['team']}': "
+                        f"${envelope['daily_used']:.2f}"
+                        f"/{f'${_d:.2f}' if _d else 'unlimited'} daily, "
+                        f"${envelope['monthly_used']:.2f}"
+                        f"/{f'${_m:.2f}' if _m else 'unlimited'} monthly"
+                    )
+                    yield f"data: {json.dumps({'error': _msg})}\n\n"
                     return
 
         models_to_try = self._failover_chain.get_models_to_try(requested_model)
@@ -4412,10 +4454,27 @@ class CredentialVault:
             if self.cost_tracker and agent_id and tokens_used:
                 pt = prompt_tokens or int(tokens_used * 0.7)
                 ct = completion_tokens or (tokens_used - pt)
-                self.cost_tracker.track(
-                    agent_id, used_model, pt, ct,
+                tracked = self.cost_tracker.track(
+                    bill_agent, used_model, pt, ct,
                     kind="coordination" if _is_coordination else "work",
                 )
+                # Ask-window accrual (M2): key by the RECIPIENT (the
+                # verified caller) so the broker can close the window at
+                # the per-ask cap — only when the bill was actually
+                # redirected to an asker. Mirrors execute_api_call:1599.
+                if (
+                    bill_agent != agent_id
+                    and self._bill_resolver is not None
+                    and isinstance(tracked, dict)
+                ):
+                    try:
+                        self._bill_resolver.note_billed_cost(
+                            agent_id, tracked.get("cost", 0.0),
+                        )
+                    except Exception as _acc_err:  # pragma: no cover
+                        logger.warning(
+                            "ask billed-cost accrual failed: %s", _acc_err,
+                        )
 
         except Exception as e:
             logger.error(f"Streaming LLM call failed: {e}")

--- a/src/host/help_requests.py
+++ b/src/host/help_requests.py
@@ -217,13 +217,58 @@ class HelpRequests:
     # ── Maintenance ────────────────────────────────────────────────
 
     def reap_old(self, max_age_sec: float = _MAX_AGE_SEC) -> int:
-        """Delete asks older than ``max_age_sec``. Returns count deleted."""
+        """Delete asks older than ``max_age_sec``. Returns count deleted.
+
+        ``blocked_task_escalation`` rows (M9) are EXEMPT: the ladder files
+        exactly one per task EVER, guarded by an eternal
+        ``blocked_human_notices`` claim, so age-reaping the row would
+        silently evaporate the stuck task's sole human surface while the
+        claim guarantees it is never re-filed. Those rows are cleared
+        instead by ``resolve``/``resolve_for_task`` when the task leaves
+        ``blocked`` (C5) — never by age.
+        """
         cutoff = time.time() - max_age_sec
         with self._conn() as conn:
             cur = conn.execute(
-                "DELETE FROM help_requests WHERE created_at < ?", (cutoff,),
+                "DELETE FROM help_requests "
+                "WHERE created_at < ? AND kind != 'blocked_task_escalation'",
+                (cutoff,),
             )
             return cur.rowcount
+
+    def open_escalation_task_ids(self) -> set[str]:
+        """Task ids (``name`` column) of open ``blocked_task_escalation`` rows.
+
+        The ladder reconcile (C5) uses this to clear Needs-you rows for
+        tasks that have since left ``blocked``.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT name FROM help_requests "
+                "WHERE kind = 'blocked_task_escalation' AND status = 'open' "
+                "AND name IS NOT NULL",
+            ).fetchall()
+        return {r[0] for r in rows}
+
+    def resolve_for_task(self, task_id: str) -> int:
+        """Delete the open ``blocked_task_escalation`` row(s) for a task (C5).
+
+        Called when the task leaves ``blocked``/completes so the
+        authoritative Needs-you feed stops asserting "human action
+        required". The once-ever ``blocked_human_notices`` claim is
+        DELIBERATELY left intact (ratified: one human escalation per task
+        ever, surviving re-blocks) — only the open row is cleared. Returns
+        the number of rows removed.
+        """
+        if not task_id:
+            return 0
+        with self._conn() as conn:
+            cur = conn.execute(
+                "DELETE FROM help_requests "
+                "WHERE kind = 'blocked_task_escalation' AND name = ?",
+                (task_id,),
+            )
+            return cur.rowcount or 0
 
     def _safe_reap(self) -> None:
         try:

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -552,6 +552,34 @@ class Blackboard:
         """Remove all watches for an agent (cleanup on deregister)."""
         self.remove_watch(agent_id)
 
+    def remove_agent_watches_prefix(self, agent_id: str, key_prefix: str) -> int:
+        """Drop an agent's watch patterns that target ``key_prefix``.
+
+        Companion to ``PubSub.unsubscribe_agent_prefix`` for the M13
+        cross-team leak: ``get_watchers_for_key`` matches the stored
+        pattern list with no current-ACL recheck, so a watch on the OLD
+        team's ``teams/{old}/`` keys keeps notifying a departed agent.
+        Scoped by prefix so the agent's retained self-scope watches survive.
+        Returns the number of patterns removed.
+        """
+        with self._write_lock:
+            patterns = list(self._watchers.get(agent_id, []))
+            stale = [p for p in patterns if p.startswith(key_prefix)]
+            if not stale:
+                return 0
+            kept = [p for p in patterns if not p.startswith(key_prefix)]
+            if kept:
+                self._watchers[agent_id] = kept
+            else:
+                self._watchers.pop(agent_id, None)
+            for pattern in stale:
+                self.db.execute(
+                    "DELETE FROM watchers WHERE agent_id = ? AND pattern = ?",
+                    (agent_id, pattern),
+                )
+            self.db.commit()
+            return len(stale)
+
     def cleanup_agent_data(self, agent_id: str) -> int:
         """Remove all data written by an agent: entries, event log, and watches."""
         self.remove_agent_watches(agent_id)
@@ -693,6 +721,38 @@ class PubSub:
             if self._db is not None:
                 self._db.execute("DELETE FROM subscriptions WHERE agent_id = ?", (agent_id,))
                 self._db.commit()
+
+    def unsubscribe_agent_prefix(self, agent_id: str, topic_prefix: str) -> int:
+        """Drop an agent's subscriptions whose topic starts with ``topic_prefix``.
+
+        Membership rewiring (leave/move/team-delete) must purge the
+        departing agent's subscriptions to its OLD team's ``teams/{old}/``
+        topics — ``publish`` delivers to the stored subscriber list with no
+        current-ACL recheck, so a stale subscription is a live cross-team
+        event leak, not inert state (M13). Scoped by prefix so the agent's
+        own retained subscriptions (its solo ``teams/{agent_id}/`` scope)
+        are untouched. Returns the number of subscriptions removed.
+        """
+        removed = 0
+        with self._lock:
+            for topic in list(self.subscriptions):
+                if not topic.startswith(topic_prefix):
+                    continue
+                if agent_id in self.subscriptions[topic]:
+                    self.subscriptions[topic] = [
+                        a for a in self.subscriptions[topic] if a != agent_id
+                    ]
+                    removed += 1
+                    if not self.subscriptions[topic]:
+                        del self.subscriptions[topic]
+                    if self._db is not None:
+                        self._db.execute(
+                            "DELETE FROM subscriptions WHERE topic = ? AND agent_id = ?",
+                            (topic, agent_id),
+                        )
+            if removed and self._db is not None:
+                self._db.commit()
+        return removed
 
     def get_subscribers(self, topic: str) -> list[str]:
         with self._lock:

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -716,6 +716,22 @@ class Tasks:
             )
             return cur.rowcount == 1
 
+    def blocked_human_notice_claimed(self, task_id: str) -> bool:
+        """Read-only peek: has the once-ever rung-4 human claim been taken?
+
+        Lets the ladder file the durable Needs-you row BEFORE consuming the
+        claim (C6) while still preserving at-most-once-per-task-ever: a
+        transient ``help_requests.db`` failure must not burn the forever-
+        claim with no row filed (which would permanently deny the task its
+        sole human escalation across every future re-block).
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM blocked_human_notices WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()
+        return row is not None
+
     def escalated_blocked_for_team(
         self, team_id: str, *, min_rung: int = 3, sample_limit: int = 3,
     ) -> tuple[int, list[str]]:

--- a/src/host/policy.py
+++ b/src/host/policy.py
@@ -513,12 +513,19 @@ class ActionPolicyEngine:
         return PolicyDecision(decision=decision, tier=tier, action_kind=action_kind)
 
     def _accepted_count(self, agent_id: str) -> int:
-        """The probation preset's "after N accepted deliverables" count
-        (plan §6/§8 #19): ``task_outcome`` + ``summary_rating`` events
-        with ``outcome == "accepted"``, restricted to
+        """The probation preset's "after N accepted DELIVERABLES" count
+        (plan §6/§8 #19): the number of DISTINCT ``(source, ref_id)``
+        deliverables whose LATEST outcome is ``accepted``, restricted to
         :data:`AUTONOMY_RATER_KINDS` (the rating-trust rule -- an
         operator-agent's own rating never counts toward probation
         release, same as every other autonomy score).
+
+        Reads :meth:`TrackRecordStore.distinct_accepted_count`, NOT the
+        raw append-only ``counts_for_agent`` ledger: probation must count
+        deliverables, not rating rows, so re-rating one task N times can't
+        release probation (M5) and a retracted acceptance (accept-then-
+        reject on the same ref) stops counting (latest event wins). The
+        raw ledger stays the display/learning surface.
 
         No store wired, or a read failure, is treated as zero accepted
         outcomes -- fail TOWARD safety (keeps the action on hold) rather
@@ -530,7 +537,7 @@ class ActionPolicyEngine:
         if store is None:
             return 0
         try:
-            counts = store.counts_for_agent(agent_id, rater_kinds=AUTONOMY_RATER_KINDS)
+            return store.distinct_accepted_count(agent_id, rater_kinds=AUTONOMY_RATER_KINDS)
         except Exception as e:
             logger.warning(
                 "probation: track record read failed for agent %r; treating "
@@ -538,10 +545,6 @@ class ActionPolicyEngine:
                 agent_id, e,
             )
             return 0
-        return (
-            counts.get("task_outcome", {}).get("accepted", 0)
-            + counts.get("summary_rating", {}).get("accepted", 0)
-        )
 
     def _write_audit(
         self,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7666,30 +7666,46 @@ def create_mesh_app(
         except ValueError as e:
             raise HTTPException(400, f"invalid artifact name: {e}")
         repo = await _drive_repo(team_id)
-        # Quota guard — same posture as receive-pack (pre-checked; one
-        # commit may overshoot, then the endpoint blocks).
-        quota = limits_mod.resolve("drive_quota_mb") * _MB
-        size = await _drive_size(repo)
-        if size > quota:
-            raise HTTPException(
-                413,
-                f"Team Drive quota exceeded ({size // _MB} MB used, quota {quota // _MB} MB).",
-            )
         message = f"{kind} artifact {name} by {caller}"
+        # M4: serialize the quota-check → commit_file (a read-tree/update-ref
+        # CAS to main) → cache-invalidate window under the per-repo drive lock
+        # — the SAME lock the review-merge path holds. Without it, two same-team
+        # agents doing a `hand_off` `data` payload concurrently (or a hand-off
+        # landing during an auto-merge / offboard commit) lose the CAS →
+        # `RefMoved` → the `drive_write_failed` envelope, which by Constraint #10
+        # tells the agent NOT to retry — the payload is silently dropped. Holding
+        # the lock also bounds N concurrent commits to a single quota overshoot.
+        # A `RefMoved` from a writer outside the lock is retried ×3 (commit_file
+        # re-reads main's tip each attempt) before surfacing as a 409.
+        quota = limits_mod.resolve("drive_quota_mb") * _MB
+        commit: str | None = None
         try:
-            commit = await team_drive.commit_file(
-                repo,
-                path,
-                content_bytes,
-                message=message,
-                author_name=caller,
-                author_email=f"{caller}@agents.local",
-            )
-        except team_drive.RefMoved as e:
-            raise HTTPException(409, str(e))
+            async with _drive_repo_lock(team_id):
+                size = await _drive_size(repo)
+                if size > quota:
+                    raise HTTPException(
+                        413,
+                        f"Team Drive quota exceeded ({size // _MB} MB used, quota {quota // _MB} MB).",
+                    )
+                last_ref_moved: team_drive.RefMoved | None = None
+                for _ in range(3):
+                    try:
+                        commit = await team_drive.commit_file(
+                            repo,
+                            path,
+                            content_bytes,
+                            message=message,
+                            author_name=caller,
+                            author_email=f"{caller}@agents.local",
+                        )
+                        break
+                    except team_drive.RefMoved as e:
+                        last_ref_moved = e
+                else:
+                    raise HTTPException(409, str(last_ref_moved))
+                _drive_size_cache.pop(str(repo), None)
         except team_drive.DriveError as e:
             raise HTTPException(500, f"artifact commit failed: {e}")
-        _drive_size_cache.pop(str(repo), None)
         short_sha = commit[:10]
         ref = f"drive://{team_id}/{path}@{short_sha}"
         blackboard.log_audit(
@@ -10561,10 +10577,15 @@ def create_mesh_app(
                     # Retry up to 3 attempts before letting the loss surface as
                     # a manifest error, so a racing commit during the offboard
                     # window can't silently drop the departing agent's record.
+                    # M4: each attempt takes the per-repo drive lock so the
+                    # offboard commit serializes against the artifact endpoint
+                    # and the review-merge path; the retry still absorbs a
+                    # RefMoved from any writer outside the lock.
                     last: BaseException | None = None
                     for _ in range(3):
                         try:
-                            return await team_drive.commit_file(*args, **kwargs)
+                            async with _drive_repo_lock(team_id):
+                                return await team_drive.commit_file(*args, **kwargs)
                         except team_drive.RefMoved as e:
                             last = e
                     raise last  # type: ignore[misc]

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6794,6 +6794,36 @@ def create_mesh_app(
 
     app._schedule_onboarding_wake = _schedule_onboarding_wake  # exposed for the dashboard
 
+    def _purge_departed_team_signals(agent_id: str, old_team: str) -> None:
+        """Cross-team event-leak fix (M13, security).
+
+        A member leaving ``old_team`` (remove / move / team delete) has its
+        blackboard ACL rewired, but ``publish`` and the blackboard watcher
+        fan-out both read the STORED subscriber/watcher lists with NO
+        current-ACL recheck — so the departed agent keeps receiving the old
+        team's ``teams/{old_team}/`` published signals and watched-key
+        notifications after it has left, crossing the team wall enforced
+        everywhere else. Purge those subscriptions/watches, scoped by
+        prefix so the agent's own retained self-scope (``teams/{agent_id}/``)
+        is untouched. Best-effort — never raise into the membership endpoint.
+        """
+        prefix = f"teams/{old_team}/"
+        if pubsub is not None:
+            try:
+                pubsub.unsubscribe_agent_prefix(agent_id, prefix)
+            except Exception as e:
+                logger.warning(
+                    "pubsub prefix purge for %s leaving %s failed: %s",
+                    agent_id, old_team, e,
+                )
+        try:
+            blackboard.remove_agent_watches_prefix(agent_id, prefix)
+        except Exception as e:
+            logger.warning(
+                "watch prefix purge for %s leaving %s failed: %s",
+                agent_id, old_team, e,
+            )
+
     @app.post("/mesh/teams/{team_name}/members")
     async def mesh_add_team_member(team_name: str, request: Request) -> dict:
         """Add an agent to a team (mesh-authed proxy)."""
@@ -6809,12 +6839,33 @@ def create_mesh_app(
         agent = body.get("agent", "").strip()
         if not agent:
             raise HTTPException(400, "agent is required")
+        # M10 — an unknown agent id (a typo, a deleted agent) must not
+        # silently create a ghost ``team_members`` row that the Phase-4
+        # lead/standup machinery then treats as real (ghost lead, ghost
+        # standup cron, ghost plate row). ``teams_store.add_member`` has no
+        # FK, so the guard lives here. "Known agent" = any authoritative
+        # record of the id — the config (agents.yaml, the create-path
+        # source of truth), the live router registry, or the ACL matrix;
+        # a ghost id has none of these. The operator is refused outright
+        # (a system agent, never team data — mirrors the create path).
+        from src.cli.config import _load_config
+
+        if agent == "operator":
+            raise HTTPException(
+                400, "Operator is a system agent and cannot be assigned to teams"
+            )
+        known_agents = set(_load_config().get("agents", {}).keys())
+        known_agents |= set(router.agent_registry.keys())
+        known_agents |= {a for a in permissions.permissions if a not in ("default", "mesh")}
+        if agent not in known_agents:
+            raise HTTPException(400, f"Unknown agent: {agent}")
         try:
             old = teams_store.add_member(team_name, agent)
         except (TeamNotFound, ValueError) as e:
             raise HTTPException(400, str(e))
         if old and old != team_name:
             _remove_team_blackboard_permissions(agent, old)
+            _purge_departed_team_signals(agent, old)
         _add_team_blackboard_permissions(agent, team_name)
         permissions.reload()
         _schedule_onboarding_wake(agent, team_name)
@@ -6832,6 +6883,7 @@ def create_mesh_app(
             raise HTTPException(400, f"Team '{team_name}' not found")
         teams_store.remove_member(team_name, agent)
         _remove_team_blackboard_permissions(agent, team_name)
+        _purge_departed_team_signals(agent, team_name)
         permissions.reload()
         return {"removed": True, "team_id": team_name, "team_name": team_name, "agent": agent}
 
@@ -6849,6 +6901,7 @@ def create_mesh_app(
             raise HTTPException(404, str(e))
         for agent in former_members:
             _remove_team_blackboard_permissions(agent, team_name)
+            _purge_departed_team_signals(agent, team_name)
         if former_members:
             permissions.reload()
         # Archive (never delete — audit trail) the team's threads. The

--- a/src/host/teams.py
+++ b/src/host/teams.py
@@ -859,28 +859,79 @@ class TeamStore:
         """Transition a ``merging`` review to ``merged`` once main is
         integrated. Raises ValueError if the row is no longer ``merging``
         — but the merge commit is already on main, so the caller must
-        surface the divergence rather than silently swallow it."""
+        surface the divergence rather than silently swallow it.
+
+        M14: also supersedes any OPEN same-branch review pinned to the SAME
+        ``head_sha`` just merged. A same-sha resubmit that raced the claim
+        window (``create_review`` only supersedes ``open`` rows, so it
+        missed the ``merging`` one and inserted its own open row) would
+        otherwise later re-merge already-integrated content — a redundant
+        merge commit that also burns an auto-merge daily-cap slot and mints
+        a duplicate track-record event. Dropping it here closes that race."""
+        now = _now()
         with self._txn() as conn:
-            row = conn.execute("SELECT status FROM drive_reviews WHERE id = ?", (review_id,)).fetchone()
+            row = conn.execute(
+                "SELECT status, team_id, branch, head_sha FROM drive_reviews WHERE id = ?",
+                (review_id,),
+            ).fetchone()
             if row is None:
                 raise ValueError(f"Review '{review_id}' not found")
             if row[0] != "merging":
                 raise ValueError(f"Review '{review_id}' is {row[0]}, expected merging")
+            team_id, branch, head_sha = row[1], row[2], row[3]
             conn.execute(
                 "UPDATE drive_reviews SET status = 'merged', reviewer = ?, merge_commit = ?, resolved_at = ? "
                 "WHERE id = ?",
-                (reviewer, merge_commit, _now(), review_id),
+                (reviewer, merge_commit, now, review_id),
             )
+            if head_sha is not None:
+                # NULL head_sha never matches (SQL NULL comparison), and
+                # superseding all NULL-sha opens would be wrong — so guard.
+                conn.execute(
+                    "UPDATE drive_reviews SET status = 'superseded', resolved_at = ? "
+                    "WHERE team_id = ? AND branch = ? AND status = 'open' "
+                    "AND head_sha = ? AND id != ?",
+                    (now, team_id, branch, head_sha, review_id),
+                )
         return self.get_review(review_id)  # type: ignore[return-value]
 
     def revert_merge_claim(self, review_id: str) -> None:
-        """Roll a ``merging`` review back to ``open`` after a failed git
-        merge (nothing reached main). No-op if the row already moved."""
+        """Roll a ``merging`` review back after a failed git merge (nothing
+        reached main). Normally returns it to ``open`` so it can be
+        re-merged.
+
+        M14: but ``create_review`` only supersedes ``open`` rows, so a
+        same-branch resubmit that raced this merge-claim window inserted a
+        NEW ``open`` review and left this ``merging`` one alone. Blindly
+        flipping back to ``open`` would then leave TWO live open reviews for
+        one branch (breaking the one-live-review-per-branch invariant). So
+        when a newer open row already owns ``(team, branch)``, this reverted
+        row is marked ``superseded`` instead — the resubmit is the live
+        review now. No-op if the row already moved off ``merging``."""
+        now = _now()
         with self._txn() as conn:
-            conn.execute(
-                "UPDATE drive_reviews SET status = 'open' WHERE id = ? AND status = 'merging'",
+            row = conn.execute(
+                "SELECT team_id, branch FROM drive_reviews WHERE id = ? AND status = 'merging'",
                 (review_id,),
-            )
+            ).fetchone()
+            if row is None:
+                return
+            team_id, branch = row[0], row[1]
+            newer_open = conn.execute(
+                "SELECT 1 FROM drive_reviews "
+                "WHERE team_id = ? AND branch = ? AND status = 'open' AND id != ? LIMIT 1",
+                (team_id, branch, review_id),
+            ).fetchone()
+            if newer_open is not None:
+                conn.execute(
+                    "UPDATE drive_reviews SET status = 'superseded', resolved_at = ? WHERE id = ?",
+                    (now, review_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE drive_reviews SET status = 'open' WHERE id = ?",
+                    (review_id,),
+                )
 
     # ── files ────────────────────────────────────────────────────
 

--- a/src/host/track_record.py
+++ b/src/host/track_record.py
@@ -265,6 +265,61 @@ class TrackRecordStore:
             counts.setdefault(source, {})[outcome] = n
         return counts
 
+    def distinct_accepted_count(
+        self,
+        agent_id: str,
+        *,
+        rater_kinds: tuple[str, ...] = AUTONOMY_RATER_KINDS,
+        outcome: str = "accepted",
+    ) -> int:
+        """Count DISTINCT deliverables whose LATEST outcome is ``outcome``.
+
+        Unlike :meth:`counts_for_agent` (raw append-only row counts — kept
+        for display/learning), this collapses the ledger to ONE event per
+        ``(source, ref_id)`` — the newest by ``(created_at, id)`` — before
+        counting. So re-rating the same task N times counts as ONE
+        deliverable, and a later ``accepted -> rejected`` correction drops
+        the deliverable from the count entirely (the latest event wins).
+
+        Restricted to ``rater_kinds`` (the rating-trust rule — defaults to
+        :data:`AUTONOMY_RATER_KINDS`) so an operator-*agent* re-rate can
+        neither inflate the count nor retract a human acceptance: the
+        autonomy-relevant state of a deliverable is decided only by the
+        rater kinds that feed the trust ladder. Used by the probation
+        preset's "after N accepted deliverables" release gate (plan §8
+        #19) — the raw ledger stays the display/learning surface.
+
+        Only ``task_outcome`` / ``summary_rating`` sources ever carry an
+        ``accepted`` outcome (drive-review vocabulary is merged/rejected/
+        auto_merged), so the default matches the pre-fix
+        task_outcome+summary_rating restriction on WHICH sources count,
+        while fixing the re-rate/retract miscount.
+        """
+        if not rater_kinds:
+            return 0
+        placeholders = ",".join("?" for _ in rater_kinds)
+        params: list[Any] = [agent_id, *rater_kinds]
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT source, ref_id, outcome FROM outcome_events "
+                f"WHERE agent_id = ? AND rater_kind IN ({placeholders}) "
+                "ORDER BY created_at DESC, id DESC",
+                params,
+            ).fetchall()
+        seen: set[tuple[str, str]] = set()
+        count = 0
+        for source, ref_id, ev_outcome in rows:
+            key = (source, ref_id)
+            if key in seen:
+                # Older event for a deliverable whose latest was already
+                # seen (rows are newest-first) — the latest already decided
+                # this deliverable's state.
+                continue
+            seen.add(key)
+            if ev_outcome == outcome:
+                count += 1
+        return count
+
     def recent_events(self, agent_id: str, limit: int = 20) -> list[dict]:
         """Newest-first events for one agent, hard-capped at 200."""
         limit = max(1, min(int(limit), 200))

--- a/tests/test_ask_teammate.py
+++ b/tests/test_ask_teammate.py
@@ -232,16 +232,22 @@ class TestAskBroker:
         assert broker.get(rec.ask_id) is None
 
     async def test_thread_store_optional_and_posted(self):
+        # ``ensure_dm_thread`` returns the thread ROW (a dict) — the real
+        # ThreadStore contract; the id lives under ``id``. ``post_message``
+        # takes ``body`` keyword-only. (The old mock returned a bare string
+        # and asserted ``body`` positional, which masked the M3 seam bug.)
         store = MagicMock()
-        store.ensure_dm_thread.return_value = "th_1"
+        store.ensure_dm_thread.return_value = {"id": "th_1"}
         broker = AskBroker(thread_store=store)
         rec = broker.create("a", "b", "why?", 30, scope_id="alpha")
         store.ensure_dm_thread.assert_called_once_with("alpha", "a", "b")
         assert broker.resolve(rec.ask_id, "because", by="b")["ok"]
         assert store.post_message.call_count == 2
         q_call, a_call = store.post_message.call_args_list
-        assert q_call.args[:3] == ("th_1", "a", "why?")
-        assert a_call.args[:3] == ("th_1", "b", "because")
+        assert q_call.args[:2] == ("th_1", "a")
+        assert q_call.kwargs["body"] == "why?"
+        assert a_call.args[:2] == ("th_1", "b")
+        assert a_call.kwargs["body"] == "because"
         assert a_call.kwargs["payload"] == {"ask_id": rec.ask_id}
 
     async def test_thread_store_error_is_nonfatal(self):

--- a/tests/test_ask_thread_post_review_fix.py
+++ b/tests/test_ask_thread_post_review_fix.py
@@ -1,0 +1,58 @@
+"""Regression test for M3 (Phase 0-5 integration review).
+
+``AskBroker._post_thread`` posted the ask question/answer into the durable
+Team Threads store with ``body`` passed positionally (``ThreadStore.post_message``
+declares it keyword-only) and assigned the dict returned by ``ensure_dm_thread``
+as the ``thread_id``. Both raised ``TypeError`` swallowed by the broker's
+non-fatal warning, so no ask Q&A ever landed in the thread store.
+
+These tests wire a real ``ThreadStore(":memory:")`` and assert both the question
+and the answer rows are persisted on the pair's DM thread.
+"""
+
+import asyncio
+
+from src.host.asks import AskBroker
+from src.host.threads import ThreadStore
+
+
+def _dm_messages(store: ThreadStore, scope_id: str, a: str, b: str) -> list[dict]:
+    thread = store.ensure_dm_thread(scope_id, a, b)
+    return store.list_messages(thread["id"])
+
+
+def test_ask_question_and_answer_land_in_thread_store():
+    async def _run():
+        store = ThreadStore(":memory:")
+        broker = AskBroker(thread_store=store)
+        record = broker.create(
+            "asker", "recipient", "what is the status?", 30, scope_id="team-x"
+        )
+        # The question must be durably recorded (was silently lost pre-fix).
+        msgs = _dm_messages(store, "team-x", "asker", "recipient")
+        assert [m["body"] for m in msgs] == ["what is the status?"]
+        assert msgs[0]["sender"] == "asker"
+        assert msgs[0]["payload"] == {"ask_id": record.ask_id}
+
+        # The answer must also land on the same DM thread.
+        result = broker.resolve(record.ask_id, "all green", by="recipient")
+        assert result == {"ok": True}
+        msgs = _dm_messages(store, "team-x", "asker", "recipient")
+        assert [m["body"] for m in msgs] == ["what is the status?", "all green"]
+        assert msgs[1]["sender"] == "recipient"
+        store.close()
+
+    asyncio.run(_run())
+
+
+def test_ask_thread_id_is_a_string_not_a_dict():
+    async def _run():
+        store = ThreadStore(":memory:")
+        broker = AskBroker(thread_store=store)
+        record = broker.create("a", "b", "q", 30, scope_id="team-y")
+        # ensure_dm_thread returns a dict; the record must hold the id string.
+        assert isinstance(record.thread_id, str)
+        assert record.thread_id == "dm:a:b"
+        store.close()
+
+    asyncio.run(_run())

--- a/tests/test_cli_remove_review_fix.py
+++ b/tests/test_cli_remove_review_fix.py
@@ -1,0 +1,101 @@
+"""Regression tests for M11 + M12 (Phase 0-5 integration review).
+
+M12 — CLI ``/remove`` had no operator guard, so ``/remove operator`` + confirm
+would offboard and destroy the human's front-door agent; the mesh (403/400)
+and dashboard ("system agent") delete surfaces both refuse it.
+
+M11 — CLI ``/remove`` skipped the per-agent data cleanup the mesh and dashboard
+delete paths run (vault / private blackboard namespace / cost+trace rows /
+wallet + ``permissions.reload()``), so a same-name recreate inherited the
+deleted agent's wallet and private namespace.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+class _FakeCtx:
+    """Minimal stand-in for ``RuntimeContext`` — only the attributes
+    ``_cmd_remove`` actually touches."""
+
+    def __init__(self, agents):
+        self.agents = dict(agents)
+        self.runtime = MagicMock()
+        self.router = MagicMock()
+        self.transport = MagicMock()
+        self.health_monitor = MagicMock()
+        self.pubsub = MagicMock()
+        self.cron_scheduler = MagicMock()
+        self.cron_scheduler.remove_agent_jobs.return_value = 0
+        self.lane_manager = MagicMock()
+        self.connector_store = None
+        self.event_bus = None
+        self.offboard_agent = None
+        self.cleanup_agent = MagicMock()
+        self._dispatch_loop = None
+
+    @property
+    def dispatch_loop(self):
+        return self._dispatch_loop
+
+
+def _make_session(ctx):
+    from src.cli.repl import REPLSession
+
+    session = REPLSession.__new__(REPLSession)  # bypass __init__ (readline setup)
+    session.ctx = ctx
+    session.current = next(iter(ctx.agents), None)
+    return session
+
+
+def _patch_confirm_and_remove_agent(monkeypatch, confirm=True):
+    monkeypatch.setattr("click.confirm", lambda *a, **k: confirm)
+    monkeypatch.setattr("src.cli.config._remove_agent", lambda name, **kw: None)
+
+
+class TestOperatorGuardM12:
+    def test_remove_operator_by_name_is_refused(self, monkeypatch):
+        _patch_confirm_and_remove_agent(monkeypatch)
+        ctx = _FakeCtx({"operator": {}, "scout": {}})
+        session = _make_session(ctx)
+        session._cmd_remove("operator")
+        # Never stopped, never cleaned up — the guard returns before any teardown.
+        ctx.runtime.stop_agent.assert_not_called()
+        ctx.cleanup_agent.assert_not_called()
+
+    def test_interactive_picker_excludes_operator(self, monkeypatch):
+        _patch_confirm_and_remove_agent(monkeypatch)
+        ctx = _FakeCtx({"operator": {}, "scout": {}})
+        session = _make_session(ctx)
+        # Empty arg → picker. With operator excluded only ``scout`` remains, so
+        # it auto-selects (len==1) and never prompts for the operator.
+        session._cmd_remove("")
+        ctx.runtime.stop_agent.assert_called_once_with("scout", remove_data=True)
+
+    def test_picker_with_only_operator_removes_nothing(self, monkeypatch):
+        _patch_confirm_and_remove_agent(monkeypatch)
+        ctx = _FakeCtx({"operator": {}})
+        session = _make_session(ctx)
+        session._cmd_remove("")
+        ctx.runtime.stop_agent.assert_not_called()
+        ctx.cleanup_agent.assert_not_called()
+
+
+class TestCleanupParityM11:
+    def test_remove_runs_per_agent_cleanup(self, monkeypatch):
+        _patch_confirm_and_remove_agent(monkeypatch)
+        ctx = _FakeCtx({"scout": {}})
+        session = _make_session(ctx)
+        session._cmd_remove("scout")
+        # The mesh/dashboard-parity teardown must run for the removed agent.
+        ctx.cleanup_agent.assert_called_once_with("scout")
+
+    def test_cleanup_seam_unwired_is_tolerated(self, monkeypatch):
+        _patch_confirm_and_remove_agent(monkeypatch)
+        ctx = _FakeCtx({"scout": {}})
+        ctx.cleanup_agent = None  # mesh app not wired (degraded case)
+        session = _make_session(ctx)
+        # Must not raise even without the seam.
+        session._cmd_remove("scout")
+        ctx.runtime.stop_agent.assert_called_once_with("scout", remove_data=True)

--- a/tests/test_coordination_split.py
+++ b/tests/test_coordination_split.py
@@ -377,6 +377,111 @@ class TestStreamingPath:
         assert [r[1] for r in _usage_rows(tracker, "worker")] == ["work"]
         tracker.close()
 
+    @pytest.mark.asyncio
+    async def test_stream_work_blocked_by_exhausted_team_envelope(self, tmp_path, monkeypatch):
+        """M1: the team envelope is enforced on the STREAMING work fork —
+        the default production transport (``llm.chat_collect`` streams).
+        Regression: the envelope lived only on ``execute_api_call`` so real
+        (streaming) traffic silently ignored it."""
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        store.add_member("alpha", "worker")
+        store.add_member("alpha", "burner")
+        store.set_budget("alpha", 0.001, None)
+        vault, tracker = _vault_and_tracker(tmp_path, monkeypatch, team_store=store)
+        tracker.track("burner", WORK_MODEL, 100_000, 50_000)
+
+        # Streaming WORK call is blocked by the exhausted envelope, and never
+        # opens a stream (no usage row lands).
+        events = []
+        async for event in vault.stream_llm(_chat_request(WORK_MODEL), agent_id="worker"):
+            events.append(event)
+        assert any("Team budget exceeded" in e for e in events)
+        assert _usage_rows(tracker, "worker") == []
+
+        # Negative control: coordination is exempt from the envelope even on
+        # the streaming fork (B2 precedence preserved).
+        async def mock_stream_acompletion(model, messages, api_key, stream=False, **kwargs):
+            return _MockStream()
+
+        with patch("litellm.acompletion", side_effect=mock_stream_acompletion):
+            events = []
+            async for event in vault.stream_llm(_chat_request(UTILITY_MODEL), agent_id="worker"):
+                events.append(event)
+        assert any("done" in e for e in events)
+        tracker.close()
+
+    @pytest.mark.asyncio
+    async def test_stream_unset_team_envelope_does_not_block(self, tmp_path, monkeypatch):
+        """M1 pin: an UNSET team envelope is UNLIMITED (B4) — the streaming
+        envelope check must not over-block a team that hasn't been given a
+        budget. Mirrors the sync ``test_zero_envelope_does_not_block``."""
+        store = TeamStore(db_path=":memory:")
+        store.create_team("alpha")
+        store.add_member("alpha", "worker")
+        # Deliberately NO set_budget — unset envelope == unlimited.
+        vault, tracker = _vault_and_tracker(tmp_path, monkeypatch, team_store=store)
+
+        async def mock_stream_acompletion(model, messages, api_key, stream=False, **kwargs):
+            return _MockStream()
+
+        with patch("litellm.acompletion", side_effect=mock_stream_acompletion):
+            events = []
+            async for event in vault.stream_llm(_chat_request(WORK_MODEL), agent_id="worker"):
+                events.append(event)
+        assert any("done" in e for e in events)
+        assert [r[1] for r in _usage_rows(tracker, "worker")] == ["work"]
+        tracker.close()
+
+
+class TestStreamingAskBilling:
+    """M2: the ask_teammate asker-billing window applies on the STREAMING
+    path too — an ask delivered to an IDLE recipient runs as a streaming
+    followup-lane work turn. Mirrors ``TestAskWindowPrecedence`` (sync)."""
+
+    @pytest.mark.asyncio
+    async def test_stream_work_redirects_billing_to_asker(self, tmp_path, monkeypatch):
+        vault, tracker = _vault_and_tracker(tmp_path, monkeypatch)
+        broker = _FakeBroker()
+        vault.set_bill_resolver(broker)
+
+        async def mock_stream_acompletion(model, messages, api_key, stream=False, **kwargs):
+            return _MockStream()
+
+        with patch("litellm.acompletion", side_effect=mock_stream_acompletion):
+            events = []
+            async for event in vault.stream_llm(_chat_request(WORK_MODEL), agent_id="worker"):
+                events.append(event)
+        assert any("done" in e for e in events)
+        # The ASKER pays for the ask turn; the recipient's ledger is untouched.
+        assert [r[1] for r in _usage_rows(tracker, "asker")] == ["work"]
+        assert _usage_rows(tracker, "worker") == []
+        # Ask-cap accrual is noted, keyed by the RECIPIENT (verified caller).
+        assert len(broker.noted) == 1
+        assert broker.noted[0][0] == "worker"
+        tracker.close()
+
+    @pytest.mark.asyncio
+    async def test_stream_coordination_bills_caller_not_asker(self, tmp_path, monkeypatch):
+        """Coordination classification WINS over an open ask window on the
+        streaming fork too — the redirect is skipped, the caller pays."""
+        vault, tracker = _vault_and_tracker(tmp_path, monkeypatch)
+        broker = _FakeBroker()
+        vault.set_bill_resolver(broker)
+
+        async def mock_stream_acompletion(model, messages, api_key, stream=False, **kwargs):
+            return _MockStream()
+
+        with patch("litellm.acompletion", side_effect=mock_stream_acompletion):
+            events = []
+            async for event in vault.stream_llm(_chat_request(UTILITY_MODEL), agent_id="worker"):
+                events.append(event)
+        assert any("done" in e for e in events)
+        assert [r[1] for r in _usage_rows(tracker, "worker")] == ["coordination"]
+        assert _usage_rows(tracker, "asker") == []
+        assert broker.noted == []
+        tracker.close()
+
 
 class TestReportingInclusive:
     """Reporting surfaces keep including coordination rows (money is money)."""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6993,6 +6993,91 @@ class TestDashboardChatStreamBusyAwareFork:
         assert events[-1]["type"] == "done"
 
 
+class TestDashboardBusyStreamHardening:
+    """M15 regression — the busy /chat/stream relay and /api/broadcast must
+    (a) gate lane sentinels through ``usable_agent_reply`` so a stopped or
+    unreachable agent's internal token never renders as its reply, and
+    (b) emit keepalive comments while ``deliver_chat`` is pending so a
+    busy-steered reply taking >120s isn't client-aborted before it lands."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_busy_stream_gates_silent_sentinel(self):
+        """M15a: a ``__SILENT__`` lane sentinel must not render as the
+        agent's reply — it is replaced with the human-readable fallback."""
+        from src.shared.types import SILENT_REPLY_TOKEN
+
+        self.components["lane_manager"].get_status.return_value = {"alpha": {"busy": True}}
+        self.components["lane_manager"].deliver_chat = AsyncMock(return_value=SILENT_REPLY_TOKEN)
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat/stream", json={"message": "hi"},
+        )
+        assert resp.status_code == 200
+        events = _parse_sse(resp.text)
+        assert SILENT_REPLY_TOKEN not in resp.text
+        assert events[-1]["type"] == "done"
+        assert events[-1]["response"] == "The agent did not produce a reply."
+        reply_chunk = [e for e in events if e["type"] == "text_delta"][-1]
+        assert reply_chunk["content"] == "The agent did not produce a reply."
+
+    def test_busy_stream_gates_dispatch_error_sentinel(self):
+        """M15a: a ``dispatch_error:`` lane shape is gated too."""
+        self.components["lane_manager"].get_status.return_value = {"alpha": {"busy": True}}
+        self.components["lane_manager"].deliver_chat = AsyncMock(
+            return_value="dispatch_error: container gone",
+        )
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat/stream", json={"message": "hi"},
+        )
+        events = _parse_sse(resp.text)
+        assert "dispatch_error:" not in resp.text
+        assert events[-1]["response"] == "The agent did not produce a reply."
+
+    def test_broadcast_gates_sentinel(self):
+        """M15a: /api/broadcast gates the same sentinels per recipient."""
+        from src.shared.types import SILENT_REPLY_TOKEN
+
+        self.components["lane_manager"].deliver_chat = AsyncMock(return_value=SILENT_REPLY_TOKEN)
+        resp = self.client.post("/dashboard/api/broadcast", json={"message": "hello all"})
+        assert resp.status_code == 200
+        for reply in resp.json()["responses"].values():
+            assert reply == "The agent did not produce a reply."
+            assert SILENT_REPLY_TOKEN not in reply
+
+    def test_busy_stream_emits_keepalive_while_pending(self, monkeypatch):
+        """M15b: while ``deliver_chat`` is pending, the busy generator emits
+        ``: keepalive`` SSE comments so the SPA's 120s no-data abort can't
+        fire before the steered reply lands."""
+        import asyncio
+
+        import src.dashboard.server as ds_server
+
+        monkeypatch.setattr(ds_server, "_BUSY_KEEPALIVE_INTERVAL_SECONDS", 0.02)
+        self.components["lane_manager"].get_status.return_value = {"alpha": {"busy": True}}
+
+        async def _slow_deliver(aid, message, *, trace_id=None, origin=None):
+            await asyncio.sleep(0.12)
+            return "the steered reply"
+
+        self.components["lane_manager"].deliver_chat = AsyncMock(side_effect=_slow_deliver)
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat/stream", json={"message": "hurry"},
+        )
+        assert resp.status_code == 200
+        # Keepalive comments are present (pre-fix the generator went silent).
+        assert ": keepalive" in resp.text
+        events = _parse_sse(resp.text)
+        assert events[-1]["type"] == "done"
+        assert events[-1]["response"] == "the steered reply"
+
+
 class TestDashboardBroadcastPrioritySteerLane:
     """Phase-4 unit 5 (plan §8 #10 residual): ``/api/broadcast`` fans out
     through ``LaneManager.deliver_chat`` per recipient instead of calling

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2928,6 +2928,14 @@ class TestLeadRecommendationUI:
         assert 'x-show="msg.lead_recommendation"' in _INDEX_HTML
         assert "'Lead recommends: ' + msg.lead_recommendation" in _INDEX_HTML
 
+    def test_both_pending_card_templates_render_the_recommendation(self):
+        """M18 parity: the recommendation binding must appear on BOTH
+        ``pending_action_card`` render sites — the Chat-tab operator panel
+        AND the messenger view (the messenger card omitted it pre-fix, so a
+        lead's advisory recommendation was invisible there)."""
+        assert _INDEX_HTML.count('x-show="msg.lead_recommendation"') == 2
+        assert _INDEX_HTML.count("'Lead recommends: ' + msg.lead_recommendation") == 2
+
     def test_inject_pending_action_card_carries_recommendation_fields(self):
         m = re.search(
             r"_injectPendingActionCard\(data\)\s*\{(.*?)\n    \},",

--- a/tests/test_drive_review_race_review_fix.py
+++ b/tests/test_drive_review_race_review_fix.py
@@ -1,0 +1,121 @@
+"""M14 regression — Team Drive review-queue race: a same-branch resubmit
+racing an in-flight merge claim must not break the one-live-review-per-
+branch invariant.
+
+``create_review`` only supersedes ``open`` rows (it misses a ``merging``
+one), so a resubmit that lands during the merge-claim window inserts a
+NEW open review alongside the claimed one. Two failure modes follow:
+
+  (A) zombie — the merge aborts (live-sha check fails) and
+      ``revert_merge_claim`` blindly flips the claimed row back to
+      ``open`` → TWO open reviews for one branch, one a stale zombie.
+  (B) double-merge — a SAME-sha resubmit while the first review merges
+      pins the already-merged sha; approving it later re-merges
+      integrated content.
+
+Store-only fix (no endpoint change): ``revert_merge_claim`` supersedes
+the reverted row when a newer open row already owns the branch;
+``finalize_merge`` supersedes any open same-branch row on the same
+head_sha it just merged.
+"""
+
+import pytest
+
+from src.host.teams import TeamStore
+
+
+@pytest.fixture
+def store():
+    s = TeamStore(db_path=":memory:")
+    s.create_team("team-x")
+    return s
+
+
+def _open_reviews(store: TeamStore, branch: str) -> list[dict]:
+    return [r for r in store.list_reviews("team-x", status="open") if r["branch"] == branch]
+
+
+def test_revert_after_resubmit_supersedes_zombie(store):
+    """Mode A: resubmit races the merge claim → revert must supersede the
+    reverted row, leaving exactly ONE open review for the branch."""
+    r1 = store.create_review("team-x", "feat-a", "member1", "first", head_sha="aaa")
+    store.claim_review_for_merge(r1["id"])  # open -> merging
+
+    # Resubmit lands during the claim window. create_review only supersedes
+    # OPEN rows, so R1 (merging) survives and R2 is inserted open.
+    r2 = store.create_review("team-x", "feat-a", "member1", "second", head_sha="bbb")
+    assert store.get_review(r1["id"])["status"] == "merging"
+    assert store.get_review(r2["id"])["status"] == "open"
+
+    # Git merge aborts (live-sha advanced) → revert.
+    store.revert_merge_claim(r1["id"])
+
+    assert store.get_review(r1["id"])["status"] == "superseded"
+    assert store.get_review(r2["id"])["status"] == "open"
+    # The invariant holds: exactly one live review for the branch.
+    assert [r["id"] for r in _open_reviews(store, "feat-a")] == [r2["id"]]
+
+
+def test_revert_without_resubmit_still_reopens(store):
+    """No resubmit raced → revert restores the row to open (unchanged
+    pre-M14 behavior, so a genuine transient git failure is re-mergeable)."""
+    r = store.create_review("team-x", "feat-b", "member1", "t", head_sha="ccc")
+    store.claim_review_for_merge(r["id"])
+    store.revert_merge_claim(r["id"])
+    assert store.get_review(r["id"])["status"] == "open"
+
+
+def test_revert_noop_when_not_merging(store):
+    """Revert is a no-op on a row that already moved off ``merging``
+    (resolve_review only acts on ``open``, so reach ``rejected`` via a
+    clean revert-to-open first)."""
+    r = store.create_review("team-x", "feat-b2", "member1", "t")
+    store.claim_review_for_merge(r["id"])
+    store.revert_merge_claim(r["id"])  # merging -> open (no resubmit raced)
+    store.resolve_review(r["id"], "rejected", reviewer="operator")  # open -> rejected
+    store.revert_merge_claim(r["id"])  # no-op: row is not merging
+    assert store.get_review(r["id"])["status"] == "rejected"
+
+
+def test_finalize_supersedes_same_sha_resubmit(store):
+    """Mode B: a same-sha resubmit racing the merge must be superseded when
+    the first review finalizes, so it can't later re-merge merged content."""
+    r1 = store.create_review("team-x", "feat-c", "member1", "first", head_sha="deadbeef")
+    store.claim_review_for_merge(r1["id"])  # open -> merging
+
+    # Same-sha resubmit during the claim window (open, same head_sha).
+    r2 = store.create_review("team-x", "feat-c", "member1", "resubmit", head_sha="deadbeef")
+    assert store.get_review(r2["id"])["status"] == "open"
+
+    store.finalize_merge(r1["id"], "mergecommit", reviewer="operator")
+
+    assert store.get_review(r1["id"])["status"] == "merged"
+    # The redundant same-sha open review is dropped.
+    assert store.get_review(r2["id"])["status"] == "superseded"
+    assert _open_reviews(store, "feat-c") == []
+
+
+def test_finalize_leaves_different_sha_resubmit_open(store):
+    """A resubmit with a DIFFERENT sha is genuinely new work — finalizing
+    the first review must leave it open (it still needs its own merge)."""
+    r1 = store.create_review("team-x", "feat-d", "member1", "first", head_sha="1111")
+    store.claim_review_for_merge(r1["id"])
+    r2 = store.create_review("team-x", "feat-d", "member1", "newer", head_sha="2222")
+
+    store.finalize_merge(r1["id"], "mc", reviewer="operator")
+
+    assert store.get_review(r1["id"])["status"] == "merged"
+    assert store.get_review(r2["id"])["status"] == "open"
+
+
+def test_finalize_null_sha_does_not_supersede_other_nulls(store):
+    """A NULL head_sha must not sweep up unrelated NULL-sha open reviews
+    (SQL NULL never equals NULL; the guard makes that explicit)."""
+    r1 = store.create_review("team-x", "feat-e", "member1", "first")  # head_sha None
+    store.claim_review_for_merge(r1["id"])
+    r2 = store.create_review("team-x", "feat-e", "member1", "other")  # head_sha None
+
+    store.finalize_merge(r1["id"], "mc", reviewer="operator")
+
+    assert store.get_review(r1["id"])["status"] == "merged"
+    assert store.get_review(r2["id"])["status"] == "open"

--- a/tests/test_ladder_helprequest_review_fix.py
+++ b/tests/test_ladder_helprequest_review_fix.py
@@ -1,0 +1,134 @@
+"""Regression tests for M9 + C5 + C6 (Phase 0-5 integration review).
+
+The blocked-task ladder files ONE durable Needs-you ``help_requests`` row per
+task ever (rung 4). Three seam defects around that row:
+
+M9 — the 14-day ``reap_old`` age-swept the ``blocked_task_escalation`` row while
+the eternal ``blocked_human_notices`` claim guaranteed it could never be re-filed
+— evaporating a still-stuck task's sole human surface.
+
+C5 — unblock/complete cleared the ladder state but not the open ``help_requests``
+row, so the authoritative Needs-you feed kept asserting "human action required".
+
+C6 — rung 4 consumed the forever-claim BEFORE inserting the row; a transient
+``help_requests.db`` failure burned the claim with no row filed, permanently
+denying the task its only human escalation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.host.chain_watcher import BlockedTaskLadder
+from src.host.help_requests import HelpRequests
+from src.host.orchestration import Tasks
+
+INTERVAL = 600.0
+FALLBACK = 48 * 3600.0
+_BUDGET_NOTE = "Budget exceeded: $2.00/$2.00 daily"
+
+
+def _store() -> Tasks:
+    return Tasks(db_path=":memory:")
+
+
+def _blocked_task(store: Tasks, *, note: str = _BUDGET_NOTE) -> dict:
+    t = store.create(creator="ops", assignee="scout", title="do the thing")
+    store.update_status(t["id"], "working", actor="scout")
+    store.update_status(t["id"], "blocked", actor="scout", blocker_note=note)
+    return store.get(t["id"])
+
+
+def _ladder(store: Tasks, clk: list, **kw) -> BlockedTaskLadder:
+    defaults: dict = dict(interval_s=INTERVAL, fallback_s=FALLBACK, wall_clock=lambda: clk[0])
+    defaults.update(kw)
+    return BlockedTaskLadder(store, **defaults)
+
+
+# ── M9: age reap exempts escalation rows ─────────────────────────────
+
+
+def test_reap_old_exempts_blocked_task_escalation():
+    hp = HelpRequests(":memory:")
+    hp.record("blocked_task_escalation", "scout", {"name": "task-1", "description": "d"})
+    hp.record("credential_request", "scout", {"name": "GITHUB_TOKEN"})
+    # Force both rows well past the reap cutoff.
+    with hp._conn() as c:
+        c.execute("UPDATE help_requests SET created_at = 0")
+    reaped = hp.reap_old(max_age_sec=1.0)
+    assert reaped == 1  # only the credential_request row
+    open_kinds = {r["kind"] for r in hp.list_open()}
+    assert open_kinds == {"blocked_task_escalation"}
+    hp.close()
+
+
+# ── C5: resolve the Needs-you row when the task leaves blocked ────────
+
+
+@pytest.mark.asyncio
+async def test_unblock_resolves_open_escalation_row():
+    s = _store()
+    hp = HelpRequests(":memory:")
+    task = _blocked_task(s)
+    clk = [0.0]
+    lad = _ladder(s, clk, help_requests=hp)
+
+    await lad.sweep_once()  # budget fast path → rung 4 → real row filed
+    assert task["id"] in hp.open_escalation_task_ids()
+    assert {r["kind"] for r in hp.list_open()} == {"blocked_task_escalation"}
+
+    # Task leaves `blocked` → the next sweep reconciles the stale row away.
+    s.update_status(task["id"], "working", actor="scout")
+    await lad.sweep_once()
+    assert hp.list_open() == []
+    # ...but the once-ever claim is deliberately preserved (no re-file on re-block).
+    assert s.blocked_human_notice_claimed(task["id"]) is True
+    hp.close()
+
+
+# ── C6: record BEFORE consuming the forever-claim ────────────────────
+
+
+class _FlakyHelp:
+    """A help-request store whose first ``record`` raises (transient DB
+    failure), then succeeds — plus the reconcile read surface."""
+
+    def __init__(self):
+        self.fail_next = True
+        self.records: list[tuple] = []
+
+    def record(self, kind, agent_id, payload):
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("help_requests.db momentarily locked")
+        self.records.append((kind, agent_id, payload))
+        return f"req-{len(self.records)}"
+
+    def open_escalation_task_ids(self):
+        return set()
+
+    def resolve_for_task(self, task_id):
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_record_failure_preserves_claim_for_retry():
+    s = _store()
+    task = _blocked_task(s)
+    clk = [0.0]
+    hp = _FlakyHelp()
+    lad = _ladder(s, clk, help_requests=hp)
+
+    # First sweep: climb to rung 4, then record() FAILS. The forever-claim
+    # must NOT be consumed (pre-fix it was consumed first → burned forever).
+    await lad.sweep_once()
+    assert hp.records == []
+    assert s.blocked_human_notice_claimed(task["id"]) is False
+
+    # Re-block → a fresh episode retries and now files successfully.
+    s.update_status(task["id"], "working", actor="scout")
+    await lad.sweep_once()
+    s.update_status(task["id"], "blocked", actor="scout", blocker_note=_BUDGET_NOTE)
+    await lad.sweep_once()
+    assert len(hp.records) == 1
+    assert s.blocked_human_notice_claimed(task["id"]) is True

--- a/tests/test_membership_review_fix.py
+++ b/tests/test_membership_review_fix.py
@@ -1,0 +1,210 @@
+"""Regression tests for M10 + M13 (Phase 0-5 integration review).
+
+M10 — the mesh add-member endpoint checked ``team_exists`` but not that the
+agent id is a real agent, so an operator typo silently created a ghost
+``team_members`` row that the Phase-4 lead/standup machinery then treated as
+real (ghost lead, ghost standup cron, ghost plate row).
+
+M13 (security) — a membership change (remove / move / team delete) rewired the
+blackboard ACL but never purged the departing agent's pubsub subscriptions or
+blackboard watches on the OLD team's ``teams/{old}/`` namespace. ``publish`` and
+the watcher fan-out read the STORED subscriber/watcher list with no current-ACL
+recheck, so the departed agent kept receiving the old team's signals — a real
+cross-team event leak.
+"""
+
+import importlib
+import json
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.host.teams import TeamStore
+
+# ── mesh.py scoped-purge unit tests (M13 primitives) ─────────────────
+
+
+def test_pubsub_unsubscribe_agent_prefix_scoped(tmp_path):
+    ps = PubSub(str(tmp_path / "ps.db"))
+    ps.subscribe("teams/x/signals/a", "agent1")
+    ps.subscribe("teams/x/status/b", "agent1")
+    ps.subscribe("teams/agent1/self", "agent1")  # retained self-scope
+    ps.subscribe("teams/x/signals/a", "agent2")  # another agent, untouched
+    removed = ps.unsubscribe_agent_prefix("agent1", "teams/x/")
+    assert removed == 2
+    assert "agent1" not in ps.get_subscribers("teams/x/signals/a")
+    assert "agent1" not in ps.get_subscribers("teams/x/status/b")
+    # The agent's own self-scope subscription survives.
+    assert "agent1" in ps.get_subscribers("teams/agent1/self")
+    # Another agent's subscription to the same topic is untouched.
+    assert "agent2" in ps.get_subscribers("teams/x/signals/a")
+    ps.close()
+
+
+def test_pubsub_prefix_purge_persists(tmp_path):
+    db = str(tmp_path / "ps.db")
+    ps = PubSub(db)
+    ps.subscribe("teams/x/signals/a", "agent1")
+    ps.unsubscribe_agent_prefix("agent1", "teams/x/")
+    ps.close()
+    # Reload from disk — the DELETE was committed, not just in-memory.
+    ps2 = PubSub(db)
+    assert "agent1" not in ps2.get_subscribers("teams/x/signals/a")
+    ps2.close()
+
+
+def test_blackboard_remove_agent_watches_prefix_scoped(tmp_path):
+    bb = Blackboard(str(tmp_path / "bb.db"))
+    bb.add_watch("agent1", "teams/x/*")
+    bb.add_watch("agent1", "teams/x/status/*")
+    bb.add_watch("agent1", "teams/agent1/*")  # retained self-scope
+    removed = bb.remove_agent_watches_prefix("agent1", "teams/x/")
+    assert removed == 2
+    remaining = bb.get_agent_watches("agent1")
+    assert remaining == ["teams/agent1/*"]
+    bb.close()
+
+
+# ── endpoint integration (M10 + M13) ─────────────────────────────────
+
+
+def _write_perms(tmp_path, permissions: dict):
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(json.dumps({"permissions": permissions}))
+    return perms_file
+
+
+@pytest.fixture
+def team_app(tmp_path, monkeypatch):
+    """Mesh app exposing its pubsub + blackboard so the leak-purge is
+    observable (mirrors ``tests/test_teams.py::team_app``)."""
+    monkeypatch.chdir(tmp_path)
+    perms_file = _write_perms(
+        tmp_path,
+        {
+            "agent1": {"blackboard_read": [], "blackboard_write": []},
+            "agent2": {"blackboard_read": [], "blackboard_write": []},
+        },
+    )
+    import src.cli.config as cli_cfg
+
+    monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", perms_file)
+    agents_file = tmp_path / "agents.yaml"
+    agents_file.write_text(
+        yaml.dump(
+            {
+                "agents": {
+                    "agent1": {"role": "a"},
+                    "agent2": {"role": "b"},
+                    "operator": {"role": "operator"},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(cli_cfg, "AGENTS_FILE", agents_file)
+
+    import src.host.server as server_module
+
+    importlib.reload(server_module)
+
+    permissions = PermissionMatrix()
+    router = MessageRouter(permissions, {"operator": "http://op:8400"})
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub(str(tmp_path / "ps.db"))
+    teams_store = TeamStore(
+        db_path=str(tmp_path / "teams.db"),
+        teams_dir=tmp_path / "teams",
+    )
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        teams_store=teams_store,
+        auth_tokens={"operator": "op-token"},
+    )
+    yield app, teams_store, pubsub, blackboard
+    blackboard.close()
+    pubsub.close()
+    importlib.reload(server_module)
+
+
+def _op_headers() -> dict:
+    return {"Authorization": "Bearer op-token", "X-Agent-ID": "operator"}
+
+
+async def _post(app, path, json_body):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        return await c.post(path, json=json_body, headers=_op_headers())
+
+
+async def _delete(app, path):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        return await c.delete(path, headers=_op_headers())
+
+
+class TestAddMemberValidationM10:
+    @pytest.mark.asyncio
+    async def test_unknown_agent_rejected(self, team_app):
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        r = await _post(app, "/mesh/teams/proj1/members", {"agent": "ghost"})
+        assert r.status_code == 400
+        assert "Unknown agent" in r.json()["detail"]
+        # No ghost membership row was written.
+        assert store.members("proj1") == []
+
+    @pytest.mark.asyncio
+    async def test_known_agent_still_accepted(self, team_app):
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        r = await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        assert r.status_code == 200
+        assert store.members("proj1") == ["agent1"]
+
+
+class TestMembershipLeakPurgeM13:
+    @pytest.mark.asyncio
+    async def test_remove_member_purges_subscriptions_and_watches(self, team_app):
+        app, store, pubsub, blackboard = team_app
+        store.create_team("proj1")
+        await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        pubsub.subscribe("teams/proj1/signals/x", "agent1")
+        blackboard.add_watch("agent1", "teams/proj1/*")
+
+        r = await _delete(app, "/mesh/teams/proj1/members/agent1")
+        assert r.status_code == 200
+        # The leak: agent1 must no longer be a subscriber/watcher of proj1.
+        assert "agent1" not in pubsub.get_subscribers("teams/proj1/signals/x")
+        assert "teams/proj1/*" not in blackboard.get_agent_watches("agent1")
+
+    @pytest.mark.asyncio
+    async def test_move_purges_old_team_subscriptions(self, team_app):
+        app, store, pubsub, blackboard = team_app
+        store.create_team("proj1")
+        store.create_team("proj2")
+        await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        pubsub.subscribe("teams/proj1/signals/x", "agent1")
+        blackboard.add_watch("agent1", "teams/proj1/status/*")
+
+        # Move agent1 → proj2 (evicts from proj1).
+        await _post(app, "/mesh/teams/proj2/members", {"agent": "agent1"})
+        assert store.team_of("agent1") == "proj2"
+        assert "agent1" not in pubsub.get_subscribers("teams/proj1/signals/x")
+        assert blackboard.get_agent_watches("agent1") == []
+
+    @pytest.mark.asyncio
+    async def test_delete_team_purges_members(self, team_app):
+        app, store, pubsub, blackboard = team_app
+        store.create_team("proj1")
+        await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        pubsub.subscribe("teams/proj1/signals/x", "agent1")
+        blackboard.add_watch("agent1", "teams/proj1/*")
+
+        r = await _delete(app, "/mesh/teams/proj1")
+        assert r.status_code == 200
+        assert "agent1" not in pubsub.get_subscribers("teams/proj1/signals/x")
+        assert "teams/proj1/*" not in blackboard.get_agent_watches("agent1")

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -52,12 +52,17 @@ def _write_yaml(path, text: str) -> None:
 
 
 def _store_with_accepted(agent_id: str, n: int, *, rater_kind: str = "human") -> TrackRecordStore:
-    """A TrackRecordStore (``:memory:``) seeded with N 'accepted'
-    ``task_outcome`` events for ``agent_id`` at the given rater kind."""
+    """A TrackRecordStore (``:memory:``) seeded with N accepted DISTINCT
+    ``task_outcome`` deliverables for ``agent_id`` at the given rater kind.
+
+    Probation counts distinct deliverables (M5), so each event gets its
+    OWN ``ref_id`` — N events == N deliverables. (A single shared ref_id
+    would collapse to one deliverable, which is precisely the re-rate
+    miscount the M5 regression tests exercise separately.)"""
     store = TrackRecordStore(db_path=":memory:")
-    for _ in range(n):
+    for i in range(n):
         store.record(
-            source="task_outcome", ref_id="t", outcome="accepted",
+            source="task_outcome", ref_id=f"t{i}", outcome="accepted",
             rater_kind=rater_kind, agent_id=agent_id,
         )
     return store
@@ -449,19 +454,56 @@ class TestProbationEscalation:
         cfg = tmp_path / "policy.yaml"
         _write_yaml(cfg, "version: 1\nprobation:\n  enabled: true\n  min_accepted: 5\n")
         store = TrackRecordStore(db_path=":memory:")
-        for _ in range(3):
+        for i in range(3):
             store.record(
-                source="task_outcome", ref_id="t", outcome="accepted",
+                source="task_outcome", ref_id=f"t{i}", outcome="accepted",
                 rater_kind="human", agent_id="scout",
             )
-        for _ in range(3):
+        for i in range(3):
             store.record(
-                source="summary_rating", ref_id="s", outcome="accepted",
+                source="summary_rating", ref_id=f"s{i}", outcome="accepted",
                 rater_kind="human", agent_id="scout",
             )
-        # 3 + 3 = 6 >= 5 -- clears probation, default resolves.
+        # 3 + 3 = 6 distinct accepted deliverables >= 5 -- clears probation.
         engine = _engine(tmp_path, config_path=str(cfg), track_record_store=store)
         assert engine.evaluate("scout", "notify_user", summary="x").decision == "allow_audit"
+
+    def test_re_rating_one_task_does_not_release_probation(self, tmp_path):
+        """M5 regression (negative control — releases probation on pre-fix
+        code): re-rating the SAME task ``accepted`` five times is ONE
+        deliverable, so ``min_accepted=5`` must stay held. Pre-fix summed
+        the raw append-only rows (5) and released."""
+        cfg = tmp_path / "policy.yaml"
+        _write_yaml(cfg, "version: 1\nprobation:\n  enabled: true\n  min_accepted: 5\n")
+        store = TrackRecordStore(db_path=":memory:")
+        for _ in range(5):
+            store.record(
+                source="task_outcome", ref_id="the-one-task", outcome="accepted",
+                rater_kind="human", agent_id="scout",
+            )
+        engine = _engine(tmp_path, config_path=str(cfg), track_record_store=store)
+        assert engine.evaluate("scout", "notify_user", summary="x").decision == "hold"
+        assert engine.evaluate("scout", "wallet_transfer", summary="x").decision == "hold"
+
+    def test_retracted_acceptance_stops_counting(self, tmp_path):
+        """M5 regression (negative control): an ``accepted`` then later
+        ``rejected`` correction on the same task must NOT count — the
+        latest event per deliverable wins. Pre-fix left the accepted row
+        counted (append-only) and released a ``min_accepted=1`` gate."""
+        cfg = tmp_path / "policy.yaml"
+        _write_yaml(cfg, "version: 1\nprobation:\n  enabled: true\n  min_accepted: 1\n")
+        store = TrackRecordStore(db_path=":memory:")
+        store.record(
+            source="task_outcome", ref_id="task-x", outcome="accepted",
+            rater_kind="human", agent_id="scout",
+        )
+        store.record(
+            source="task_outcome", ref_id="task-x", outcome="rejected",
+            rater_kind="human", agent_id="scout",
+        )
+        engine = _engine(tmp_path, config_path=str(cfg), track_record_store=store)
+        # 0 net accepted deliverables < 1 -- still on probation.
+        assert engine.evaluate("scout", "notify_user", summary="x").decision == "hold"
 
     def test_operator_agent_rated_outcomes_never_count(self, tmp_path):
         """Rating-trust rule: operator-agent ratings are excluded from
@@ -583,7 +625,7 @@ class TestProbationFailsToSafety:
         cfg = tmp_path / "policy.yaml"
         _write_yaml(cfg, "version: 1\nprobation:\n  enabled: true\n  min_accepted: 1\n")
         broken_store = MagicMock()
-        broken_store.counts_for_agent.side_effect = RuntimeError("db is gone")
+        broken_store.distinct_accepted_count.side_effect = RuntimeError("db is gone")
         engine = _engine(tmp_path, config_path=str(cfg), track_record_store=broken_store)
         d = engine.evaluate("scout", "notify_user", summary="x")
         assert d.decision == "hold"

--- a/tests/test_steer_sweep_review_fix.py
+++ b/tests/test_steer_sweep_review_fix.py
@@ -1,0 +1,112 @@
+"""M17 regression — a wait-reply chat steer whose caller ALREADY timed
+out must not be silently dropped when the ending turn is an agenda /
+heartbeat turn.
+
+Background (plan §8 #10 + #1213 fix-2): a busy-chat steer rides the
+``_steer_queue`` as a 3-tuple ``(text, system_note, reply_future)``. The
+caller waits on ``reply_future`` via ``asyncio.wait_for`` — which, on
+timeout, CANCELS the future (so ``reply_future.done()`` is True) and
+returns ``(True, None)`` to the caller. ``(True, None)`` means "genuinely
+injected, do NOT dispatch a followup" — so if the heartbeat drain/sweep
+then discards the queue tuple, the message text is lost forever.
+
+#1213 fix-2 handled the LIVE-future subcase (caller still waiting →
+resolve None → dedicated followup). This covers the narrower ALREADY-
+TIMED-OUT subcase: the entry must be REQUEUED so the next real (non-
+heartbeat) turn's catch-all drain delivers the text.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.agent.loop import AgentLoop
+
+
+def _make_loop() -> AgentLoop:
+    memory = MagicMock()
+    memory.get_high_salience_facts = MagicMock(return_value=[])
+    memory.search = AsyncMock(return_value=[])
+    memory.log_action = AsyncMock()
+
+    tools = MagicMock()
+    tools.get_tool_definitions = MagicMock(return_value=[])
+    tools.get_descriptions = MagicMock(return_value="- no tools")
+    tools.list_tools = MagicMock(return_value=[])
+
+    llm = MagicMock()
+    llm.default_model = "test-model"
+
+    mesh_client = MagicMock()
+
+    return AgentLoop(
+        agent_id="test_agent",
+        role="assistant",
+        memory=memory,
+        tools=tools,
+        llm=llm,
+        mesh_client=mesh_client,
+    )
+
+
+async def _timed_out_entry(loop: AgentLoop, text: str) -> asyncio.Future:
+    """Reproduce the production race: enqueue a wait-reply steer while the
+    agent is working, let the caller's ``wait_for`` time out (cancelling
+    the future) — leaving the 3-tuple on the queue with a done future."""
+    loop.state = "working"
+    loop.current_task = None
+    injected, reply = await loop.inject_steer_and_wait(text, timeout=0.01)
+    # The caller genuinely timed out: injected True, reply None, and the
+    # future was cancelled by asyncio.wait_for.
+    assert (injected, reply) == (True, None)
+    return injected
+
+
+@pytest.mark.asyncio
+async def test_sweep_requeues_timed_out_future_entry():
+    """The end-of-heartbeat sweep must REQUEUE a timed-out 3-tuple (not
+    drop it), so a later real turn's drain delivers the message."""
+    loop = _make_loop()
+    await _timed_out_entry(loop, "answer me after the agenda turn")
+
+    loop._sweep_heartbeat_steer_futures()
+
+    # Requeued — the next real turn's catch-all drain delivers the text.
+    assert not loop._steer_queue.empty()
+    drained = loop._drain_steer_messages()
+    assert drained == [("answer me after the agenda turn", False)]
+    # A cancelled future is never folded into the next turn's resolve set.
+    assert loop._turn_steer_futures == []
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_drain_requeues_timed_out_future_entry():
+    """The initial heartbeat drain must also requeue (not drop) a timed-out
+    3-tuple, and never inject its text into the agenda prompt."""
+    loop = _make_loop()
+    await _timed_out_entry(loop, "delivered on the next turn")
+
+    steered = loop._drain_steer_messages(heartbeat=True)
+
+    # Never injected into the agenda turn ...
+    assert steered == []
+    # ... but requeued for the next real turn to deliver.
+    assert not loop._steer_queue.empty()
+    assert loop._drain_steer_messages() == [("delivered on the next turn", False)]
+
+
+@pytest.mark.asyncio
+async def test_live_future_still_consumed_and_resolved_none():
+    """Regression guard: a LIVE (not-done) wait-reply future is still
+    consumed and resolved None on the heartbeat path (the #1213 fix-2
+    behavior) — only the ALREADY-DONE case changed."""
+    loop = _make_loop()
+    live = asyncio.get_running_loop().create_future()
+    await loop._steer_queue.put(("live chat", False, live))
+
+    loop._sweep_heartbeat_steer_futures()
+
+    assert live.done() and live.result() is None
+    # Consumed, not requeued — the live caller dispatches its own followup.
+    assert loop._steer_queue.empty()

--- a/tests/test_team_drive.py
+++ b/tests/test_team_drive.py
@@ -822,6 +822,70 @@ class TestDriveArtifactEndpoints:
         assert _b64.b64decode(read.json()["content"]) == raw
 
     @pytest.mark.asyncio
+    async def test_commit_retries_transient_ref_moved(self, drive_env, monkeypatch):
+        """M4: a lost CAS (RefMoved) from a racing main-ref writer is retried
+        — commit_file re-reads main's tip each attempt — instead of hard-failing
+        the hand_off with the no-retry ``drive_write_failed`` envelope
+        (Constraint #10), which silently drops the payload."""
+        app = drive_env["app"]
+        real_commit = drive_mod.commit_file
+        calls = {"n": 0}
+
+        async def flaky_commit(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise drive_mod.RefMoved("main moved (test)")
+            return await real_commit(*args, **kwargs)
+
+        monkeypatch.setattr(drive_mod, "commit_file", flaky_commit)
+        resp = await self._commit(
+            app, "team-x", "member1",
+            {"kind": "artifact", "name": "retry.md", "content": "# ok"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["committed"] is True
+        assert calls["n"] == 2  # first attempt lost the CAS, second won
+
+    @pytest.mark.asyncio
+    async def test_commit_holds_repo_lock_during_write(self, drive_env, monkeypatch):
+        """M4: the quota→commit→invalidate window runs under the per-repo
+        drive lock — the SAME lock the review-merge path holds — so a
+        concurrent artifact commit / auto-merge / offboard can't interleave
+        and lose the CAS."""
+        app = drive_env["app"]
+        real_commit = drive_mod.commit_file
+        observed = {"locked": None}
+
+        async def observing_commit(*args, **kwargs):
+            lock = app.state.drive_repo_locks.get("team-x")
+            observed["locked"] = bool(lock and lock.locked())
+            return await real_commit(*args, **kwargs)
+
+        monkeypatch.setattr(drive_mod, "commit_file", observing_commit)
+        resp = await self._commit(
+            app, "team-x", "member1",
+            {"kind": "artifact", "name": "locked.md", "content": "# ok"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert observed["locked"] is True
+
+    @pytest.mark.asyncio
+    async def test_commit_ref_moved_exhausted_returns_409(self, drive_env, monkeypatch):
+        """M4: a RefMoved that persists past the retry budget surfaces as a
+        409 (resubmit) — never a silent success."""
+        app = drive_env["app"]
+
+        async def always_ref_moved(*args, **kwargs):
+            raise drive_mod.RefMoved("main keeps moving (test)")
+
+        monkeypatch.setattr(drive_mod, "commit_file", always_ref_moved)
+        resp = await self._commit(
+            app, "team-x", "member1",
+            {"kind": "artifact", "name": "nope.md", "content": "x"},
+        )
+        assert resp.status_code == 409, resp.text
+
+    @pytest.mark.asyncio
     async def test_commit_cross_team_403(self, drive_env):
         resp = await self._commit(
             drive_env["app"], "team-x", "outsider",

--- a/tests/test_track_record.py
+++ b/tests/test_track_record.py
@@ -173,6 +173,49 @@ def test_counts_for_agent_unknown_agent_is_empty(store):
 
 
 # =============================================================================
+# distinct_accepted_count (probation release gate — M5)
+# =============================================================================
+
+
+def test_distinct_accepted_counts_deliverables_not_rows(store):
+    """M5: re-rating ONE task ``accepted`` N times is ONE deliverable —
+    the raw ledger sees N rows, the distinct count sees 1."""
+    for _ in range(5):
+        store.record(source="task_outcome", ref_id="t", outcome="accepted", rater_kind="human", agent_id="a")
+    assert store.counts_for_agent("a")["task_outcome"]["accepted"] == 5
+    assert store.distinct_accepted_count("a") == 1
+
+
+def test_distinct_accepted_latest_event_wins(store):
+    """An ``accepted`` then later ``rejected`` correction on the same ref
+    drops out (latest event per deliverable decides its state)."""
+    store.record(source="task_outcome", ref_id="t", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="task_outcome", ref_id="t", outcome="rejected", rater_kind="human", agent_id="a")
+    assert store.distinct_accepted_count("a") == 0
+
+
+def test_distinct_accepted_counts_across_sources(store):
+    """Distinct deliverables span sources — ``(source, ref_id)`` is the
+    key, so a task and a summary sharing a ref_id are two deliverables."""
+    store.record(source="task_outcome", ref_id="x", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="summary_rating", ref_id="x", outcome="accepted", rater_kind="human", agent_id="a")
+    assert store.distinct_accepted_count("a") == 2
+
+
+def test_distinct_accepted_respects_rater_kind_filter(store):
+    """Only autonomy-safe rater kinds count by default — an operator-agent
+    re-rate neither inflates the count nor retracts a human acceptance."""
+    store.record(source="task_outcome", ref_id="t1", outcome="accepted", rater_kind="human", agent_id="a")
+    store.record(source="task_outcome", ref_id="t2", outcome="accepted", rater_kind="operator_agent", agent_id="a")
+    assert store.distinct_accepted_count("a") == 1  # operator_agent excluded (default AUTONOMY_RATER_KINDS)
+    assert store.distinct_accepted_count("a", rater_kinds=("human", "operator_agent")) == 2
+
+
+def test_distinct_accepted_unknown_agent_is_zero(store):
+    assert store.distinct_accepted_count("nobody") == 0
+
+
+# =============================================================================
 # recent_events
 # =============================================================================
 


### PR DESCRIPTION
Phase 0–5 integration review: close the must-fix seam defects so the **whole teams feature works seamlessly** end-to-end. Reconstructed on top of `main` (`9fda9f15`, "Phase 5 CLOSED"); all changes authored on scoped commits with regression tests + negative controls.

## Teams-core correctness

| Finding | Seam | Repair |
|---|---|---|
| **M1** | team envelope (B4/§8 #11) × streaming task execution | The team budget **envelope** is now enforced on `stream_llm` — the **default** production work transport (`llm.chat_collect` streams). It previously lived only on the non-streaming `execute_api_call`, so real traffic ignored it. Unset/0 envelope stays unlimited (B4); same error shape the sync fork yields. |
| **M2** | asker-billed window (§8 #11) × streaming execution | `ask_teammate` asker-billing is applied on the streaming path too: `bill_agent` resolved once per call (skipped for coordination — B2 precedence), envelope/preflight/usage target the asker, and the per-ask cap accrues. Idle-recipient asks no longer silently bill the recipient. |
| **M3** | AskBroker ↔ ThreadStore | `ask_teammate` Q&A now actually persists to the durable thread store (was a swallowed `TypeError` on every post → no Q&A ever landed). Stale unit-3 mock aligned with the real `ensure_dm_thread`→dict / keyword-only `body` contract. |
| **M4** | direct-commit × review-fix repo lock × auto-merge | Team Drive `main`-ref writers (`hand_off` `data` payloads + offboard commits) are serialized under the per-repo lock the review-merge path already holds, with a `RefMoved` retry ×3. Concurrent hand-offs no longer lose the CAS → `drive_write_failed` → silent payload drop (Constraint #10). |
| **M10** | add-member × Phase-4 lead/standup | Both add-member endpoints reject unknown/ghost agent ids and refuse the operator — no more ghost membership → ghost lead / ghost standup cron / ghost plate. |
| **M13** | membership change × pubsub/blackboard fan-out | Cross-team event leak closed: leaving/moving/deleting a team purges the departing agent's pubsub subscriptions and blackboard watches on the old `teams/{old}/` prefix (publish + watcher fan-out read stored lists with no ACL recheck). Scoped so the agent's retained self-scope survives. |
| **M14** | drive review-queue resubmit × merge claim | Same-branch resubmit during the merge-claim window no longer produces a duplicate/re-mergeable review. |
| **M15** | Team Room busy-path SSE | Lane sentinels gated + keepalive on the busy-path chat relay. |

## Also included (non-teams review fixes, already tested on their branches)

- **M5** probation counts distinct accepted deliverables, not ledger re-rates
- **M9 / C5 / C6** blocked-task human escalation made durable across its lifecycle
- **M11 / M12** CLI `/remove` runs per-agent cleanup and refuses the operator
- **M17** timed-out wait-reply steer requeued instead of dropped on an agenda turn
- **M18** lead recommendation rendered on the messenger pending card

## Verification

- Full non-e2e suite green: **9043 passed, 26 skipped** (`pytest -n 4 --dist=loadfile`); the only red was a known pre-existing flake (`TestTelegramStop::test_stop_calls_shutdown_and_logs`), which passes in isolation.
- New regression tests with negative controls: streaming envelope enforced + unset-envelope-not-over-blocked (M1), streaming ask-billing redirect + coordination-wins (M2), drive commit retry-absorbs-RefMoved / holds-repo-lock / exhausted→409 (M4).
- `ruff check` clean across all touched files.

Report: `docs/plans/2026-07-12-phase0-5-integration-review-findings.md`.
