### PR TITLE
fix(dashboard): align blackboard namespace taxonomy with the signals-only model

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -149,7 +149,7 @@ Three sub-views toggled via the `activityView` state var:
 
 **Live Events** — Real-time event feed streamed via WebSocket. Events include LLM calls, tool executions, text streaming deltas, messages sent/received, blackboard writes/deletes, agent state changes, and health changes. Filter by event type using chip toggles. Events are capped at 500 in the browser. Click any row to expand a type-specific detail panel. Note: per-token `text_delta` events are delivered via the direct streaming chat endpoint (not the WebSocket event bus) to avoid flooding the buffer.
 
-**Blackboard** — Browse, search, write, and delete shared state entries. Entries display as expandable card rows with agent avatars, color-coded namespace badges (tasks / context / signals / goals / artifacts / history), value summary, and relative timestamps. Filter by key prefix or by writing agent. New entries are highlighted with a flash animation. History namespace entries (`history/*`) cannot be deleted.
+**Blackboard** — Browse, search, write, and delete shared coordination-signal entries. The blackboard is signals-only (Phase-2 unit 4): deliverable payloads (`output/*`, `artifacts/*`) live in the Team Drive, surfaced under the Team Hub's **Files** tab, not here. Entries display as expandable card rows with agent avatars, color-coded namespace badges (status / tasks / context / signals / reviews / drafts / leads / …), value summary, and relative timestamps. Quick-filter shortcuts cover the canonical coordination namespaces (`status/`, `tasks/`, `context/`, `signals/`, `reviews/`, `drafts/`); filter by any key prefix or by writing agent. New entries are highlighted with a flash animation. History namespace entries (`history/*`) cannot be deleted.
 
 ### Operator Sub-tab
 

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -896,10 +896,12 @@ select:focus-visible,
 
 .ns-status    { background: rgba(16, 185, 129, 0.12); color: #34d399; border: 1px solid rgba(16, 185, 129, 0.25); }
 .ns-tasks     { background: rgba(245, 158, 11, 0.12); color: #fbbf24; border: 1px solid rgba(245, 158, 11, 0.25); }
-.ns-research  { background: rgba(59, 130, 246, 0.12); color: #60a5fa; border: 1px solid rgba(59, 130, 246, 0.25); }
+.ns-context   { background: rgba(6, 182, 212, 0.12);  color: #22d3ee; border: 1px solid rgba(6, 182, 212, 0.25); }
+.ns-signals   { background: rgba(20, 184, 166, 0.12); color: #2dd4bf; border: 1px solid rgba(20, 184, 166, 0.25); }
+.ns-reviews   { background: rgba(99, 102, 241, 0.15); color: #818cf8; border: 1px solid rgba(99, 102, 241, 0.3); }
 .ns-drafts    { background: rgba(168, 85, 247, 0.12); color: #c084fc; border: 1px solid rgba(168, 85, 247, 0.25); }
-.ns-artifacts { background: rgba(139, 92, 246, 0.12); color: #a78bfa; border: 1px solid rgba(139, 92, 246, 0.25); }
-.ns-output    { background: rgba(99, 102, 241, 0.15); color: #818cf8; border: 1px solid rgba(99, 102, 241, 0.3); }
+.ns-leads     { background: rgba(236, 72, 153, 0.12); color: #f472b6; border: 1px solid rgba(236, 72, 153, 0.25); }
+.ns-research  { background: rgba(59, 130, 246, 0.12); color: #60a5fa; border: 1px solid rgba(59, 130, 246, 0.25); }
 .ns-alerts    { background: rgba(239, 68, 68, 0.12);  color: #f87171; border: 1px solid rgba(239, 68, 68, 0.25); }
 .ns-default   { background: rgba(107, 114, 128, 0.08); color: #6b7280; border: 1px solid rgba(107, 114, 128, 0.2); }
 
@@ -942,10 +944,12 @@ select:focus-visible,
 
 .bb-entry-row.bb-expanded.ns-accent-status    { border-left-color: rgba(16, 185, 129, 0.5); }
 .bb-entry-row.bb-expanded.ns-accent-tasks     { border-left-color: rgba(245, 158, 11, 0.5); }
-.bb-entry-row.bb-expanded.ns-accent-research  { border-left-color: rgba(59, 130, 246, 0.5); }
+.bb-entry-row.bb-expanded.ns-accent-context   { border-left-color: rgba(6, 182, 212, 0.5); }
+.bb-entry-row.bb-expanded.ns-accent-signals   { border-left-color: rgba(20, 184, 166, 0.5); }
+.bb-entry-row.bb-expanded.ns-accent-reviews   { border-left-color: rgba(99, 102, 241, 0.5); }
 .bb-entry-row.bb-expanded.ns-accent-drafts    { border-left-color: rgba(168, 85, 247, 0.5); }
-.bb-entry-row.bb-expanded.ns-accent-artifacts { border-left-color: rgba(139, 92, 246, 0.5); }
-.bb-entry-row.bb-expanded.ns-accent-output    { border-left-color: rgba(99, 102, 241, 0.5); }
+.bb-entry-row.bb-expanded.ns-accent-leads     { border-left-color: rgba(236, 72, 153, 0.5); }
+.bb-entry-row.bb-expanded.ns-accent-research  { border-left-color: rgba(59, 130, 246, 0.5); }
 .bb-entry-row.bb-expanded.ns-accent-alerts    { border-left-color: rgba(239, 68, 68, 0.5); }
 .bb-entry-row.bb-expanded.ns-accent-default   { border-left-color: rgba(107, 114, 128, 0.3); }
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11923,13 +11923,20 @@ function dashboard() {
       return idx === -1 ? '' : key.substring(0, idx + 1);
     },
 
+    // Blackboard is signals-only (Phase-2 unit 4): output/* and artifacts/*
+    // payload flows moved to the Team Drive, so they no longer appear here.
+    // Recognized coordination namespaces — the canonical set (status/tasks/
+    // context/signals) plus the common template ones (reviews/drafts/leads/
+    // research/alerts). Anything else falls through to the 'default' badge.
     _bbNsMap: {
       'status/': 'status',
       'tasks/': 'tasks',
-      'output/': 'output',
-      'research/': 'research',
+      'context/': 'context',
+      'signals/': 'signals',
+      'reviews/': 'reviews',
       'drafts/': 'drafts',
-      'artifacts/': 'artifacts',
+      'leads/': 'leads',
+      'research/': 'research',
       'alerts/': 'alerts',
     },
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2087,7 +2087,7 @@
                   </button>
                 </div>
                 <div class="flex gap-1.5 flex-wrap mb-3">
-                  <template x-for="ns in ['status/', 'tasks/', 'research/', 'drafts/', 'artifacts/', 'alerts/']" :key="ns">
+                  <template x-for="ns in ['status/', 'tasks/', 'context/', 'signals/', 'reviews/', 'drafts/']" :key="ns">
                     <button @click="bbPrefix = (bbPrefix === ns ? '' : ns); fetchBlackboard()"
                       class="text-[11px] px-1.5 py-0.5 rounded-md border transition-all"
                       :class="bbPrefix === ns ? 'border-cyan-500/60 bg-cyan-900/20 text-cyan-300' : 'border-gray-800 text-gray-500 hover:text-gray-400'">
@@ -2262,7 +2262,7 @@
               <!-- ── MEMBERS ── -->
               <div x-show="teamHubTab === 'members'" x-cloak class="px-4 py-3">
                 <div class="flex items-start justify-between gap-3 mb-3">
-                  <p class="text-xs text-gray-500">Agents assigned to this team. Members share context and can communicate through the team blackboard.</p>
+                  <p class="text-xs text-gray-500">Agents assigned to this team. Members share the team's Drive, threads, and coordination board.</p>
                   <button @click="hireForTeam(activeTeam)"
                     class="text-xs px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors flex-shrink-0 inline-flex items-center gap-1.5"
                     title="Ask the operator to review this team's goals and members, draft job descriptions, and propose hires">


### PR DESCRIPTION
The Team Hub's **Advanced → State (blackboard)** component still advertised a namespace taxonomy from *before* the Phase-2-unit-4 redesign that made the blackboard signals-only and moved deliverable payloads to the Team Drive. This aligns the UI to the actual coordination model.

## The drift
- The filter-shortcut pills were `status/ tasks/ research/ drafts/ artifacts/ alerts/` — but:
  - **`artifacts/` is dead** on the blackboard (`output/*`/`artifacts/*` moved to the Team Drive in Phase-2 unit 4; `mesh_tool.py:523` and `image_gen_tool.py:134` both note *"the blackboard `artifacts/*` pointer is GONE"*; the default `blackboard_write` ACL is now only `tasks/*, context/*, status/*` — `cli/config.py`). It also collided with the Team Hub's **Files** tab, which *is* the Drive where artifacts now live.
  - The two **canonical** default namespaces `context/` and `signals/` were **missing** from the shortcuts.
- The `_bbNsMap` badge/colour taxonomy (`app.js`) still mapped the dead `output/`/`artifacts/` and lacked `context/`/`signals/`, so real entries in those namespaces rendered as the generic "default" grey badge.
- `docs/dashboard.md` listed yet a third namespace set (`… goals / artifacts / history`). UI, JS, and docs all disagreed.

## The fix (dashboard-only)
- **Pills** → the canonical STAY set documented in CLAUDE.md: `status/ tasks/ context/ signals/ reviews/ drafts/`.
- **`_bbNsMap`** → recognizes every real namespace (`status tasks context signals reviews drafts leads research alerts`; dead `output`/`artifacts` removed), so long-tail entries get correct colour badges; unknown keys still fall through to `default`.
- **CSS** → added badge + expanded-accent colours for `context/signals/reviews/leads`; removed the dead `output/artifacts` rules.
- **Copy** → Members intro now reads "share the team's Drive, threads, and coordination board" (was "communicate through the team blackboard"); `docs/dashboard.md` blackboard section reconciled (signals-only note + Files-tab pointer + accurate badge list).

No backend/API change; no test pinned the old strings. Verified against real write frequency in `src/` (`tasks` 58, `status` 57, `leads` 13, `reviews` 8, `drafts` 7, `signals` 4, `context` 2; `artifacts`/`output` = 0).
