### PR TITLE
Phase 0–5 review residuals: auto-merge governance durability + hibernation seam + delivery

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1415,16 +1415,26 @@ class RuntimeContext:
         if self.health_monitor is not None:
             self.health_monitor.set_queue_depth_fn(self.lane_manager.get_queue_depth)
 
-        # Idle-sweep activity stamp for the direct-bypass chat paths (plan
-        # §8 #24) — ``chat_done`` covers the dashboard idle/busy stream +
-        # non-stream chat + every lane-mediated ``_direct_dispatch`` turn;
-        # ``message_sent`` additionally covers the CLI REPL streaming path
-        # (which never emits ``chat_done``). Lane-internal activity
-        # (worker finally / steer injection) is already stamped directly
-        # inside ``lanes.py`` — this listener only needs to reach the
-        # paths that bypass the lane entirely.
+        # Idle-sweep activity stamp for the direct-bypass turn paths (plan
+        # §8 #24, M7) — activity is stamped at turn START *and* END so a
+        # LIVE turn on a non-lane path is never invisible to the idle sweep
+        # (the pre-fix set only stamped at turn end, so a multi-second
+        # direct turn showed ``last_activity`` from the PREVIOUS turn and
+        # could be hibernated mid-turn):
+        #   START: ``chat_user_message`` (dashboard idle/busy chat stream +
+        #     non-stream chat + steer) and ``message_received`` (the CLI
+        #     REPL streaming path and the channel — Telegram/Discord/Slack —
+        #     streaming turns, both of which bypass the lane entirely).
+        #   END:   ``chat_done`` (dashboard streams + non-stream chat + every
+        #     lane-mediated ``_direct_dispatch`` turn) and ``message_sent``.
+        # Lane-internal activity (worker finally / steer injection) is
+        # already stamped directly inside ``lanes.py``; the cron ``/heartbeat``
+        # path stamps before+after via ``activity_fn``. Over-stamping only
+        # ever DELAYS hibernation (safe); under-stamping is the mid-turn bug.
         def _activity_event_listener(evt: dict) -> None:
-            if evt.get("type") not in ("chat_done", "message_sent"):
+            if evt.get("type") not in (
+                "chat_user_message", "message_received", "chat_done", "message_sent",
+            ):
                 return
             agent = evt.get("agent")
             if not agent or self.lane_manager is None:
@@ -2008,6 +2018,16 @@ class RuntimeContext:
 
         if isinstance(self.transport, HttpTransport):
             self.transport.set_ensure_running_fn(
+                getattr(app, "ensure_agent_running", None),
+            )
+        # Same seam for the MessageRouter (M6): a ``send_message`` /
+        # ``/mesh/message`` to a hibernated recipient POSTs directly to the
+        # container URL and bypasses the transport, so the router needs its
+        # own cold-wake-before-deliver hook — otherwise a hibernated teammate
+        # is never auto-woken on this delivery path (violates §8 #24's
+        # "auto-wakes on demand").
+        if self.router is not None:
+            self.router.set_ensure_running_fn(
                 getattr(app, "ensure_agent_running", None),
             )
         # Idle-agent hibernation sweep (plan §8 #24) — built inside
@@ -2742,50 +2762,47 @@ class RuntimeContext:
             from src.host.chain_watcher import BlockedTaskLadder, ChainWatcher
             from src.shared.utils import dumps_safe
 
-            def _log_ladder_send(fut) -> None:
+            def _ladder_enqueue_nudge(agent: str, message: str) -> bool:
+                # Shared rung-1/2 delivery: enqueue a system-composed followup
+                # turn on the target agent. System-note flagged (no human typed
+                # it) so it lands in the transcript as role=system, never
+                # impersonating the user or feeding ``looks_like_correction``.
+                # Bills the nudged agent's normal WORK ledger.
+                #
+                # C4: returns True ONLY when the nudge was durably ACCEPTED by
+                # the lane (enqueue succeeded), False when it could not be
+                # delivered (no lane/loop, or the enqueue raised). The ladder
+                # advances the rung only on True, so a failed dispatch
+                # (loop/container down) re-drives the SAME rung next sweep
+                # instead of climbing past it. We wait only for the ENQUEUE (a
+                # fast lane-queue put) — NEVER the agent turn — so the sweep
+                # still never blocks on an agent's work.
+                if self.lane_manager is None or self._dispatch_loop is None:
+                    return False
                 try:
-                    fut.result()
+                    fut = asyncio.run_coroutine_threadsafe(
+                        self.lane_manager.enqueue(
+                            agent, message, mode="followup", system_note=True,
+                        ),
+                        self._dispatch_loop,
+                    )
                 except Exception as e:
-                    logger.warning("ladder nudge dispatch failed: %s", e)
+                    logger.warning("ladder nudge dispatch failed to schedule for %s: %s", agent, e)
+                    return False
+                try:
+                    fut.result(timeout=10)
+                except Exception as e:
+                    logger.warning("ladder nudge enqueue failed for %s: %s", agent, e)
+                    return False
+                return True
 
-            def _ladder_send_assignee(agent: str, message: str) -> None:
-                # Rung 1 — a followup turn on the assignee. System-composed
-                # (no human typed it), so it MUST carry the system-note flag
-                # exactly like rung 2 below: without it the nudge lands in the
-                # assignee's transcript as a role=user message (indistinguishable
-                # from a real operator message) and runs through
-                # ``looks_like_correction`` — a host-authored escalation must
-                # never be able to write itself into the agent's corrections
-                # learnings. (Phase-5 review finding: the prior ``deliver_chat``
-                # path had no ``system_note`` parameter to thread the flag
-                # through, so the busy→steer fork silently bypassed the marker;
-                # a queued followup is the correct posture for a not-time-
-                # critical blocked-task nudge anyway.) Fire-and-forget onto the
-                # dispatch loop so the sweep never blocks; bills the nudged
-                # agent's normal WORK ledger.
-                if self.lane_manager is None or self._dispatch_loop is None:
-                    return
-                fut = asyncio.run_coroutine_threadsafe(
-                    self.lane_manager.enqueue(
-                        agent, message, mode="followup", system_note=True,
-                    ),
-                    self._dispatch_loop,
-                )
-                fut.add_done_callback(_log_ladder_send)
+            def _ladder_send_assignee(agent: str, message: str) -> bool:
+                # Rung 1 — a followup turn on the assignee.
+                return _ladder_enqueue_nudge(agent, message)
 
-            def _ladder_send_creator(agent: str, message: str) -> None:
-                # Rung 2 — a followup turn on the task creator. System-
-                # composed (no human typed it), same fire-and-forget +
-                # work-ledger posture as rung 1.
-                if self.lane_manager is None or self._dispatch_loop is None:
-                    return
-                fut = asyncio.run_coroutine_threadsafe(
-                    self.lane_manager.enqueue(
-                        agent, message, mode="followup", system_note=True,
-                    ),
-                    self._dispatch_loop,
-                )
-                fut.add_done_callback(_log_ladder_send)
+            def _ladder_send_creator(agent: str, message: str) -> bool:
+                # Rung 2 — a followup turn on the task creator.
+                return _ladder_enqueue_nudge(agent, message)
 
             def _ladder_lead_of(team_id: str | None) -> str | None:
                 store = getattr(self, "teams_store", None)

--- a/src/host/auto_merge.py
+++ b/src/host/auto_merge.py
@@ -22,17 +22,25 @@ on, or fails because of, this module):
      approve, zero flag/revert decay events. Includes the self-approval
      hard block: a lead approving its own submission is never a pair,
      checked before spending a query on a pair that can never qualify.
-  3. Execute through the SAME claim-first machinery the human merge
-     endpoint uses (``TeamStore.claim_review_for_merge`` /
-     ``drive.merge_branch`` / ``finalize_merge`` / ``revert_merge_claim``) —
-     no git logic is reimplemented here. A concurrent human merge
-     losing/winning the claim is harmless (the claim 409-equivalent path
-     just aborts).
-  4. Record a ``rater_kind="system"`` track-record event
-     (``resolution="auto_merged"``) + one ``blackboard.log_audit`` row.
-     The self-reinforcement guard lives in ``track_record.py``:
+  3. Claim + re-verify the reviewed tip (``TeamStore.claim_review_for_merge``
+     / ``branch_head_sha``) — a deleted/advanced branch reverts the claim
+     and skips (a resubmit, not an auto-merge; never consumes the cap).
+  4. RESERVE the cap slot: record the ``rater_kind="system"`` /
+     ``resolution="auto_merged"`` track-record event BEFORE the irreversible
+     merge (C2). The cap counts these rows, so a failed durable write must
+     fail CLOSED (revert + skip) — recording after a best-effort append (the
+     pre-fix order) let a full/read-only ledger bypass ``auto_merge_daily_cap``
+     indefinitely. The self-reinforcement guard lives in ``track_record.py``:
      system-rated events never feed :meth:`pair_trust`'s floor count.
-  5. Notify — an operator-chat note (best-effort, injected via
+  5. Execute the merge + finalize as ONE cancellation-atomic unit
+     (``_merge_and_finalize`` under ``asyncio.shield``, C1) so a consumer
+     cancellation (mesh shutdown) can never land between ``update-ref`` and
+     finalize — the exact window that would strand a ``merging`` row and an
+     UNRECORDED landed commit. The unit reverts ``merging→open`` on any git
+     failure and finalizes on success — never leaving a stranded row.
+     A concurrent human merge losing/winning the claim is harmless.
+  7. Audit (``blackboard.log_audit``).
+  8. Notify — an operator-chat note (best-effort, injected via
      ``notify_fn`` so this module has no direct transport dependency),
      with a decaying sampling rate that asks for post-review.
 
@@ -46,6 +54,7 @@ and drive git plumbing those already use) is read back in via
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import random
 import time
 from dataclasses import dataclass
@@ -53,7 +62,6 @@ from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
 from src.host import drive as team_drive
