### PR TITLE
operator: wire team spend + agent budget/track-record readback

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1052,6 +1052,46 @@ async def get_team_outputs(
 
 
 @tool(
+    name="inspect_team_spend",
+    operator_only=True,
+    description=(
+        "Read a team's aggregate spend: total cost + tokens for the "
+        "period, its daily/monthly budget envelope (null = unlimited), "
+        "and a per-member cost/token breakdown. Use this to answer "
+        "'how much has this team spent' or 'who on the team is burning "
+        "the most budget' without fanning out inspect_agents per member."
+    ),
+    parameters={
+        "team_name": {
+            "type": "string",
+            "description": "Team name",
+        },
+        "period": {
+            "type": "string",
+            "description": "today | yesterday | week | month",
+            "default": "today",
+        },
+    },
+)
+async def inspect_team_spend(
+    team_name: str,
+    period: str = "today",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Aggregate team spend + envelope + per-member breakdown."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    try:
+        return await mesh_client.get_team_spend(team_name, period=period)
+    except Exception as e:
+        return {"error": f"Failed to read spend for {team_name}: {e}"}
+
+
+@tool(
     name="workflow_snapshot",
     operator_only=True,
     description=(
@@ -1401,12 +1441,70 @@ async def await_task_event(
     }
 
 
+async def _fetch_budget_headroom(agent_id: str, mesh_client) -> dict:
+    """Best-effort budget headroom (today/limit + month/limit) for one agent.
+
+    Sourced from ``GET /mesh/agents/{id}/metrics`` (``mesh_client.
+    get_agent_metrics``), which already computes the same
+    ``cost_tracker.check_budget`` shape used for preflight enforcement.
+    A fetch/shape failure degrades to an error sentinel — never raises,
+    so it can't break the surrounding ``inspect_agents`` profile read.
+    """
+    try:
+        metrics = await mesh_client.get_agent_metrics(agent_id)
+    except Exception as e:
+        return {"error": f"Failed to read budget headroom for {agent_id}: {e}"}
+    budget = metrics.get("budget", {}) if isinstance(metrics, dict) else {}
+    return {
+        "today_used": budget.get("daily_used"),
+        "today_limit": budget.get("daily_limit"),
+        "month_used": budget.get("monthly_used"),
+        "month_limit": budget.get("monthly_limit"),
+    }
+
+
+def _summarize_track_record_counts(counts: dict) -> dict:
+    """Collapse ``{source: {outcome: count}}`` to accepted/rework/rejected.
+
+    Summed across every source (``task_outcome``, ``summary_rating``,
+    ``drive_review``) — each source keeps its own outcome vocabulary
+    (drive_review's accept-equivalent is ``merged``, not counted here),
+    but ``accepted``/``rework``/``rejected`` are shared enough vocabulary
+    to give a single at-a-glance summary.
+    """
+    summary = {"accepted": 0, "rework": 0, "rejected": 0}
+    for outcomes in (counts or {}).values():
+        if not isinstance(outcomes, dict):
+            continue
+        for key in summary:
+            summary[key] += int(outcomes.get(key, 0) or 0)
+    return summary
+
+
+async def _fetch_track_record_summary(agent_id: str, mesh_client) -> dict:
+    """Best-effort accepted/rework/rejected summary for one agent.
+
+    Sourced from ``GET /mesh/agents/{id}/track-record`` (``mesh_client.
+    get_agent_track_record``) — the durable outcome ledger. A
+    fetch/shape failure degrades to an error sentinel rather than
+    raising.
+    """
+    try:
+        record = await mesh_client.get_agent_track_record(agent_id)
+    except Exception as e:
+        return {"error": f"Failed to read track record for {agent_id}: {e}"}
+    counts = record.get("counts", {}) if isinstance(record, dict) else {}
+    return _summarize_track_record_counts(counts)
+
+
 @tool(
     name="inspect_agents",
     operator_only=True,
     description=(
         "Read agents. Without agent_id: roster summary. With agent_id: "
-        "depth='profile' returns role/capabilities/INTERFACE; "
+        "depth='profile' returns role/capabilities/INTERFACE plus "
+        "budget_headroom (today_used/today_limit, month_used/month_limit) "
+        "and track_record_summary (accepted/rework/rejected counts); "
         "depth='history' adds recent activity log. depth defaults to summary. "
         "Pass stale_threshold_hours=N to also annotate each agent in the "
         "roster with its stale-task count and up-to-5 oldest stale task IDs."
@@ -1541,9 +1639,22 @@ async def inspect_agents(
 
     # depth == "profile" or "summary" with an agent_id → profile call
     try:
-        return await mesh_client.get_agent_profile(agent_id)
+        profile = await mesh_client.get_agent_profile(agent_id)
     except Exception as e:
         return {"error": f"Failed to read profile for {agent_id}: {e}"}
+
+    # depth == "profile" additionally enriches with budget headroom
+    # (today/limit + month/limit) and a track-record summary
+    # (accepted/rework/rejected counts) — Phase-1 observability wiring
+    # for /mesh/agents/{id}/metrics + /mesh/agents/{id}/track-record.
+    # Each sub-fetch is independently best-effort: a failure degrades to
+    # an {"error": ...} sentinel on that one field rather than failing
+    # the whole profile read (the profile itself already succeeded).
+    if depth == "profile" and isinstance(profile, dict) and "error" not in profile:
+        profile["budget_headroom"] = await _fetch_budget_headroom(agent_id, mesh_client)
+        profile["track_record_summary"] = await _fetch_track_record_summary(agent_id, mesh_client)
+
+    return profile
 
 
 # ── Action tools ────────────────────────────────────────────

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -2134,6 +2134,34 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def get_agent_track_record(self, agent_id: str) -> dict:
+        """Get an agent's durable track record (accepted/rework/rejected/...).
+
+        Returns ``{"agent_id", "counts", "autonomy_counts", "recent"}``.
+        Self-or-operator-or-internal on the mesh side (see
+        ``get_agent_track_record`` in ``src/host/server.py``).
+        """
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/track-record",
+        )
+        _raise_with_body(response)
+        return response.json()
+
+    async def get_team_spend(self, team: str, period: str = "today") -> dict:
+        """Aggregate cost data for a team: total spend, envelope, per-member.
+
+        Unknown team (or no cost tracker wired) keeps the mesh-side
+        error-dict contract — ``{"team": team, "error": "..."}`` rather
+        than an HTTP error, so callers should check for ``"error"`` in
+        the result rather than relying on an exception.
+        """
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/costs/team/{team}",
+            params={"period": period},
+        )
+        _raise_with_body(response)
+        return response.json()
+
     async def get_agent_stale_tasks(
         self, agent_id: str, threshold_hours: int = 24,
     ) -> dict:

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -63,12 +63,15 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
     ToolGroup(
         key="fleet_setup",
         label="Fleet setup",
-        intent="build or restructure a team (create agents/teams, apply templates)",
+        intent=(
+            "build, restructure, or check spend on a team (create agents/"
+            "teams, apply templates, read team spend)"
+        ),
         tools=(
             "create_agent", "create_team", "apply_template", "list_templates",
             "add_agents_to_team", "remove_agents_from_team", "manage_team",
             "manage_agent", "edit_agent", "read_agent_config",
-            "update_team_context", "set_team_lead",
+            "update_team_context", "set_team_lead", "inspect_team_spend",
         ),
         operator_only=True,
     ),

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1741,6 +1741,11 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "notify_user",
     "inspect_agents",
     "inspect_teams",
+    # Team spend readback (Phase-1 observability) — aggregate cost +
+    # envelope + per-member breakdown for one team, backed by
+    # GET /mesh/costs/team/{team}. Sits alongside inspect_agents /
+    # inspect_teams as a monitoring read tool.
+    "inspect_team_spend",
     "list_agent_queue",
     "get_team_outputs",
     "summarize_team_progress",

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11464,6 +11464,7 @@ function dashboard() {
         create_agent: 'adding a teammate',
         apply_template: 'building a team from a template',
         inspect_agents: 'reviewing the team',
+        inspect_team_spend: 'checking team spend',
         list_available_models: 'checking available models',
         compose_work_summary: 'composing a work summary',
         workflow_snapshot: 'mapping the workflow',

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -346,6 +346,121 @@ async def test_inspect_agents_metrics_failure_falls_back_to_full_fanout():
     assert mc.get_agent_stale_tasks.await_count == 2
 
 
+# ── inspect_agents(depth='profile') budget headroom + track record ──
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_profile_surfaces_budget_headroom_and_track_record():
+    """depth='profile' enriches the profile with budget headroom (today/
+    month used+limit) and a track-record accepted/rework/rejected summary,
+    sourced from get_agent_metrics / get_agent_track_record."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.get_agent_profile = AsyncMock(return_value={
+        "agent_id": "writer", "role": "writer",
+    })
+    mc.get_agent_metrics = AsyncMock(return_value={
+        "agent_id": "writer",
+        "budget": {
+            "allowed": True,
+            "daily_used": 1.5,
+            "daily_limit": 10.0,
+            "monthly_used": 20.0,
+            "monthly_limit": 200.0,
+        },
+    })
+    mc.get_agent_track_record = AsyncMock(return_value={
+        "agent_id": "writer",
+        "counts": {
+            "task_outcome": {"accepted": 4, "rework": 1},
+            "drive_review": {"merged": 2, "rejected": 1},
+        },
+        "recent": [],
+    })
+
+    result = await inspect_agents("writer", depth="profile", mesh_client=mc)
+
+    assert result["budget_headroom"] == {
+        "today_used": 1.5,
+        "today_limit": 10.0,
+        "month_used": 20.0,
+        "month_limit": 200.0,
+    }
+    assert result["track_record_summary"] == {
+        "accepted": 4, "rework": 1, "rejected": 1,
+    }
+    mc.get_agent_metrics.assert_awaited_once_with("writer")
+    mc.get_agent_track_record.assert_awaited_once_with("writer")
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_profile_degrades_when_metrics_fetch_fails():
+    """A metrics-fetch failure degrades to an error sentinel on that one
+    field — inspect_agents(depth='profile') must still return the profile."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.get_agent_profile = AsyncMock(return_value={
+        "agent_id": "writer", "role": "writer",
+    })
+    mc.get_agent_metrics = AsyncMock(side_effect=RuntimeError("mesh down"))
+    mc.get_agent_track_record = AsyncMock(return_value={
+        "agent_id": "writer",
+        "counts": {"task_outcome": {"accepted": 1}},
+    })
+
+    result = await inspect_agents("writer", depth="profile", mesh_client=mc)
+
+    assert result["agent_id"] == "writer"
+    assert "error" in result["budget_headroom"]
+    assert result["track_record_summary"] == {
+        "accepted": 1, "rework": 0, "rejected": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_profile_degrades_when_track_record_fetch_fails():
+    """A track-record-fetch failure degrades to an error sentinel on that
+    one field without touching budget_headroom or the base profile."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.get_agent_profile = AsyncMock(return_value={
+        "agent_id": "writer", "role": "writer",
+    })
+    mc.get_agent_metrics = AsyncMock(return_value={
+        "budget": {
+            "daily_used": 0.0, "daily_limit": 10.0,
+            "monthly_used": 0.0, "monthly_limit": 200.0,
+        },
+    })
+    mc.get_agent_track_record = AsyncMock(side_effect=RuntimeError("mesh down"))
+
+    result = await inspect_agents("writer", depth="profile", mesh_client=mc)
+
+    assert result["agent_id"] == "writer"
+    assert result["budget_headroom"]["today_limit"] == 10.0
+    assert "error" in result["track_record_summary"]
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_summary_depth_does_not_enrich():
+    """Only depth='profile' enriches — depth='summary' with an agent_id
+    still hits get_agent_profile but stays back-compat (no extra fields)."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.get_agent_profile = AsyncMock(return_value={
+        "agent_id": "writer", "role": "writer",
+    })
+    result = await inspect_agents("writer", mesh_client=mc)
+    assert "budget_headroom" not in result
+    assert "track_record_summary" not in result
+    mc.get_agent_metrics.assert_not_called()
+    mc.get_agent_track_record.assert_not_called()
+
+
 # ── inspect_teams read-back (goal + budget) tests ────────────
 
 
@@ -404,6 +519,81 @@ async def test_inspect_teams_single_team_returns_goal_and_budget():
     assert result["success_criteria"] == ["done"]
     assert result["budget_daily_usd"] == 2.0
     assert result["budget_monthly_usd"] == 40.0
+
+
+# ── inspect_team_spend tests ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inspect_team_spend_no_mesh_client():
+    from src.agent.builtins.operator_tools import inspect_team_spend
+
+    result = await inspect_team_spend("growth")
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_inspect_team_spend_returns_aggregate_and_breakdown():
+    """Happy path: total spend, envelope, and per-member breakdown pass
+    through from mesh_client.get_team_spend unchanged."""
+    from src.agent.builtins.operator_tools import inspect_team_spend
+
+    mc = MagicMock()
+    mc.get_team_spend = AsyncMock(return_value={
+        "team": "growth",
+        "period": "today",
+        "total_cost": 3.25,
+        "total_tokens": 12000,
+        "daily_limit": 10.0,
+        "monthly_limit": 200.0,
+        "agents": [
+            {"agent": "writer", "cost": 2.0, "tokens": 8000},
+            {"agent": "scout", "cost": 1.25, "tokens": 4000},
+        ],
+    })
+    result = await inspect_team_spend("growth", mesh_client=mc)
+    assert result["team"] == "growth"
+    assert result["total_cost"] == 3.25
+    assert result["daily_limit"] == 10.0
+    assert result["monthly_limit"] == 200.0
+    assert len(result["agents"]) == 2
+    mc.get_team_spend.assert_awaited_once_with("growth", period="today")
+
+
+@pytest.mark.asyncio
+async def test_inspect_team_spend_custom_period_forwarded():
+    from src.agent.builtins.operator_tools import inspect_team_spend
+
+    mc = MagicMock()
+    mc.get_team_spend = AsyncMock(return_value={"team": "growth", "period": "month"})
+    await inspect_team_spend("growth", period="month", mesh_client=mc)
+    mc.get_team_spend.assert_awaited_once_with("growth", period="month")
+
+
+@pytest.mark.asyncio
+async def test_inspect_team_spend_unknown_team_surfaces_mesh_error():
+    """Unknown team keeps the mesh-side error-dict contract -- no exception,
+    just an 'error' key the caller can check."""
+    from src.agent.builtins.operator_tools import inspect_team_spend
+
+    mc = MagicMock()
+    mc.get_team_spend = AsyncMock(return_value={
+        "team": "ghost", "error": "Unknown team (or no team store wired)",
+    })
+    result = await inspect_team_spend("ghost", mesh_client=mc)
+    assert result["error"] == "Unknown team (or no team store wired)"
+
+
+@pytest.mark.asyncio
+async def test_inspect_team_spend_transport_failure_surfaces_error():
+    from src.agent.builtins.operator_tools import inspect_team_spend
+
+    mc = MagicMock()
+    mc.get_team_spend = AsyncMock(side_effect=RuntimeError("connection refused"))
+    result = await inspect_team_spend("growth", mesh_client=mc)
+    assert "error" in result
+    assert "connection refused" in result["error"]
 
 
 # ── create_agent tests ──────────────────────────��───────────


### PR DESCRIPTION
## Summary
- Phase-1 of `docs/plans/2026-07-16-autonomous-team-delivery.md`: a product review found well-built backend endpoints with no operator-facing tool wrapper — the operator couldn't see team spend or a worker's budget headroom / track record in one call.
- `inspect_agents(depth='profile')` now additionally returns `budget_headroom` (today/month used+limit) and `track_record_summary` (accepted/rework/rejected), sourced from the existing `GET /mesh/agents/{id}/metrics` and `GET /mesh/agents/{id}/track-record` endpoints via two new `mesh_client` methods (`get_agent_metrics` already existed; added `get_agent_track_record`). Each sub-fetch is independently best-effort — a failure degrades to an `{"error": ...}` sentinel on that one field rather than breaking the profile read.
- New operator-only, read-only tool `inspect_team_spend(team_name, period)` wraps `GET /mesh/costs/team/{team}` via a new `mesh_client.get_team_spend()` method — returns aggregate spend, the daily/monthly envelope, and a per-member breakdown. Registered in the `fleet_setup` tool group (`src/agent/tool_groups.py`) and the operator allowlist (`_OPERATOR_ALLOWED_TOOLS` in `src/cli/config.py`).
- Added the required `inspect_team_spend` entry to the dashboard's `verbForTool` map (`src/dashboard/static/js/app.js`) so `TestVerbForToolCompleteness` stays green.
- No new mesh endpoints; `src/host/**` and `src/shared/operator_playbooks.py` untouched.

## Test plan
- [x] `tests/test_operator_tools.py` — 5 new tests for `inspect_agents(depth='profile')` enrichment (happy path, metrics-fetch failure, track-record-fetch failure, summary depth stays unenriched) + 5 new tests for `inspect_team_spend` (no mesh client, happy path, custom period, unknown team, transport failure).
- [x] `tests/test_dashboard_ui.py::TestVerbForToolCompleteness` — confirms the new tool has a verb map entry.
- [x] Targeted gate: `PYTHONPATH="$PWD" LITELLM_MODE=PRODUCTION python -m pytest tests/test_operator_tools.py tests/test_dashboard_ui.py tests/test_grouped_tools.py -q` → 389 passed, 3 skipped.
- [x] `ruff check` on touched files — clean.