### PR TITLE
fix(dashboard): map set_team_lead verb (green main)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11470,6 +11470,7 @@ function dashboard() {
         team_drive: 'working in the team drive',
         recommend_pending_action: 'recommending on a held action',
         allocate_member_budget: 'allocating a teammate\'s budget',
+        set_team_lead: 'appointing a team lead',
       };
       if (map[toolName]) return map[toolName];
       // Fallback: humanise the snake_case tool name.


### PR DESCRIPTION
Hotfix: #1266 added the `set_team_lead` operator tool but not its `verbForTool` map entry, so `tests/test_dashboard_ui.py::TestVerbForToolCompleteness` (every @tool builtin must be mapped or allowlisted) failed on CI shard 2 — which landed red on main via an admin merge. Adds `set_team_lead: 'appointing a team lead'` to the app.js map, matching sibling team tools. JS-only; the failing test now passes.