### PR TITLE
Add configurable fail-closed posture for the team-budget envelope

### DIFF
--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -472,9 +472,20 @@ class CostTracker:
 
         Returns ``{"allowed": True, "team": None}`` when the agent has no
         team, no store is wired, or the team's envelope is unset/0
-        (= unlimited). Fails OPEN on store read errors — the envelope is
-        an additional governor on top of the always-on per-agent budget,
-        and a storage hiccup must not take down the whole LLM path.
+        (= unlimited) — those are legitimate "no envelope" cases, not
+        errors, and are unaffected by the posture knob below.
+
+        On a store READ ERROR the posture is CONFIGURABLE
+        (``limits.team_envelope_fail_closed`` /
+        ``OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED``). The default (False) fails
+        OPEN — the envelope is an additional governor on top of the
+        always-on per-agent budget, and a storage hiccup must not take down
+        the whole LLM path. Set True (Phase-0 safety substrate,
+        docs/plans/2026-07-16-autonomous-team-delivery.md §0) to fail CLOSED:
+        the read error BLOCKS the call, returning an ``{"allowed": False,
+        "reason": "envelope_check_unavailable", ...}`` dict shaped like a
+        real envelope-exceeded result, so an unattended fleet cannot keep
+        spending through a governor it can no longer read.
         """
         store = self._team_store
         if store is None or not agent:
@@ -485,6 +496,23 @@ class CostTracker:
                 return {"allowed": True, "team": None}
             trow = store.get_team(team)
         except Exception as e:
+            from src.shared.limits import team_envelope_fail_closed
+
+            if team_envelope_fail_closed():
+                logger.warning("Team envelope check FAILED CLOSED (store read failed): %s", e)
+                # Shape-compatible with the real envelope-exceeded return so
+                # the credentials.py blocked path (which subscripts
+                # daily_used/monthly_used/estimated_cost) renders cleanly.
+                return {
+                    "allowed": False,
+                    "team": None,
+                    "reason": "envelope_check_unavailable",
+                    "estimated_cost": 0.0,
+                    "daily_used": 0.0,
+                    "daily_limit": None,
+                    "monthly_used": 0.0,
+                    "monthly_limit": None,
+                }
             logger.warning("Team envelope check skipped (store read failed): %s", e)
             return {"allowed": True, "team": None}
         if trow is None:

--- a/src/shared/limits.py
+++ b/src/shared/limits.py
@@ -270,6 +270,43 @@ def coordination_daily_cap_usd() -> float:
     return clamped
 
 
+# Team-budget envelope posture on a STORE READ ERROR (Phase-0 safety
+# substrate, docs/plans/2026-07-16-autonomous-team-delivery.md §0). The
+# envelope (``CostTracker.team_envelope_check``) is a financial governor;
+# historically a TeamStore read hiccup made it fail OPEN — silently skip the
+# check — so a storage blip could never take down the LLM path. Under
+# unattended autonomy that silently disables a spend governor, so this knob
+# lets an operator make the SAME read-error path fail CLOSED (block the call)
+# instead. Bool-valued, so it lives outside the int-only ``LIMIT_SPECS``
+# table with the same env-override contract as the float caps above.
+#
+# DEFAULTS TO FALSE (fail open = the historical behavior) — a naive
+# always-closed would halt the fleet on a benign partial-boot read error.
+# The default flip is deferred to Phase-0 exit; the resolver honors the
+# default constant when the env is unset, so flipping it later needs no
+# call-site change. This governs the READ-ERROR path ONLY — the legitimate
+# "no envelope" cases (no team, no store, unset/0 = unlimited) are
+# unaffected either way.
+TEAM_ENVELOPE_FAIL_CLOSED_DEFAULT = False
+_TRUE_ENV_VALUES = ("1", "true", "yes", "on")
+
+
+def team_envelope_fail_closed() -> bool:
+    """Resolve the team-envelope store-read-error posture (env override).
+
+    ``True`` → a ``team_envelope_check`` store read error BLOCKS the call
+    (fail closed); ``False`` (default) → the check is skipped (fail open,
+    the historical behavior). Reads ``OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED``;
+    an unset value keeps ``TEAM_ENVELOPE_FAIL_CLOSED_DEFAULT`` (so the
+    deferred default flip needs no call-site change), and any unrecognized
+    value reads as False.
+    """
+    raw = os.environ.get("OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED")
+    if raw is None:
+        return TEAM_ENVELOPE_FAIL_CLOSED_DEFAULT
+    return raw.strip().lower() in _TRUE_ENV_VALUES
+
+
 # Kernel-executed auto-merge sampling (plan §8 #20). Fraction of a
 # trust-cleared pair's auto-merges flagged for human post-review — high
 # at first, decaying once the pair has accumulated

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -496,9 +496,12 @@ class TestTeamEnvelopeCheck:
         check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
         assert check["allowed"] is True
 
-    def test_store_error_fails_open(self):
-        """The envelope is an additional governor — a store hiccup must
-        not take down the LLM path (the per-agent budget still applies)."""
+    def test_store_error_fails_open_by_default(self, monkeypatch):
+        """DEFAULT posture: the envelope is an additional governor — a store
+        hiccup must not take down the LLM path (the per-agent budget still
+        applies). The fail-closed knob defaults False, so with no env
+        override a store read error stays fail-open."""
+        monkeypatch.delenv("OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED", raising=False)
 
         class _Boom:
             def team_of(self, agent):
@@ -507,6 +510,83 @@ class TestTeamEnvelopeCheck:
         self.tracker.set_team_store(_Boom())
         check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
         assert check["allowed"] is True
+
+    def test_store_error_fails_closed_when_flag_set(self, monkeypatch):
+        """Phase-0 safety knob: with OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED
+        on, a team_of read error BLOCKS the call instead of silently
+        disabling the governor."""
+        monkeypatch.setenv("OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED", "true")
+
+        class _Boom:
+            def team_of(self, agent):
+                raise RuntimeError("db locked")
+
+        self.tracker.set_team_store(_Boom())
+        check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
+        assert check["allowed"] is False
+        assert check["reason"] == "envelope_check_unavailable"
+
+    def test_get_team_error_fails_closed_when_flag_set(self, monkeypatch):
+        """The get_team leg of the read (not just team_of) also honors the
+        fail-closed knob."""
+        monkeypatch.setenv("OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED", "1")
+
+        class _BoomOnGet:
+            def team_of(self, agent):
+                return "teamA"
+
+            def get_team(self, team):
+                raise RuntimeError("db locked")
+
+        self.tracker.set_team_store(_BoomOnGet())
+        check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
+        assert check["allowed"] is False
+        assert check["reason"] == "envelope_check_unavailable"
+
+    def test_fail_closed_dict_is_blocked_path_shape_compatible(self, monkeypatch):
+        """The fail-closed dict carries the fields credentials.py's blocked
+        path subscripts (daily_used / monthly_used / estimated_cost / team),
+        so a real block renders cleanly instead of raising KeyError."""
+        monkeypatch.setenv("OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED", "yes")
+
+        class _Boom:
+            def team_of(self, agent):
+                raise RuntimeError("db locked")
+
+        self.tracker.set_team_store(_Boom())
+        check = self.tracker.team_envelope_check("alice", "openai/gpt-4o")
+        # Every field the credentials.py blocked branches read must exist.
+        for key in ("team", "daily_used", "monthly_used", "estimated_cost"):
+            assert key in check, f"fail-closed dict missing {key!r}"
+        # And it must render the way the caller formats it, no exception.
+        _d, _m = check.get("daily_limit"), check.get("monthly_limit")
+        rendered = (
+            f"Team budget exceeded for team '{check['team']}': "
+            f"${check['daily_used']:.2f}"
+            f"/{f'${_d:.2f}' if _d else 'unlimited'} daily, "
+            f"${check['monthly_used']:.2f}"
+            f"/{f'${_m:.2f}' if _m else 'unlimited'} monthly "
+            f"(estimated next call: ${check['estimated_cost']:.4f})"
+        )
+        assert "unlimited daily" in rendered
+
+    def test_flag_does_not_affect_normal_paths(self, monkeypatch):
+        """Negative control: the knob governs the read-ERROR path ONLY. With
+        it on, a healthy store's legitimate 'no envelope' cases (unset/0 =
+        unlimited, solo/teamless) and a real exceeded envelope are all
+        unchanged."""
+        monkeypatch.setenv("OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED", "true")
+        # Unset envelope on a healthy store still allows (B4 unlimited).
+        assert self.tracker.team_envelope_check("bob", "openai/gpt-4o")["allowed"] is True
+        # Teamless agent still allowed, team None.
+        solo = self.tracker.team_envelope_check("loner", "openai/gpt-4o")
+        assert solo["allowed"] is True and solo["team"] is None
+        # A genuinely exceeded envelope still blocks (not via the error path).
+        self.store.set_budget("teamA", 0.001, None)
+        self.tracker.track("alice", "openai/gpt-4o", 10_000, 5_000)
+        blocked = self.tracker.team_envelope_check("bob", "openai/gpt-4o")
+        assert blocked["allowed"] is False
+        assert "reason" not in blocked  # real exceed, not the unavailable path
 
 
 class TestCostTrackerCleanup:


### PR DESCRIPTION
## What

`CostTracker.team_envelope_check` (`src/host/costs.py`) is a financial governor on the LLM path. Today its `except Exception` store-read-error block **fails OPEN** — it returns `{"allowed": True, "team": None}`, so a transient `TeamStore` read error silently disables the whole team envelope.

This adds a configurable knob so the same read-error path can **fail CLOSED** instead:

- **New limit** `limits.team_envelope_fail_closed` (`src/shared/limits.py`), env override `OPENLEGION_TEAM_ENVELOPE_FAIL_CLOSED`, same resolver/default contract as the existing float caps (`ask_bill_cap_usd`, `coordination_daily_cap_usd`).
- When the knob is `True`, a store read error returns `{"allowed": False, "team": None, "reason": "envelope_check_unavailable", ...}`. When `False`, the current fail-open return is unchanged. The existing `logger.warning` is kept; the fail-closed path adds a distinct warning.
- Only the **store-read-error** path is touched. The `trow is None` path and the B4 "unset/0 = unlimited" path are legitimate "no envelope" cases and are left exactly as-is.

## Non-breaking default

The knob **defaults to `False`** — today's fail-open behavior is preserved exactly. A naive always-fail-closed could halt the fleet on a benign partial-boot read error, so the default flip is **deferred to Phase-0 exit**. The resolver honors the default constant when the env is unset, so the later flip needs no call-site change.

## Caller shape-compatibility

The fail-closed dict is shaped like a real envelope-exceeded result. Both work-path blocked branches in `src/host/credentials.py` subscript `envelope['daily_used']` / `envelope['monthly_used']` (sync `execute_api_call` fork) and additionally `envelope['estimated_cost']` (sync fork) — a bare `{"allowed": False}` would raise `KeyError`. The dict therefore carries `team`, `daily_used`, `monthly_used`, `estimated_cost`, `daily_limit`, `monthly_limit`, so the blocked path renders a clean "Team budget exceeded…" outcome on both the sync and streaming (`stream_llm`) forks. The image-gen caller reads only `allowed`/`team` and was already safe.

## Tests

`tests/test_costs.py::TestTeamEnvelopeCheck`:
- `test_store_error_fails_open_by_default` (updated from the old unconditional `test_store_error_fails_open`) — default posture still fails open.
- `test_store_error_fails_closed_when_flag_set` — knob on, `team_of` raises → `allowed False`.
- `test_get_team_error_fails_closed_when_flag_set` — the `get_team` leg also honors the knob.
- `test_fail_closed_dict_is_blocked_path_shape_compatible` — asserts the dict renders through the caller's exact f-string with no `KeyError`.
- `test_flag_does_not_affect_normal_paths` (negative control) — with the knob on, unset/0-envelope, solo, and genuinely-exceeded paths are all unchanged.

Gate: `tests/test_costs.py` (56) + `tests/test_coordination_split.py` (33) → **89 passed**. `ruff check src/host/costs.py src/shared/limits.py` clean.

Part of the Phase-0 safety substrate in `docs/plans/2026-07-16-autonomous-team-delivery.md` (§0).