### PR TITLE
feat(teams): auto-appoint lead on add-members + teach the levers

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6970,6 +6970,35 @@ def create_mesh_app(
             _purge_departed_team_signals(agent, old)
         _add_team_blackboard_permissions(agent, team_name)
         permissions.reload()
+        # Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
+        # delivery.md §1/§3): the operator's documented team-build order is
+        # create-empty-team → create-agents → ``add_agents_to_team``, so the
+        # add-members path — NOT just ``mesh_create_team`` — is where a team
+        # first crosses out of solo territory. Without mirroring the create-
+        # path auto-appoint here, a by-the-book team sits LEADERLESS until the
+        # next mesh reboot's backfill, leaving the lead-gated stewardship
+        # machinery (standup, goal-coverage probe, blocked-task escalation,
+        # drive-review verdicts) dormant. Appoint the first real member as
+        # lead once the roster reaches >=2 real members — but NEVER re-appoint
+        # over an existing lead, and NEVER the operator (already excluded from
+        # membership; ``set_lead`` re-checks real membership + refuses the
+        # operator). A solo/one-member team self-leads (no lead row). Best-
+        # effort: a failure here must not fail the add-members response; the
+        # boot backfill catches any drift.
+        try:
+            _team = teams_store.get_team(team_name) or {}
+            _real_members = [m for m in _team.get("members", []) if m != "operator"]
+            if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
+                try:
+                    teams_store.set_lead(team_name, _real_members[0])
+                    # Wire the new lead's standup cron immediately (same helper
+                    # the dedicated lead endpoint uses) so stewardship starts
+                    # now, not at the next mesh restart.
+                    _sync_standup_job_on_lead_change(team_name, _real_members[0])
+                except (TeamNotFound, ValueError) as e:
+                    logger.warning("auto-appoint lead for team %s failed: %s", team_name, e)
+        except Exception as e:
+            logger.warning("auto-appoint lead check for team %s failed: %s", team_name, e)
         _schedule_onboarding_wake(agent, team_name)
         return {"added": True, "team_id": team_name, "team_name": team_name, "agent": agent}
 

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -356,6 +356,25 @@ about gut health". Success criteria are 2–5 measurable checks, e.g. \
 "100 unique landing-page visitors per day", "Posts ranked on page 1 \
 for target keyword". No confirmation gate — just call it.
 
+   **Ensure the team has a lead once the roster is 2+.** A non-solo team \
+needs one accountability owner: the lead receives standup duty, \
+goal-coverage and blocked-task escalation alerts, and advisory review \
+verdicts — without one, that whole stewardship loop stays dormant. \
+add_agents_to_team AUTO-APPOINTS the first member as lead the moment a \
+team crosses to two real members, so usually you don't lift a finger. To \
+hand the role to a specific agent (the senior or owning one), call \
+set_team_lead(team_name, agent_name) — it reassigns over the auto-pick. \
+A solo/one-member team self-leads and needs no lead.
+
+   **Set a spend envelope.** An unset team budget is UNLIMITED — every \
+member's LLM spend runs uncapped. Put a sane ceiling on the team with \
+manage_team(action='set_budget', team_name=X, daily_usd=..., \
+monthly_usd=...); supply BOTH limits, since an omitted or 0 field means \
+unlimited for that period. Pick a default proportional to the team's \
+size and cadence (e.g. a modest daily cap for a 2-3 agent content team) \
+— you can always raise it later. This is the aggregate envelope across \
+all members; per-member allocation is a separate lead-side lever.
+
 4. **Customize instructions**: For each agent, call edit_agent(agent_id, \
 "instructions", value, reason="user_asked") — instructions is a soft field \
 so it applies immediately. Excellent instructions are specific:
@@ -520,6 +539,39 @@ asking — the user can Undo if you got it wrong.
 6. If everything is green, tell the user in one line.
 
 Surface issues briefly when the user engages. Mention once, don't repeat.
+
+## Improvement levers — act, don't just observe
+
+Monitoring is only half the job. When you spot a problem, these are the \
+tools that actually change agent behavior. Use them proactively, not \
+only when the user asks:
+
+- **rate_delivery(task_id, outcome, feedback)** — review a completed \
+deliverable and record your judgment. This is not just bookkeeping: \
+``rework``/``rejected`` feedback is pushed into the rated agent's \
+learnings so it does better next time (and ``rework`` auto-spawns a \
+follow-up task). Rate deliverables as they land — a steady stream of \
+honest ratings is the single biggest lever on agent quality.
+
+- **set_agent_goals(agent_id, goals)** — the tool that ACTUALLY \
+redirects one worker. Its standing goals ride that agent's every prompt \
+and steer its idle heartbeats. Reach for this — not set_team_goal, which \
+sets the shared team north star — when a single agent has drifted or \
+needs a new focus.
+
+- **manage_task(task_id, action)** — reroute a stuck task to a \
+better-suited agent (action='reroute', new_assignee=...) or retry a \
+failed one (action='retry'). Don't let a blocked/failed task sit — move \
+it.
+
+- **inspect_team_spend(team_name)** — check a team's actual spend \
+against its envelope. A team near or over budget is why its work stalls \
+(over-budget agents refuse new tasks); raise the ceiling with \
+manage_team(action='set_budget', ...) or rebalance the load.
+
+- **inspect_teams(team_name=X)** — read a team's goal (north_star / \
+success_criteria), lead, and budget back so you can confirm they're \
+still set and sane before diagnosing deeper.
 
 ## Outcome ratings (Board tab)
 

--- a/tests/test_cron_standup.py
+++ b/tests/test_cron_standup.py
@@ -418,6 +418,96 @@ class TestPostToChannelNotAgentSettable:
             importlib.reload(server_module)
 
 
+class TestAddMemberAutoAppointWiresStandup:
+    """Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
+    delivery.md §1/§3): the ``POST /mesh/teams/{name}/members`` endpoint
+    (what ``add_agents_to_team`` calls) must wire the auto-appointed lead's
+    standup cron LIVE — not defer it to the next mesh reboot's reconcile."""
+
+    @pytest.mark.asyncio
+    async def test_add_member_crossing_to_two_wires_standup_job(self, tmp_path, monkeypatch):
+        import importlib
+        import json as _json
+
+        import yaml as _yaml
+        from httpx import ASGITransport, AsyncClient
+
+        monkeypatch.chdir(tmp_path)
+        import src.cli.config as cli_cfg
+
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(
+            _json.dumps(
+                {
+                    "permissions": {
+                        "agent1": {"blackboard_read": [], "blackboard_write": []},
+                        "agent2": {"blackboard_read": [], "blackboard_write": []},
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", perms_file)
+        agents_file = tmp_path / "agents.yaml"
+        agents_file.write_text(
+            _yaml.dump(
+                {
+                    "agents": {
+                        "agent1": {"role": "a"},
+                        "agent2": {"role": "b"},
+                        "operator": {"role": "operator"},
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(cli_cfg, "AGENTS_FILE", agents_file)
+
+        import src.host.server as server_module
+
+        importlib.reload(server_module)
+        from src.host.cron import CronScheduler
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.teams import TeamStore
+
+        permissions = PermissionMatrix()
+        router = MessageRouter(
+            permissions,
+            {"operator": "http://op:8400", "agent1": "http://a1:8400", "agent2": "http://a2:8400"},
+        )
+        blackboard = Blackboard(str(tmp_path / "bb.db"))
+        cron_scheduler = CronScheduler(config_path=str(tmp_path / "cron.json"))
+        teams_store = TeamStore(db_path=str(tmp_path / "teams.db"), teams_dir=tmp_path / "teams")
+        teams_store.create_team("squad")
+        app = server_module.create_mesh_app(
+            blackboard=blackboard,
+            pubsub=PubSub(),
+            router=router,
+            permissions=permissions,
+            teams_store=teams_store,
+            cron_scheduler=cron_scheduler,
+            auth_tokens={"operator": "op-token"},
+        )
+        hdr = {"Authorization": "Bearer op-token", "X-Agent-ID": "operator"}
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r1 = await c.post("/mesh/teams/squad/members", json={"agent": "agent1"}, headers=hdr)
+                assert r1.status_code == 200, r1.text
+                # Solo so far: no lead, no standup job yet.
+                assert teams_store.get_team("squad")["lead_agent_id"] is None
+                assert cron_scheduler.find_standup_job("squad") is None
+                r2 = await c.post("/mesh/teams/squad/members", json={"agent": "agent2"}, headers=hdr)
+                assert r2.status_code == 200, r2.text
+            # Crossed to two members: first member auto-appointed + standup wired live.
+            assert teams_store.get_team("squad")["lead_agent_id"] == "agent1"
+            job = cron_scheduler.find_standup_job("squad")
+            assert job is not None
+            assert job.agent == "agent1"
+            assert job.post_to_channel == "squad"
+        finally:
+            blackboard.close()
+            importlib.reload(server_module)
+
+
 # ── Boot reconcile (cli/runtime.RuntimeContext._reconcile_standup_jobs) ──
 
 

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -206,6 +206,12 @@ class TestPlaybookConstants:
         assert "north star" in _PLAYBOOK_TEAM_BUILD.lower()
         assert "request_credential" in _PLAYBOOK_TEAM_BUILD
         assert "request_browser_login" in _PLAYBOOK_TEAM_BUILD
+        # Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
+        # delivery.md §1/§3): the team-build playbook must steer the
+        # operator to ensure a lead and set a spend envelope.
+        assert "set_team_lead" in _PLAYBOOK_TEAM_BUILD
+        assert "set_budget" in _PLAYBOOK_TEAM_BUILD
+        assert "UNLIMITED" in _PLAYBOOK_TEAM_BUILD
 
         assert "edit_agent" in _PLAYBOOK_EDIT
         # New guidance for the act-and-undo posture must be present.
@@ -218,6 +224,17 @@ class TestPlaybookConstants:
         assert "check_inbox" in _PLAYBOOK_MONITOR
         assert "get_system_status" in _PLAYBOOK_MONITOR
         assert "inspect_agents" in _PLAYBOOK_MONITOR
+        # Phase-1 improvement levers (docs/plans/2026-07-16-autonomous-team-
+        # delivery.md §1/§3): the monitor playbook must advertise the
+        # behavior-changing levers, not just observation tools.
+        for lever in (
+            "rate_delivery",
+            "set_agent_goals",
+            "manage_task",
+            "inspect_team_spend",
+            "inspect_teams",
+        ):
+            assert lever in _PLAYBOOK_MONITOR, f"monitor playbook missing lever {lever}"
 
         assert "request_credential" in _PLAYBOOK_CREDENTIALS
         assert "request_browser_login" in _PLAYBOOK_CREDENTIALS

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -97,6 +97,7 @@ def team_app(tmp_path, monkeypatch):
         {
             "agent1": {"blackboard_read": [], "blackboard_write": []},
             "agent2": {"blackboard_read": [], "blackboard_write": []},
+            "agent3": {"blackboard_read": [], "blackboard_write": []},
         },
     )
     import src.cli.config as cli_cfg
@@ -111,6 +112,7 @@ def team_app(tmp_path, monkeypatch):
                 "agents": {
                     "agent1": {"role": "a"},
                     "agent2": {"role": "b"},
+                    "agent3": {"role": "c"},
                     "operator": {"role": "operator"},
                 },
             }
@@ -313,6 +315,62 @@ class TestMeshTeamEndpoints:
         assert r.status_code == 400
         assert "system agent" in r.json()["detail"]
         assert store.members("proj1") == []
+
+    @pytest.mark.asyncio
+    async def test_add_member_crossing_to_two_auto_appoints_lead(self, team_app):
+        """Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
+        delivery.md §1/§3): the documented build order is create-empty-team
+        → create-agents → add_agents_to_team, so the add-members path must
+        mirror the create-path auto-appoint. Crossing to two real members
+        appoints the FIRST member (agent1) as lead."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        r1 = await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        assert r1.status_code == 200, r1.text
+        # Solo so far — self-leads, no lead row.
+        assert store.get_team("proj1")["lead_agent_id"] is None
+        r2 = await _post(app, "/mesh/teams/proj1/members", {"agent": "agent2"})
+        assert r2.status_code == 200, r2.text
+        assert store.get_team("proj1")["lead_agent_id"] == "agent1"
+
+    @pytest.mark.asyncio
+    async def test_add_single_member_appoints_no_lead(self, team_app):
+        """A one-member team self-leads — the add-members path writes no
+        lead row for a solo roster."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        r = await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        assert r.status_code == 200, r.text
+        assert store.get_team("proj1")["lead_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_add_member_to_led_team_leaves_lead_unchanged(self, team_app):
+        """Never re-appoint over an existing lead: adding a third member to
+        a team whose lead is NOT the auto-pick must leave the lead intact."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        store.add_member("proj1", "agent1")
+        store.add_member("proj1", "agent2")
+        # Explicit non-default lead (agent2, not the first-by-rowid agent1).
+        store.set_lead("proj1", "agent2")
+        r = await _post(app, "/mesh/teams/proj1/members", {"agent": "agent3"})
+        assert r.status_code == 200, r.text
+        assert store.members("proj1") == ["agent1", "agent2", "agent3"]
+        assert store.get_team("proj1")["lead_agent_id"] == "agent2"
+
+    @pytest.mark.asyncio
+    async def test_add_member_appointment_failure_does_not_fail_add(self, team_app):
+        """Best-effort appointment: a set_lead failure must not fail the
+        add-members response — the member is still added, lead stays NULL,
+        and the boot backfill catches the drift."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        await _post(app, "/mesh/teams/proj1/members", {"agent": "agent1"})
+        with patch.object(store, "set_lead", side_effect=ValueError("boom")):
+            r = await _post(app, "/mesh/teams/proj1/members", {"agent": "agent2"})
+        assert r.status_code == 200, r.text
+        assert store.team_of("agent2") == "proj1"
+        assert store.get_team("proj1")["lead_agent_id"] is None
 
     @pytest.mark.asyncio
     async def test_move_agent_between_teams_evicts_and_rewires(self, team_app):


### PR DESCRIPTION
## What

Phase-1 of `docs/plans/2026-07-16-autonomous-team-delivery.md` (§1/§3).

PR #1266 wired lead auto-appointment into team **creation**
(`mesh_create_team`), but the operator's documented build order is
create-empty-team → create-agents → `add_agents_to_team`. That
add-members path (`POST /mesh/teams/{name}/members`) had **no lead
logic**, so a team built exactly as instructed stayed LEADERLESS until
the next mesh reboot's backfill — leaving the lead-gated stewardship loop
(standup, goal-coverage probe, blocked-task escalation, drive-review
verdicts) dormant on every operator-built team.

## Changes

**`src/host/server.py` — auto-appoint on add-members.** After a member is
added, if the team now has ≥2 real (non-`operator`) members and no lead,
appoint the first member via `teams_store.set_lead(...)` and wire its
standup cron via `_sync_standup_job_on_lead_change(...)` — mirroring
`mesh_create_team` exactly. Best-effort: never re-appoint over an
existing lead, never the operator, never fail the add-members response;
the boot backfill still catches drift.

**`src/shared/operator_playbooks.py` — teach the levers.**
- Team-build playbook: ensure a lead once the roster is 2+ (auto-appoints;
  `set_team_lead(team_name, agent_name)` reassigns) and set a spend
  envelope via `manage_team(action='set_budget', ...)` (an unset team
  envelope is UNLIMITED).
- Fleet-monitoring playbook: advertise the zero-coverage
  behavior-changing levers — `rate_delivery`, `set_agent_goals` (vs
  `set_team_goal`), `manage_task`, `inspect_team_spend` (sibling PR), and
  reading goal/budget/lead back via `inspect_teams`.

## Tests
- `test_teams.py`: crossing to ≥2 auto-appoints; single-member add
  appoints none; add to an already-led team leaves the lead unchanged;
  appointment failure doesn't fail the add.
- `test_cron_standup.py`: add-members crossing to two wires the
  auto-appointed lead's standup cron live.
- `test_operator_playbooks.py`: pin the new lead/budget/lever guidance.

Gate: `tests/test_teams.py tests/test_cron_standup.py
tests/test_dashboard_ui.py tests/test_operator_playbooks.py` → 381
passed, 3 skipped. `ruff check` clean on touched files.

Scope: only `src/host/server.py` (members endpoint) + `operator_playbooks.py`
+ tests. Create-team / goal endpoints and `src/agent`, `src/dashboard`
untouched (sibling PRs own those).