### PR TITLE
Team signal ledger: close the coordination loops (author feedback, fan-in, heartbeat drain)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -2434,6 +2434,65 @@ class RuntimeContext:
             if self.lane_manager is not None:
                 self.lane_manager.mark_activity(agent)
 
+        def unseen_events(agent: str) -> dict | None:
+            """Unseen-actionable-events probe input (team signal ledger,
+            Item 1): mesh-side ThreadStore cursor read only, never the
+            container. Returns None fast when the agent has no UNSEEN
+            actionable back-edge / review events; otherwise builds a bounded
+            summary AND marks those events seen and returns
+            ``{"count", "summary"}``.
+
+            Mark-on-surface is the storm guard: cron guarantees an actionable
+            plate always dispatches, so this probe returning a summary IS the
+            presentation point — marking here means the same events never
+            re-trigger the heartbeat on the next tick. Lazy ``self.thread_store``
+            ref (mirrors the sibling seams); a missing store or any read
+            failure degrades to "no probe" (None)."""
+            store = getattr(self, "thread_store", None)
+            if store is None:
+                return None
+            try:
+                count = store.count_unseen_actionable(agent)
+            except Exception as e:
+                logger.debug("unseen_events count failed for '%s': %s", agent, e)
+                return None
+            if not count:
+                return None
+            try:
+                events = store.unseen_actionable_events(agent)
+            except Exception as e:
+                logger.debug("unseen_events fetch failed for '%s': %s", agent, e)
+                return None
+            if not events:
+                return None
+            # Bounded, plain-language summary of the unseen actionable events.
+            kinds: dict[str, int] = {}
+            samples: list[str] = []
+            for ev in events:
+                k = str(ev.get("kind") or "event")
+                kinds[k] = kinds.get(k, 0) + 1
+                if len(samples) < 3:
+                    ref = ev.get("task_id") or ev.get("review_id") or ""
+                    samples.append(f"{k}{(' ' + str(ref)) if ref else ''}")
+            breakdown = ", ".join(f"{n}x {k}" for k, n in sorted(kinds.items()))
+            sample_txt = f" (e.g. {', '.join(samples)})" if samples else ""
+            summary = (
+                f"{count} unseen actionable event(s): {breakdown}{sample_txt}. "
+                "Call check_inbox to act on them -- failed/blocked tasks you "
+                "own or your Team Drive reviews that were rejected / failed to "
+                "merge."
+            )
+            # Mark-on-surface: advance the cursor past everything surfaced.
+            # Use max(...) (not events[0]) — the list is created_at-ordered,
+            # so a backdated row can carry a higher id, and the cursor must
+            # clear ALL surfaced rows to prevent a re-trigger.
+            try:
+                max_id = max(int(ev.get("id") or 0) for ev in events)
+                store.mark_events_seen(agent, max_id)
+            except Exception as e:
+                logger.debug("mark_events_seen failed for '%s': %s", agent, e)
+            return {"count": count, "summary": summary}
+
         self.cron_scheduler = CronScheduler(
             dispatch_fn=cron_dispatch,
             invoke_fn=invoke_tool,
@@ -2477,6 +2536,12 @@ class RuntimeContext:
             goal_coverage_fn=goal_coverage,
             agent_status_fn=agent_status,
             activity_fn=agent_activity,
+            # Team signal ledger (Item 1): the heartbeat backstop probe.
+            # NOT lead-gated — every agent's unseen actionable back-edge /
+            # review events force an actionable plate, with mark-on-surface
+            # as the storm guard. Lazy ``self.thread_store`` inside the
+            # closure, like the sibling mesh-side probes above.
+            unseen_events_fn=unseen_events,
         )
         self._cron_job_count = len(self.cron_scheduler.jobs)
 

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -125,6 +125,7 @@ class CronScheduler:
         goal_coverage_fn: Callable | None = None,
         agent_status_fn: Callable | None = None,
         activity_fn: Callable | None = None,
+        unseen_events_fn: Callable | None = None,
     ):
         self.config_path = Path(config_path)
         self.jobs: dict[str, CronJob] = {}
@@ -200,6 +201,20 @@ class CronScheduler:
         # paths that bypass the lane (tool-invoke jobs, ``/heartbeat``).
         self.agent_status_fn = agent_status_fn
         self.activity_fn = activity_fn
+        # Unseen-actionable-events probe input (team signal ledger, Item 1):
+        # ``unseen_events_fn(agent) -> {"count", "summary"} | None`` reads
+        # the mesh-side ThreadStore cursor ONLY (never a container). Unlike
+        # ``lead_reviews_fn`` this is NOT lead-gated — it applies to EVERY
+        # agent: a non-None summary means the agent has UNSEEN actionable
+        # back-edge/review events, so the plate is ACTIONABLE and the summary
+        # rides the plate directive (see the probe below). This is the
+        # heartbeat BACKSTOP that guarantees an actionable event surfaces
+        # even if its direct wake was missed. The closure marks the events
+        # seen as it builds the summary (mark-on-surface) — cron guarantees
+        # an actionable plate always dispatches, so surfacing == presentation
+        # — which is the storm guard: a surfaced event never re-triggers.
+        # A read failure degrades to "no probe" (None), like the lead probes.
+        self.unseen_events_fn = unseen_events_fn
         # Host-published channel post (§8 #14): wired so ``_execute_job``
         # can post a standup (or any ``post_to_channel``-tagged) job's
         # dispatch response into the team's channel thread. None in
@@ -1245,6 +1260,35 @@ class CronScheduler:
                         f"Team goals are set but only {count} open task(s) advance "
                         f"them for team {team_id} -- review the goals, decompose "
                         "under-covered ones into tasks, and hand them off to the team."
