### PR TITLE
dashboard: surface team goal criteria, plate probe names, blocked work

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6185,18 +6185,27 @@ def create_dashboard_router(
             health_map = {h["agent"]: h.get("status") for h in health_monitor.get_status()}
 
         # Current task per member: the (at most one, by design — B1
-        # single-lane) "working" task. One team-scoped query, not one
-        # per member.
+        # single-lane) "working" task, plus any "blocked" task. Without
+        # the blocked bucket a blocked agent has no working task, so it
+        # rendered identically to an idle one — the room's whole point
+        # is a glance at who's doing what, and "stopped, waiting on
+        # something" is not the same as "nothing to do". One team-scoped
+        # query per status bucket, not one per member.
         current_task_by_agent: dict[str, dict] = {}
+        blocked_task_by_agent: dict[str, dict] = {}
         if tasks_store is not None:
             try:
-                for row in tasks_store.list_team(team_name, statuses=["working"]):
+                for row in tasks_store.list_team(team_name, statuses=["working", "blocked"]):
                     assignee = row.get("assignee")
-                    if assignee and assignee not in current_task_by_agent:
-                        current_task_by_agent[assignee] = {
+                    if not assignee:
+                        continue
+                    bucket = current_task_by_agent if row.get("status") == "working" else blocked_task_by_agent
+                    if assignee not in bucket:
+                        bucket[assignee] = {
                             "id": row.get("id"),
                             "title": row.get("title"),
                             "status": row.get("status"),
+                            "blocker_note": row.get("blocker_note"),
                         }
             except Exception as e:
                 logger.warning("Team Room %s: tasks lookup failed: %s", team_name, e)
@@ -6211,6 +6220,7 @@ def create_dashboard_router(
                 "busy": bool(status.get("busy", False)),
                 "queued": status.get("queued", 0),
                 "current_task": current_task_by_agent.get(agent_id),
+                "blocked_task": blocked_task_by_agent.get(agent_id),
                 "plate": plate,
                 "health": health_map.get(agent_id),
             })

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -2829,6 +2829,15 @@ function dashboard() {
       return `${Math.round(s / 86400)}d`;
     },
 
+    // Plain-English label for a heartbeat probe name (Team Room plate
+    // line). The room payload only carries the raw snake_case probe
+    // name (e.g. "goal_coverage", "lead_blocked_tasks") — this just
+    // makes it readable without a lookup table to keep in sync with
+    // ``cron.py``'s probe names.
+    probeLabel(name) {
+      return String(name || '').replace(/_/g, ' ');
+    },
+
     // One-line "what's happening now" for the collapsed pipeline card:
     // the first non-terminal stage and what it's doing. Plain text.
     pipelineCurrentLabel(p) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1774,10 +1774,21 @@
                    plate per agent. Composed read-only view; the operator's
                    default landing when opening a team.) ── -->
               <div x-show="teamHubTab === 'room'" x-cloak class="px-4 py-3" data-testid="team-room-panel">
-                <!-- Team goal header -->
-                <div x-show="teamRoom?.team?.north_star" class="mb-3 px-3 py-2 rounded-lg bg-indigo-900/10 border border-indigo-800/30" data-testid="team-room-goal">
+                <!-- Team goal header — north_star + its success_criteria
+                     checklist (the room payload already carries both;
+                     only north_star rendered before, so the criteria a
+                     lead/agent is actually working toward were invisible). -->
+                <div x-show="teamRoom?.team?.north_star || (teamRoom?.team?.success_criteria || []).length" class="mb-3 px-3 py-2 rounded-lg bg-indigo-900/10 border border-indigo-800/30" data-testid="team-room-goal">
                   <div class="text-[11px] uppercase tracking-wide text-indigo-400/80 mb-0.5">Team goal</div>
-                  <div class="text-xs text-gray-300" x-text="teamRoom?.team?.north_star"></div>
+                  <div class="text-xs text-gray-300" x-show="teamRoom?.team?.north_star" x-text="teamRoom?.team?.north_star"></div>
+                  <ul x-show="(teamRoom?.team?.success_criteria || []).length" class="mt-1.5 space-y-0.5" data-testid="team-room-success-criteria">
+                    <template x-for="(c, ci) in (teamRoom?.team?.success_criteria || [])" :key="'crit-' + ci">
+                      <li class="text-[11px] text-gray-400 flex items-start gap-1.5">
+                        <span class="text-indigo-400/70">✓</span>
+                        <span x-text="c"></span>
+                      </li>
+                    </template>
+                  </ul>
                 </div>
 
                 <!-- first-load spinner -->
