### PR TITLE
feat(teams): appoint a lead for every non-solo team (Phase 1)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2089,6 +2089,47 @@ async def update_team_context(
 
 
 @tool(
+    name="set_team_lead",
+    operator_only=True,
+    description=(
+        "Appoint an existing team member as the team's LEAD — the "
+        "accountability owner who receives standup duty, goal-coverage "
+        "and blocked-task escalation alerts, and advisory review verdicts. "
+        "The agent must already be a member of the team; the operator "
+        "cannot be a lead, and a solo/one-member team needs none (it "
+        "self-leads). This is team data, not a permission tier — it grants "
+        "the lead zero permission elevation."
+    ),
+    parameters={
+        "team_name": {"type": "string", "description": "Team name"},
+        "agent_name": {
+            "type": "string",
+            "description": "The team member to appoint as lead",
+        },
+    },
+)
+async def set_team_lead(
+    team_name: str = "",
+    agent_name: str = "",
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
+) -> dict:
+    """Appoint a team member as lead (activates the stewardship loop)."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not team_name or not agent_name:
+        return {"error": "team_name and agent_name are required"}
+    try:
+        return await mesh_client.set_team_lead(team_name, agent_name)
+    except Exception as e:
+        return {"error": f"Failed to set team lead: {e}"}
+
+
+@tool(
     name="update_team_brief",
     operator_only=True,
     description=(

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1360,6 +1360,23 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def set_team_lead(self, team_name: str, agent_id: str) -> dict:
+        """Appoint a team's lead via mesh proxy (``PUT /mesh/teams/{name}/lead``).
+
+        Mirrors ``update_team_context``'s PUT shape. The endpoint is
+        operator-or-internal; the store re-validates real membership
+        (rejecting the operator and non-members) so a bad appointment
+        surfaces as an HTTP 400 raised here.
+        """
+        client = await self._get_client()
+        response = await client.put(
+            f"{self.mesh_url}/mesh/teams/{team_name}/lead",
+            json={"agent_id": agent_id},
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json()
+
     async def set_task_outcome(
         self,
         task_id: str,

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -68,7 +68,7 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
             "create_agent", "create_team", "apply_template", "list_templates",
             "add_agents_to_team", "remove_agents_from_team", "manage_team",
             "manage_agent", "edit_agent", "read_agent_config",
-            "update_team_context",
+            "update_team_context", "set_team_lead",
         ),
         operator_only=True,
     ),

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1810,6 +1810,11 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "add_agents_to_team",
     "remove_agents_from_team",
     "update_team_context",
+    # Lead appointment (Phase-1 autonomous-team-delivery) — installs the
+    # accountability owner that activates the lead-gated stewardship
+    # machinery (standup, goal-coverage, blocked-task escalation, review
+    # verdicts). Lead is team data, not a permission tier.
+    "set_team_lead",
     # P2 — section-scoped TEAM.md updates (fleet-wide knowledge
     # propagation; canonical use: '## User Preferences').
     "update_team_brief",

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -2783,9 +2783,51 @@ class RuntimeContext:
                         e,
                     )
 
+    def _backfill_team_leads(self) -> None:
+        """Appoint a lead for each active non-solo team that has none.
+
+        Phase-1 of the autonomous-team-delivery plan (docs/plans/
+        2026-07-16-autonomous-team-delivery.md §1/§3): the lead-gated
+        stewardship machinery (goal-coverage probe, standup, blocked-task
+        rung-3 escalation, drive-review verdicts) is dormant for any team
+        with a NULL lead. ``create_team`` now auto-appoints for NEW teams;
+        this backfill covers teams that predate that change (and any team
+        left leaderless by a live lead-clear path). Appoints the first
+        non-operator member — a deliberate stepping stone (a follow-up
+        upgrades to a purpose-built coordinator agent). Solo / team-of-one
+        self-leads (no lead row — nobody to coordinate).
+
+        Runs BEFORE ``_reconcile_standup_jobs`` so the standup reconcile
+        (which reads ``lead_agent_id`` fresh) picks up the appointments.
+        Idempotent, cheap, best-effort — a failure here must never crash
+        boot; ``set_lead`` re-validates membership and refuses the operator.
+        """
+        try:
+            teams = self.teams_store.list_teams(include_archived=False)
+        except Exception as e:
+            logger.warning("team-lead backfill failed to load teams: %s", e)
+            return
+        for name, meta in teams.items():
+            if (meta.get("status") or "active") == "archived":
+                continue
+            if meta.get("lead_agent_id"):
+                continue
+            members = [m for m in (meta.get("members") or []) if m != "operator"]
+            if len(members) < 2:
+                # Solo / team-of-one self-leads — no lead row.
+                continue
+            try:
+                self.teams_store.set_lead(name, members[0])
+                logger.info(
+                    "backfilled lead %s for leaderless team %s", members[0], name
+                )
+            except Exception as e:
+                logger.warning("team-lead backfill for team %s failed: %s", name, e)
+
     def _start_background(self) -> None:
         self._reconcile_heartbeats()
         self._reconcile_work_summary_jobs()
+        self._backfill_team_leads()
         self._reconcile_standup_jobs()
 
         # Start cron

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6716,6 +6716,31 @@ def create_mesh_app(
                 # new members' team patterns apply to the very next
                 # blackboard/pubsub call (not at the next mesh restart).
                 permissions.reload()
+        # Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
+        # delivery.md §1/§3): a non-solo team must never commit leaderless,
+        # or the lead-gated stewardship machinery (goal-coverage probe,
+        # standup job, blocked-task rung-3 escalation, drive-review verdicts)
+        # stays dormant for operator-built teams. Appoint the first real
+        # member as lead — a deliberate stepping stone (a follow-up upgrades
+        # to a purpose-built coordinator agent + an operator fallback for the
+        # monitoring signals). The operator is already rejected from
+        # ``members`` above, and ``set_lead`` re-checks real membership +
+        # refuses the operator. A solo/one-member team self-leads — no lead
+        # row (nobody to coordinate). Best-effort: a failure here must not
+        # fail team creation; the boot backfill catches any drift.
+        lead_id: str | None = None
+        _real_members = [m for m in members if m != "operator"]
+        if len(_real_members) >= 2:
+            try:
+                teams_store.set_lead(name, _real_members[0])
+                lead_id = _real_members[0]
+            except (TeamNotFound, ValueError) as e:
+                logger.warning("auto-appoint lead for team %s failed: %s", name, e)
+        if lead_id is not None:
+            # Wire the new lead's standup cron immediately (same helper the
+            # dedicated lead endpoint uses) so stewardship starts now, not at
+            # the next mesh restart. No-op when cron_scheduler is unwired.
+            _sync_standup_job_on_lead_change(name, lead_id)
         # Team channel thread (Phase-2 Team Threads): create the durable
         # channel and point the team row at it. Best-effort — a thread
         # hiccup must not fail team creation; the boot backfill catches

--- a/tests/test_cron_standup.py
+++ b/tests/test_cron_standup.py
@@ -642,3 +642,101 @@ class TestReconcileStandupJobs:
         )
         RuntimeContext._reconcile_standup_jobs(_Stub())
         assert scheduler.find_standup_job("alpha") is None
+
+
+# ── Boot lead backfill (cli/runtime.RuntimeContext._backfill_team_leads) ──
+
+
+def _seed_team(store, name: str, members: list[str], *, status: str = "active"):
+    """Create a team with ``members`` and NO lead (pre-Phase-1 shape)."""
+    store.create_team(name)
+    for m in members:
+        store.add_member(name, m)
+    if status != "active":
+        store.set_status(name, status)
+
+
+class TestBackfillTeamLeads:
+    """``_backfill_team_leads`` (Phase-1 autonomous-team-delivery): appoint
+    the first non-operator member as lead for every active NON-SOLO team
+    that predates auto-appointment and has a NULL lead. Solo/team-of-one
+    self-leads (no lead row); existing leads and archived teams untouched."""
+
+    def _stub(self, store):
+        class _Stub:
+            teams_store = store
+        return _Stub()
+
+    def test_backfill_appoints_first_member_for_leaderless_team(self, tmp_path):
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob"])
+        assert store.get_team("alpha")["lead_agent_id"] is None
+
+        from src.cli.runtime import RuntimeContext
+        RuntimeContext._backfill_team_leads(self._stub(store))
+
+        assert store.get_team("alpha")["lead_agent_id"] == "ada"
+
+    def test_backfill_skips_solo_team_of_one(self, tmp_path):
+        store = _team_store(tmp_path)
+        _seed_team(store, "solo", ["ada"])  # one member = self-leads
+
+        from src.cli.runtime import RuntimeContext
+        RuntimeContext._backfill_team_leads(self._stub(store))
+
+        assert store.get_team("solo")["lead_agent_id"] is None
+
+    def test_backfill_skips_empty_team(self, tmp_path):
+        store = _team_store(tmp_path)
+        _seed_team(store, "ghost", [])
+
+        from src.cli.runtime import RuntimeContext
+        RuntimeContext._backfill_team_leads(self._stub(store))
+
+        assert store.get_team("ghost")["lead_agent_id"] is None
+
+    def test_backfill_is_idempotent_and_keeps_existing_lead(self, tmp_path):
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob"])
+        store.set_lead("alpha", "bob")  # already led
+
+        from src.cli.runtime import RuntimeContext
+        RuntimeContext._backfill_team_leads(self._stub(store))
+        # Existing lead preserved, not overwritten with the first member.
+        assert store.get_team("alpha")["lead_agent_id"] == "bob"
+        # Second run is a no-op.
+        RuntimeContext._backfill_team_leads(self._stub(store))
+        assert store.get_team("alpha")["lead_agent_id"] == "bob"
+
+    def test_backfill_skips_archived_team(self, tmp_path):
+        store = _team_store(tmp_path)
+        _seed_team(store, "old", ["ada", "bob"], status="archived")
+
+        from src.cli.runtime import RuntimeContext
+        RuntimeContext._backfill_team_leads(self._stub(store))
+
+        assert store.get_team("old")["lead_agent_id"] is None
+
+    def test_backfill_then_standup_reconcile_creates_job(self, tmp_path):
+        """End-to-end: a leaderless multi-member team gets a lead at boot,
+        and the standup reconcile (run after) then wires its standup job."""
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob"])
+
+        from src.host.cron import CronScheduler
+        scheduler = CronScheduler(config_path=str(tmp_path / "cron.json"))
+
+        class _Stub:
+            cron_scheduler = scheduler
+            teams_store = store
+
+        from src.cli.runtime import RuntimeContext
+        stub = _Stub()
+        # Boot order: backfill BEFORE the standup reconcile.
+        RuntimeContext._backfill_team_leads(stub)
+        RuntimeContext._reconcile_standup_jobs(stub)
+
+        assert store.get_team("alpha")["lead_agent_id"] == "ada"
+        job = scheduler.find_standup_job("alpha")
+        assert job is not None
+        assert job.agent == "ada"

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1796,3 +1796,82 @@ async def test_set_agent_goals_requires_operator(monkeypatch):
     result = await set_agent_goals("researcher", ["Goal."], mesh_client=mc)
     assert "error" in result
     mc.set_agent_goals.assert_not_awaited()
+
+
+# ── set_team_lead (Phase-1 autonomous-team-delivery) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_team_lead_appoints_valid_member():
+    from src.agent.builtins.operator_tools import set_team_lead
+
+    mc = MagicMock()
+    mc.set_team_lead = AsyncMock(return_value={
+        "success": True, "team_name": "squad", "lead_agent_id": "ada",
+    })
+    result = await set_team_lead("squad", "ada", mesh_client=mc)
+    mc.set_team_lead.assert_awaited_once_with("squad", "ada")
+    assert result["lead_agent_id"] == "ada"
+
+
+@pytest.mark.asyncio
+async def test_set_team_lead_surfaces_operator_rejection():
+    """The store rejects the operator (HTTP 400); the tool surfaces it."""
+    from src.agent.builtins.operator_tools import set_team_lead
+
+    mc = MagicMock()
+    mc.set_team_lead = AsyncMock(side_effect=Exception(
+        "Client error '400 Bad Request': Operator is a system agent and "
+        "cannot be a team lead",
+    ))
+    result = await set_team_lead("squad", "operator", mesh_client=mc)
+    assert "error" in result
+    assert "system agent" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_team_lead_surfaces_non_member_rejection():
+    """A non-member appointment surfaces as an error envelope."""
+    from src.agent.builtins.operator_tools import set_team_lead
+
+    mc = MagicMock()
+    mc.set_team_lead = AsyncMock(side_effect=Exception(
+        "Client error '400 Bad Request': Agent 'ghost' is not a member of "
+        "team 'squad' — the lead must be a real team member.",
+    ))
+    result = await set_team_lead("squad", "ghost", mesh_client=mc)
+    assert "error" in result
+    assert "not a member" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_team_lead_requires_both_args():
+    from src.agent.builtins.operator_tools import set_team_lead
+
+    mc = MagicMock()
+    mc.set_team_lead = AsyncMock()
+    result = await set_team_lead("squad", "", mesh_client=mc)
+    assert "error" in result
+    mc.set_team_lead.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_team_lead_no_mesh_client():
+    from src.agent.builtins.operator_tools import set_team_lead
+
+    result = await set_team_lead("squad", "ada", mesh_client=None)
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_set_team_lead_blocked_for_non_operator(monkeypatch):
+    """Defence-in-depth: non-operator env (no ALLOWED_TOOLS) is refused."""
+    from src.agent.builtins.operator_tools import set_team_lead
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    mc = MagicMock()
+    mc.set_team_lead = AsyncMock()
+    result = await set_team_lead("squad", "ada", mesh_client=mc)
+    assert "error" in result
+    mc.set_team_lead.assert_not_awaited()

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -196,6 +196,40 @@ class TestMeshTeamEndpoints:
             assert sorted(perms["permissions"][agent]["blackboard_write"]) == expected
 
     @pytest.mark.asyncio
+    async def test_create_multi_member_auto_appoints_lead(self, team_app):
+        """Phase-1 leadership loop: a non-solo team must never commit
+        leaderless — the first non-operator member is appointed lead so the
+        lead-gated stewardship machinery activates for operator-built teams."""
+        app, store, _, _ = team_app
+        r = await _post(
+            app,
+            "/mesh/teams",
+            {"name": "squad", "members": ["agent1", "agent2"]},
+        )
+        assert r.status_code == 200, r.text
+        assert store.get_team("squad")["lead_agent_id"] == "agent1"
+
+    @pytest.mark.asyncio
+    async def test_create_solo_member_gets_no_lead(self, team_app):
+        """A one-member team self-leads — no lead row is written."""
+        app, store, _, _ = team_app
+        r = await _post(
+            app,
+            "/mesh/teams",
+            {"name": "lonely", "members": ["agent1"]},
+        )
+        assert r.status_code == 200, r.text
+        assert store.get_team("lonely")["lead_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_no_members_gets_no_lead(self, team_app):
+        """An empty team has no member to lead — lead stays NULL."""
+        app, store, _, _ = team_app
+        r = await _post(app, "/mesh/teams", {"name": "empty"})
+        assert r.status_code == 200, r.text
+        assert store.get_team("empty")["lead_agent_id"] is None
+
+    @pytest.mark.asyncio
     async def test_create_with_member_from_other_team_strips_old_acl(self, team_app):
         """Creating a team whose initial members include an agent already
         on another team must evict the membership AND swap the blackboard


### PR DESCRIPTION
## Why

The team stewardship machinery — the **goal-coverage probe**, the **standup job**, the **blocked-task rung-3 escalation**, and the **drive-review verdicts** — is entirely lead-gated: each begins with a `led_team(agent)` check and returns nothing for a team whose `lead_agent_id` is NULL. But operator-built teams committed leaderless (`TeamStore.create_team` leaves the pointer NULL) and the operator had **no tool** to install a lead — so that whole loop sat dormant for exactly the teams the operator builds.

This is **Phase 1** of `docs/plans/2026-07-16-autonomous-team-delivery.md` (§1 finding 1, §3 Phase 1): make every non-solo team have a lead so the *existing* machinery activates.

## What

1. **Auto-appoint at team creation** (`server.py` `POST /mesh/teams`): when a team is created with ≥2 real members and no explicit lead, the first non-operator member is appointed via the existing `TeamStore.set_lead`, and its standup cron is wired immediately via the existing `_sync_standup_job_on_lead_change`. A solo / team-of-one self-leads — **no lead row**.
2. **Boot backfill** (`runtime.py` `_backfill_team_leads`, run in `_start_background` **before** `_reconcile_standup_jobs`): for each active non-solo team with a NULL lead and ≥1 member, appoint the first non-operator member. Idempotent, cheap, best-effort — never crashes boot; the standup reconcile then picks the appointment up.
3. **Operator `set_team_lead(team_name, agent_name)` tool** (`operator_tools.py`, operator-only) → new `MeshClient.set_team_lead` → the **existing** operator-or-internal `PUT /mesh/teams/{name}/lead` endpoint. Registered in `_OPERATOR_ALLOWED_TOOLS` (`cli/config.py`) and the `fleet_setup` tool group (`tool_groups.py`).

### Endpoint / registration sites used
- Endpoint: `PUT /mesh/teams/{team_name}/lead` (`mesh_set_team_lead`, operator-or-internal) — unchanged.
- Standup wiring: existing `_sync_standup_job_on_lead_change` / `ensure_standup_job`.
- Registration: `_OPERATOR_ALLOWED_TOOLS` + `TOOL_GROUPS["fleet_setup"]`.

## Invariants preserved
- The operator is **never** appointed (`set_lead` refuses it, and it is stripped from the member list first).
- `set_lead`'s real-membership validation is untouched.
- Solo / team-of-one gets **no lead**.

## Stepping-stone note
This appoints an existing **member** as lead — a deliberate stepping stone. A follow-up will upgrade to a dedicated **purpose-built coordinator agent** (own prompt/identity/reserved reasoning capacity) and add an **operator fallback** for the monitoring signals, since a busy member-lead's heartbeat can be skipped (`loop.py` heartbeat-skip-when-busy) — see the design doc §2.1 / §5.

## Tests
- `tests/test_teams.py`: `test_create_multi_member_auto_appoints_lead`, `test_create_solo_member_gets_no_lead`, `test_create_no_members_gets_no_lead`.
- `tests/test_operator_tools.py`: `test_set_team_lead_appoints_valid_member`, `test_set_team_lead_surfaces_operator_rejection`, `test_set_team_lead_surfaces_non_member_rejection`, `test_set_team_lead_requires_both_args`, `test_set_team_lead_no_mesh_client`, `test_set_team_lead_blocked_for_non_operator`.
- `tests/test_cron_standup.py` (`TestBackfillTeamLeads`): appoints first member for a leaderless multi-member team; skips solo/empty/archived; idempotent + preserves an existing lead; end-to-end backfill → standup-reconcile creates the job.

Local gate (touched files + consistency suites): **485 passed** (`PYTHONPATH LITELLM_MODE=PRODUCTION pytest`), `ruff check` clean.