-from src.host.track_record import record_best_effort
 from src.shared import limits as limits_mod
 from src.shared.utils import dumps_safe, setup_logging
 
@@ -136,6 +144,71 @@ def should_sample(rate: float, rng: random.Random) -> bool:
     return rng.random() < rate
 
 
+async def _merge_and_finalize(
+    teams_store: Any,
+    repo: Any,
+    review_id: str,
+    claimed: dict[str, Any],
+    recorded_sha: str | None,
+    live_sha: str,
+    message: str,
+    merge_branch_fn: Callable[..., Awaitable[str]],
+) -> tuple[str, dict] | None:
+    """The cancellation-atomic critical section (C1): merge the reviewed
+    commit into main, then finalize the review row.
+
+    Run as its OWN task (``asyncio.ensure_future``) and awaited under
+    ``asyncio.shield`` by :func:`consider_auto_merge`, so a cancellation
+    of the consumer can never land BETWEEN the git ``update-ref`` and
+    ``finalize_merge`` — the exact window that would otherwise advance
+    main after the coroutine is gone, leaving an UNRECORDED landed commit
+    and a stranded ``merging`` row. This unit fully owns the claim's
+    resolution: it reverts ``merging→open`` on ANY git failure and
+    finalizes on success, so it NEVER leaves a stranded ``merging`` row.
+
+    Returns ``(commit, resolved)`` on success, ``None`` on a (reverted)
+    merge failure. Only ``CancelledError`` can escape — and only when
+    THIS task is itself cancelled (loop teardown), never from the
+    consumer detaching.
+    """
+    try:
+        commit = await merge_branch_fn(repo, recorded_sha or live_sha, message=message)
+    except team_drive.MergeConflict as e:
+        teams_store.revert_merge_claim(review_id)
+        logger.info("auto-merge reverted claim for review %s: merge conflict: %s", review_id, e)
+        return None
+    except team_drive.RefMoved as e:
+        teams_store.revert_merge_claim(review_id)
+        logger.info(
+            "auto-merge reverted claim for review %s: ref moved (lost CAS — a human merge likely won): %s",
+            review_id, e,
+        )
+        return None
+    except team_drive.DriveError as e:
+        teams_store.revert_merge_claim(review_id)
+        logger.warning("auto-merge git failure for review %s: %s", review_id, e)
+        return None
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        teams_store.revert_merge_claim(review_id)
+        logger.exception("auto-merge unexpected git failure for review %s", review_id)
+        return None
+    try:
+        resolved = teams_store.finalize_merge(review_id, commit, reviewer=AUTO_MERGE_RATER)
+    except ValueError:
+        # The row moved out from under us — should not happen (nothing
+        # else touches a 'merging' row) — but the commit IS on main, so
+        # surface the divergence honestly rather than pretend it didn't
+        # land. Best-effort shape for the steps in the caller.
+        logger.exception(
+            "auto-merge finalize divergence for review %s (commit %s already on main)",
+            review_id, commit,
+        )
+        resolved = {**claimed, "status": "merged", "merge_commit": commit}
+    return commit, resolved
+
+
 async def consider_auto_merge(
     *,
     team_id: str,
@@ -151,15 +224,22 @@ async def consider_auto_merge(
     clock: Callable[[], float] = time.time,
     rng: random.Random | None = None,
 ) -> None:
-    """Run the auto-merge pipeline for one lead-approved review. Never raises.
+    """Run the auto-merge pipeline for one lead-approved review.
+
+    Never raises an ordinary exception — the outer net absorbs it (the
+    verdict endpoint's fire-and-forget ``asyncio.create_task`` contract).
+    ``CancelledError`` DOES propagate (C1): a cancelled consumer must
+    unwind, but only AFTER the claim is settled — the claim is reverted
+    (if the merge had not begun) or the shielded merge/finalize unit is
+    let run to completion, so a cancellation never strands a ``merging``
+    row or lands an unrecorded commit.
 
     ``repo`` is the team's already-resolved bare-repo path (the caller uses
     the SAME resolver the human merge endpoint uses — ``server.py``'s
     ``_drive_repo`` — so this function stays git-transport-agnostic).
     ``merge_branch_fn`` / ``branch_head_sha_fn`` default to the real
     ``drive.py`` functions and are only overridden by tests. Every exit path
-    logs its reason; nothing here ever propagates to the caller (the verdict
-    endpoint's fire-and-forget ``asyncio.create_task`` contract).
+    logs its reason.
     """
     review_id = review.get("id", "")
     author = review.get("author", "")
@@ -170,6 +250,8 @@ async def consider_auto_merge(
 
     lock: asyncio.Lock | None = None
     lock_held = False
+    claimed_review = False   # C1: a claim exists (review row is `merging`)…
+    claim_settled = False    # …that a later step has resolved (merged or reverted).
     try:
         if track_record_store is None:
             _skip("no track record store wired")
@@ -220,58 +302,53 @@ async def consider_auto_merge(
         except ValueError as e:
             _skip(f"claim lost — already resolved: {e}")
             return
+        claimed_review = True
         branch = claimed.get("branch")
         recorded_sha = claimed.get("head_sha")
         message = (
             f"Auto-merge review {review_id}: {claimed.get('title', '')} "
             f"(branch {branch}, by {author}, lead-approved by {lead_verdict_by})"
         )
+
+        # Re-verify the reviewed tip is still live BEFORE reserving a cap
+        # slot — a deleted/advanced branch is a resubmit, not an auto-merge,
+        # and must not consume the daily cap.
         try:
             loop = asyncio.get_running_loop()
             live_sha = await loop.run_in_executor(None, branch_head_sha_fn, repo, branch)
-            if not live_sha:
+        except asyncio.CancelledError:
+            # Cancelled before the merge began — nothing landed on main;
+            # revert the claim so we never strand a `merging` row (C1).
+            with contextlib.suppress(Exception):
                 teams_store.revert_merge_claim(review_id)
-                _skip("branch deleted since approval")
-                return
-            if recorded_sha and live_sha != recorded_sha:
-                teams_store.revert_merge_claim(review_id)
-                _skip("branch advanced since approval — resubmit required")
-                return
-            commit = await merge_branch_fn(repo, recorded_sha or live_sha, message=message)
-        except team_drive.MergeConflict as e:
-            teams_store.revert_merge_claim(review_id)
-            _skip(f"merge conflict: {e}")
-            return
-        except team_drive.RefMoved as e:
-            teams_store.revert_merge_claim(review_id)
-            _skip(f"ref moved (lost CAS — a human merge likely won the race): {e}")
-            return
-        except team_drive.DriveError as e:
-            teams_store.revert_merge_claim(review_id)
-            logger.warning("auto-merge git failure for review %s: %s", review_id, e)
-            return
+            claim_settled = True
+            raise
         except Exception:
             teams_store.revert_merge_claim(review_id)
-            logger.exception("auto-merge unexpected git failure for review %s", review_id)
+            claim_settled = True
+            logger.exception("auto-merge branch head check failed for review %s", review_id)
+            return
+        if not live_sha:
+            teams_store.revert_merge_claim(review_id)
+            claim_settled = True
+            _skip("branch deleted since approval")
+            return
+        if recorded_sha and live_sha != recorded_sha:
+            teams_store.revert_merge_claim(review_id)
+            claim_settled = True
+            _skip("branch advanced since approval — resubmit required")
             return
 
-        try:
-            resolved = teams_store.finalize_merge(review_id, commit, reviewer=AUTO_MERGE_RATER)
-        except ValueError:
-            # The row moved out from under us — should not happen (nothing
-            # else touches a 'merging' row) — but the commit IS on main, so
-            # surface the divergence honestly rather than pretend it didn't
-            # land. Best-effort shape for the steps below.
-            logger.exception(
-                "auto-merge finalize divergence for review %s (commit %s already on main)",
-                review_id, commit,
-            )
-            resolved = {**claimed, "status": "merged", "merge_commit": commit}
-
-        # Step 4: record. Sampling decay reads the PRIOR auto-merge count
-        # for this pair (before this one), so the pair's first
-        # `auto_merge_sample_decay_after` auto-merges sample at the initial
-        # rate and later ones decay to the floor rate.
+        # Step 4a: RESERVE the daily-cap slot BEFORE the irreversible merge
+        # (C2). The cap counts `auto_merged` rows, but the merge is a git
+        # side effect on main — so if this durable increment can't be
+        # written (full / read-only track_record.db) the merge must NOT
+        # proceed. A best-effort append AFTER the merge (the pre-fix order)
+        # let every approval merge while the count stayed flat, silently
+        # bypassing `auto_merge_daily_cap`. Recording first is fail-CLOSED:
+        # a rare merge failure after a successful reserve over-counts the
+        # cap (conservative — never under-counts). Sampling decay reads the
+        # pair's PRIOR auto-merge count, available now.
         rate = sample_rate_for(
             pair.get("auto_merged", 0),
             initial=limits_mod.auto_merge_sample_rate_initial(),
@@ -279,25 +356,61 @@ async def consider_auto_merge(
             floor=limits_mod.auto_merge_sample_rate_floor(),
         )
         sampled = should_sample(rate, rng)
-        record_best_effort(
-            track_record_store,
-            source="drive_review",
-            ref_id=review_id,
-            outcome="auto_merged",
-            rater_kind="system",
-            agent_id=author,
-            team_id=team_id,
-            rated_by=AUTO_MERGE_RATER,
-            details={
-                "branch": branch,
-                "lead_agent_id": lead_verdict_by,
-                "lead_verdict_by": lead_verdict_by,
-                "lead_verdict": "approve",
-                "resolution": "auto_merged",
-                "resolved_by": AUTO_MERGE_RATER,
-                "sampled": sampled,
-            },
+        try:
+            track_record_store.record(
+                source="drive_review",
+                ref_id=review_id,
+                outcome="auto_merged",
+                rater_kind="system",
+                agent_id=author,
+                team_id=team_id,
+                rated_by=AUTO_MERGE_RATER,
+                details={
+                    "branch": branch,
+                    "lead_agent_id": lead_verdict_by,
+                    "lead_verdict_by": lead_verdict_by,
+                    "lead_verdict": "approve",
+                    "resolution": "auto_merged",
+                    "resolved_by": AUTO_MERGE_RATER,
+                    "sampled": sampled,
+                },
+            )
+        except Exception:
+            # Fail closed: the cap slot could not be durably reserved, so do
+            # NOT merge — a bypassed cap is worse than a skipped auto-merge.
+            teams_store.revert_merge_claim(review_id)
+            claim_settled = True
+            logger.exception(
+                "auto-merge cap-record failed for review %s — failing closed (no merge)", review_id,
+            )
+            return
+
+        # Step 4b: merge + finalize as ONE cancellation-atomic unit (C1),
+        # run as its own task and awaited under `shield` so a consumer
+        # cancellation can never land between `update-ref` and finalize —
+        # the unit runs to completion (finalize or revert) regardless.
+        merge_task = asyncio.ensure_future(
+            _merge_and_finalize(
+                teams_store, repo, review_id, claimed, recorded_sha, live_sha,
+                message, merge_branch_fn,
+            )
         )
+        try:
+            outcome = await asyncio.shield(merge_task)
+        except asyncio.CancelledError:
+            # Let the shielded unit finish (finalize the landed commit or
+            # revert a failed merge) so we never strand a `merging` row or
+            # land an unrecorded commit, then propagate the cancellation —
+            # detaching only this consumer, never the merge itself.
+            with contextlib.suppress(BaseException):
+                await asyncio.shield(merge_task)
+            claim_settled = True
+            raise
+        claim_settled = True  # the merge task resolved the claim (merged or reverted)
+        if outcome is None:
+            return  # merge failed; `_merge_and_finalize` already reverted + logged
+        commit, resolved = outcome
+
         if audit_fn is not None:
             try:
                 # ``after_value`` carries a small JSON blob (not just the
@@ -351,6 +464,11 @@ async def consider_auto_merge(
         # Outermost net: the verdict endpoint's response must never block
         # on, or fail because of, this consumer.
         logger.exception("auto-merge consumer raised for review %s (team %s)", review_id, team_id)
+        # C1 safety net: an unexpected error after the claim but before the
+        # merge task resolved it would otherwise strand a `merging` row.
+        if claimed_review and not claim_settled:
+            with contextlib.suppress(Exception):
+                teams_store.revert_merge_claim(review_id)
     finally:
         # Release the cap lock on any early return (cap reached, trust floor,
         # lost claim, git failure) or exception before the pre-notify release.

--- a/src/host/chain_watcher.py
+++ b/src/host/chain_watcher.py
@@ -103,12 +103,20 @@ class BlockedTaskLadder:
     verbs. State (rung + last climb) is durable in the tasks store and
     resets when a task leaves ``blocked`` (cleared by the sweep; a flip
     faster than one sweep interval keeps its prior rung — bounded, benign).
-    Every climb is CAS-claimed (``ladder_climb``) so racing sweeps or a
-    restart replay can't double-send, and writes one audit row via
-    ``audit_fn`` (``action="blocked_task_escalation"`` at the wiring site).
+    Each rung DELIVERS first, then advances only on a SUCCESSFUL (or
+    legitimately-skipped) delivery (C4): a failed rung-1/2 dispatch
+    (loop/container down, reported ``False`` by the seam) leaves the rung
+    un-advanced so the next sweep re-drives the SAME assignee/creator
+    rather than climbing past it toward the human — honouring the
+    indefinite-retry-of-rungs-1-3 requirement. The advance is CAS-claimed
+    (``ladder_climb``) so racing sweeps or a restart replay can't
+    double-send, and writes one audit row via ``audit_fn``
+    (``action="blocked_task_escalation"`` at the wiring site).
 
     Delivery seams may be sync (the runtime passes fire-and-forget
-    wrappers so a sweep never blocks on an agent turn) or async (tests).
+    wrappers so a sweep never blocks on an agent TURN — they still report
+    enqueue acceptance so a failed dispatch un-advances the rung) or async
+    (tests). A seam returns falsey/raises to signal a delivery failure.
     """
 
     def __init__(
@@ -239,11 +247,17 @@ class BlockedTaskLadder:
         if now - last_climb < interval_s:
             return
         target = rung + 1
-        if not self._tasks.ladder_climb(task_id, rung, target, now=now):
-            return  # lost the claim to a concurrent sweep — it sends, we don't
+        # C4: DELIVER FIRST, then advance the rung ONLY on a successful (or
+        # legitimately-skipped) delivery. The pre-fix order CAS-advanced the
+        # rung BEFORE the fire-and-forget send, so a failed rung-1/2 dispatch
+        # (loop/container down) silently climbed toward creator/lead without
+        # ever re-driving the assignee — contradicting §8 #22's
+        # indefinite-retry-of-rungs-1-3 requirement. A failed delivery now
+        # leaves the rung un-advanced; the next sweep re-drives the SAME rung.
         detail: dict = {}
+        delivered = True
         if target == 1:
-            await self._send(
+            delivered = await self._send(
                 self._deliver_assignee, task.get("assignee") or "",
                 self._rung1_message(task, task_id, note), "assignee", task_id,
             )
@@ -255,7 +269,7 @@ class BlockedTaskLadder:
             elif creator == self._operator_id:
                 detail["skipped"] = "creator_is_operator"
             else:
-                await self._send(
+                delivered = await self._send(
                     self._deliver_creator, creator,
                     self._rung2_message(task, task_id, note), "creator", task_id,
                 )
@@ -264,6 +278,12 @@ class BlockedTaskLadder:
             lead = self._lead_of(task.get("team_id"))
             if not lead:
                 detail["skipped"] = "no_lead"
+        if not delivered:
+            # Rung-1/2 dispatch FAILED — do NOT advance. The next sweep
+            # re-drives the same rung (indefinite retry of rungs 1-3).
+            return
+        if not self._tasks.ladder_climb(task_id, rung, target, now=now):
+            return  # lost the claim to a concurrent sweep — it sends, we don't
         self._audit(task_id, target, detail)
 
     # ── rung mechanics ───────────────────────────────────────────
@@ -271,15 +291,23 @@ class BlockedTaskLadder:
     async def _send(
         self, fn: Callable | None, agent: str, message: str,
         label: str, task_id: str,
-    ) -> None:
+    ) -> bool:
+        """Deliver one nudge. Returns True when it was accepted (or there is
+        nothing to deliver — no seam wired / no target agent), False ONLY
+        when a WIRED delivery seam RAISED or reported failure (``False``).
+        The caller advances the rung only on True, so a genuine delivery
+        failure (loop/container down) leaves the rung un-advanced for the
+        next sweep to re-drive the SAME rung (C4)."""
         if fn is None or not agent:
-            return
+            return True  # nothing to deliver here — the rung legitimately climbs
         try:
             result = fn(agent, message)
             if asyncio.iscoroutine(result):
-                await result
+                result = await result
+            return result is not False
         except Exception as e:
             logger.warning("ladder: %s nudge for task %s failed: %s", label, task_id, e)
+            return False
 
     def _lead_of(self, team_id: str | None) -> str | None:
         if self._lead_of_fn is None or not team_id:

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -631,6 +631,20 @@ class CronScheduler:
                 )
                 continue
 
+    def _stamp_activity(self, agent: str) -> None:
+        """Stamp the idle-sweep's last-activity clock for ``agent`` (plan
+        §8 #24, M7). Called BEFORE a heartbeat/message LLM dispatch (so a
+        multi-second turn isn't hibernated mid-flight — the sweep would
+        otherwise see ``last_activity`` from the previous turn) and AFTER a
+        real non-suppressed dispatch. Best-effort; a missing/failed stamp
+        never affects the dispatch."""
+        if self.activity_fn is None:
+            return
+        try:
+            self.activity_fn(agent)
+        except Exception as e:
+            logger.debug("activity_fn failed for '%s': %s", agent, e)
+
     async def _execute_job(self, job: CronJob, manual: bool = False) -> str | None:
         lock = self._job_locks[job.id]
         if lock.locked():
@@ -876,6 +890,17 @@ class CronScheduler:
 
                         message = "\n\n".join(sections)
 
+                        # Idle-sweep pre-stamp (plan §8 #24, M7): this
+                        # branch is the ACTIONABLE plate — an LLM turn WILL
+                        # dispatch below, and it can run for several seconds.
+                        # Stamp NOW (turn start) so the idle sweep can't
+                        # hibernate the agent mid-heartbeat; the post-dispatch
+                        # stamp below refreshes it on completion. (Only fires
+                        # on the actionable path — a gated/empty plate never
+                        # reaches here, so hibernation still triggers when the
+                        # agent is genuinely idle.)
+                        self._stamp_activity(job.agent)
+
                         # Use dedicated heartbeat endpoint when available.
                         if self.heartbeat_dispatch_fn:
                             hb_result = await self.heartbeat_dispatch_fn(
@@ -923,14 +948,9 @@ class CronScheduler:
                     # (non-suppressed) dispatch means the agent is NOT
                     # idle right now — covers cron paths that bypass the
                     # lane entirely (tool-invoke jobs, ``/heartbeat``),
-                    # which the lane worker's own stamp never sees.
-                    if self.activity_fn is not None:
-                        try:
-                            self.activity_fn(job.agent)
-                        except Exception as e:
-                            logger.debug(
-                                "activity_fn failed for '%s': %s", job.agent, e,
-                            )
+                    # which the lane worker's own stamp never sees. The
+                    # heartbeat path also stamps BEFORE the dispatch (M7).
+                    self._stamp_activity(job.agent)
 
                     # Host-published channel post (§8 #14): a standup (or
                     # any message job the host tagged) publishes its

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -14,7 +14,7 @@ import sqlite3
 import threading
 import time
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -830,6 +830,38 @@ class MessageRouter:
         self._client_lock: asyncio.Lock | None = None
         self._client_lock_loop: asyncio.AbstractEventLoop | None = None
         self._trace_store = trace_store
+        # Cold-wake seam (plan §8 #24, M6): the SAME injectable
+        # ``ensure_agent_running`` the ``HttpTransport`` wires — a hibernated
+        # recipient of a ``send_message`` / ``/mesh/message`` must be woken
+        # here too (the router POSTs directly to ``{url}/message``, bypassing
+        # the transport, so without this seam a hibernated teammate is never
+        # auto-woken on demand). None (standalone tests) disables it.
+        self._ensure_running_fn: Callable[[str], Awaitable[bool]] | None = None
+
+    def set_ensure_running_fn(
+        self, fn: Callable[[str], Awaitable[bool]] | None,
+    ) -> None:
+        """Wire the cold-wake seam after construction (mirrors
+        ``HttpTransport.set_ensure_running_fn``). ``fn(agent_id) -> bool``
+        is a cheap no-op for a running agent and a cold-wake-then-wait for a
+        hibernated one. Called at the top of ``route`` before target
+        resolution; pass ``None`` to disable (the default)."""
+        self._ensure_running_fn = fn
+
+    async def _ensure_running(self, agent_id: str) -> None:
+        """Best-effort cold-wake before delivering a routed message.
+
+        Never raises and never blocks the caller on a wake failure — a
+        hibernated agent that fails to wake just stays unreachable, which
+        ``_resolve_target`` / the delivery retry below already surface.
+        """
+        fn = self._ensure_running_fn
+        if fn is None or not agent_id:
+            return
+        try:
+            await fn(agent_id)
+        except Exception as e:
+            logger.warning("router ensure_running_fn failed for '%s': %s", agent_id, e)
 
     def _get_client_lock(self) -> asyncio.Lock:
         loop = asyncio.get_running_loop()
@@ -873,6 +905,13 @@ class MessageRouter:
         if not self.permissions.can_message(message.from_agent, message.to):
             logger.warning(f"Permission denied: {message.from_agent} -> {message.to}")
             return {"error": f"{message.from_agent} cannot message {message.to}"}
+
+        # Cold-wake a hibernated recipient BEFORE resolving its target (M6):
+        # the wake re-registers the restarted container's FRESH url in the
+        # registry, so a same-session stale-url delivery failure and a
+        # post-restart "No agent found" both become a wake-then-deliver. A
+        # no-op for a running agent; never raises.
+        await self._ensure_running(message.to)
 
         target_url = self._resolve_target(message.to)
         if not target_url:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -769,6 +769,31 @@ class HibernationSweeper:
     def stop(self) -> None:
         self._running = False
 
+    def _busy_or_working(self, agent_id: str, lane_status: dict) -> bool:
+        """True if the agent is doing (or queued to do) work right now, so
+        it must NOT be hibernated. Fails CLOSED — an uncertain read returns
+        True (never hibernate on a doubtful signal). ``lane_status`` is a
+        caller-supplied ``get_status()`` snapshot so this can be re-run
+        against a FRESH snapshot immediately before the stop (M7)."""
+        st = lane_status.get(agent_id, {})
+        if st.get("busy") or st.get("queued", 0) > 0:
+            return True
+        if self._tasks_store is not None:
+            try:
+                if self._tasks_store.has_working_task(agent_id):
+                    return True
+            except Exception as e:
+                logger.debug("hibernation sweep: task check failed for %s: %s", agent_id, e)
+                return True  # fail CLOSED — never hibernate on an uncertain read
+        if self._ask_broker is not None:
+            try:
+                if self._ask_broker.has_open_asks(agent_id):
+                    return True
+            except Exception as e:
+                logger.debug("hibernation sweep: ask check failed for %s: %s", agent_id, e)
+                return True
+        return False
+
     async def _tick(self) -> None:
         idle_minutes = shared_limits.resolve("hibernate_idle_minutes")
         if idle_minutes <= 0:
@@ -792,30 +817,28 @@ class HibernationSweeper:
             status = (agent_cfg or {}).get("status", "active") or "active"
             if status != "active":
                 continue  # already hibernated/archived — not a candidate
-            st = lane_status.get(agent_id, {})
-            if st.get("busy") or st.get("queued", 0) > 0:
+            if self._busy_or_working(agent_id, lane_status):
                 continue
-            if self._tasks_store is not None:
-                try:
-                    if self._tasks_store.has_working_task(agent_id):
-                        continue
-                except Exception as e:
-                    logger.debug(
-                        "hibernation sweep: task check failed for %s: %s", agent_id, e,
-                    )
-                    continue  # fail CLOSED — never hibernate on an uncertain read
-            if self._ask_broker is not None:
-                try:
-                    if self._ask_broker.has_open_asks(agent_id):
-                        continue
-                except Exception as e:
-                    logger.debug(
-                        "hibernation sweep: ask check failed for %s: %s", agent_id, e,
-                    )
-                    continue
             last_activity = self._lane_manager.last_activity(agent_id)
             if (now - last_activity) < idle_seconds:
                 continue
+            # M7: re-check against a FRESH read immediately before the stop.
+            # The per-tick ``lane_status``/``now`` snapshot above was taken
+            # once and can be tens of seconds stale by the time this loop
+            # reaches a later agent (it awaits multi-second hibernate ops
+            # between agents). A turn that STARTED mid-tick — including a
+            # direct-bypass turn (dashboard/CLI/channel stream, cron
+            # heartbeat), which stamps ``last_activity`` at turn start (M7)
+            # but never sets a lane ``busy`` flag — must abort the stop.
+            try:
+                fresh_status = self._lane_manager.get_status()
+            except Exception as e:
+                logger.debug("hibernation sweep: fresh status read failed for %s: %s", agent_id, e)
+                continue  # fail CLOSED
+            if self._busy_or_working(agent_id, fresh_status):
+                continue
+            if (time.time() - self._lane_manager.last_activity(agent_id)) < idle_seconds:
+                continue  # a direct-path turn stamped activity mid-tick
             try:
                 await self._hibernate_fn(agent_id, caller="sweep")
                 logger.info(
@@ -3281,6 +3304,8 @@ def create_mesh_app(
         tool = str(payload.get("tool", ""))
         arguments = payload.get("arguments") or {}
         result = await _execute_connector_call(caller, connector, tool, arguments)
+        delivered = False
+        delivery_error: str | None = None
         if lane_manager is not None and caller:
             try:
                 note = (
@@ -3288,11 +3313,52 @@ def create_mesh_app(
                     f"executed. Result: {dumps_safe(result)[:1500]}"
                 )
                 await lane_manager.enqueue(caller, note, mode="followup", system_note=True)
+                delivered = True
             except Exception as e:
+                delivery_error = str(e)
                 logger.warning(
                     "delivering held connector_call result to %s failed: %s", caller, e,
                 )
-        return {"delivered": True, "change_id": record["nonce"], "result": result}
+        else:
+            delivery_error = "no delivery channel (lane manager or caller unavailable)"
+
+        if delivered:
+            return {"delivered": True, "change_id": record["nonce"], "result": result}
+
+        # C7: the state-changing connector call SUCCEEDED but its result could
+        # not be delivered back to the proposing agent (the original HTTP
+        # caller is long gone; the consumed hold can't be replayed). Do NOT
+        # re-execute — a retry would duplicate the external side effect — and
+        # do NOT report a clean ``delivered: true`` (which would invite exactly
+        # that retry). Persist the result durably so it isn't lost, and return
+        # a split status the confirm response surfaces honestly.
+        try:
+            blackboard.log_audit(
+                action="connector_call_result_undelivered",
+                target=f"{connector}:{tool}",
+                field=caller,
+                after_value=dumps_safe({
+                    "nonce": record.get("nonce"),
+                    "result": result,
+                    "delivery_error": delivery_error,
+                })[:2000],
+                actor="mesh",
+                provenance="system",
+            )
+        except Exception as e:
+            logger.warning("persisting undelivered connector_call result failed: %s", e)
+        return {
+            "delivered": False,
+            "side_effect": "done",
+            "result_delivery": "failed",
+            "change_id": record["nonce"],
+            "result": result,
+            "error": (
+                f"connector call {connector}:{tool} executed successfully but its result could "
+                f"not be delivered to '{caller}': {delivery_error}. The side effect was NOT "
+                "retried — do not re-run the call; the result is persisted in the mesh audit log."
+            ),
+        }
 
     app.pending_executors["connector_call"] = _execute_held_connector_call
 
@@ -7256,6 +7322,54 @@ def create_mesh_app(
             },
         )
 
+    def _record_decay_or_error(
+        review_id: str,
+        *,
+        outcome: str,
+        author: str | None,
+        team_id: str,
+        rated_by: str,
+        details: dict,
+        extra_error_detail: dict | None = None,
+    ) -> None:
+        """Enforce an auto-merge trust-decay write (plan §8 #20 steps 6/7, C3).
+
+        Unlike ``record_best_effort``, a failure here MUST surface: if the
+        ``auto_merge_flagged`` / ``auto_merge_reverted`` decay event can't be
+        durably written, ``pair_trust`` sees no decay and the NEXT
+        lead-approved review for the pair would auto-merge despite the
+        operator's explicit flag/revert. So the endpoint returns an error
+        instead of a false success — the operator learns the decay did NOT
+        take effect (and can retry) rather than trusting a silent no-op.
+        """
+        if track_record_store is None:
+            raise HTTPException(
+                503, "track record store not configured — auto-merge trust decay cannot be recorded",
+            )
+        try:
+            track_record_store.record(
+                source="drive_review",
+                ref_id=review_id,
+                outcome=outcome,
+                rater_kind="human",
+                agent_id=author,
+                team_id=team_id,
+                rated_by=rated_by,
+                details=details,
+            )
+        except Exception as e:
+            logger.error("auto-merge trust-decay write failed for review %s: %s", review_id, e)
+            err = {
+                "error": "trust_decay_not_recorded",
+                "message": (
+                    f"trust decay for review {review_id} could NOT be recorded — the pair's "
+                    "auto-merge eligibility is UNCHANGED; retry so the flag/revert takes effect"
+                ),
+            }
+            if extra_error_detail:
+                err.update(extra_error_detail)
+            raise HTTPException(500, err) from e
+
     @app.post("/mesh/teams/{team_id}/drive/reviews/{review_id}/merge")
     async def drive_merge_review(team_id: str, review_id: str, request: Request) -> dict:
         """Integrate a reviewed branch into main (operator-or-internal).
@@ -7530,13 +7644,13 @@ def create_mesh_app(
         review = _drive_auto_merged_review_or_error(team_id, review_id)
         team = teams_store.get_team(team_id) or {}
         lead = review.get("lead_verdict_by") or team.get("lead_agent_id")
-        record_best_effort(
-            track_record_store,
-            source="drive_review",
-            ref_id=review_id,
+        # C3: enforce the decay write — a failure 500s instead of returning a
+        # false ``flagged: true`` (which would let the next lead-approved
+        # review for the pair auto-merge despite this explicit flag).
+        _record_decay_or_error(
+            review_id,
             outcome="auto_merge_flagged",
-            rater_kind="human",
-            agent_id=review.get("author"),
+            author=review.get("author"),
             team_id=team_id,
             rated_by=caller,
             details={
@@ -7589,13 +7703,15 @@ def create_mesh_app(
                 _drive_size_cache.pop(str(repo), None)
         team = teams_store.get_team(team_id) or {}
         lead = review.get("lead_verdict_by") or team.get("lead_agent_id")
-        record_best_effort(
-            track_record_store,
-            source="drive_review",
-            ref_id=review_id,
+        # C3: enforce the decay write. The git revert commit has already
+        # landed on main; if the decay record fails we 500 (so the operator
+        # knows the pair's trust was NOT decayed and can retry) but surface
+        # the landed ``revert_commit`` in the error so they don't blindly
+        # re-run the revert. Do NOT silently return success.
+        _record_decay_or_error(
+            review_id,
             outcome="auto_merge_reverted",
-            rater_kind="human",
-            agent_id=review.get("author"),
+            author=review.get("author"),
             team_id=team_id,
             rated_by=caller,
             details={
@@ -7604,6 +7720,7 @@ def create_mesh_app(
                 "resolution": "auto_merge_reverted",
                 "revert_commit": revert_sha,
             },
+            extra_error_detail={"revert_commit": revert_sha, "side_effect": "revert_landed"},
         )
         blackboard.log_audit(
             action="drive_review_auto_merge_reverted",
@@ -10903,6 +11020,61 @@ def create_mesh_app(
                 logger.debug("agent_woken emit failed: %s", e)
         return True
 
+    def _launch_wake(agent_id: str, *, trigger: str, shared_fut: "concurrent.futures.Future") -> None:
+        """Run ``_wake_agent_core`` as its OWN task on a stable loop, then
+        resolve ``shared_fut`` for the claimer + every joined waiter (M8).
+
+        The wake MUST outlive the coroutine that claimed it: if the
+        claiming trigger — e.g. a disconnecting/timing-out SSE request —
+        is cancelled mid-wake, the container restart still runs to
+        completion (``_wake_teardown`` still fires on failure) and the
+        shared future is still resolved, so no waiter is left awaiting a
+        never-resolved future (which would wedge a cron-heartbeat waiter
+        holding its per-job lock forever). The task detaches ONLY the
+        cancelled caller; the wake itself is never interrupted.
+
+        ``dispatch_loop`` (the long-lived lane loop) is preferred so the
+        wake survives even a transient trigger loop (e.g. ``request_sync``
+        driving its own ``asyncio.run``); without one wired (tests /
+        minimal boots) an independent task on the current running loop is
+        still detached from the claiming coroutine's cancellation.
+        """
+
+        async def _run_wake() -> None:
+            try:
+                result = await _wake_agent_core(agent_id, trigger=trigger)
+            except BaseException as e:  # noqa: BLE001 - the future MUST resolve on ANY exit (incl. CancelledError) or joined waiters hang forever
+                cancelled = isinstance(e, (asyncio.CancelledError, KeyboardInterrupt, SystemExit))
+                with _wake_claim_lock:
+                    if _wake_futures.get(agent_id) is shared_fut:
+                        _wake_futures.pop(agent_id, None)
+                if not shared_fut.done():
+                    try:
+                        # On cancellation resolve to a clean False ("still
+                        # unreachable") so waiters get a bool, not a
+                        # CancelledError propagated across the shared future.
+                        shared_fut.set_result(False) if cancelled else shared_fut.set_exception(e)
+                    except Exception:
+                        pass
+                if cancelled:
+                    raise
+                logger.error("wake_agent: unhandled error for '%s': %s", agent_id, e)
+                return
+            with _wake_claim_lock:
+                if _wake_futures.get(agent_id) is shared_fut:
+                    _wake_futures.pop(agent_id, None)
+            if not shared_fut.done():
+                try:
+                    shared_fut.set_result(result)
+                except Exception:
+                    pass
+
+        loop = dispatch_loop if (dispatch_loop is not None and dispatch_loop.is_running()) else None
+        if loop is not None:
+            asyncio.run_coroutine_threadsafe(_run_wake(), loop)
+        else:
+            asyncio.ensure_future(_run_wake())
+
     async def ensure_agent_running(agent_id: str, *, trigger: str = "dispatch") -> bool:
         """Cold-wake seam (plan §8 #24 leg 3) — the injectable
         ``ensure_running_fn`` wired into ``HttpTransport`` in
@@ -10924,6 +11096,12 @@ def create_mesh_app(
         cron loop) — wake the container exactly once; every waiter after
         the first joins the SAME in-flight wake via
         ``asyncio.wrap_future`` and no-ops once it resolves.
+
+        Cancellation-safe (M8): the actual wake runs as an independent
+        task (``_launch_wake``), so a cancelled claimer/waiter detaches
+        only itself — the shared future is always resolved by the wake
+        task and the future is locked RUNNING at claim time so a
+        cancelled awaiter can never cancel it out from under the others.
         """
         status = _status_overrides.get(agent_id, "active")
         if status == "active":
@@ -10936,26 +11114,26 @@ def create_mesh_app(
             is_claimer = fut is None
             if is_claimer:
                 fut = concurrent.futures.Future()
+                # Lock the shared future RUNNING before anyone can attach:
+                # ``asyncio.wrap_future`` forwards a waiter's cancellation to
+                # ``fut.cancel()``, a no-op once RUNNING — so one cancelled
+                # awaiter can never cancel the shared wake for the rest.
+                fut.set_running_or_notify_cancel()
                 _wake_futures[agent_id] = fut
 
-        if not is_claimer:
-            try:
-                return await asyncio.wrap_future(fut)
-            except Exception:
-                return False
+        if is_claimer:
+            _launch_wake(agent_id, trigger=trigger, shared_fut=fut)
 
         try:
-            result = await _wake_agent_core(agent_id, trigger=trigger)
-        except Exception as e:
-            logger.error("wake_agent: unhandled error for '%s': %s", agent_id, e)
-            result = False
-            fut.set_exception(e)
-        else:
-            fut.set_result(result)
-        finally:
-            with _wake_claim_lock:
-                _wake_futures.pop(agent_id, None)
-        return result
+            return await asyncio.wrap_future(fut)
+        except Exception:
+            # The wake task set an exception on the shared future (an
+            # unexpected error in ``_wake_agent_core``). Degrade to "still
+            # unreachable" rather than propagating into the caller. A
+            # CancelledError (BaseException) is NOT caught here — it
+            # propagates so the cancelled trigger unwinds cleanly, detaching
+            # only itself while the wake task runs on to completion.
+            return False
 
     app.ensure_agent_running = ensure_agent_running  # exposed for the transport seam
     app.get_agent_status = lambda agent_id: _status_overrides.get(agent_id, "active")

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -297,6 +297,122 @@ class TestDailyCap:
         assert statuses == {"merged", "open"}, statuses
 
 
+class TestCancellationSafety:
+    """C1: a cancelled auto-merge consumer must never strand a `merging`
+    row or land an unrecorded commit."""
+
+    @_requires_merge_tree
+    async def test_cancel_mid_merge_still_finalizes_and_records(self, repo_env):
+        """Cancel the consumer while the git merge is in flight — the
+        shielded merge/finalize unit still runs to completion, so the review
+        finalizes and the auto_merge is recorded (never a stranded `merging`
+        row, never an unrecorded landed commit)."""
+        store, track = repo_env["store"], repo_env["track"]
+        _seed_events(track, submitter="member1", lead="member2", outcome="merged", count=5)
+        review = _make_review(repo_env, "feat-cancel", "c.md", "hi\n")
+
+        gate = asyncio.Event()
+
+        async def _slow_merge(repo, sha, *, message):
+            await gate.wait()  # block mid `update-ref` so we can cancel
+            return await drive_mod.merge_branch(repo, sha, message=message)
+
+        def _stub_head(repo, branch):
+            return review["head_sha"]
+
+        consumer = asyncio.ensure_future(
+            _run(repo_env, review, merge_branch_fn=_slow_merge, branch_head_sha_fn=_stub_head),
+        )
+        await asyncio.sleep(0.05)  # claim + cap-reserve done; blocked in the merge
+        assert store.get_review(review["id"])["status"] == "merging"
+
+        consumer.cancel()
+        gate.set()  # release the merge so the shielded unit can finish
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+
+        resolved = store.get_review(review["id"])
+        assert resolved["status"] == "merged", "no stranded `merging` row after cancellation"
+        assert resolved["merge_commit"]
+        events = [e for e in track.recent_events("member1") if e["outcome"] == "auto_merged"]
+        assert len(events) == 1, "the auto_merge was recorded despite the cancellation"
+
+    async def test_negative_control_bare_await_cancel_strands_merging_row(self, repo_env):
+        """Documents the C1 bug the shielded unit prevents: awaiting the
+        merge DIRECTLY (no cancellation-atomic section) and cancelling
+        mid-merge leaves the review stranded `merging` with the commit
+        never finalized — the exact pre-fix failure."""
+        store = repo_env["store"]
+        review = _make_review(repo_env, "feat-strand")
+        store.claim_review_for_merge(review["id"])  # row -> merging
+        assert store.get_review(review["id"])["status"] == "merging"
+
+        gate = asyncio.Event()
+
+        async def _bare_consumer():
+            await gate.wait()  # "mid update-ref"
+            store.finalize_merge(review["id"], "deadbeef" * 5, reviewer="x")
+
+        t = asyncio.ensure_future(_bare_consumer())
+        await asyncio.sleep(0.02)
+        t.cancel()  # cancelled mid-merge, NO shielded section
+        with pytest.raises(asyncio.CancelledError):
+            await t
+        # finalize never ran → the row is STRANDED `merging` (the bug).
+        assert store.get_review(review["id"])["status"] == "merging"
+
+
+class TestCapRecordDurability:
+    """C2: the daily cap must never be silently bypassed by a track-record
+    append failure — recording the cap slot is a REQUIRED, fail-closed step
+    BEFORE the irreversible merge."""
+
+    async def test_cap_record_failure_fails_closed_no_merge(self, repo_env, monkeypatch):
+        store, track = repo_env["store"], repo_env["track"]
+        _seed_events(track, submitter="member1", lead="member2", outcome="merged", count=5)
+        review = _make_review(repo_env, "feat-capfail")
+
+        merged = {"called": False}
+
+        async def _should_not_merge(repo, sha, *, message):
+            merged["called"] = True
+            return "nope" * 10
+
+        def _stub_head(repo, branch):
+            return review["head_sha"]
+
+        def _boom_record(**kw):
+            raise RuntimeError("track_record.db read-only")
+
+        monkeypatch.setattr(track, "record", _boom_record)
+
+        await _run(repo_env, review, merge_branch_fn=_should_not_merge, branch_head_sha_fn=_stub_head)
+
+        assert merged["called"] is False, "the merge must NOT run when the cap slot can't be recorded"
+        assert store.get_review(review["id"])["status"] == "open", "claim reverted, not merged"
+
+    async def test_negative_control_cap_record_success_allows_merge(self, repo_env):
+        """Negative control: with the cap record succeeding, the SAME setup
+        DOES auto-merge — proving the fail-closed only triggers on a record
+        failure, and that the cap slot is recorded before the merge."""
+        store, track = repo_env["store"], repo_env["track"]
+        _seed_events(track, submitter="member1", lead="member2", outcome="merged", count=5)
+        review = _make_review(repo_env, "feat-capok")
+
+        async def _ok_merge(repo, sha, *, message):
+            return "abc123" * 6  # fake landed commit (no real git needed)
+
+        def _stub_head(repo, branch):
+            return review["head_sha"]
+
+        await _run(repo_env, review, merge_branch_fn=_ok_merge, branch_head_sha_fn=_stub_head)
+
+        assert store.get_review(review["id"])["status"] == "merged"
+        assert track.count_events(
+            source="drive_review", outcome="auto_merged", rater_kind="system",
+        ) == 1
+
+
 class TestConcurrencyAndSampling:
     @_requires_merge_tree
     async def test_concurrent_human_merge_loses_claim_harmlessly(self, repo_env):
@@ -754,3 +870,57 @@ class TestFlagAndRevertEndpoints:
                 headers=_headers("operator"),
             )
         assert resp.status_code == 409
+
+    # ── C3: the trust-decay write is ENFORCED (no false success) ─────
+
+    @_requires_merge_tree
+    @pytest.mark.asyncio
+    async def test_flag_500_when_decay_write_fails(self, app_env, monkeypatch):
+        """C3: if the decay track-record write fails, flag-auto-merge returns
+        an ERROR (not a false ``flagged: true``) so the operator knows the
+        pair's auto-merge eligibility was NOT changed. Negative control: the
+        sibling ``test_flag_auto_merge_operator_only`` returns 200 +
+        ``flagged == 1`` when the SAME write succeeds."""
+        review = await self._auto_merged_review(app_env)
+        app = app_env["app"]
+
+        def _boom(**kw):
+            raise RuntimeError("track_record.db read-only")
+
+        monkeypatch.setattr(app.track_record_store, "record", _boom)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                f"/mesh/teams/team-x/drive/reviews/{review['id']}/flag-auto-merge",
+                headers=_headers("operator"),
+            )
+        assert resp.status_code == 500, resp.text
+        assert resp.json()["detail"]["error"] == "trust_decay_not_recorded"
+        # The decay did NOT take effect — the pair is still un-flagged.
+        assert app.track_record_store.pair_trust("member2", "member1")["flagged"] == 0
+
+    @_requires_merge_tree
+    @pytest.mark.asyncio
+    async def test_revert_500_when_decay_write_fails_surfaces_revert_commit(self, app_env, monkeypatch):
+        """C3: revert-merge's git revert lands, but if the decay write fails
+        the endpoint 500s (not a silent success) and surfaces the landed
+        ``revert_commit`` so the operator doesn't blindly re-run the revert."""
+        review = await self._auto_merged_review(app_env)
+        app = app_env["app"]
+
+        def _boom(**kw):
+            raise RuntimeError("track_record.db read-only")
+
+        monkeypatch.setattr(app.track_record_store, "record", _boom)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                f"/mesh/teams/team-x/drive/reviews/{review['id']}/revert-merge",
+                headers=_headers("operator"),
+            )
+        assert resp.status_code == 500, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error"] == "trust_decay_not_recorded"
+        assert detail["revert_commit"], "the git revert landed — surface it so the operator doesn't re-run"
+        assert detail["side_effect"] == "revert_landed"
+        assert app.track_record_store.pair_trust("member2", "member1")["flagged"] == 0

--- a/tests/test_chain_watcher.py
+++ b/tests/test_chain_watcher.py
@@ -882,25 +882,70 @@ async def test_interval_zero_disables_whole_ladder():
 
 
 @pytest.mark.asyncio
-async def test_ladder_send_failure_does_not_stall_the_climb():
-    """A raising delivery seam is logged and isolated — the rung climb
-    (already claimed) stands and later rungs still fire."""
+async def test_ladder_failed_delivery_does_not_advance_rung():
+    """C4: a rung-1 dispatch that FAILS (loop/container down) must NOT
+    advance the rung — the next sweep re-drives the SAME assignee until it
+    lands, honouring §8 #22's indefinite-retry-of-rungs-1-3 requirement. A
+    raising seam is still logged + isolated (the sweep never crashes).
+
+    Negative control is the contrast within the test: a FAILING delivery
+    leaves rung==0 (the pre-fix code CAS-advanced BEFORE the send, so it
+    climbed to 1 regardless — the exact C4 bug); once the SAME seam starts
+    succeeding, the rung finally advances to 1.
+    """
     s = _store()
     task = _blocked_task(s)
     clk = [0.0]
 
-    def _boom(agent, message):
-        raise RuntimeError("transport down")
+    down = {"broken": True}
 
-    creator = _Sender()
-    lad = _ladder(s, clk, deliver_assignee=_boom, deliver_creator=creator)
+    def _flaky_assignee(agent, message):
+        if down["broken"]:
+            raise RuntimeError("transport down")  # loop/container down
+        return None  # delivered
+
+    lad = _ladder(s, clk, deliver_assignee=_flaky_assignee)
+    await lad.sweep_once()                     # observe → rung 0
+    assert s.ladder_state(task["id"])["rung"] == 0
+
+    clk[0] += INTERVAL
+    await lad.sweep_once()                     # rung-1 send RAISES — isolated
+    assert s.ladder_state(task["id"])["rung"] == 0, "a failed delivery must NOT advance the rung (C4)"
+
+    clk[0] += INTERVAL
+    await lad.sweep_once()                     # still down → still re-driving rung 1
+    assert s.ladder_state(task["id"])["rung"] == 0, "a persistently-failing rung must keep retrying, never climb past"
+
+    # The seam recovers — now the SAME rung finally lands and advances.
+    down["broken"] = False
+    clk[0] += INTERVAL
+    await lad.sweep_once()
+    assert s.ladder_state(task["id"])["rung"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ladder_seam_reporting_false_does_not_advance_rung():
+    """C4: a delivery seam that RETURNS ``False`` (couldn't enqueue — the
+    runtime wrapper's no-lane/failed-enqueue signal) is a delivery failure
+    too — the rung stays put; a truthy/None return advances it."""
+    s = _store()
+    task = _blocked_task(s)
+    clk = [0.0]
+    outcome = {"ok": False}
+
+    def _reports(agent, message):
+        return outcome["ok"]  # False = not delivered
+
+    lad = _ladder(s, clk, deliver_assignee=_reports)
     await lad.sweep_once()
     clk[0] += INTERVAL
-    await lad.sweep_once()          # rung 1 send raises — isolated
-    assert s.ladder_state(task["id"])["rung"] == 1
+    await lad.sweep_once()
+    assert s.ladder_state(task["id"])["rung"] == 0  # False return → no advance
+
+    outcome["ok"] = True
     clk[0] += INTERVAL
-    await lad.sweep_once()          # rung 2 proceeds normally
-    assert [a for a, _ in creator.calls] == ["ops"]
+    await lad.sweep_once()
+    assert s.ladder_state(task["id"])["rung"] == 1  # truthy return → advance
 
 
 # ── Ladder: chain-watcher piggyback ──────────────────────────────

--- a/tests/test_connectors_remote.py
+++ b/tests/test_connectors_remote.py
@@ -328,6 +328,43 @@ class TestConnectorCallPolicyGate:
         assert kwargs.get("mode") == "followup"
         assert kwargs.get("system_note") is True
 
+    def test_hold_confirm_result_delivery_failure_not_clean_success(self, mesh_env_hold):
+        """C7: the state-changing connector call SUCCEEDS, but the follow-up
+        lane enqueue (result delivery) FAILS. The confirm must NOT report a
+        clean ``delivered: true`` — that would invite the agent to retry and
+        duplicate the external side effect. It returns ``delivered: false``
+        with the executed result + a 'result delivery failed' status, the
+        result is persisted to the audit log, and the side effect ran EXACTLY
+        ONCE (never re-executed).
+
+        Negative control is the sibling
+        ``test_hold_confirm_executes_and_delivers_followup_note``: identical
+        flow with a WORKING enqueue returns ``delivered: true``.
+        """
+        client, _store, _gateway, bb, lane_manager = mesh_env_hold
+        lane_manager.enqueue = AsyncMock(side_effect=RuntimeError("lane down"))
+
+        propose = self._call(client, "alpha")
+        nonce = propose.json()["change_id"]
+        digest = propose.json()["payload_digest"]
+        confirm = client.post(
+            "/mesh/config/confirm",
+            json={"change_id": nonce, "payload_digest": digest},
+            headers=_human_headers("operator"),
+        )
+        assert confirm.status_code == 200, confirm.text
+        body = confirm.json()
+        assert body["delivered"] is False               # NOT a clean success
+        assert body["result_delivery"] == "failed"
+        assert body["side_effect"] == "done"
+        assert body["result"] == {"result": "done"}     # the executed result is preserved
+        assert "not be delivered" in body["error"]
+        # The connector side effect executed exactly ONCE — never re-run.
+        assert len(FakeSession.instances) == 1
+        # The result is persisted durably so it isn't lost.
+        undelivered = bb.get_audit_log(action="connector_call_result_undelivered")["entries"]
+        assert len(undelivered) == 1
+
     def test_hold_confirm_single_use(self, mesh_env_hold):
         client, *_ = mesh_env_hold
         propose = self._call(client, "alpha")

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -488,6 +488,51 @@ class TestHeartbeat:
         call_msg = dispatch.call_args[0][1]
         assert "Probe Alerts" in call_msg
 
+    @pytest.mark.asyncio
+    async def test_heartbeat_stamps_activity_before_dispatch(self):
+        """M7: the idle-sweep activity clock is stamped BEFORE the
+        (multi-second) heartbeat LLM dispatch, not only after — so the sweep
+        can't hibernate the agent mid-heartbeat (which sees the pre-turn
+        ``last_activity`` and thinks the agent is idle)."""
+        stamps: list[str] = []
+        stamps_when_dispatch_ran: list[int] = []
+
+        async def dispatch(agent, message):
+            # How many activity stamps had ALREADY fired when the dispatch
+            # began — proves the pre-stamp lands before the turn.
+            stamps_when_dispatch_ran.append(len(stamps))
+            return "did the work"
+
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=dispatch,
+            pending_tasks_fn=lambda agent: 1,   # actionable plate → dispatches
+            activity_fn=lambda agent: stamps.append(agent),
+        )
+        job = sched.add_job(agent="test", schedule="every 15m", message="heartbeat", heartbeat=True)
+        await sched._execute_job(job)
+        assert stamps_when_dispatch_ran and stamps_when_dispatch_ran[0] >= 1, "pre-dispatch stamp missing"
+        assert len(stamps) >= 2, "must stamp both before AND after the dispatch"
+
+    @pytest.mark.asyncio
+    async def test_empty_heartbeat_tick_does_not_stamp_activity(self):
+        """Negative control for the pre-stamp: a gated/empty heartbeat that
+        never dispatches must NOT stamp activity — otherwise every cheap tick
+        would reset the idle clock and hibernation could never trigger."""
+        stamps: list[str] = []
+        dispatch = AsyncMock(return_value="x")
+        mock_bb = MagicMock()
+        mock_bb.list_by_prefix.return_value = []
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=dispatch, blackboard=mock_bb,
+            activity_fn=lambda agent: stamps.append(agent),
+        )
+        job = sched.add_job(agent="test", schedule="every 15m", message="heartbeat", heartbeat=True)
+        with patch.object(sched, "_run_heartbeat_probes", return_value=[]):
+            result = await sched._execute_job(job)
+        dispatch.assert_not_called()
+        assert result is None
+        assert stamps == []
+
     def test_find_heartbeat_job(self):
         sched = CronScheduler(config_path=self.config_path)
         sched.add_job(agent="researcher", schedule="every 30m", message="check", heartbeat=False)

--- a/tests/test_hibernation.py
+++ b/tests/test_hibernation.py
@@ -441,6 +441,79 @@ class TestWake:
         bb.close()
 
 
+# ── M8: cold-wake single-flight cancellation-safety ──────────────────
+
+
+class _SlowContainerManager(_FakeContainerManager):
+    """Gates ``wait_for_agent`` on an event so a wake can be cancelled
+    mid-flight. ``wait_result`` decides success/failure after release."""
+
+    def __init__(self):
+        super().__init__()
+        self.gate = asyncio.Event()
+        self.wait_result = False
+
+    async def wait_for_agent(self, agent_id, timeout=30):
+        await self.gate.wait()
+        return self.wait_result
+
+
+class TestWakeCancellationSafety:
+    async def test_negative_control_unresolved_future_hangs_waiters(self):
+        """Documents the M8 bug the fix prevents: the pre-fix single-flight
+        popped the shared ``concurrent.futures.Future`` on claimer
+        cancellation WITHOUT resolving it, so every waiter joined via
+        ``asyncio.wrap_future`` awaited forever. This reproduces that raw
+        mechanism — an unresolved future never wakes its waiter."""
+        import concurrent.futures
+        import contextlib
+
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+        waiter = asyncio.ensure_future(asyncio.wrap_future(fut))
+        # Never resolved (the old `finally: _wake_futures.pop(...)` with no
+        # set_result/set_exception) → the waiter hangs.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(waiter), timeout=0.3)
+        waiter.cancel()
+        with contextlib.suppress(BaseException):
+            await waiter
+
+    async def test_cancelled_claimer_resolves_waiters_and_runs_teardown(self, tmp_path, monkeypatch):
+        """M8: cancel the claimer mid-wake — the waiter still RESOLVES (does
+        not hang) and ``_wake_teardown`` still fires. The wake runs as its
+        own task, so the claimer's cancellation detaches only itself."""
+        cm = _SlowContainerManager()  # wait_for_agent blocks, then fails
+        app, bb, _cm, tr, hm, eb, cfg = _build_app(
+            tmp_path, monkeypatch, agent_status="hibernated", container_manager=cm,
+        )
+
+        claimer = asyncio.create_task(app.ensure_agent_running("scout"))
+        await asyncio.sleep(0.05)                 # claimer reaches wait_for_agent
+        waiter = asyncio.create_task(app.ensure_agent_running("scout"))
+        await asyncio.sleep(0.02)                 # waiter joins the in-flight future
+        assert cm.started, "the wake task started the container before cancellation"
+
+        claimer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await claimer
+
+        # Release the wake — it completes (fails) on its independent task.
+        cm.gate.set()
+        result = await asyncio.wait_for(waiter, timeout=2.0)
+        assert result is False                    # waiter resolved, NOT hung
+
+        # Teardown ran even though the claimer was cancelled: the container
+        # is stopped WITHOUT data removal and health is deregistered, and
+        # status is never falsely flipped to active.
+        assert ("scout", False) in cm.stopped
+        assert not any(remove for _a, remove in cm.stopped), cm.stopped
+        hm.unregister.assert_called_with("scout")
+        assert cfg["agents"]["scout"]["status"] == "hibernated"
+        # The single-flight entry was cleaned up — a later wake can reclaim.
+        assert await app.ensure_agent_running("scout") in (True, False)
+        bb.close()
+
+
 # ── Boot + heartbeat-reconcile asymmetry ─────────────────────────────
 
 
@@ -723,6 +796,30 @@ class TestCronHibernatedTicks:
 # ── Idle sweep ────────────────────────────────────────────────────────
 
 
+class _MidTickLane:
+    """Lane-manager stub whose ``get_status``/``last_activity`` return one
+    value on the tick snapshot and a DIFFERENT value on the sweep's fresh
+    re-check (M7) — so a turn that starts mid-tick can be simulated
+    deterministically (no ``await`` point exists between the two reads to
+    mutate a real lane from the test)."""
+
+    def __init__(self, *, first_status, recheck_status, first_activity, recheck_activity):
+        self._status_seq = [first_status, recheck_status]
+        self._activity_seq = [first_activity, recheck_activity]
+        self._status_calls = 0
+        self._activity_calls = 0
+
+    def get_status(self):
+        idx = min(self._status_calls, 1)
+        self._status_calls += 1
+        return self._status_seq[idx]
+
+    def last_activity(self, agent):
+        idx = min(self._activity_calls, 1)
+        self._activity_calls += 1
+        return self._activity_seq[idx]
+
+
 def _sweeper(tmp_path, *, agents_cfg, lane_manager=None, tasks_store=None,
              ask_broker=None, wake_available_fn=None):
     hibernate_calls: list[tuple[str, str]] = []
@@ -858,6 +955,62 @@ class TestHibernationSweeper:
         lm._activity["scout"] = time.time() - 999 * 60
         sweeper, calls = _sweeper(
             tmp_path, agents_cfg={"scout": {"status": "archived"}}, lane_manager=lm,
+        )
+        await sweeper._tick()
+        assert calls == []
+
+    # ── M7: re-check freshly immediately before the stop ─────────────
+
+    async def test_negative_control_stale_idle_agent_is_hibernated(self, tmp_path, monkeypatch):
+        """Negative control for the M7 re-check: an agent that is idle on
+        BOTH the tick snapshot AND the fresh re-check (no turn started
+        mid-tick) IS hibernated — proving the re-check doesn't block a
+        genuinely-idle stop."""
+        monkeypatch.setenv("OPENLEGION_HIBERNATE_IDLE_MINUTES", "10")
+        old = time.time() - 20 * 60
+        lane = _MidTickLane(
+            first_status={"scout": {"busy": False, "queued": 0}},
+            recheck_status={"scout": {"busy": False, "queued": 0}},
+            first_activity=old, recheck_activity=old,
+        )
+        sweeper, calls = _sweeper(
+            tmp_path, agents_cfg={"scout": {"status": "active"}}, lane_manager=lane,
+        )
+        await sweeper._tick()
+        assert calls == [("scout", "sweep")]
+
+    async def test_turn_becoming_busy_mid_tick_aborts_the_stop(self, tmp_path, monkeypatch):
+        """M7: the per-tick snapshot showed the agent idle, but by the time
+        the sweep reaches the stop a lane turn has started — the FRESH
+        re-check catches ``busy`` and aborts (the pre-fix sweep hibernated
+        off the stale snapshot)."""
+        monkeypatch.setenv("OPENLEGION_HIBERNATE_IDLE_MINUTES", "10")
+        old = time.time() - 20 * 60
+        lane = _MidTickLane(
+            first_status={"scout": {"busy": False, "queued": 0}},
+            recheck_status={"scout": {"busy": True, "queued": 0}},   # turn started mid-tick
+            first_activity=old, recheck_activity=old,
+        )
+        sweeper, calls = _sweeper(
+            tmp_path, agents_cfg={"scout": {"status": "active"}}, lane_manager=lane,
+        )
+        await sweeper._tick()
+        assert calls == []
+
+    async def test_direct_turn_activity_stamp_mid_tick_aborts_the_stop(self, tmp_path, monkeypatch):
+        """M7: a direct-bypass turn (dashboard/CLI/channel stream, cron
+        heartbeat) stamps ``last_activity`` at turn START but never sets a
+        lane ``busy`` flag. The fresh re-check on the activity clock catches
+        the mid-tick stamp and aborts the stop."""
+        monkeypatch.setenv("OPENLEGION_HIBERNATE_IDLE_MINUTES", "10")
+        lane = _MidTickLane(
+            first_status={"scout": {"busy": False, "queued": 0}},
+            recheck_status={"scout": {"busy": False, "queued": 0}},  # direct turn = never lane-busy
+            first_activity=time.time() - 20 * 60,                    # idle at snapshot
+            recheck_activity=time.time(),                            # turn stamped activity mid-tick
+        )
+        sweeper, calls = _sweeper(
+            tmp_path, agents_cfg={"scout": {"status": "active"}}, lane_manager=lane,
         )
         await sweeper._tick()
         assert calls == []

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2658,3 +2658,61 @@ def test_rekey_never_reruns_on_canonical_v1_db(tmp_path):
         assert bb.get_agent_watches("agent1") == ["projects/*"]
     finally:
         bb.close()
+
+
+# === M6: MessageRouter cold-wake seam (send_message wakes a hibernated recipient) ===
+
+
+@pytest.mark.asyncio
+async def test_route_cold_wakes_hibernated_recipient_before_resolve():
+    """M6: routing to a hibernated recipient calls the injected wake seam
+    BEFORE target resolution — the wake re-registers the restarted
+    container's fresh URL, so a recipient absent from the registry
+    (post-restart) is woken-then-delivered instead of failing 'No agent
+    found'. Mirrors the ``HttpTransport`` cold-wake seam for the direct
+    ``/mesh/message`` router path."""
+    from src.shared.types import AgentMessage
+
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "alice": AgentPermissions(agent_id="alice", can_message=["*"]),
+        "bob": AgentPermissions(agent_id="bob", can_message=["*"]),
+    }
+    # bob is NOT in the registry (its hibernated container's url was dropped).
+    router = MessageRouter(permissions=perms, agent_registry={"alice": "http://a:8400"})
+    router._get_client = _make_async_returner(_FakeDeliveryClient())
+
+    waked: list[str] = []
+
+    async def _wake(agent_id: str) -> bool:
+        waked.append(agent_id)
+        router.register_agent(agent_id, "http://bob-fresh:8400")  # cold-wake re-registers
+        return True
+
+    router.set_ensure_running_fn(_wake)
+
+    result = await router.route(
+        AgentMessage(from_agent="alice", to="bob", type="query", payload={}),
+    )
+    assert waked == ["bob"]        # the recipient was woken…
+    assert result == {"ok": True}  # …BEFORE resolve → delivery succeeded
+
+
+@pytest.mark.asyncio
+async def test_negative_control_no_wake_seam_never_wakes_recipient():
+    """Negative control: the pre-fix router (no wake seam wired) never wakes
+    a hibernated recipient — one absent from the registry just fails
+    'No agent found', the exact M6 bug the seam fixes."""
+    from src.shared.types import AgentMessage
+
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "alice": AgentPermissions(agent_id="alice", can_message=["*"]),
+        "bob": AgentPermissions(agent_id="bob", can_message=["*"]),
+    }
+    router = MessageRouter(permissions=perms, agent_registry={"alice": "http://a:8400"})
+    # No set_ensure_running_fn — bob stays unregistered, never woken.
+    result = await router.route(
+        AgentMessage(from_agent="alice", to="bob", type="query", payload={}),
+    )
+    assert result == {"error": "No agent found for target: bob"}

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3024,13 +3024,16 @@ class TestSystemNoteCallSites:
 
     def test_runtime_sites_flagged(self):
         src = self._src("src/cli/runtime.py")
-        # cron_dispatch + verification wake + the blocked-task ladder's
-        # rung-1 assignee followup AND rung-2 creator followup
-        # (``_ladder_send_assignee`` / ``_ladder_send_creator``, plan §8 #22
-        # — both mesh-composed, no human typed them; rung 1 was corrected
-        # from a ``deliver_chat`` call that could not carry the flag,
-        # Phase-5 review finding).
-        assert src.count("system_note=True") == 4
+        # Three literal sites: cron_dispatch + verification wake + the
+        # blocked-task ladder's shared rung-1/rung-2 delivery helper
+        # (``_ladder_enqueue_nudge``, plan §8 #22 — mesh-composed, no human
+        # typed it; both ``_ladder_send_assignee`` and
+        # ``_ladder_send_creator`` route through it, so the single flagged
+        # enqueue covers both rungs. C4 consolidated the two prior sites
+        # into this one helper — the flag guarantee is unchanged).
+        assert src.count("system_note=True") == 3
+        # Pin that both ladder rungs route through the flagged helper.
+        assert src.count("_ladder_enqueue_nudge(") >= 3  # def + 2 call sites
         # Rung 1 must NOT regress to the flag-less deliver_chat path.
         assert "self.lane_manager.deliver_chat(agent, message)" not in src
 


### PR DESCRIPTION
The final batch of Phase 0–5 integration-review must-fixes — the "record/deliver-after-irreversible-action fails silently" cluster plus the hibernation seam gaps. Off `main`; regression tests with negative controls throughout.

## Governance (auto-merge is an active feature)
- **C2 — daily cap fails OPEN on ledger-append failure.** The `auto_merged` track-record row is now a REQUIRED reserve written *before* the irreversible merge; a durable-write failure reverts the claim and skips (fail-closed). A full/read-only `track_record.db` previously let every approval merge while the count stayed flat, silently bypassing `auto_merge_daily_cap`. (Rare over-count on a post-reserve merge failure is conservative — never under-counts.)
- **C3 — flag/revert reported success even when trust decay wasn't enforced.** `flag-auto-merge` / `revert-merge` now enforce the decay write via `_record_decay_or_error` → 500 `trust_decay_not_recorded` on failure (revert surfaces the landed `revert_commit`), so the operator's flag/revert can't silently no-op and let the pair auto-merge again.
- **C1 — auto-merge cancellation stranded a review / landed an unrecorded commit.** Merge+finalize now run as one cancellation-atomic unit (`_merge_and_finalize` under `asyncio.shield`); a cancelled consumer lets the shielded unit finish then unwinds, and an outer backstop reverts a still-`merging` claim. Never a stranded `merging` row or an unrecorded landed commit.

## Hibernation seam (opt-in, default-OFF — but correctness-critical when on)
- **M8 — cold-wake single-flight leaked a never-resolved future on cancellation.** The wake runs as its own task on the stable dispatch loop; the shared `concurrent.futures.Future` is locked RUNNING at claim (so a cancelled awaiter can't cancel it for the rest) and is always resolved on any exit incl. `BaseException`; teardown always fires. No more permanently-wedged cron-heartbeat waiters / running-but-labelled-hibernated zombie.
- **M6 — `send_message` never woke a hibernated teammate.** `MessageRouter.route` gained the same `ensure_agent_running` cold-wake seam the transport has, called before `_resolve_target`.
- **M7 — idle sweep could hibernate an agent mid-turn.** Activity is now stamped at turn START on the direct-bypass paths (chat/message received, cron heartbeat before+after), and the sweep re-checks busy+activity immediately before the stop.

## Delivery durability
- **C4 — blocked-task ladder advanced past a FAILED rung-1 delivery.** Deliver-first, climb-only-on-success: a failed rung-1/2/3 dispatch leaves the rung un-advanced for the next sweep to retry (§8 #22 indefinite retry of rungs 1–3).
- **C7 — a successful held connector side effect could lose its result while reporting success.** On post-side-effect enqueue failure: no re-execution, the result is persisted to the audit log, and the executor returns `delivered:false` / `result_delivery:"failed"` with the result — so the agent isn't told "clean success" and prompted to retry a duplicate external side effect.

## Verification
Consolidated full non-e2e gate green: **9061 passed, 42 skipped** (`-n 4 --dist=loadfile`, split halves); sole red is the known `TestTelegramStop` xdist flake (green in isolation). `ruff check` clean. Two existing tests updated (not silenced): the ladder send-failure test pinned the C4 bug, and a runtime `system_note` count dropped 4→3 when the two ladder seams were DRY-consolidated (the flag guarantee is unchanged and re-pinned).

Report: `docs/plans/2026-07-12-phase0-5-integration-review-findings.md`.