@@ -1798,8 +1809,8 @@
                               <img :src="agentAvatarUrl(m.agent_id)" :alt="m.agent_id">
                             </div>
                             <span class="w-2 h-2 rounded-full flex-shrink-0"
-                              :class="m.busy ? 'bg-amber-400' : 'bg-emerald-400'"
-                              :title="m.busy ? 'Busy' : 'Idle'"></span>
+                              :class="m.blocked_task ? 'bg-red-400' : (m.busy ? 'bg-amber-400' : 'bg-emerald-400')"
+                              :title="m.blocked_task ? 'Blocked' : (m.busy ? 'Busy' : 'Idle')"></span>
                             <span class="text-xs text-gray-300 truncate" x-text="m.agent_id"></span>
                             <span x-show="m.is_lead"
                               class="text-[11px] px-1.5 py-0.5 rounded bg-amber-900/30 text-amber-400 border border-amber-800/40 flex-shrink-0"
@@ -1810,14 +1821,32 @@
                           </div>
                           <div class="text-[11px] text-gray-400 mt-1.5 truncate" x-show="m.current_task"
                             :title="m.current_task?.title" x-text="'Working: ' + (m.current_task?.title || '')"></div>
-                          <div class="text-[11px] text-gray-500 mt-1" x-show="!m.current_task">No active task.</div>
+                          <div class="text-[11px] text-gray-500 mt-1" x-show="!m.current_task && !m.blocked_task">No active task.</div>
                           <div class="text-[11px] text-gray-500 mt-1" data-testid="team-room-plate-line">
-                            <template x-if="m.plate">
-                              <span x-text="(m.plate.triggered_probes?.length || 0) + ' items on plate · last checked ' + relativeTime(m.plate.checked_at)"></span>
-                            </template>
                             <template x-if="!m.plate">
                               <span>plate unknown</span>
                             </template>
+                            <template x-if="m.plate">
+                              <span x-text="(m.plate.triggered_probes?.length || 0) + ' items on plate · last checked ' + relativeTime(m.plate.checked_at)"></span>
+                            </template>
+                            <!-- Probe names, not just a count — "3 items on
+                                 plate" alone doesn't distinguish goal-coverage
+                                 from a blocked-task escalation from a lead
+                                 review. -->
+                            <div x-show="m.plate && (m.plate.triggered_probes || []).length" class="flex flex-wrap gap-1 mt-1" data-testid="team-room-plate-probes">
+                              <template x-for="p in (m.plate?.triggered_probes || [])" :key="p">
+                                <span class="text-[10px] px-1.5 py-0.5 rounded bg-gray-700/50 text-gray-400 border border-gray-700/60" :title="p" x-text="probeLabel(p)"></span>
+                              </template>
+                            </div>
+                          </div>
+                          <!-- Blocked state — read-only: free-form blocked
+                               tasks are operator-handled, no resolve action
+                               here. Without this, a blocked agent had no
+                               "working" task and rendered as idle. -->
+                          <div class="text-[11px] text-red-300 mt-1.5" x-show="m.blocked_task" data-testid="team-room-member-blocked">
+                            <div class="truncate" :title="m.blocked_task?.title" x-text="'Blocked: ' + (m.blocked_task?.title || '')"></div>
+                            <div class="text-red-400/70 truncate" x-show="m.blocked_task?.blocker_note"
+                              :title="m.blocked_task?.blocker_note" x-text="_humanizeBlocker(m.blocked_task?.blocker_note).label"></div>
                           </div>
                         </div>
                       </template>
@@ -4632,6 +4661,55 @@
           </section>
         </template>
 
