### PR TITLE
Stop request_credential from lying about delivery on failure

### DIFF
--- a/src/agent/builtins/vault_tool.py
+++ b/src/agent/builtins/vault_tool.py
@@ -150,7 +150,12 @@ async def request_credential(
     except Exception:
         pass  # Vault may not be available yet; proceed with the request
 
-    # Emit credential request event to the dashboard via the mesh
+    # Emit credential request event to the dashboard via the mesh. In an
+    # unattended/autonomous run this event IS the delivery mechanism (the
+    # dashboard "needs-you" surface + steer-on-save) — unlike the vault_list
+    # check above, a failure here is NOT best-effort: if it never reaches
+    # the user, the agent must not believe the request was delivered, or
+    # it can park forever waiting on a save that will never happen.
     request_id = ""
     try:
         resp = await mesh_client.request_credential_from_user(
@@ -158,8 +163,21 @@ async def request_credential(
         )
         if isinstance(resp, dict):
             request_id = str(resp.get("request_id") or "")
-    except Exception:
-        pass  # Best effort — the tool result itself is the primary mechanism
+    except Exception as e:
+        return {
+            "requested": False,
+            "name": name,
+            "error": (
+                f"Credential request for '{name}' was NOT delivered to the "
+                f"user: {e}. You MUST NOT report this as requested — no "
+                "request reached the user, so they have nothing to save."
+            ),
+            "recovery_hint": (
+                "Retry request_credential once. If it keeps failing, tell "
+                "the user/operator directly (e.g. notify_user) instead of "
+                "silently waiting for a save that will never arrive."
+            ),
+        }
 
     result: dict = {
         "requested": True,

--- a/tests/test_credential_request.py
+++ b/tests/test_credential_request.py
@@ -110,13 +110,35 @@ class TestRequestCredentialTool:
         assert result["requested"] is True
 
     @pytest.mark.asyncio
-    async def test_mesh_request_failure_still_returns_result(self):
-        """If the mesh call fails, tool should still return requested=True."""
+    async def test_mesh_request_failure_returns_honest_failure(self):
+        """If delivery to the user fails, the tool MUST NOT claim success.
+
+        In an unattended/autonomous run the mesh event is the only
+        delivery mechanism (dashboard "needs-you" + steer-on-save); a
+        swallowed failure here used to make the agent believe the
+        request reached the user when it never did, parking it forever.
+        """
         from src.agent.builtins.vault_tool import request_credential
 
         mock_client = AsyncMock()
         mock_client.vault_list.return_value = []
         mock_client.request_credential_from_user.side_effect = Exception("Network error")
+
+        result = await request_credential(
+            name="key", description="desc", mesh_client=mock_client,
+        )
+        assert result["requested"] is not True
+        assert "error" in result
+        assert "recovery_hint" in result
+
+    @pytest.mark.asyncio
+    async def test_mesh_request_success_still_returns_requested_true(self):
+        """Negative control: the happy path is unaffected by the failure fix."""
+        from src.agent.builtins.vault_tool import request_credential
+
+        mock_client = AsyncMock()
+        mock_client.vault_list.return_value = []
+        mock_client.request_credential_from_user.return_value = {"requested": True, "name": "key"}
 
         result = await request_credential(
             name="key", description="desc", mesh_client=mock_client,


### PR DESCRIPTION
## Summary

Phase 0 (safety substrate) of `docs/plans/2026-07-16-autonomous-team-delivery.md` requires coordination tools to fail honestly instead of letting autonomous work park silently on a swallowed error.

`request_credential` in `src/agent/builtins/vault_tool.py` called `mesh_client.request_credential_from_user(...)` inside a bare `try/except Exception: pass` and then **unconditionally** returned `{"requested": True, ...}`. In an unattended/autonomous run, that mesh event is the only delivery mechanism (dashboard "needs-you" surface + steer-on-save) — if the call raised, the agent believed the request had reached the user and could wait forever for a save that would never happen.

- On delivery failure, the tool now returns a directive failure envelope: `requested: False`, `error` (explicitly says "you MUST NOT report this as requested"), and `recovery_hint` (retry once, then escalate via `notify_user`) — matching this codebase's coordination-tool failure-envelope convention (Constraint #10 / `_failed_transition_envelope` in `coordination_tool.py`).
- The happy path is unchanged: success still returns `requested: True` with the same fields (`name`, `handle`, `message`, `request_id` if present).
- The `already_exists` early-return and the best-effort `vault_list()` existence check are untouched — that check is genuinely best-effort and doesn't gate the request.
- Tool schema and function signature are unchanged.

## Test plan

- [x] Added `test_mesh_request_failure_returns_honest_failure` (`tests/test_credential_request.py`) — delivery raises → result has `requested is not True`, `error`, and `recovery_hint`.
- [x] Added `test_mesh_request_success_still_returns_requested_true` — negative control confirming the happy path still returns `requested: True`.
- [x] Updated `test_mesh_request_failure_still_returns_result` (renamed to `test_mesh_request_failure_returns_honest_failure`) which previously asserted the old swallow-and-succeed behavior.
- [x] `PYTHONPATH="$PWD" LITELLM_MODE=PRODUCTION python -m pytest tests/test_credential_request.py -q` → 17 passed
- [x] `ruff check src/agent/builtins/vault_tool.py` → all checks passed