+                    ),
+                ))
+
+        # Probe 8: unseen actionable events (team signal ledger, Item 1) —
+        # the heartbeat BACKSTOP. Applies to EVERY agent (NOT lead-gated):
+        # a non-None summary means the agent has unseen actionable back-edge
+        # / review events, so the plate is ACTIONABLE and the summary rides
+        # the directive (surfaced in the "Probe Alerts" section like every
+        # other triggered probe). Mesh-side ThreadStore read only — never a
+        # container call, so it never cold-wakes a hibernated agent; a read
+        # failure degrades to "no probe". The closure marks the events seen
+        # as it builds the summary (mark-on-surface) — this probe running is
+        # the presentation point, since cron always dispatches an actionable
+        # plate — so a surfaced event never re-triggers the heartbeat.
+        if self.unseen_events_fn is not None:
+            try:
+                unseen = self.unseen_events_fn(agent)
+            except Exception as e:
+                logger.debug("unseen_events_fn failed for '%s': %s", agent, e)
+                unseen = None
+            if unseen:
+                count = unseen.get("count", 0)
+                summary = unseen.get("summary", "")
+                results.append(HeartbeatProbeResult(
+                    name="unseen_events",
+                    triggered=True,
+                    detail=(
+                        summary
+                        or f"{count} unseen actionable event(s) -- call check_inbox to act on them."
                     ),
                 ))
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7235,6 +7235,21 @@ def create_mesh_app(
         head_sha = await loop.run_in_executor(None, team_drive.branch_head_sha, repo, branch)
         if not head_sha:
             raise HTTPException(400, f"branch '{branch}' does not exist on the Team Drive — push it first")
+        # Item 2: capture the live review this submit will supersede
+        # (``create_review`` marks the prior OPEN same-(team,branch) review
+        # ``superseded`` in the same txn) so we can close the loop to ITS
+        # author. Read BEFORE the write; best-effort — a prelook failure
+        # never blocks the submit.
+        superseded_prior: list[dict] = []
+        try:
+            superseded_prior = [
+                r for r in teams_store.list_reviews(team_id, status="open")
+                if r.get("branch") == branch
+            ]
+        except Exception as e:
+            logger.debug(
+                "supersede prelook failed for team %s branch %s: %s", team_id, branch, e,
+            )
         # Pin the reviewed tip so the merge integrates this EXACT commit even
         # if the worker advances the branch after approval (TOCTOU guard).
         review = teams_store.create_review(team_id, branch, caller, title, summary, head_sha=head_sha)
@@ -7246,6 +7261,13 @@ def create_mesh_app(
             after_value=review["id"],
             provenance="agent",
         )
+        for prior in superseded_prior:
+            prior_author = prior.get("author")
+            # Skip a self-resubmit (the author already knows) and the
+            # brand-new row itself (defensive).
+            if not prior_author or prior_author == caller or prior.get("id") == review.get("id"):
+                continue
+            _signal_review_author(team_id, prior, "review_superseded", resolved_by=caller)
         return {"submitted": True, "review": review}
 
     @app.get("/mesh/teams/{team_id}/drive/reviews")
@@ -7414,6 +7436,10 @@ def create_mesh_app(
             commit = await team_drive.merge_branch(repo, recorded_sha or live_sha, message=message)
         except team_drive.MergeConflict as e:
             teams_store.revert_merge_claim(review_id)
+            _signal_review_author(
+                team_id, review, "review_merge_failed",
+                note=f"merge conflict: {str(e)[:400]}", resolved_by=caller,
+            )
             raise HTTPException(
                 409,
                 {
@@ -7428,12 +7454,25 @@ def create_mesh_app(
             )
         except team_drive.RefMoved as e:
             teams_store.revert_merge_claim(review_id)
+            _signal_review_author(
+                team_id, review, "review_merge_failed",
+                note=str(e)[:400], resolved_by=caller,
+            )
             raise HTTPException(409, str(e))
         except team_drive.DriveError as e:
             teams_store.revert_merge_claim(review_id)
             raise HTTPException(500, f"merge failed: {e}")
-        except HTTPException:
+        except HTTPException as e:
             teams_store.revert_merge_claim(review_id)
+            # Merge-preflight 409s (branch deleted / branch changed since
+            # review) — signal the author to resolve and resubmit (Item 2).
+            # A non-409 (defensive) is re-raised untouched with no signal.
+            if e.status_code == 409:
+                detail = e.detail if isinstance(e.detail, str) else "branch changed — resubmit"
+                _signal_review_author(
+                    team_id, review, "review_merge_failed",
+                    note=detail[:400], resolved_by=caller,
+                )
             raise
         # The merge landed on main; finalize merging → merged.
         try:
@@ -7454,6 +7493,8 @@ def create_mesh_app(
             provenance="user",
         )
         _record_drive_review_outcome(team_id, review_id, resolved, "merged", caller)
+        # Item 2: close the review loop to the author (informational).
+        _signal_review_author(team_id, resolved, "review_merged", resolved_by=caller)
         return {"merged": True, "review": resolved, "merge_commit": commit}
 
     @app.post("/mesh/teams/{team_id}/drive/reviews/{review_id}/reject")
@@ -7478,6 +7519,8 @@ def create_mesh_app(
             provenance="user",
         )
         _record_drive_review_outcome(team_id, review_id, resolved, "rejected", caller)
+        # Item 2: close the review loop to the author (actionable — rework).
+        _signal_review_author(team_id, resolved, "review_rejected", resolved_by=caller)
         return {"rejected": True, "review": resolved}
 
     async def _post_auto_merge_note(
@@ -7492,6 +7535,13 @@ def create_mesh_app(
         callers already wrap this in a try/except (a note failure must
         never affect the merge that already landed).
         """
+        # Item 2: close the review loop to the AUTHOR — the kernel merged
+        # their branch (informational). This lives here (NOT in the
+        # transport-agnostic ``auto_merge`` module) where ``thread_store`` +
+        # the wake helper are in scope. It fires BEFORE the operator-note
+        # early-returns below so the author is signalled even in deployments
+        # with no operator container. ``resolved_by`` = the approving lead.
+        _signal_review_author(team_id, review, "review_merged", resolved_by=lead_verdict_by)
         if transport is None:
             return
         from src.cli.config import _OPERATOR_AGENT_ID
@@ -7606,6 +7656,14 @@ def create_mesh_app(
             provenance="agent",
         )
         if verdict == "approve":
+            # Item 2: close the review loop to the author (informational —
+            # the lead approved). A lead REJECT verdict is deliberately NOT
+            # signalled: it is advisory only, the review stays OPEN, and the
+            # operator's eventual reject/merge is the terminal author signal
+            # (mirrors the task's enumeration of "approve-verdict").
+            _signal_review_author(
+                team_id, resolved, "review_approved", note=note, resolved_by=caller,
+            )
             task = asyncio.create_task(_run_auto_merge_consumer(team_id, resolved, caller))
             _auto_merge_tasks.add(task)
             task.add_done_callback(_auto_merge_tasks.discard)
@@ -8286,6 +8344,125 @@ def create_mesh_app(
             kind="event",
             payload=payload,
         )
+
+    # Review outcome signals (team signal ledger, Item 2). The review
+    # AUTHOR (``review["author"]`` — stored, non-forgeable) is the party
+    # who must act on a rejection / merge-failure and wants to know about a
+    # merge / approval / supersede; today they only learn by polling
+    # ``list_reviews``. Mirror the task back-edge: a host-side event row on
+    # the team CHANNEL thread (reviews have no per-task thread) + a direct
+    # low-priority author wake. Coalesced per review id so a burst (e.g. a
+    # merge-preflight 409 retry) can't spam.
+    _REVIEW_WAKE_WINDOW_SECONDS = 60.0
+    _review_wake_state: dict[str, float] = {}
+
+    def _record_review_event(team_id: str, recipient: str, payload: dict) -> None:
+        """Write a review-outcome event row on the team's CHANNEL thread.
+
+        The review analogue of ``_record_task_event`` (reviews have no
+        per-task thread): ``ensure_channel`` + a host-side ``kind='event'``
+        ``post_message`` addressed to ``recipient``. Host-side write only —
+        no agent-facing endpoint posts these (thread-writer invariant).
+        Raises on failure so the caller can log-and-continue.
+        """
+        th = thread_store.ensure_channel(team_id)
+        thread_store.post_message(
+            th["id"],
+            "mesh",
+            recipient=recipient,
+            kind="event",
+            payload=payload,
+        )
+
+    def _signal_review_author(
+        team_id: str,
+        review: dict,
+        kind: str,
+        *,
+        note: str | None = None,
+        resolved_by: str | None = None,
+    ) -> None:
+        """Close the review feedback loop to the AUTHOR (Item 2).
+
+        Records a ``kind`` event addressed to ``review["author"]`` on the
+        team channel thread, then wakes the author via the SAME lane helper
+        the task back-edge uses. The actionable outcomes (``review_rejected``
+        / ``review_merge_failed``) are in ``ACTIONABLE_EVENT_KINDS`` so
+        Item 1's heartbeat backstop force-surfaces them if the direct wake is
+        ever missed; the informational outcomes (``review_merged`` /
+        ``review_approved`` / ``review_superseded``) ride only the coalesced
+        low-priority wake.
+
+        The recipient is ALWAYS the author — never the operator / lead /
+        merger (unless they authored the review), which is the negative
+        control the task calls for. The wake is skipped when the author
+        resolved their own review (no self-notify) or isn't a registered
+        agent, and coalesced per review id. Best-effort — a signal failure
+        never destabilizes the resolution that already committed.
+        """
+        author = review.get("author")
+        review_id = review.get("id")
+        if not author:
+            return
+        payload = {
+            "kind": kind,
+            "review_id": review_id,
+            "branch": review.get("branch"),
+            "title": review.get("title"),
+            "note": note,
+            "resolved_by": resolved_by,
+            "team_id": team_id,
+            "ts": int(time.time()),
+        }
+        try:
+            _record_review_event(team_id, str(author), payload)
+        except Exception as e:
+            logger.warning(
+                "Review event write failed for review %s: %s", review_id, e,
+            )
+            return
+        if resolved_by is not None and author == resolved_by:
+            return  # no self-notify when the author resolved their own review
+        if author not in router.agent_registry:
+            return
+        if lane_manager is None or dispatch_loop is None:
+            return
+        now = time.time()
+        wake_key = str(review_id or f"{team_id}:{review.get('branch')}")
+        if now - _review_wake_state.get(wake_key, 0.0) < _REVIEW_WAKE_WINDOW_SECONDS:
+            return
+        _review_wake_state[wake_key] = now
+        verb = {
+            "review_merged": "was MERGED into main",
+            "review_rejected": "was REJECTED — rework the branch and resubmit",
+            "review_approved": "was APPROVED by the lead",
+            "review_superseded": "was SUPERSEDED by a newer submission for the same branch",
+            "review_merge_failed": (
+                "could NOT be merged (branch changed / deleted / conflict) — "
+                "resolve against main and resubmit"
+            ),
+        }.get(kind, f"reached {kind}")
+        branch = review.get("branch") or "(branch)"
+        wake_msg = (
+            f"Your Team Drive review {review_id} (branch {branch}) {verb}. "
+            "Call check_inbox to see the details."
+        )
+        _try_wake_agent(
+            str(author),
+            wake_msg,
+            None,
+            auto_notify=False,
+            on_fail=lambda e: logger.warning(
+                "Review author wake for %s on review %s failed: %s",
+                author, review_id, e,
+            ),
+        )
+
+    # Expose the review-author signal so tests can exercise every outcome
+    # kind directly (mirrors the ``app._write_task_event_back_edge``
+    # exposure above). Not consumed by any production caller — the review
+    # endpoints call the closure directly.
+    app._signal_review_author = _signal_review_author
 
     def _wake_operator_for_human_chain(
         task_record: dict,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -11407,6 +11407,17 @@ def create_mesh_app(
                 )
             raise HTTPException(404, f"Agent '{agent_id}' not found")
         events = thread_store.list_events_for(agent_id)
+        # Team signal ledger (Item 1): a proactive check_inbox clears the
+        # unseen flag — advance the durable read cursor past everything just
+        # surfaced so the heartbeat backstop doesn't re-fire for events the
+        # agent has already seen. Best-effort; a cursor hiccup must never
+        # sink the read the agent asked for.
+        if events:
+            try:
+                max_id = max(int(e.get("id") or 0) for e in events)
+                thread_store.mark_events_seen(agent_id, max_id)
+            except Exception as e:
+                logger.debug("mark_events_seen failed for '%s': %s", agent_id, e)
         return {"agent_id": agent_id, "events": events, "count": len(events)}
 
     @app.post("/mesh/teams/{team_name}/propose-delete")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -8305,6 +8305,22 @@ def create_mesh_app(
     _OPERATOR_RECOVERY_WAKE_WINDOW_S = 600.0
     _operator_recovery_wake_times: deque[float] = deque()
 
+    # Creator back-edge (team signal ledger, Item 3): the IMMEDIATE
+    # ``creator`` of a task — the parent agent that created this child task
+    # and is waiting to synthesize its result (fan-in / join) — is, for a
+    # multi-hop chain, a DIFFERENT agent from the root ``origin_user`` the
+    # block below serves; a human-origin chain short-circuits that block
+    # entirely, so the parent got NOTHING. Waking the creator is justified
+    # by STORED task ownership (``task_record["creator"]`` is stamped at
+    # task-creation time, non-forgeable) — a DIFFERENT justification from
+    # the origin path's forgeable-origin guard, which is left untouched.
+    # ``task_completed`` joins the wake kinds here (unlike the origin path):
+    # a fan-in parent must learn a child FINISHED, not just failed/blocked.
+    # Separate rate-limit state from ``_back_edge_wake_state`` so a creator
+    # wake never coalesces-away the operator/origin wake for the same task.
+    _CREATOR_WAKE_KINDS = frozenset({"task_completed", "task_failed", "task_blocked"})
+    _creator_wake_state: dict[str, float] = {}
+
     def _task_thread_scope(task_record: dict) -> str:
         """Effective team scope for a task's thread (Team Threads).
 
@@ -8575,6 +8591,122 @@ def create_mesh_app(
                 e,
             )
 
+    def _write_creator_back_edge(
+        task_record: dict,
+        *,
+        event_kind: str,
+        payload_extras: dict | None,
+        origin_user: str | None,
+    ) -> None:
+        """Deliver a task transition to the IMMEDIATE ``creator`` (Item 3).
+
+        Runs ALONGSIDE — and independently of — the ``origin_user`` block in
+        :func:`_write_task_event_back_edge`, so a fan-in parent learns its
+        child finished even when the root origin points at a distant
+        chain-root (or is a human, which short-circuits the origin block
+        entirely). Eligibility:
+
+          * ``creator`` is a real, registered agent (a genuine parent, not a
+            channel / human / absent creator);
+          * ``creator != assignee`` — no self-notify on a self-handoff;
+          * ``creator != origin_user`` — DEDUP: when they are the same agent
+            the origin block already records the event (and, for actionable
+            kinds, wakes it under its own guard), so this path must not
+            double up.
+
+        The wake is gated by STORED ownership, not origin, so it is safe for
+        ALL of ``_CREATOR_WAKE_KINDS`` (incl. ``task_completed``). It does
+        NOT thread ``task_id`` into the lane: the parent's turn is a
+        synthesis turn ABOUT the child (reasoning over its result), not an
+        execution of the already-terminal child task — same rationale as the
+        operator recovery wake. Best-effort throughout; the transition has
+        already committed.
+        """
+        creator = task_record.get("creator")
+        assignee = task_record.get("assignee")
+        task_id = task_record.get("id")
+        if not creator or not task_id:
+            return
+        if creator == assignee:
+            return
+        if origin_user is not None and creator == origin_user:
+            return
+        if creator == "operator":
+            # The operator has dedicated signal channels — the A2 recovery
+            # wake for human chains, the origin path for its own agent-origin
+            # tasks, and check_inbox on every heartbeat — so a generic creator
+            # signal here would only DOUBLE-wake it (notably alongside the A2
+            # recovery wake on a human-origin failure it created). Skip it to
+            # honour the no-double-signal / no-cost-storm invariants; nothing
+            # is lost (a human-origin completion it created was heartbeat-
+            # picked-up pre-Item-3 too). Matches the ``assignee != "operator"``
+            # literal the A2 guard above uses.
+            return
+        if creator not in router.agent_registry:
+            return
+        payload: dict = {
+            "kind": event_kind,
+            "task_id": task_id,
+            "recipient": assignee,
+            "title": task_record.get("title"),
+            "status": task_record.get("status"),
+            "ts": int(time.time()),
+        }
+        if payload_extras:
+            # Sentinel keys above take precedence — extras can't shadow the
+            # canonical schema fields (mirrors the origin path).
+            for k, v in payload_extras.items():
+                if k not in payload:
+                    payload[k] = v
+        try:
+            _record_task_event(task_record, str(creator), payload)
+        except Exception as e:
+            logger.warning(
+                "Creator back-edge write failed for task %s: %s", task_id, e,
+            )
+            return
+        if event_kind not in _CREATOR_WAKE_KINDS:
+            return
+        if lane_manager is None or dispatch_loop is None:
+            return
+        now = time.time()
+        if now - _creator_wake_state.get(task_id, 0.0) < _BACK_EDGE_WAKE_WINDOW_SECONDS:
+            return
+        _creator_wake_state[task_id] = now
+        origin_dict = task_record.get("origin") or {}
+        try:
+            wake_origin = MessageOrigin(
+                kind="agent",
+                channel=str(origin_dict.get("channel") or ""),
+                user=str(creator),
+            )
+            title = task_record.get("title") or "(no title)"
+            wake_msg = (
+                f"Child task {task_id} ({title}) you created reached "
+                f"{event_kind}. Call check_inbox to see the event payload "
+                "and continue — synthesize or unblock as needed."
+            )
+            _try_wake_agent(
+                str(creator),
+                wake_msg,
+                wake_origin,
+                auto_notify=False,
+                # Continue the child's session so the parent's synthesis work
+                # stays on the same trace (this fires from update_task_status,
+                # which doesn't seed the contextvar — pass it explicitly, like
+                # the origin path).
+                trace_id=task_record.get("trace_id"),
+                on_fail=lambda e: logger.warning(
+                    "Creator back-edge wake for %s on task %s failed: %s",
+                    creator, task_id, e,
+                ),
+            )
+        except Exception as e:
+            logger.warning(
+                "Creator back-edge wake for %s on task %s failed: %s",
+                creator, task_id, e,
+            )
+
     def _write_task_event_back_edge(
         task_record: dict,
         *,
@@ -8608,6 +8740,20 @@ def create_mesh_app(
             assignee = task_record.get("assignee")
             creator = task_record.get("creator")
             task_id = task_record.get("id")
+
+            # Item 3 — deliver to the IMMEDIATE creator (fan-in / join)
+            # FIRST, before the origin-based early-returns below. The
+            # creator path is independently justified by stored ownership,
+            # so it must run for EVERY origin shape (agent, operator, and —
+            # unlike the origin block — human-origin chains, which return
+            # early). Its own guards (real agent, ``!= assignee``, ``!=
+            # origin_user`` dedup) keep it from doubling the origin path.
+            _write_creator_back_edge(
+                task_record,
+                event_kind=event_kind,
+                payload_extras=payload_extras,
+                origin_user=str(origin_user) if origin_user else None,
+            )
 
             # Eligibility — only cross-agent agent/operator handoffs.
             # Self-handoffs (sender == recipient) suppress so an

--- a/src/host/threads.py
+++ b/src/host/threads.py
@@ -57,7 +57,18 @@ VALID_MESSAGE_KINDS: frozenset[str] = frozenset({"message", "event"})
 # Back-edge event kinds the recipient must act on. Mirrors the mesh's
 # ``_BACK_EDGE_WAKE_KINDS`` — these get the long (7-day) serving window
 # in ``list_events_for`` so an originator can recover after a gap.
-ACTIONABLE_EVENT_KINDS: frozenset[str] = frozenset({"task_failed", "task_blocked"})
+#
+# Team signal ledger (Item 2): the two review outcomes that require the
+# review AUTHOR to act — a rejection (rework the branch) and a
+# merge-preflight failure (branch changed/deleted/conflicted, resubmit)
+# — join the actionable set so Item 1's heartbeat backstop force-surfaces
+# them if the direct author wake was ever missed. The other review
+# outcomes (``review_merged`` / ``review_approved`` / ``review_superseded``)
+# stay INFORMATIONAL on purpose: promptness for those rides the direct
+# low-priority wake, not a forced heartbeat plate.
+ACTIONABLE_EVENT_KINDS: frozenset[str] = frozenset(
+    {"task_failed", "task_blocked", "review_rejected", "review_merge_failed"}
+)
 
 # Query windows for ``list_events_for``. These replace the old
 # blackboard TTLs byte-for-byte in effect: actionable events surface
@@ -180,6 +191,20 @@ class ThreadStore:
                     ON thread_messages(thread_id, created_at);
                 CREATE INDEX IF NOT EXISTS idx_thread_messages_recipient
                     ON thread_messages(recipient, kind, created_at);
+
+                -- Durable per-recipient read cursor (team signal ledger,
+                -- Item 1). ``last_seen_id`` is a monotonic high-water mark
+                -- over ``thread_messages.id``: everything at or below it has
+                -- already been surfaced to the recipient (via the heartbeat
+                -- backstop or a proactive check_inbox), so the "does this
+                -- agent have UNSEEN actionable events?" probe can answer
+                -- cheaply without re-firing an LLM turn for the same events
+                -- on every heartbeat. Canonical v1 — created here, no ALTER.
+                CREATE TABLE IF NOT EXISTS event_cursors (
+                    recipient    TEXT PRIMARY KEY,
+                    last_seen_id INTEGER NOT NULL DEFAULT 0,
+                    updated_at   REAL
+                );
 
                 PRAGMA user_version = 1;
                 """
@@ -522,6 +547,131 @@ class ThreadStore:
             envelope["created_at"] = msg["created_at"]
             events.append(envelope)
         return events[:EVENT_QUERY_LIMIT]
+
+    # ── unseen-actionable cursor (team signal ledger, Item 1) ────
+    #
+    # ``list_events_for`` above is a WINDOW read (7d/24h) with no memory of
+    # what a recipient has already seen — so the heartbeat backstop can't
+    # cheaply ask "does this agent have UNSEEN actionable events?" without
+    # re-firing an LLM turn for the same events every interval. The
+    # ``event_cursors`` table adds that memory: ``count_unseen_actionable``
+    # /``unseen_actionable_events`` read strictly ABOVE the cursor, and
+    # ``mark_events_seen`` advances it (mark-on-surface). The window read
+    # stays cursor-free — a proactive ``check_inbox`` still sees every event
+    # in its serving window regardless of the cursor; only the heartbeat
+    # re-trigger is gated.
+
+    def _event_cursor(self, conn: sqlite3.Connection, recipient: str) -> int:
+        row = conn.execute(
+            "SELECT last_seen_id FROM event_cursors WHERE recipient = ?",
+            (recipient,),
+        ).fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    def _scan_unseen_actionable(self, recipient: str) -> list[dict]:
+        """Deduped, actionable, UNSEEN event message rows for ``recipient``.
+
+        The single shared pass behind ``count_unseen_actionable`` and
+        ``unseen_actionable_events`` so the two agree exactly (count ==
+        number of returned envelopes, up to the hard bound). Applies, in
+        order: the cursor filter (``id > last_seen_id`` — the "unseen"
+        clause), the 7-day actionable serving window, the SAME newest-per-
+        task overwrite dedupe as ``list_events_for`` (a later
+        ``task_completed`` shadows an earlier ``task_blocked`` for the same
+        task, so a resolved blocker never nags), and finally the
+        actionable-kind filter. Newest-first (by ``created_at``), bounded
+        by :data:`EVENT_QUERY_LIMIT`. Mesh-side DB read only — never a
+        container call, so it never cold-wakes a hibernated agent.
+        """
+        now = time.time()
+        cutoff = now - EVENT_ACTIONABLE_WINDOW_SECONDS
+        with self._conn() as conn:
+            cursor = self._event_cursor(conn, recipient)
+            rows = conn.execute(
+                f"SELECT {self._MESSAGE_COLS} FROM thread_messages "
+                "WHERE recipient = ? AND kind = 'event' AND id > ? AND created_at >= ? "
+                "ORDER BY created_at DESC, id DESC LIMIT ?",
+                (recipient, cursor, cutoff, EVENT_QUERY_LIMIT),
+            ).fetchall()
+        survivors: list[dict] = []
+        seen: set[str] = set()
+        for r in rows:  # newest-first — the first row per task key wins
+            msg = self._row_to_message(r)
+            thread_id = str(msg["thread_id"] or "")
+            key = thread_id if thread_id.startswith("task:") else f"msg:{msg['id']}"
+            if key in seen:
+                continue
+            # Mark BEFORE the actionable check (same as ``list_events_for``):
+            # an informational newest row must still shadow the task's older
+            # actionable transitions rather than let a stale one resurface.
+            seen.add(key)
+            payload = msg["payload"] if isinstance(msg["payload"], dict) else {}
+            if payload.get("kind") not in ACTIONABLE_EVENT_KINDS:
+                continue
+            survivors.append(msg)
+        return survivors
+
+    def count_unseen_actionable(self, recipient: str) -> int:
+        """Cheap count of UNSEEN actionable events for ``recipient``.
+
+        The backstop probe's short-circuit: 0 means the heartbeat need not
+        escalate on this account, so a non-lead/idle agent pays only for
+        this bounded, indexed read. Consistent with
+        :meth:`unseen_actionable_events` by construction (both share
+        :meth:`_scan_unseen_actionable`), so ``count > 0`` iff that method
+        returns a non-empty list.
+        """
+        return len(self._scan_unseen_actionable(recipient))
+
+    def unseen_actionable_events(
+        self, recipient: str, *, limit: int = EVENT_QUERY_LIMIT,
+    ) -> list[dict]:
+        """UNSEEN actionable event envelopes for ``recipient``, newest-first.
+
+        Same envelope shape as :meth:`list_events_for` (stored payload +
+        ``id`` / ``thread_id`` / ``created_at``). The caller learns the max
+        id to mark as seen via ``max(e["id"] for e in <result>)`` — the
+        list is ordered by ``created_at`` (not id), so use ``max`` rather
+        than the first element: a backdated row can carry a higher id than a
+        newer-timestamped one, and the cursor must jump past ALL surfaced
+        rows to prevent a re-trigger.
+        """
+        limit = max(1, min(int(limit), EVENT_QUERY_LIMIT))
+        events: list[dict] = []
+        for msg in self._scan_unseen_actionable(recipient)[:limit]:
+            payload = msg["payload"] if isinstance(msg["payload"], dict) else {}
+            envelope = dict(payload)
+            envelope["id"] = msg["id"]
+            envelope["thread_id"] = msg["thread_id"]
+            envelope["created_at"] = msg["created_at"]
+            events.append(envelope)
+        return events
+
+    def mark_events_seen(self, recipient: str, up_to_id: int) -> None:
+        """Advance ``recipient``'s read cursor to ``max(existing, up_to_id)``.
+
+        Monotonic UPSERT — an out-of-order or stale mark can never regress
+        the high-water mark. A non-positive ``up_to_id`` is a no-op (nothing
+        to advance past). This is the storm guard: once events are surfaced
+        (heartbeat backstop or proactive ``check_inbox``), they don't
+        re-trigger.
+        """
+        try:
+            up_to = int(up_to_id)
+        except (TypeError, ValueError):
+            return
+        if up_to <= 0:
+            return
+        now = time.time()
+        with self._conn() as conn:
+            conn.execute(
+                "INSERT INTO event_cursors (recipient, last_seen_id, updated_at) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT(recipient) DO UPDATE SET "
+                "last_seen_id = MAX(last_seen_id, excluded.last_seen_id), "
+                "updated_at = excluded.updated_at",
+                (recipient, up_to, now),
+            )
 
     # ── reaper ───────────────────────────────────────────────────
 

--- a/tests/test_back_edge_helper.py
+++ b/tests/test_back_edge_helper.py
@@ -230,14 +230,16 @@ class TestBackEdgeHelperEligibility:
         )
         assert lane.calls == []
 
-    def test_origin_user_mismatch_writes_event_but_does_not_wake(
+    def test_origin_user_mismatch_writes_event_but_does_not_wake_origin(
         self, mesh_app_with_back_edge,
     ):
-        """L9 binding: when ``origin.user`` is not the task ``creator``
-        (forged origin, or a multi-hop chain whose origin points at a
-        distant root), the back-edge EVENT is still recorded so the
-        originator's check_inbox/heartbeat sees it — but the privileged
-        wake is skipped so no arbitrary agent is interrupted."""
+        """L9 binding (origin path) is unchanged: when ``origin.user`` is not
+        the task ``creator`` (forged origin, or a multi-hop chain whose origin
+        points at a distant root), the back-edge EVENT is still recorded for
+        the origin — but the ORIGIN-path forgeable-origin wake guard skips
+        waking it. (The separate, stored-ownership creator path DOES wake the
+        real creator — see ``TestCreatorBackEdge``; this test asserts the
+        origin guard itself is untouched.)"""
         app, thread_store, lane, _loop = mesh_app_with_back_edge
         # origin.user="analyst" (claimed) but creator="scout" (real).
         rec = _record(
@@ -253,12 +255,15 @@ class TestBackEdgeHelperEligibility:
         _settle()
 
         # Event IS recorded for the claimed origin (delivery intact).
-        events = _events_for(thread_store, "analyst")
         assert any(
-            e.get("task_id") == "task_mismatch_1" for e in events
+            e.get("task_id") == "task_mismatch_1"
+            for e in _events_for(thread_store, "analyst")
         )
-        # But NO wake — origin_user != creator.
-        assert lane.calls == []
+        # The origin path did NOT wake the (forgeable) origin_user.
+        assert not any(c["args"][0] == "analyst" for c in lane.calls), (
+            "forgeable origin_user must never get an ownership-based wake "
+            "via the origin path"
+        )
 
     def test_origin_user_matches_creator_wakes(self, mesh_app_with_back_edge):
         """L9 binding: the legit case (origin.user == creator) still
@@ -302,26 +307,31 @@ class TestBackEdgeHelperEligibility:
         assert not any(
             e.get("task_id") == "task_human_1" for e in events
         )
-        # ...but the operator gets the event + a recovery wake.
+        # ...but the operator gets the event + a recovery wake. (The
+        # immediate creator ``scout`` also gets its own creator-path wake now
+        # — Item 3 — so filter for the operator wake specifically.)
         op_events = _events_for(thread_store, "operator")
         assert any(
             e.get("task_id") == "task_human_1" for e in op_events
         )
-        assert len(lane.calls) == 1
-        assert lane.calls[0]["args"][0] == "operator"
-        wake_msg = lane.calls[0]["args"][1]
+        op_wakes = [c for c in lane.calls if c["args"][0] == "operator"]
+        assert len(op_wakes) == 1
+        wake_msg = op_wakes[0]["args"][1]
         assert "task_human_1" in wake_msg
         assert "already informed" in wake_msg
         # No task_id threading — the operator's turn is ABOUT the task,
         # not an execution of it; auto-close must not touch the row.
-        assert lane.calls[0]["kwargs"].get("task_id") is None
-        assert lane.calls[0]["kwargs"].get("auto_notify") is False
+        assert op_wakes[0]["kwargs"].get("task_id") is None
+        assert op_wakes[0]["kwargs"].get("auto_notify") is False
 
     def test_human_origin_completion_does_not_wake_operator(
         self, mesh_app_with_back_edge,
     ):
-        """Successful human-origin chains stay quiet — recovery wakes are
-        for failed/blocked only."""
+        """Successful human-origin chains stay quiet FOR THE OPERATOR —
+        operator recovery wakes are for failed/blocked only. (The immediate
+        creator ``scout`` still learns of the completion via its own creator
+        path — Item 3, fan-in — so assert only that the OPERATOR isn't woken
+        and gets no event.)"""
         app, thread_store, lane, _loop = mesh_app_with_back_edge
         rec = _record(
             "task_human_2", status="done",
@@ -338,15 +348,19 @@ class TestBackEdgeHelperEligibility:
         assert not any(
             e.get("task_id") == "task_human_2" for e in op_events
         )
-        assert lane.calls == []
+        assert not any(c["args"][0] == "operator" for c in lane.calls)
 
     def test_human_origin_operator_assignee_not_self_woken(
         self, mesh_app_with_back_edge,
     ):
-        """The operator's own failed tasks don't trigger a self-wake."""
+        """The operator's own failed tasks don't trigger a self-wake.
+
+        ``creator`` is the operator here too: the A2 guard skips (assignee ==
+        operator) and the Item 3 creator path skips (creator == operator has
+        its own dedicated channels), so nothing fires."""
         app, _thread_store, lane, _loop = mesh_app_with_back_edge
         rec = _record(
-            "task_human_3", assignee="operator",
+            "task_human_3", assignee="operator", creator="operator",
             origin={"kind": "human", "channel": "web", "user": "u1"},
         )
 
@@ -362,7 +376,9 @@ class TestBackEdgeHelperEligibility:
         self, mesh_app_with_back_edge,
     ):
         """Burst coalescing: lane timeout + sweep retry on the same task
-        produce ONE operator wake inside the 60s window."""
+        produce ONE operator wake inside the 60s window. (The creator ``scout``
+        is also woken once — Item 3 — under its own per-task window; filter for
+        the operator wake to assert the A2 coalescing specifically.)"""
         app, _thread_store, lane, _loop = mesh_app_with_back_edge
         rec = _record(
             "task_human_4",
@@ -377,7 +393,8 @@ class TestBackEdgeHelperEligibility:
         )
         _settle()
 
-        assert len(lane.calls) == 1
+        op_wakes = [c for c in lane.calls if c["args"][0] == "operator"]
+        assert len(op_wakes) == 1
 
 
 class TestBackEdgeTracePropagation:
@@ -608,3 +625,199 @@ class TestOperatorRecoveryWakeGlobalThrottle:
             c for c in lane.calls if c["args"][0] == "operator"
         ]
         assert len(operator_wakes) == 5  # _OPERATOR_RECOVERY_WAKE_MAX
+
+
+class TestCreatorBackEdge:
+    """Team signal ledger (Item 3): the IMMEDIATE ``creator`` (a fan-in /
+    join parent) is delivered the transition + woken by STORED ownership,
+    independently of the forgeable-origin path. Registered agents in the
+    fixture: operator, scout, analyst, writer.
+    """
+
+    def test_creator_receives_event_and_wakes_on_completed(
+        self, mesh_app_with_back_edge,
+    ):
+        """A child created by analyst (root origin points at scout) delivers
+        the COMPLETION to analyst AND wakes analyst — fan-in needs to know a
+        child finished (the origin path never wakes on completion)."""
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "fanin_done", status="done", creator="analyst", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_completed", payload_extras={"summary": "child done"},
+        )
+        _settle()
+
+        # Creator analyst got the event + a wake.
+        analyst_ev = next(
+            e for e in _events_for(thread_store, "analyst")
+            if e.get("task_id") == "fanin_done"
+        )
+        assert analyst_ev["kind"] == "task_completed"
+        analyst_wakes = [c for c in lane.calls if c["args"][0] == "analyst"]
+        assert len(analyst_wakes) == 1
+        # Root origin scout still gets its informational event (no wake).
+        assert any(
+            e.get("task_id") == "fanin_done" for e in _events_for(thread_store, "scout")
+        )
+        assert not any(c["args"][0] == "scout" for c in lane.calls)
+
+    def test_creator_receives_event_and_wakes_on_failed(
+        self, mesh_app_with_back_edge,
+    ):
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "fanin_fail", status="failed", creator="analyst", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        assert any(
+            e.get("task_id") == "fanin_fail" for e in _events_for(thread_store, "analyst")
+        )
+        analyst_wakes = [c for c in lane.calls if c["args"][0] == "analyst"]
+        assert len(analyst_wakes) == 1
+        # Origin scout: event recorded, but NOT woken (origin_user != creator).
+        assert not any(c["args"][0] == "scout" for c in lane.calls)
+
+    def test_creator_wake_omits_task_id(self, mesh_app_with_back_edge):
+        """The parent's turn is a SYNTHESIS turn ABOUT the child, not an
+        execution of the already-terminal child task — so no task_id is
+        threaded (auto-close must not touch the row), like the operator
+        recovery wake."""
+        app, _thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "fanin_notaskid", status="done", creator="analyst", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_completed", payload_extras={"summary": "ok"},
+        )
+        _settle()
+
+        analyst_wake = next(c for c in lane.calls if c["args"][0] == "analyst")
+        assert analyst_wake["kwargs"].get("task_id") is None
+        assert analyst_wake["kwargs"].get("auto_notify") is False
+
+    def test_creator_dedup_when_equals_origin_user(self, mesh_app_with_back_edge):
+        """Single-hop (creator == origin_user == scout): the creator path
+        dedups and only the origin path acts — exactly ONE wake, no double."""
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "single_hop", status="failed", creator="scout", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "x"},
+        )
+        _settle()
+
+        scout_events = [
+            e for e in _events_for(thread_store, "scout") if e.get("task_id") == "single_hop"
+        ]
+        assert len(scout_events) == 1  # not doubled
+        assert len(lane.calls) == 1
+        assert lane.calls[0]["args"][0] == "scout"
+
+    def test_creator_equals_assignee_not_self_notified(self, mesh_app_with_back_edge):
+        """creator == assignee (self-handoff on the child) → no creator
+        signal to writer; the origin path still serves scout."""
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "self_child", status="failed", creator="writer", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "x"},
+        )
+        _settle()
+
+        # writer (creator==assignee) got nothing; no writer wake.
+        assert not any(
+            e.get("task_id") == "self_child" for e in _events_for(thread_store, "writer")
+        )
+        assert not any(c["args"][0] == "writer" for c in lane.calls)
+        # scout (origin) still gets its event.
+        assert any(
+            e.get("task_id") == "self_child" for e in _events_for(thread_store, "scout")
+        )
+
+    def test_unregistered_creator_gets_no_event(self, mesh_app_with_back_edge):
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "ghost_child", status="failed", creator="ghost", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "x"},
+        )
+        _settle()
+
+        assert not any(
+            e.get("task_id") == "ghost_child" for e in _events_for(thread_store, "ghost")
+        )
+        assert not any(c["args"][0] == "ghost" for c in lane.calls)
+
+    def test_creator_path_fires_for_human_origin_fanin(self, mesh_app_with_back_edge):
+        """The origin block short-circuits for a human root, but the creator
+        path (which runs first) still delivers to the immediate agent parent."""
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "human_fanin", status="done", creator="analyst", assignee="writer",
+            origin={"kind": "human", "channel": "telegram", "user": "9999"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_completed", payload_extras={"summary": "ok"},
+        )
+        _settle()
+
+        assert any(
+            e.get("task_id") == "human_fanin" for e in _events_for(thread_store, "analyst")
+        )
+        assert [c for c in lane.calls if c["args"][0] == "analyst"]
+        # The human origin gets no mesh event; no operator wake (completion).
+        assert not any(
+            e.get("task_id") == "human_fanin" for e in _events_for(thread_store, "9999")
+        )
+        assert not any(c["args"][0] == "operator" for c in lane.calls)
+
+    def test_operator_creator_is_skipped(self, mesh_app_with_back_edge):
+        """creator == operator is skipped by the creator path (the operator
+        has its own channels) — no double-signal."""
+        app, thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "op_creator", status="failed", creator="operator", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "x"},
+        )
+        _settle()
+
+        assert not any(
+            e.get("task_id") == "op_creator" for e in _events_for(thread_store, "operator")
+        )
+        assert not any(c["args"][0] == "operator" for c in lane.calls)
+
+    def test_creator_wake_rate_limited_per_task(self, mesh_app_with_back_edge):
+        """A burst on the same child coalesces to ONE creator wake."""
+        app, _thread_store, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "fanin_burst", status="failed", creator="analyst", assignee="writer",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "1"},
+        )
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed", payload_extras={"error": "2"},
+        )
+        _settle()
+
+        analyst_wakes = [c for c in lane.calls if c["args"][0] == "analyst"]
+        assert len(analyst_wakes) == 1

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -2364,3 +2364,144 @@ class TestGoalCoverageGapHelper:
         teams, tasks = self._stores()
         assert self._gap(None, tasks) is None
         assert self._gap(teams, None) is None
+
+
+class TestUnseenEventsProbe:
+    """Team signal ledger (Item 1): the heartbeat BACKSTOP probe. NOT
+    lead-gated — a non-None ``unseen_events_fn`` summary makes the plate
+    actionable for EVERY agent, and the summary rides the plate directive.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_absent_when_unwired(self):
+        sched = CronScheduler(config_path=self.config_path)
+        results = sched._run_heartbeat_probes("worker")
+        assert not any(r.name == "unseen_events" for r in results)
+
+    def test_none_summary_gives_no_probe(self):
+        sched = CronScheduler(
+            config_path=self.config_path, unseen_events_fn=lambda agent: None,
+        )
+        results = sched._run_heartbeat_probes("worker")
+        assert not any(r.name == "unseen_events" for r in results)
+
+    def test_summary_triggers_probe_for_any_agent(self):
+        sched = CronScheduler(
+            config_path=self.config_path,
+            unseen_events_fn=lambda agent: {"count": 3, "summary": "3 unseen: check_inbox"},
+        )
+        # A plain worker (not a lead) still gets the triggered probe.
+        results = sched._run_heartbeat_probes("worker")
+        probe = next(r for r in results if r.name == "unseen_events")
+        assert probe.triggered is True
+        assert "3 unseen" in probe.detail
+
+    def test_probe_failure_degrades_quietly(self):
+        def _boom(agent):
+            raise RuntimeError("thread store unavailable")
+
+        sched = CronScheduler(config_path=self.config_path, unseen_events_fn=_boom)
+        results = sched._run_heartbeat_probes("worker")  # must not raise
+        assert not any(r.name == "unseen_events" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_probe_escalates_empty_plate_and_snapshots(self):
+        """The backstop probe alone escalates an otherwise-empty plate for a
+        NON-lead worker, and the plate snapshot records ``unseen_events`` in
+        ``triggered_probes``."""
+        dispatch = AsyncMock(return_value="acting on inbox")
+        mock_bb = MagicMock()
+        mock_bb.list_by_prefix.return_value = []
+        ctx = AsyncMock(return_value={
+            "heartbeat_rules": "", "daily_logs": "",
+            "is_default_heartbeat": True, "has_recent_activity": False,
+        })
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=dispatch,
+            blackboard=mock_bb, context_fn=ctx,
+            goals_fn=lambda agent: None, utility_model_fn=lambda: "",
+            unseen_events_fn=lambda agent: {"count": 2, "summary": "2 unseen actionable events"},
+        )
+        job = sched.add_job(agent="worker", schedule="every 15m", message="heartbeat", heartbeat=True)
+        with patch(
+            "src.host.cron.shutil.disk_usage",
+            return_value=MagicMock(used=0, total=100, free=100),
+        ):
+            result = await sched._execute_job(job)
+        assert result == "acting on inbox"
+        dispatch.assert_called_once()
+        call_msg = dispatch.call_args[0][1]
+        assert "Probe Alerts" in call_msg
+        assert "2 unseen actionable events" in call_msg
+        snap = sched.get_last_plate("worker")
+        assert snap is not None
+        assert snap["actionable"] is True
+        assert "unseen_events" in snap["triggered_probes"]
+
+
+class TestUnseenEventsClosure:
+    """The ``unseen_events`` closure wired by ``_create_cron_scheduler`` reads
+    the mesh-side ThreadStore cursor and marks-on-surface (the storm guard)."""
+
+    def _ctx(self):
+        from src.cli.runtime import RuntimeContext
+
+        ctx = RuntimeContext.__new__(RuntimeContext)
+        ctx.async_dispatch = AsyncMock(return_value="ok")
+        ctx.transport = MagicMock()
+        ctx.blackboard = None
+        ctx.trace_store = None
+        ctx.event_bus = None
+        ctx.cfg = {}
+        ctx.health_monitor = None
+        ctx.lane_manager = None
+        return ctx
+
+    def test_closure_reads_marks_and_prevents_retrigger(self):
+        from src.host.threads import ThreadStore
+
+        store = ThreadStore(":memory:")
+        th = store.ensure_task_thread("scout", "t1")
+        store.post_message(th["id"], "mesh", recipient="scout", kind="event",
+                           payload={"kind": "task_failed", "task_id": "t1"})
+        th2 = store.ensure_task_thread("scout", "t2")
+        store.post_message(th2["id"], "mesh", recipient="scout", kind="event",
+                           payload={"kind": "task_blocked", "task_id": "t2"})
+
+        ctx = self._ctx()
+        ctx.thread_store = store
+        ctx._create_cron_scheduler()
+        fn = ctx.cron_scheduler.unseen_events_fn
+
+        summary = fn("scout")
+        assert summary is not None
+        assert summary["count"] == 2
+        assert "task_failed" in summary["summary"] or "task_blocked" in summary["summary"]
+        # Mark-on-surface: a second call returns None (events already seen).
+        assert fn("scout") is None
+        store.close()
+
+    def test_closure_no_store_returns_none(self):
+        ctx = self._ctx()
+        # No thread_store attribute at all.
+        ctx._create_cron_scheduler()
+        assert ctx.cron_scheduler.unseen_events_fn("scout") is None
+
+    def test_closure_informational_only_returns_none(self):
+        from src.host.threads import ThreadStore
+
+        store = ThreadStore(":memory:")
+        th = store.ensure_task_thread("scout", "t1")
+        store.post_message(th["id"], "mesh", recipient="scout", kind="event",
+                           payload={"kind": "task_completed", "task_id": "t1"})
+        ctx = self._ctx()
+        ctx.thread_store = store
+        ctx._create_cron_scheduler()
+        assert ctx.cron_scheduler.unseen_events_fn("scout") is None
+        store.close()

--- a/tests/test_review_signals.py
+++ b/tests/test_review_signals.py
@@ -1,0 +1,305 @@
+"""Tests for the team signal ledger's review-outcome signals (Item 2).
+
+Each Team-Drive review outcome (merge / reject / lead approve-verdict /
+supersede / merge-preflight failure) must close the feedback loop to the
+review AUTHOR: a host-side ``kind='event'`` row on the team CHANNEL thread
+addressed to the author, plus a direct low-priority author wake. The
+actionable outcomes (``review_rejected`` / ``review_merge_failed``) also
+join ``ACTIONABLE_EVENT_KINDS`` so Item 1's heartbeat backstop surfaces
+them.
+
+Two layers:
+  * the exposed ``app._signal_review_author`` helper — every outcome kind +
+    the negative controls (recipient is always the author, self-notify
+    skip, coalescing), fast and git-free;
+  * the reject + lead-verdict ENDPOINTS end-to-end (no git needed) — proves
+    the real wiring and the "author, never the operator/lead" control.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import threading
+import time
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.host.teams import TeamStore
+from src.host.threads import ThreadStore
+
+TOKENS = {
+    "operator": "op-token",
+    "member1": "m1-token",
+    "member2": "m2-token",
+    "outsider": "out-token",
+}
+
+
+def _headers(agent: str) -> dict:
+    return {"Authorization": f"Bearer {TOKENS[agent]}", "X-Agent-ID": agent}
+
+
+class _FakeLane:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def enqueue(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return "ok"
+
+
+@pytest.fixture
+def review_env(tmp_path, monkeypatch):
+    """Mesh app wired with a real TeamStore + ThreadStore + a fake lane and a
+    background dispatch loop, so review-outcome signals can write events AND
+    fire author wakes. team-x: member1 (author) + member2. All of member1 /
+    member2 / operator are registered so wakes can target them."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_DB", str(tmp_path / "tasks.db"))
+
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(
+        yaml.dump({"permissions": {a: {} for a in ("operator", "member1", "member2", "outsider")}})
+    )
+    agents_file = tmp_path / "agents.yaml"
+    agents_file.write_text(
+        yaml.dump({"agents": {a: {"role": "w"} for a in ("operator", "member1", "member2", "outsider")}})
+    )
+    import src.cli.config as cli_cfg
+
+    monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", perms_file)
+    monkeypatch.setattr(cli_cfg, "AGENTS_FILE", agents_file)
+
+    import src.host.server as server_module
+
+    importlib.reload(server_module)
+
+    permissions = PermissionMatrix(config_path=str(perms_file))
+    router = MessageRouter(permissions, {
+        "operator": "http://operator:8400",
+        "member1": "http://member1:8400",
+        "member2": "http://member2:8400",
+    })
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    store = TeamStore(db_path=str(tmp_path / "teams.db"), teams_dir=tmp_path / "teams")
+    store.create_team("team-x")
+    store.add_member("team-x", "member1")
+    store.add_member("team-x", "member2")
+    thread_store = ThreadStore(":memory:")
+
+    lane = _FakeLane()
+    loop = asyncio.new_event_loop()
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        teams_store=store,
+        thread_store=thread_store,
+        lane_manager=lane,  # type: ignore[arg-type]
+        dispatch_loop=loop,
+        auth_tokens=dict(TOKENS),
+    )
+    yield {
+        "app": app, "store": store, "thread_store": thread_store, "lane": lane,
+    }
+    loop.call_soon_threadsafe(loop.stop)
+    t.join(timeout=2)
+    blackboard.close()
+    thread_store.close()
+    loop.close()
+    importlib.reload(server_module)
+
+
+def _settle(seconds: float = 0.05) -> None:
+    time.sleep(seconds)
+
+
+def _events(thread_store, recipient):
+    return thread_store.list_events_for(recipient)
+
+
+# ── helper-level: every outcome kind + negative controls ─────────
+
+def _review(author="member1", rid="rev_1", branch="feat-a"):
+    return {"id": rid, "author": author, "branch": branch, "title": "work"}
+
+
+class TestSignalReviewAuthorHelper:
+    def test_merged_informational_event_and_wake(self, review_env):
+        app, ts, lane = review_env["app"], review_env["thread_store"], review_env["lane"]
+        app._signal_review_author("team-x", _review(), "review_merged", resolved_by="operator")
+        _settle()
+        ev = next(e for e in _events(ts, "member1") if e.get("review_id") == "rev_1")
+        assert ev["kind"] == "review_merged"
+        assert ev["team_id"] == "team-x"
+        assert [c for c in lane.calls if c["args"][0] == "member1"]
+        # Informational — NOT surfaced by the Item 1 actionable probe.
+        assert ts.count_unseen_actionable("member1") == 0
+
+    def test_rejected_is_actionable(self, review_env):
+        app, ts, lane = review_env["app"], review_env["thread_store"], review_env["lane"]
+        app._signal_review_author("team-x", _review(), "review_rejected", resolved_by="operator")
+        _settle()
+        assert any(e.get("kind") == "review_rejected" for e in _events(ts, "member1"))
+        assert [c for c in lane.calls if c["args"][0] == "member1"]
+        # Actionable — the heartbeat backstop will force-surface it.
+        assert ts.count_unseen_actionable("member1") == 1
+
+    def test_merge_failed_is_actionable(self, review_env):
+        app, ts = review_env["app"], review_env["thread_store"]
+        app._signal_review_author(
+            "team-x", _review(), "review_merge_failed",
+            note="branch changed", resolved_by="operator",
+        )
+        _settle()
+        ev = next(e for e in _events(ts, "member1") if e.get("kind") == "review_merge_failed")
+        assert ev["note"] == "branch changed"
+        assert ts.count_unseen_actionable("member1") == 1
+
+    def test_approved_and_superseded_informational(self, review_env):
+        app, ts = review_env["app"], review_env["thread_store"]
+        app._signal_review_author("team-x", _review(rid="rA"), "review_approved", resolved_by="member2")
+        app._signal_review_author("team-x", _review(rid="rS"), "review_superseded", resolved_by="member1")
+        _settle()
+        kinds = {e.get("kind") for e in _events(ts, "member1")}
+        assert {"review_approved", "review_superseded"} <= kinds
+        assert ts.count_unseen_actionable("member1") == 0
+
+    def test_negative_control_recipient_is_only_the_author(self, review_env):
+        """The operator/lead who RESOLVED the review never receives the
+        event — only the author does."""
+        app, ts = review_env["app"], review_env["thread_store"]
+        app._signal_review_author("team-x", _review(author="member1"), "review_rejected", resolved_by="operator")
+        _settle()
+        assert any(e.get("review_id") == "rev_1" for e in _events(ts, "member1"))
+        assert not any(e.get("review_id") == "rev_1" for e in _events(ts, "operator"))
+        assert not any(e.get("review_id") == "rev_1" for e in _events(ts, "member2"))
+
+    def test_self_resolution_records_event_but_no_wake(self, review_env):
+        app, ts, lane = review_env["app"], review_env["thread_store"], review_env["lane"]
+        app._signal_review_author("team-x", _review(author="member1"), "review_merged", resolved_by="member1")
+        _settle()
+        # Event still recorded (durable ledger)...
+        assert any(e.get("review_id") == "rev_1" for e in _events(ts, "member1"))
+        # ...but no self-wake.
+        assert lane.calls == []
+
+    def test_unregistered_author_records_event_no_wake(self, review_env):
+        app, ts, lane = review_env["app"], review_env["thread_store"], review_env["lane"]
+        app._signal_review_author("team-x", _review(author="ghost"), "review_rejected", resolved_by="operator")
+        _settle()
+        assert any(e.get("review_id") == "rev_1" for e in _events(ts, "ghost"))
+        assert lane.calls == []
+
+    def test_wake_coalesced_per_review(self, review_env):
+        app, lane = review_env["app"], review_env["lane"]
+        app._signal_review_author("team-x", _review(), "review_rejected", resolved_by="operator")
+        app._signal_review_author("team-x", _review(), "review_merge_failed", resolved_by="operator")
+        _settle()
+        # Same review id twice inside the window → ONE author wake.
+        assert len([c for c in lane.calls if c["args"][0] == "member1"]) == 1
+
+
+# ── endpoint-level: reject + lead verdict (no git) ───────────────
+
+class TestReviewEndpointSignals:
+    @pytest.mark.asyncio
+    async def test_reject_signals_author_and_makes_plate_actionable(self, review_env):
+        store, app, ts, lane = (
+            review_env["store"], review_env["app"], review_env["thread_store"], review_env["lane"],
+        )
+        review = store.create_review("team-x", "feat-a", "member1", "t")
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                f"/mesh/teams/team-x/drive/reviews/{review['id']}/reject",
+                headers=_headers("operator"),
+            )
+        assert resp.status_code == 200, resp.text
+        _settle()
+        # Author got the actionable review_rejected event + a wake.
+        ev = next(e for e in _events(ts, "member1") if e.get("review_id") == review["id"])
+        assert ev["kind"] == "review_rejected"
+        assert ev["resolved_by"] == "operator"
+        assert [wk for wk in lane.calls if wk["args"][0] == "member1"]
+        # Cross-item: surfaces via Item 1's unseen-actionable probe.
+        assert ts.count_unseen_actionable("member1") >= 1
+        # Negative control: the operator (resolver) is NOT a recipient.
+        assert not any(e.get("review_id") == review["id"] for e in _events(ts, "operator"))
+
+    @pytest.mark.asyncio
+    async def test_reject_by_author_self_no_wake(self, review_env):
+        """An internal caller acting AS the author (author == resolver) still
+        records the event but does not self-wake."""
+        store, app, ts, lane = (
+            review_env["store"], review_env["app"], review_env["thread_store"], review_env["lane"],
+        )
+        review = store.create_review("team-x", "feat-a", "member1", "t")
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                f"/mesh/teams/team-x/drive/reviews/{review['id']}/reject",
+                headers={"x-mesh-internal": "1", "X-Agent-ID": "member1"},
+            )
+        assert resp.status_code == 200, resp.text
+        _settle()
+        assert any(e.get("review_id") == review["id"] for e in _events(ts, "member1"))
+        assert lane.calls == []
+
+    @pytest.mark.asyncio
+    async def test_lead_approve_verdict_signals_author_informational(self, review_env):
+        store, app, ts, lane = (
+            review_env["store"], review_env["app"], review_env["thread_store"], review_env["lane"],
+        )
+        store.set_lead("team-x", "member2")
+        review = store.create_review("team-x", "feat-a", "member1", "t")
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                f"/mesh/teams/team-x/drive/reviews/{review['id']}/verdict",
+                json={"verdict": "approve", "note": "ship it"},
+                headers=_headers("member2"),
+            )
+        assert resp.status_code == 200, resp.text
+        _settle()
+        ev = next(e for e in _events(ts, "member1") if e.get("review_id") == review["id"])
+        assert ev["kind"] == "review_approved"
+        assert ev["note"] == "ship it"
+        assert [wk for wk in lane.calls if wk["args"][0] == "member1"]
+        # Informational — does NOT make the plate actionable.
+        assert ts.count_unseen_actionable("member1") == 0
+        # Negative control: the lead (member2) is NOT a recipient.
+        assert not any(e.get("review_id") == review["id"] for e in _events(ts, "member2"))
+
+    @pytest.mark.asyncio
+    async def test_lead_reject_verdict_does_not_signal(self, review_env):
+        """A lead REJECT verdict is advisory (review stays OPEN); it is
+        deliberately NOT signalled — the operator's eventual reject/merge is
+        the terminal author signal."""
+        store, app, ts, lane = (
+            review_env["store"], review_env["app"], review_env["thread_store"], review_env["lane"],
+        )
+        store.set_lead("team-x", "member2")
+        review = store.create_review("team-x", "feat-a", "member1", "t")
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                f"/mesh/teams/team-x/drive/reviews/{review['id']}/verdict",
+                json={"verdict": "reject", "note": "needs work"},
+                headers=_headers("member2"),
+            )
+        assert resp.status_code == 200, resp.text
+        _settle()
+        assert not any(e.get("review_id") == review["id"] for e in _events(ts, "member1"))
+        assert lane.calls == []

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -736,8 +736,10 @@ async def test_back_edge_tolerates_non_dict_result(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_terminal_transition_skips_back_edge_for_human_origin(tmp_path):
-    """origin_kind=='human' must NOT write a back-edge (humans use lane forward path)."""
+async def test_terminal_transition_skips_origin_back_edge_for_human_origin(tmp_path):
+    """origin_kind=='human' writes NO origin-path back-edge (humans use the
+    lane forward path). The IMMEDIATE creator ``alpha`` DOES get one now,
+    though — Item 3, fan-in — so it is excluded from the negative check."""
     from httpx import ASGITransport, AsyncClient
 
     app, bb, tasks_store, _ = _setup_mesh_app(tmp_path)
@@ -761,10 +763,13 @@ async def test_terminal_transition_skips_back_edge_for_human_origin(tmp_path):
             )
         assert resp.status_code == 200, resp.text
 
-        # No back-edge for any plausible origin_user variant.
-        for candidate in ("u_42", "telegram", "alpha", "beta"):
+        # No origin-path back-edge for the human / channel / assignee.
+        for candidate in ("u_42", "telegram", "beta"):
             events = app.thread_store.list_events_for(candidate)
             assert not any(e.get("task_id") == task_id for e in events)
+        # The immediate creator (alpha) DOES get the completion (Item 3).
+        creator_events = app.thread_store.list_events_for("alpha")
+        assert any(e.get("task_id") == task_id for e in creator_events)
     finally:
         _teardown_mesh(bb, tasks_store)
 

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -721,3 +721,126 @@ class TestCheckInboxMultiplicity:
             blackboard.close()
             thread_store.close()
             importlib.reload(server_module)
+
+
+class TestUnseenActionableCursor:
+    """Durable per-recipient read cursor (team signal ledger, Item 1).
+
+    ``count_unseen_actionable`` / ``unseen_actionable_events`` answer "does
+    this agent have UNSEEN actionable events?" strictly ABOVE the cursor;
+    ``mark_events_seen`` advances it (mark-on-surface) so a surfaced event
+    never re-triggers the heartbeat backstop.
+    """
+
+    def _post(self, store, task_id, kind, recipient="scout", age=0.0):
+        th = store.ensure_task_thread("scout", task_id)
+        m = store.post_message(
+            th["id"], "mesh", recipient=recipient, kind="event",
+            payload={"kind": kind, "task_id": task_id},
+        )
+        if age:
+            _age_message(store, m["id"], age)
+        return m
+
+    def _post_review(self, store, team, kind, review_id, recipient="author1"):
+        ch = store.ensure_channel(team)
+        return store.post_message(
+            ch["id"], "mesh", recipient=recipient, kind="event",
+            payload={"kind": kind, "review_id": review_id},
+        )
+
+    def test_count_reflects_new_actionable_events(self, store):
+        self._post(store, "t1", "task_failed")
+        self._post(store, "t2", "task_blocked")
+        self._post(store, "t3", "task_completed")  # informational
+        assert store.count_unseen_actionable("scout") == 2
+        assert {e["kind"] for e in store.unseen_actionable_events("scout")} == {
+            "task_failed", "task_blocked",
+        }
+
+    def test_informational_only_is_not_actionable(self, store):
+        """The plate must NOT go actionable on informational-only events."""
+        self._post(store, "t1", "task_completed")
+        self._post(store, "t2", "task_cancelled")
+        self._post_review(store, "team", "review_merged", "r1")
+        self._post_review(store, "team", "review_approved", "r2")
+        self._post_review(store, "team", "review_superseded", "r3")
+        assert store.count_unseen_actionable("scout") == 0
+        assert store.count_unseen_actionable("author1") == 0
+        assert store.unseen_actionable_events("author1") == []
+
+    def test_review_outcomes_are_actionable_and_not_deduped(self, store):
+        """Rejected + merge-failed are actionable; channel-thread events are
+        NOT collapsed (each is its own message)."""
+        self._post_review(store, "team", "review_rejected", "r1")
+        self._post_review(store, "team", "review_merge_failed", "r2")
+        self._post_review(store, "team", "review_merged", "r3")  # info
+        assert store.count_unseen_actionable("author1") == 2
+        assert {e["kind"] for e in store.unseen_actionable_events("author1")} == {
+            "review_rejected", "review_merge_failed",
+        }
+
+    def test_mark_prevents_retrigger(self, store):
+        self._post(store, "t1", "task_failed")
+        self._post(store, "t2", "task_blocked")
+        events = store.unseen_actionable_events("scout")
+        # Negative control: WITHOUT the mark, the probe keeps returning them.
+        assert store.count_unseen_actionable("scout") == 2
+        assert store.count_unseen_actionable("scout") == 2
+        # Mark-on-surface: once surfaced, they don't re-trigger.
+        store.mark_events_seen("scout", max(e["id"] for e in events))
+        assert store.count_unseen_actionable("scout") == 0
+        assert store.unseen_actionable_events("scout") == []
+
+    def test_new_event_after_mark_trips_again(self, store):
+        m = self._post(store, "t1", "task_failed")
+        store.mark_events_seen("scout", m["id"])
+        assert store.count_unseen_actionable("scout") == 0
+        self._post(store, "t2", "task_failed")
+        assert store.count_unseen_actionable("scout") == 1
+
+    def test_overwrite_resolved_blocker_not_actionable(self, store):
+        """A later informational transition (task_completed after
+        task_blocked) shadows the stale actionable one — same overwrite
+        semantics as list_events_for."""
+        self._post(store, "t1", "task_blocked", age=3600)
+        self._post(store, "t1", "task_completed")
+        assert store.count_unseen_actionable("scout") == 0
+        assert store.unseen_actionable_events("scout") == []
+
+    def test_cursor_is_per_recipient(self, store):
+        self._post(store, "t1", "task_failed", recipient="scout")
+        self._post(store, "t2", "task_failed", recipient="analyst")
+        store.mark_events_seen("scout", 10_000)
+        assert store.count_unseen_actionable("scout") == 0
+        # analyst's cursor is untouched.
+        assert store.count_unseen_actionable("analyst") == 1
+
+    def test_mark_is_monotonic(self, store):
+        m = self._post(store, "t1", "task_failed")
+        store.mark_events_seen("scout", m["id"] + 50)
+        store.mark_events_seen("scout", m["id"])  # cannot regress
+        with store._conn() as conn:
+            row = conn.execute(
+                "SELECT last_seen_id FROM event_cursors WHERE recipient = ?", ("scout",),
+            ).fetchone()
+        assert row[0] == m["id"] + 50
+
+    def test_mark_nonpositive_is_noop(self, store):
+        self._post(store, "t1", "task_failed")
+        store.mark_events_seen("scout", 0)
+        store.mark_events_seen("scout", -5)
+        assert store.count_unseen_actionable("scout") == 1
+
+    def test_actionable_window_bounds_count(self, store):
+        """Actionable events aged past the 7-day serving window drop out of
+        the unseen count (same window as list_events_for)."""
+        self._post(store, "t_old", "task_failed", age=604_800 + 120)
+        self._post(store, "t_new", "task_blocked")
+        assert store.count_unseen_actionable("scout") == 1
+        assert [e["task_id"] for e in store.unseen_actionable_events("scout")] == ["t_new"]
+
+    def test_cursor_table_is_canonical_v1(self, store):
+        with store._conn() as conn:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(event_cursors)").fetchall()}
+        assert cols == {"recipient", "last_seen_id", "updated_at"}


### PR DESCRIPTION
Closes the coordination-delivery loops so a team delivers reliably **no matter the task shape** (linear, fan-out, fan-in/join, review-feedback). A first-pass product review + an independent Codex second pass found that the only reliable delivery primitive was the explicit `hand_off`; every *other* signal (a review outcome, a merged artifact, a fan-in child result) had no push and relied on polling. This adds the missing loops without weakening any existing invariant.

## Item 1 — Durable recipient event cursor + heartbeat drain (the backstop)
`ThreadStore` gains an `event_cursors(recipient, last_seen_id)` table (`CREATE TABLE IF NOT EXISTS`, canonical v1) + `count_unseen_actionable` / `unseen_actionable_events` / `mark_events_seen` (monotonic), sharing one scan so count⟺fetch agree. `ACTIONABLE_EVENT_KINDS` extends to include `review_rejected` / `review_merge_failed`. A new **`unseen_events_fn` heartbeat probe** (cron, for *every* agent — not lead-gated) makes the plate actionable when a recipient has unseen actionable events; the runtime closure **marks-on-surface** so it never re-fires the same events (storm guard), and `check_inbox` advances the cursor too. Worst-case delivery latency becomes one heartbeat instead of "never".

## Item 2 — Drive review outcomes reach the author
Merge / reject / approve-verdict / supersede / merge-preflight-fail now host-write an event addressed to `review["author"]` (stored, non-forgeable) + a coalesced low-priority wake. `review_rejected` / `review_merge_failed` are **actionable** (surface via Item 1's probe); merged/approved/superseded are informational. Kernel auto-merge signals the author from `_post_auto_merge_note` (server-side, keeping `auto_merge.py` transport-agnostic). Closes the review feedback loop that was previously silent to the submitter.

## Item 3 — Immediate-creator back-edge (fan-in / join)
The task back-edge now *also* delivers to and wakes the immediate **`creator`** (the parent agent that spawned a child task and is waiting to synthesize results) — including on `task_completed`, not just failed/blocked. **Security invariant preserved:** the creator wake is justified by *stored* task ownership (stamped at creation), NOT the forgeable `origin_user`; the entire existing `origin_user` block and its forgeable-origin wake guard are untouched (zero removed lines). Guards: real registered agent, `!= assignee`, `!= origin_user` (dedup), `!= operator`.

## Verification
New tests with negative controls: `TestUnseenActionableCursor` (mark prevents re-trigger; informational-only not actionable), `TestUnseenEventsProbe/Closure` (non-lead actionable plate; mark-on-surface no-re-trigger), `test_review_signals.py` (all 5 outcomes; recipient is only the author; self-resolution no wake; reject→unseen-count end-to-end), `TestCreatorBackEdge` (fan-in delivers+wakes creator; dedup single-hop; not self-notify; **origin-guard test still asserts the forgeable `origin_user` is never woken**). 354 passed across the new/touched files locally; subagent module gates green (test_threads/cron/runtime/coordination/back_edge/review_signals 636, team_drive 110, mesh 105, auto_merge/hibernation/ask 165). ruff clean.

Deliberate judgment calls: a lead *reject verdict* is advisory (review stays `open`) so it is NOT signalled as `review_rejected` (only the terminal operator reject is); the creator path skips `operator` to avoid double-signalling the A2 recovery wake; `count_unseen_actionable` applies the same overwrite-dedupe as the fetch to avoid a resolved-blocker counting forever.