+        <!-- Blocked tasks panel — fleet-wide status='blocked' list. The
+             dashboard already fetched this into ``workplaceBlockers``
+             (loadWorkplaceBlockers) but nothing rendered it, so a blocked
+             task was invisible fleet-wide. Deliberately read-only: no
+             Cancel/Restart row actions — free-form blocked tasks are
+             operator-handled, not user-resolvable from here (see
+             docs/plans/2026-07-16-autonomous-team-delivery.md). Rows
+             still open the drill-in modal for detail, same as Stuck tasks. -->
+        <template x-if="workplaceErrors.blockers">
+          <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-2"
+               role="alert" data-testid="workplace-blockers-error">
+            <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.blockers"></span>
+            <button type="button" @click="retryWorkplaceSection('blockers')"
+              class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
+          </div>
+        </template>
+        <template x-if="workplaceEnabled && workplaceBlockers.length">
+          <section class="bg-red-950/30 border border-red-800/50 rounded-xl p-3 mb-3"
+            data-testid="board-blocked-tasks"
+            aria-label="Blocked tasks">
+            <div class="flex items-center justify-between mb-2">
+              <div class="flex items-center gap-2">
+                <span class="text-[11px] uppercase tracking-wide text-red-300 font-semibold">Blocked tasks</span>
+                <span class="font-mono px-1.5 rounded bg-red-700/40 text-red-100 text-[11px]"
+                  x-text="workplaceBlockers.length"></span>
+              </div>
+              <span class="text-[11px] text-red-300/70">Read-only — blocked work is operator-handled</span>
+            </div>
+            <div class="space-y-1.5">
+              <template x-for="b in workplaceBlockers" :key="'blocked-' + b.id">
+                <button type="button" class="w-full flex items-center gap-2 bg-gray-900/40 border border-red-800/30 rounded-md px-2.5 py-1.5 text-left"
+                  data-testid="board-blocked-task-row"
+                  @click="openTaskDrillIn(b.id)">
+                  <div class="min-w-0 flex-1">
+                    <div class="text-xs text-gray-100 truncate"
+                      :title="b.title"
+                      x-text="truncateTitle(b.title, 80)"></div>
+                    <div class="text-[11px] text-red-200/80 mt-0.5">
+                      <span x-text="b.assignee || '(unassigned)'"></span>
+                      <span x-show="b.team_id" class="text-gray-400"
+                        x-text="'· ' + (b.team_id || '')"></span>
+                      <span class="ml-1 text-red-300" x-text="'· ' + _humanizeBlocker(b.blocker_note).label"></span>
+                    </div>
+                  </div>
+                </button>
+              </template>
+            </div>
+          </section>
+        </template>
 
         <!-- Phase 4 — task cancel confirmation modal. Opens via
              ``confirmCancelTask`` from the stuck-tasks [Cancel] button

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3535,7 +3535,7 @@ class TestTeamRoomEndpoint:
         teams_store.add_member("team", "alpha")
         teams_store.add_member("team", "beta")
         teams_store.set_lead("team", "alpha")
