### PR TITLE
feat(teams): make team goal readable by operator and propagate to running members

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1893,7 +1893,11 @@ async def archive_audit_before(
     description=(
         "Read team info. detail='names' lists name+description; "
         "detail='status' adds task-count rollups (requires v2). "
-        "Setting team_name returns full detail for that team."
+        "Setting team_name returns full detail for that team, "
+        "including its north_star / success_criteria goal and its "
+        "daily/monthly budget envelope (budget_daily_usd / "
+        "budget_monthly_usd) — use this to read back a goal or budget "
+        "you set."
     ),
     parameters={
         "detail": {

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6612,6 +6612,13 @@ def create_mesh_app(
         the archive state when ``include_archived`` is set. The ``name``
         / ``team_name`` keys both ride on each row so callers tracking
         either field keep working.
+
+        Phase-1 (design doc §1 finding 4): the goal + budget columns
+        (``north_star`` / ``success_criteria`` / ``budget_daily_usd`` /
+        ``budget_monthly_usd``) now ride each row too — previously they
+        were stripped here, so the operator's ``inspect_teams`` could not
+        read back the very goal/budget it had just set. Additive fields;
+        older callers ignore the new keys.
         """
         caller = _extract_verified_agent_id(request)
         if not _caller_is_operator(caller, request) and not _is_internal_caller(request):
@@ -6628,6 +6635,10 @@ def create_mesh_app(
                     "created_at": pdata.get("created_at", ""),
                     "status": pdata.get("status", "active") or "active",
                     "lead_agent_id": pdata.get("lead_agent_id"),
+                    "north_star": pdata.get("north_star"),
+                    "success_criteria": pdata.get("success_criteria"),
+                    "budget_daily_usd": pdata.get("budget_daily_usd"),
+                    "budget_monthly_usd": pdata.get("budget_monthly_usd"),
                 }
             )
         return {"teams": result}
@@ -8163,6 +8174,41 @@ def create_mesh_app(
             teams_store.set_goal(team_name, north_star, success_criteria)
         except TeamNotFound:
             raise HTTPException(404, f"Team '{team_name}' not found")
+
+        # Phase-1 (design doc §1 finding 4): set_goal previously only
+        # persisted + emitted an event, so a goal never reached RUNNING
+        # members — redirecting a busy team was inert to in-flight work.
+        # Mirror the goal into a reserved ``## Goal`` section of the team's
+        # shared TEAM.md and live-push it to running members, REUSING the
+        # brief writer's section-scoped write + concurrent push
+        # (``replace_markdown_section`` + ``_push_team_md``). Best-effort:
+        # a TEAM.md/push hiccup must NEVER fail the goal write itself
+        # (the persisted row above is the source of truth), and a team
+        # with no shared TEAM.md (pure-DB store / solo team-of-one with no
+        # scaffold) no-ops cleanly.
+        try:
+            team_md_path = teams_store.team_md_path(team_name)
+            if team_md_path is not None:
+                goal_lines: list[str] = []
+                if north_star:
+                    goal_lines.append(north_star)
+                if success_criteria:
+                    if goal_lines:
+                        goal_lines.append("")
+                    goal_lines.append("Success criteria:")
+                    goal_lines.extend(f"- {sc}" for sc in success_criteria)
+                goal_md = "\n".join(goal_lines) or "_No goal set._"
+                team_md_path.parent.mkdir(parents=True, exist_ok=True)
+                existing = (
+                    team_md_path.read_text(errors="replace")
+                    if team_md_path.exists()
+                    else f"# {team_name}\n"
+                )
+                updated = replace_markdown_section(existing, "Goal", goal_md)
+                team_md_path.write_text(updated)
+                await _push_team_md(team_name, updated)
+        except Exception as e:  # noqa: BLE001 — best-effort mirror, never fail the write
+            logger.warning("goal mirror/push for team %s failed: %s", team_name, e)
 
         _emit_team_event(
             event_bus,

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -346,6 +346,66 @@ async def test_inspect_agents_metrics_failure_falls_back_to_full_fanout():
     assert mc.get_agent_stale_tasks.await_count == 2
 
 
+# ── inspect_teams read-back (goal + budget) tests ────────────
+
+
+@pytest.mark.asyncio
+async def test_inspect_teams_no_mesh_client():
+    from src.agent.builtins.operator_tools import inspect_teams
+
+    result = await inspect_teams()
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_inspect_teams_full_list_surfaces_goal_and_budget():
+    """Phase-1 read-back: inspect_teams passes the mesh row through, so the
+    goal (north_star/success_criteria) + budget envelope are readable."""
+    from src.agent.builtins.operator_tools import inspect_teams
+
+    mc = MagicMock()
+    mc.list_teams = AsyncMock(return_value={"teams": [
+        {
+            "name": "growth",
+            "north_star": "Ship $10k MRR",
+            "success_criteria": ["100 visits/day"],
+            "budget_daily_usd": 5.0,
+            "budget_monthly_usd": 100.0,
+        },
+    ]})
+    result = await inspect_teams(mesh_client=mc)
+    row = result["teams"][0]
+    assert row["north_star"] == "Ship $10k MRR"
+    assert row["success_criteria"] == ["100 visits/day"]
+    assert row["budget_daily_usd"] == 5.0
+    assert row["budget_monthly_usd"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_inspect_teams_single_team_returns_goal_and_budget():
+    """Setting team_name returns the full row (goal + budget) for one team."""
+    from src.agent.builtins.operator_tools import inspect_teams
+
+    mc = MagicMock()
+    mc.list_teams = AsyncMock(return_value={"teams": [
+        {
+            "name": "growth",
+            "north_star": "Ship it",
+            "success_criteria": ["done"],
+            "budget_daily_usd": 2.0,
+            "budget_monthly_usd": 40.0,
+        },
+        {"name": "other", "north_star": None},
+    ]})
+    result = await inspect_teams(team_name="growth", mesh_client=mc)
+    assert result["name"] == "growth"
+    assert result["north_star"] == "Ship it"
+    assert result["success_criteria"] == ["done"]
+    assert result["budget_daily_usd"] == 2.0
+    assert result["budget_monthly_usd"] == 40.0
+
+
 # ── create_agent tests ──────────────────────────��───────────
 
 

--- a/tests/test_team_goal.py
+++ b/tests/test_team_goal.py
@@ -326,3 +326,220 @@ async def test_endpoint_set_goal_clears_when_empty(goal_app):
     body = r.json()
     assert body["north_star"] is None
     assert body["success_criteria"] is None
+
+
+# ── Read-back: GET /mesh/teams surfaces goal + budget ────────────────
+
+
+@pytest.mark.asyncio
+async def test_endpoint_list_teams_returns_goal_and_budget(goal_app):
+    """Phase-1 read-back: the row carries north_star / success_criteria /
+    budget so the operator's inspect_teams can read back what it set
+    (previously these were stripped from the mesh_list_teams row)."""
+    app, teams_store = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/growth/goal",
+            json={
+                "north_star": "Ship $10k MRR",
+                "success_criteria": ["100 visits/day"],
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200
+        # Budget rides the same row — set it directly on the store.
+        teams_store.set_budget("growth", 5.0, 100.0)
+        listing = await c.get("/mesh/teams", headers={"X-Agent-ID": "operator"})
+    assert listing.status_code == 200, listing.text
+    rows = {t["name"]: t for t in listing.json()["teams"]}
+    growth = rows["growth"]
+    assert growth["north_star"] == "Ship $10k MRR"
+    assert growth["success_criteria"] == ["100 visits/day"]
+    assert growth["budget_daily_usd"] == 5.0
+    assert growth["budget_monthly_usd"] == 100.0
+    # Additive/back-compat: the legacy keys still ride the row.
+    assert growth["name"] == "growth"
+    assert growth["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_list_teams_goal_defaults_none(goal_app):
+    """A team with no goal set reads back null goal/budget fields (the
+    keys are always present — additive, back-compat)."""
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        listing = await c.get("/mesh/teams", headers={"X-Agent-ID": "operator"})
+    row = {t["name"]: t for t in listing.json()["teams"]}["growth"]
+    assert row["north_star"] is None
+    assert row["success_criteria"] is None
+    assert row["budget_daily_usd"] is None
+    assert row["budget_monthly_usd"] is None
+
+
+# ── Goal propagation: mirror into TEAM.md + push to running members ──
+
+
+class _FakeGoalTransport:
+    """Records ``PUT /team`` pushes so the propagation tests can assert the
+    goal content reached running members. ``fail=True`` makes every push
+    raise, exercising the best-effort guarantee (the goal write must still
+    succeed)."""
+
+    def __init__(self, fail: bool = False):
+        self.calls: list[dict] = []
+        self.fail = fail
+
+    async def request(self, agent_id, method, path, json=None, timeout=120, headers=None):
+        self.calls.append({
+            "agent_id": agent_id, "method": method, "path": path, "json": json,
+        })
+        if self.fail:
+            raise RuntimeError("member unreachable")
+        return {"updated": True}
+
+
+@pytest.fixture
+def goal_push_app(tmp_path, monkeypatch, request):
+    """Disk-backed TeamStore (real team.md scaffold) + fake transport so
+    the goal endpoint's TEAM.md mirror + running-member push are
+    observable. ``indirect`` param toggles a transport that raises on
+    every push."""
+    from src.host.teams import TeamStore
+
+    fail_push = getattr(request, "param", False)
+    monkeypatch.chdir(tmp_path)
+    server_module = _reload_server(monkeypatch)
+
+    permissions = PermissionMatrix()
+    for aid, perms in {
+        "operator": {"can_route_tasks": True, "can_manage_teams": True},
+        "writer": {"can_route_tasks": False},
+    }.items():
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+
+    # writer is RUNNING (in the registry); editor is a member but stopped
+    # (absent from the registry) → only writer should be pushed to.
+    router = MessageRouter(permissions, {
+        "operator": "http://op:8400",
+        "writer": "http://writer:8400",
+    })
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    teams_store = TeamStore(
+        db_path=str(tmp_path / "teams.db"),
+        teams_dir=tmp_path / "teams",
+    )
+    transport = _FakeGoalTransport(fail=fail_push)
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=PubSub(),
+        router=router,
+        permissions=permissions,
+        teams_store=teams_store,
+        transport=transport,  # type: ignore[arg-type]
+    )
+    teams_store.create_team("growth", description="growth project")
+    teams_store.add_member("growth", "writer")
+    teams_store.add_member("growth", "editor")
+    team_md = tmp_path / "teams" / "growth" / "team.md"
+    yield app, teams_store, transport, team_md
+    blackboard.close()
+    importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_mirrors_into_team_md_and_pushes(goal_push_app):
+    """set_goal mirrors the north_star + success criteria into a reserved
+    ``## Goal`` section of TEAM.md and pushes it to running members —
+    closing the design-doc §1-finding-4 'ghost goal' gap."""
+    app, teams_store, transport, team_md = goal_push_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/growth/goal",
+            json={
+                "north_star": "Ship $10k MRR landing page",
+                "success_criteria": ["100 visits/day", "5 demos/wk"],
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+
+    on_disk = team_md.read_text()
+    assert "## Goal" in on_disk
+    assert "Ship $10k MRR landing page" in on_disk
+    assert "- 100 visits/day" in on_disk
+    assert "- 5 demos/wk" in on_disk
+    # Section-scoped: original scaffold context is preserved.
+    assert "growth project" in on_disk
+
+    # Pushed to the RUNNING member only (writer), never the stopped one.
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    assert call["agent_id"] == "writer"
+    assert call["path"] == "/team"
+    # The pushed content is exactly the updated TEAM.md (carries the goal).
+    assert call["json"]["content"] == on_disk
+    assert "Ship $10k MRR landing page" in call["json"]["content"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("goal_push_app", [True], indirect=True)
+async def test_endpoint_set_goal_survives_push_failure(goal_push_app):
+    """A push that raises must NOT fail the goal write (best-effort): the
+    persisted row is the source of truth and the mirror still happens."""
+    app, teams_store, transport, team_md = goal_push_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/growth/goal",
+            json={"north_star": "keep going", "success_criteria": ["ship"]},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["north_star"] == "keep going"
+    # Goal still persisted despite the failing push.
+    assert teams_store.get_team("growth")["north_star"] == "keep going"
+    # TEAM.md mirror still written (the write precedes the push).
+    assert "## Goal" in team_md.read_text()
+    assert "keep going" in team_md.read_text()
+    # The push WAS attempted against the running member (and raised).
+    assert transport.calls and transport.calls[0]["agent_id"] == "writer"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_survives_mirror_failure(goal_push_app, monkeypatch):
+    """A TEAM.md write/format hiccup must NOT fail the goal write; the
+    mirror aborts cleanly before any push is attempted."""
+    import src.host.server as server_module
+
+    app, teams_store, transport, _team_md = goal_push_app
+    monkeypatch.setattr(
+        server_module,
+        "replace_markdown_section",
+        MagicMock(side_effect=RuntimeError("disk full")),
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/growth/goal",
+            json={"north_star": "resilient", "success_criteria": ["x"]},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    assert teams_store.get_team("growth")["north_star"] == "resilient"
+    # Mirror aborted before reaching the push.
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_no_team_md_is_noop(goal_app):
+    """Solo/teamless team with no shared TEAM.md (pure-DB store): the goal
+    persists and the mirror no-ops cleanly (no crash, no push)."""
+    app, teams_store = goal_app
+    # goal_app's store is :memory: (teams_dir=None) → no TEAM.md path.
+    assert teams_store.team_md_path("growth") is None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/growth/goal",
+            json={"north_star": "solo goal"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    assert teams_store.get_team("growth")["north_star"] == "solo goal"


### PR DESCRIPTION
## Why

Phase-1 of `docs/plans/2026-07-16-autonomous-team-delivery.md`. A product review found the team goal is a "ghost" (design doc §1 finding 4): `set_team_goal` wrote a DB column with **zero readers in `src/agent/`**, so a goal never reached a running member, and the operator had **no tool to read a team's goal/budget back**. This fixes both, safely and additively.

## What

**Read-back** — `GET /mesh/teams` (`mesh_list_teams`) previously stripped `north_star` / `success_criteria` / `budget_daily_usd` / `budget_monthly_usd` from each row. They now ride the row (additive, back-compat). The operator's `inspect_teams` tool passes them through and its description now advertises the read-back.

**Goal-as-event (propagation)** — after the persisted `teams_store.set_goal(...)`, `POST /mesh/teams/{name}/goal` mirrors the north_star + success criteria into a reserved `## Goal` section of the team's shared TEAM.md and live-pushes it to running members, **reusing the exact brief mechanism**: `replace_markdown_section` (section-scoped write) + `_push_team_md` (concurrent per-member `PUT /team`). 

## Invariants

- **Best-effort:** the whole mirror/push is wrapped — a TEAM.md/push hiccup logs a warning and never fails the goal write (the persisted row is the source of truth).
- **Solo/teamless with no TEAM.md** (pure-DB store) no-ops cleanly (`team_md_path` is `None`).
- Additive / back-compat only; goals stay **operator-write-only** (no worker write path added).

## Scope

Touches only `src/host/server.py` (`mesh_list_teams` + the `POST .../goal` handler), `src/agent/builtins/operator_tools.py` (`inspect_teams`), and tests. The team-members endpoint and dashboard are untouched (sibling PRs own those).

## Tests

`tests/test_team_goal.py`: `test_endpoint_list_teams_returns_goal_and_budget`, `test_endpoint_list_teams_goal_defaults_none`, `test_endpoint_set_goal_mirrors_into_team_md_and_pushes`, `test_endpoint_set_goal_survives_push_failure`, `test_endpoint_set_goal_survives_mirror_failure`, `test_endpoint_set_goal_no_team_md_is_noop`.
`tests/test_operator_tools.py`: `test_inspect_teams_no_mesh_client`, `test_inspect_teams_full_list_surfaces_goal_and_budget`, `test_inspect_teams_single_team_returns_goal_and_budget`.

Gate (`test_teams.py test_operator_tools.py test_dashboard_ui.py test_team_goal.py test_team_brief.py`): **436 passed, 3 skipped**. `ruff check` clean on touched files.