-        teams_store.set_goal("team", "Ship it")
+        teams_store.set_goal("team", "Ship it", ["Well is dug", "Water tested safe"])
 
         # alpha: busy + queued, working a task
         self.components["lane_manager"].get_status.return_value = {
@@ -3573,6 +3573,7 @@ class TestTeamRoomEndpoint:
         assert data["team"]["name"] == "team"
         assert data["team"]["description"] == "desc"
         assert data["team"]["north_star"] == "Ship it"
+        assert data["team"]["success_criteria"] == ["Well is dug", "Water tested safe"]
         assert data["team"]["lead_agent_id"] == "alpha"
 
         members = {m["agent_id"]: m for m in data["members"]}
@@ -3585,15 +3586,47 @@ class TestTeamRoomEndpoint:
         assert alpha["current_task"]["title"] == "Dig the well"
         assert alpha["current_task"]["status"] == "working"
         assert alpha["plate"] == plate
+        assert alpha["blocked_task"] is None
 
         beta = members["beta"]
         assert beta["is_lead"] is False
         assert beta["busy"] is False
         assert beta["current_task"] is None
         assert beta["plate"] is None
+        assert beta["blocked_task"] is None
 
         assert len(data["threads"]) == 1
         assert data["threads"][0]["id"] == ch["id"]
+
+    def test_blocked_task_surfaced_separately_from_current_task(self):
+        """A BLOCKED task must not disappear from the room payload just
+        because the composer's ``current_task`` query is scoped to
+        ``working`` — otherwise a blocked agent has no current_task and
+        renders identically to an idle one. ``blocked_task`` carries the
+        title + blocker_note so the Team Room can show why an agent
+        looks stopped instead of just idle."""
+        teams_store = self.components["teams_store"]
+        teams_store.create_team("team")
+        teams_store.add_member("team", "alpha")
+
+        rec = self.tasks_store.create(
+            creator="operator", assignee="alpha", title="Fetch the API key", team_id="team",
+        )
+        self.tasks_store.update_status(rec["id"], "working", actor="alpha")
+        self.tasks_store.update_status(
+            rec["id"], "blocked", actor="alpha", blocker_note="cred:stripe_api_key",
+        )
+
+        resp = self.client.get("/dashboard/api/teams/team/room")
+        assert resp.status_code == 200
+        member = resp.json()["members"][0]
+
+        # No "working" task, so current_task stays None...
+        assert member["current_task"] is None
+        # ...but blocked_task surfaces the same underlying task.
+        assert member["blocked_task"]["title"] == "Fetch the API key"
+        assert member["blocked_task"]["status"] == "blocked"
+        assert member["blocked_task"]["blocker_note"] == "cred:stripe_api_key"
 
     def test_member_with_no_lane_status_defaults_idle(self):
         """A member absent from lane_manager.get_status() still appears,

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2908,6 +2908,80 @@ class TestTeamRoomSubTab:
         assert "'POST'" not in block and '"POST"' not in block
 
 
+class TestTeamRoomGoalAndBlockedVisibility:
+    """Phase-1 (plan §1, docs/plans/2026-07-16-autonomous-team-delivery.md)
+    dashboard-only visibility fixes: the room payload already carried
+    ``success_criteria`` and per-agent ``blocked_task`` data the panel
+    never rendered, and the plate line showed a bare probe count."""
+
+    def test_success_criteria_rendered_in_goal_box(self):
+        idx = _INDEX_HTML.index('data-testid="team-room-goal"')
+        block = _INDEX_HTML[idx:idx + 900]
+        assert "team-room-success-criteria" in block
+        assert "teamRoom?.team?.success_criteria" in block
+        assert "teamRoom?.team?.north_star" in block
+
+    def test_plate_line_renders_probe_names_not_just_count(self):
+        idx = _INDEX_HTML.index('data-testid="team-room-plate-line"')
+        block = _INDEX_HTML[idx:idx + 1200]
+        assert "team-room-plate-probes" in block
+        assert "triggered_probes" in block
+        assert "probeLabel(p)" in block
+
+    def test_probe_label_helper_defined(self):
+        assert "probeLabel(name)" in _APP_JS_TEXT
+
+    def test_member_card_renders_blocked_state_not_idle(self):
+        """A blocked agent must stop reading as idle: the busy/idle dot
+        and its tooltip must both branch on ``m.blocked_task``, and a
+        dedicated read-only "Blocked: ..." line must render."""
+        idx = _INDEX_HTML.index('data-testid="team-room-member-card"')
+        block = _INDEX_HTML[idx:idx + 4200]
+        assert "m.blocked_task ? 'bg-red-400'" in block
+        assert "m.blocked_task ? 'Blocked'" in block
+        assert 'data-testid="team-room-member-blocked"' in block
+        assert "'Blocked: ' + (m.blocked_task?.title" in block
+        assert "_humanizeBlocker(m.blocked_task?.blocker_note).label" in block
+        # No fake resolve button on this read-only card.
+        assert "resolveBlocked" not in block
+        assert "<button" not in block[block.index('data-testid="team-room-member-blocked"'):]
+
+    def test_no_active_task_excludes_blocked_members(self):
+        idx = _INDEX_HTML.index('data-testid="team-room-member-card"')
+        block = _INDEX_HTML[idx:idx + 4200]
+        assert 'x-show="!m.current_task && !m.blocked_task"' in block
+
+
+class TestWorkplaceBlockedTasksPanel:
+    """Phase-1 fix: ``workplaceBlockers`` (loaded by
+    ``loadWorkplaceBlockers`` from ``/api/workplace/blockers``) was
+    fetched but never rendered anywhere in the Work tab. The new panel
+    is deliberately read-only — free-form blocked tasks are operator-
+    handled, not user-resolvable, so there is no resolve/unblock CTA."""
+
+    def test_panel_present_and_bound_to_workplace_blockers(self):
+        assert 'data-testid="board-blocked-tasks"' in _INDEX_HTML
+        assert 'data-testid="board-blocked-task-row"' in _INDEX_HTML
+        idx = _INDEX_HTML.index('data-testid="board-blocked-tasks"')
+        block = _INDEX_HTML[idx:idx + 1800]
+        assert "workplaceBlockers" in block
+        assert "_humanizeBlocker(b.blocker_note).label" in block
+
+    def test_panel_is_read_only_no_resolve_button(self):
+        idx = _INDEX_HTML.index('data-testid="board-blocked-tasks"')
+        end = _INDEX_HTML.index("</section>", idx)
+        block = _INDEX_HTML[idx:end]
+        assert "<button" not in block or "openTaskDrillIn" in block
+        assert "Cancel</button>" not in block
+        assert "Restart agent</button>" not in block
+
+    def test_error_banner_uses_existing_retry_helper(self):
+        assert 'data-testid="workplace-blockers-error"' in _INDEX_HTML
+        idx = _INDEX_HTML.index('data-testid="workplace-blockers-error"')
+        block = _INDEX_HTML[max(0, idx - 300):idx + 300]
+        assert "retryWorkplaceSection('blockers')" in block
+
+
 # ── Phase-5 U5: lead advisory recommendations + autonomy log (§8 #19) ──
 
 


### PR DESCRIPTION
## Summary

Phase-1 of `docs/plans/2026-07-16-autonomous-team-delivery.md` (Team invariants +
stewardship) calls out that the operator's stewardship signals only matter if a
human can actually see them. This PR is a dashboard-only visibility pass: three
places where the dashboard already fetches data but never renders it.

- **Team goal box** (`templates/index.html`, Team Room panel): `GET
  /api/teams/{name}/room` already returns `success_criteria` alongside
  `north_star`, but only `north_star` was rendered. Now renders the criteria as
  a small checklist next to the goal.
- **Plate line** (`templates/index.html`): showed only `triggered_probes.length
  + ' items on plate'`. A `goal_coverage` probe, a `lead_blocked_tasks`
  escalation, and a `lead_pending_reviews` alert all looked identical. Now
  renders the probe names (small pills, `probeLabel()` in `app.js` turns
  `snake_case` into readable text).
- **Blocked work was invisible in two places**:
  - `src/dashboard/server.py`'s Team Room composer queried
    `tasks_store.list_team(team, statuses=["working"])` only, so a BLOCKED
    agent had no `current_task` and rendered exactly like an idle one. The
    composer now also buckets each member's `blocked` task (title +
    `blocker_note`); the member card shows a red dot instead of green/idle
    and a read-only "Blocked: ..." line (reuses the existing
    `_humanizeBlocker` helper).
  - `app.js` already fetched `/api/workplace/blockers` into
    `workplaceBlockers` (`loadWorkplaceBlockers`) but nothing rendered it.
    Added a read-only "Blocked tasks" panel to the Work tab, following the
    existing Stuck Tasks panel's layout/testid conventions minus the
    Cancel/Restart actions — free-form blocked tasks are operator-handled,
    not user-resolvable, so this panel deliberately has no resolve button.

No `src/host/**` or `src/agent/**` changes (those are sibling PRs' scope) —
purely `src/dashboard/**` + dashboard tests.

## Test plan

- [x] `tests/test_dashboard_ui.py` (pinned UI/markup contract) — added
      `TestTeamRoomGoalAndBlockedVisibility` + `TestWorkplaceBlockedTasksPanel`,
      kept every pre-existing pinned substring/offset check green.
- [x] `tests/test_dashboard.py::TestTeamRoomEndpoint` — extended the composed
      payload test to assert `success_criteria` round-trips and
      `blocked_task is None` for non-blocked members; added
      `test_blocked_task_surfaced_separately_from_current_task`.
- [x] Full gate: `tests/test_dashboard_ui.py tests/test_dashboard*.py` — 896
      passed, 3 skipped (pre-existing e2e skips), 0 failed.
- [x] `ruff check src/dashboard/server.py` — clean.