### PR TITLE
operator: add assess_team_progress goal-progress read

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2390,6 +2390,181 @@ async def summarize_team_progress(
         return {"error": f"Failed to summarize {target}: {e}"}
 
 
+# Instruction the OPERATOR (its own LLM turn) follows to turn the composed
+# evidence bundle into a per-criterion goal-progress judgement. The tool does
+# NOT make an LLM/utility-model call — it only gathers criteria + real evidence
+# and hands the judging to the operator, which is why the verdict rubric lives
+# here (and mirrored in the tool description) rather than being computed in code.
+_ASSESS_GUIDANCE = (
+    "Judge THIS turn whether the team is actually achieving its goal — do not "
+    "defer. For EACH success criterion below, decide ONE status and cite the "
+    "specific completed_work / blocked evidence that supports it:\n"
+    "  - met — the evidence clearly satisfies the criterion.\n"
+    "  - on_track — partial evidence, credibly trending toward met.\n"
+    "  - at_risk — thin/contradictory evidence, or blockers threaten it.\n"
+    "  - no_evidence — nothing in the completed work speaks to this criterion.\n"
+    "  - needs_external_metric — the criterion is MEASURABLE (a count, "
+    "percentage, revenue, ranking, signups, traffic figure). You CANNOT "
+    "confirm the real number from this bundle; do NOT invent or estimate a "
+    "figure. Mark it needs_external_metric and verify the actual value against "
+    "the external platform (analytics, the store/dashboard, the repo, the ad "
+    "account) before ever claiming it is met.\n"
+    "completed_work is EVIDENCE, not proof; task_counts alone never establish "
+    "that a goal was met. For any criterion that comes out at_risk or "
+    "no_evidence, ACT rather than just reporting: decompose the gap into a "
+    "concrete task via hand_off, re-brief the team (update_team_brief / "
+    "set_team_goal), or ask the team what is blocking (ask_teammate)."
+)
+
+
+@tool(
+    name="assess_team_progress",
+    operator_only=True,
+    description=(
+        "Judge whether a team is ACHIEVING its goal — not just how many "
+        "tasks it has closed. This is the goal-progress read: it composes the "
+        "team's north_star + success_criteria with the REAL evidence "
+        "(recent completed work + result summaries + artifact refs, the task-"
+        "count rollup, and current blockers) into one bundle so you can rate "
+        "each criterion. It does NOT decide for you — YOU produce, per "
+        "criterion, a status in {met | on_track | at_risk | no_evidence | "
+        "needs_external_metric} with the supporting evidence. Treat any "
+        "MEASURABLE criterion (a count, %, revenue, ranking, traffic) as "
+        "needs_external_metric and verify the true number against the external "
+        "platform — never hallucinate a figure. For at_risk / no_evidence "
+        "criteria, ACT: decompose the gap via hand_off, re-brief the team, or "
+        "ask the team what's blocking. Read the returned assessment_guidance. "
+        "Returns {team, north_star, criteria, completed_work, task_counts, "
+        "blocked, window, assessment_guidance} (+ notes on any degraded read)."
+    ),
+    parameters={
+        "team_name": {
+            "type": "string",
+            "description": "Team name to assess",
+        },
+        "since": {
+            "type": "string",
+            "description": (
+                "Evidence window for completed work — ISO timestamp or "
+                "duration string ('7d', '30d'). Default '14d'. Widen it to "
+                "cover a longer-running goal."
+            ),
+            "default": "14d",
+        },
+    },
+)
+async def assess_team_progress(
+    team_name: str = "",
+    since: str = "14d",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Compose a goal-vs-evidence bundle for the operator to judge.
+
+    DATA-COMPOSITION only — no LLM/utility-model call here. Reuses three
+    existing operator reads: ``list_teams`` (north_star + success_criteria),
+    ``team_outputs`` (completed-work evidence: title + result_summary +
+    artifact_refs) and ``team_summary`` (task-count rollup + current
+    blockers). Each sub-read is independently guarded — a failure degrades
+    to a partial bundle plus a ``notes`` entry and NEVER raises, so a single
+    flaky endpoint can't sink the whole assessment. Untrusted worker text
+    (titles, result summaries, blocker notes, the goal strings) is passed
+    through :func:`sanitize_for_prompt` at this boundary before it enters the
+    operator's LLM context. The per-criterion verdict rubric is NOT computed
+    here — it rides ``assessment_guidance`` + the tool description for the
+    operator to apply.
+    """
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not isinstance(team_name, str) or not team_name.strip():
+        return {"error": "team_name is required"}
+    target = team_name.strip()
+    window = since if isinstance(since, str) and since.strip() else "14d"
+
+    notes: list[str] = []
+
+    # 1) Goal: north_star + success_criteria via the same list_teams read
+    #    inspect_teams uses. A read failure degrades (note) rather than
+    #    raising; an unknown team (read OK, name absent) is a hard error.
+    north_star = None
+    criteria: list[str] = []
+    try:
+        teams = await mesh_client.list_teams()
+        rows = teams.get("teams", []) if isinstance(teams, dict) else []
+        match = next((p for p in rows if p.get("name") == target), None)
+        if match is None:
+            return {"error": f"Team '{target}' not found"}
+        raw_ns = match.get("north_star")
+        if raw_ns:
+            north_star = sanitize_for_prompt(str(raw_ns))
+        raw_criteria = match.get("success_criteria") or []
+        if isinstance(raw_criteria, list):
+            criteria = [
+                sanitize_for_prompt(str(c))
+                for c in raw_criteria
+                if str(c).strip()
+            ]
+    except Exception as e:
+        notes.append(f"goal_read_failed: {str(e)[:200]}")
+
+    # 2) Completed-work evidence via team_outputs (over the window).
+    completed_work: list[dict] = []
+    try:
+        outputs = await mesh_client.team_outputs(target, since=window)
+        raw_outputs = outputs.get("outputs", []) if isinstance(outputs, dict) else []
+        for o in raw_outputs:
+            completed_work.append(
+                {
+                    "title": sanitize_for_prompt(str(o.get("title") or "")),
+                    "result_summary": sanitize_for_prompt(
+                        str(o.get("result_summary") or "")
+                    ),
+                    "artifact_refs": o.get("artifact_refs", []) or [],
+                }
+            )
+    except Exception as e:
+        notes.append(f"completed_work_read_failed: {str(e)[:200]}")
+
+    # 3) Task-count rollup + current blockers via team_summary (one read
+    #    covers both — blockers ride ``top_blockers`` so no extra call).
+    task_counts: dict = {}
+    blocked: list[dict] = []
+    try:
+        summary = await mesh_client.team_summary(target)
+        if isinstance(summary, dict):
+            task_counts = summary.get("counts", {}) or {}
+            for b in summary.get("top_blockers", []) or []:
+                blocked.append(
+                    {
+                        "id": b.get("id"),
+                        "assignee": b.get("assignee"),
+                        "title": sanitize_for_prompt(str(b.get("title") or "")),
+                        "blocker_note": sanitize_for_prompt(
+                            str(b.get("blocker_note") or "")
+                        ),
+                    }
+                )
+    except Exception as e:
+        notes.append(f"task_counts_read_failed: {str(e)[:200]}")
+
+    bundle = {
+        "team": target,
+        "north_star": north_star,
+        "criteria": criteria,
+        "completed_work": completed_work,
+        "task_counts": task_counts,
+        "blocked": blocked,
+        "window": window,
+        "assessment_guidance": _ASSESS_GUIDANCE,
+    }
+    if notes:
+        bundle["notes"] = notes
+    return bundle
+
+
 @tool(
     name="compose_work_summary",
     operator_only=True,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -249,6 +249,9 @@ _READ_ONLY_TOOLS = frozenset({
     # Peer file reads (full /data volume, not just artifacts/) — read-only.
     "list_peer_files", "read_peer_file",
     "get_team_outputs",
+    # Goal-progress composition — pure read (no LLM call, no external
+    # mutation), so a turn that only assesses isn't miscounted as work.
+    "assess_team_progress",
     # Memory / file reads (writes go through memory_save / write_file)
     "memory_search", "memory_think", "read_file",
     # Credential discovery — names only, no values

--- a/src/agent/tool_groups.py
+++ b/src/agent/tool_groups.py
@@ -96,6 +96,7 @@ TOOL_GROUPS: tuple[ToolGroup, ...] = (
         intent="set or review team goals and rate deliveries",
         tools=(
             "set_team_goal", "manage_goals", "rate_delivery",
+            "assess_team_progress",
         ),
         operator_only=True,
     ),

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1749,6 +1749,11 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "list_agent_queue",
     "get_team_outputs",
     "summarize_team_progress",
+    # Goal-progress assessment (Tier-3) — composes the team's north_star +
+    # success_criteria with real completed-work evidence + task counts +
+    # blockers so the operator can judge each criterion (met / on_track /
+    # at_risk / no_evidence / needs_external_metric). Pure read — no LLM call.
+    "assess_team_progress",
     # Composes and persists a work summary card for the Work tab.
     # Backed by ``WorkSummariesStore``; the daily cron invokes this
     # tool directly (no LLM cost per fire). User rates via dashboard.

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11467,6 +11467,7 @@ function dashboard() {
         inspect_team_spend: 'checking team spend',
         list_available_models: 'checking available models',
         compose_work_summary: 'composing a work summary',
+        assess_team_progress: 'assessing team progress',
         workflow_snapshot: 'mapping the workflow',
         await_task_event: 'waiting on a task',
         inspect_task_run: 'diagnosing a task run',

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -10237,8 +10237,11 @@ def create_mesh_app(
 
         ``since`` accepts an ISO timestamp or duration string (``"24h"``,
         ``"7d"``); default is the last 7 days. Returns one entry per
-        completed task with its title, assignee, completion time, and
-        artifact refs.
+        completed task with its title, assignee, completion time,
+        ``result_summary`` (the worker's own report of what it produced —
+        the primary evidence for goal-progress assessment; may be null for
+        tasks completed without a summary) and artifact refs. Raw text —
+        the caller sanitizes at its LLM boundary.
         """
         store = tasks_store
         caller = _extract_verified_agent_id(request)
@@ -10261,6 +10264,7 @@ def create_mesh_app(
                     "title": r["title"],
                     "assignee": r["assignee"],
                     "completed_at": completed_at,
+                    "result_summary": r.get("result_summary"),
                     "artifact_refs": r.get("artifact_refs", []) or [],
                 }
             )

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -573,6 +573,16 @@ manage_team(action='set_budget', ...) or rebalance the load.
 success_criteria), lead, and budget back so you can confirm they're \
 still set and sane before diagnosing deeper.
 
+- **assess_team_progress(team_name)** — when reviewing whether a team is \
+actually ACHIEVING its goal (not just closing tasks), call this. It composes \
+the north_star + success_criteria with real evidence (completed-work \
+summaries + artifacts + task counts + blockers) so you can rate each \
+criterion met / on_track / at_risk / no_evidence / needs_external_metric. \
+Treat measurable criteria (counts, %, revenue) as needs_external_metric — \
+verify the real number against the external platform, never guess it. For \
+any at_risk / no_evidence criterion, ACT: decompose the gap via hand_off, \
+re-brief the team, or ask_teammate what's blocking.
+
 ## Outcome ratings (Board tab)
 
 Operators can now rate completed tasks in the Board tab as \

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -596,6 +596,187 @@ async def test_inspect_team_spend_transport_failure_surfaces_error():
     assert "connection refused" in result["error"]
 
 
+# ── assess_team_progress (Tier-3 goal-progress composition) ──────────
+
+
+def _assess_mesh(*, criteria=None, outputs=None, counts=None, blockers=None):
+    """Build a MagicMock mesh_client wired for assess_team_progress.
+
+    Defaults describe one team named 'growth' with a goal + one completed
+    task carrying a result_summary + a task-count rollup + one blocker.
+    """
+    mc = MagicMock()
+    mc.list_teams = AsyncMock(return_value={"teams": [
+        {
+            "name": "growth",
+            "north_star": "Ship $10k MRR",
+            "success_criteria": criteria if criteria is not None else [
+                "100 signups", "landing page live",
+            ],
+        },
+        {"name": "other", "north_star": "unrelated"},
+    ]})
+    mc.team_outputs = AsyncMock(return_value={
+        "team_id": "growth",
+        "outputs": outputs if outputs is not None else [
+            {
+                "id": "t1",
+                "title": "Build landing page",
+                "result_summary": "Shipped landing page at example.com",
+                "artifact_refs": ["drive://growth/landing.html@abc"],
+            },
+        ],
+    })
+    mc.team_summary = AsyncMock(return_value={
+        "counts": counts if counts is not None else {
+            "active": 2, "blocked": 1, "done": 1, "failed": 0, "cancelled": 0,
+        },
+        "top_blockers": blockers if blockers is not None else [
+            {
+                "id": "t2",
+                "assignee": "scout",
+                "title": "Wire analytics",
+                "blocker_note": "waiting on GA credential",
+            },
+        ],
+    })
+    return mc
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_no_mesh_client():
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    result = await assess_team_progress("growth")
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_requires_team_name():
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh()
+    result = await assess_team_progress("   ", mesh_client=mc)
+    assert "error" in result
+    assert "team_name" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_composes_criteria_evidence_and_counts():
+    """Happy path: goal criteria + completed-work evidence + task counts +
+    blockers + assessment guidance all land in one bundle."""
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh()
+    result = await assess_team_progress("growth", mesh_client=mc)
+
+    assert result["team"] == "growth"
+    assert result["north_star"] == "Ship $10k MRR"
+    # Each success criterion string is surfaced for the operator to judge.
+    assert result["criteria"] == ["100 signups", "landing page live"]
+    # Completed work is real evidence: title + result_summary + artifact refs.
+    assert len(result["completed_work"]) == 1
+    ev = result["completed_work"][0]
+    assert ev["title"] == "Build landing page"
+    assert ev["result_summary"] == "Shipped landing page at example.com"
+    assert ev["artifact_refs"] == ["drive://growth/landing.html@abc"]
+    # Task-count rollup + current blockers.
+    assert result["task_counts"]["blocked"] == 1
+    assert result["blocked"][0]["id"] == "t2"
+    assert result["blocked"][0]["blocker_note"] == "waiting on GA credential"
+    # Guidance carries the per-criterion verdict vocabulary + external-metric
+    # rule (the tool itself makes NO LLM call).
+    guidance = result["assessment_guidance"]
+    for status in (
+        "met", "on_track", "at_risk", "no_evidence", "needs_external_metric",
+    ):
+        assert status in guidance
+    assert "hand_off" in guidance
+    # Since window echoed back; no degraded-read notes on the happy path.
+    assert result["window"] == "14d"
+    assert "notes" not in result
+    # Composed from existing reads only — over the requested window.
+    mc.team_outputs.assert_awaited_once_with("growth", since="14d")
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_since_window_forwarded():
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh()
+    await assess_team_progress("growth", since="30d", mesh_client=mc)
+    mc.team_outputs.assert_awaited_once_with("growth", since="30d")
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_unknown_team():
+    """Read succeeds but the team isn't in the roster → hard not-found."""
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh()
+    result = await assess_team_progress("nope", mesh_client=mc)
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_degrades_when_outputs_read_fails():
+    """A sub-read failure yields a partial bundle + a note, never raises."""
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh()
+    mc.team_outputs = AsyncMock(side_effect=RuntimeError("outputs endpoint down"))
+    result = await assess_team_progress("growth", mesh_client=mc)
+
+    # Goal + counts still composed; completed_work degraded to empty.
+    assert result["north_star"] == "Ship $10k MRR"
+    assert result["completed_work"] == []
+    assert result["task_counts"]["blocked"] == 1
+    assert "notes" in result
+    assert any("completed_work_read_failed" in n for n in result["notes"])
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_degrades_when_summary_read_fails():
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh()
+    mc.team_summary = AsyncMock(side_effect=RuntimeError("summary down"))
+    result = await assess_team_progress("growth", mesh_client=mc)
+
+    # Evidence still present; counts/blocked degrade gracefully.
+    assert len(result["completed_work"]) == 1
+    assert result["task_counts"] == {}
+    assert result["blocked"] == []
+    assert any("task_counts_read_failed" in n for n in result["notes"])
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_no_criteria_still_returns_bundle():
+    """A team with a north_star but no success_criteria still composes —
+    criteria is just empty, and guidance still rides the bundle."""
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    mc = _assess_mesh(criteria=[])
+    result = await assess_team_progress("growth", mesh_client=mc)
+    assert result["criteria"] == []
+    assert result["assessment_guidance"]
+    assert "notes" not in result
+
+
+@pytest.mark.asyncio
+async def test_assess_team_progress_blocked_for_non_operator(monkeypatch):
+    """Defence-in-depth: non-operator (no ALLOWED_TOOLS) is rejected."""
+    from src.agent.builtins.operator_tools import assess_team_progress
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    mc = _assess_mesh()
+    result = await assess_team_progress("growth", mesh_client=mc)
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+
+
 # ── create_agent tests ──────────────────────────��───────────
 
 


### PR DESCRIPTION
## Why

Today nothing links a team's `success_criteria` to its actual work — the only notion of "progress" is task-counts, so the core autonomy question ("is this team achieving what it was told to?") is unanswerable. Per `docs/plans/2026-07-16-autonomous-team-delivery.md` §1 finding 5: `success_criteria` are strings never evaluated; the fleet can be busy but not effective.

This is the Tier-3 v1: make goal progress **evidence-grounded and assessable**.

## What

A new operator-only `assess_team_progress(team_name, since="14d")` in `operator_tools.py` that **composes existing reads** (no new mesh endpoints, no new mesh_client methods):

- `list_teams` → `north_star` + `success_criteria`
- `team_outputs` → completed-work evidence: `title` + `result_summary` + `artifact_refs` over a window
- `team_summary` → task-count rollup + current blockers (via `top_blockers`)

Returned bundle: `{team, north_star, criteria, completed_work, task_counts, blocked, window, assessment_guidance}` (+ `notes` on any degraded read).

It is a **data-composition tool — it makes NO LLM/utility-model call**. The per-criterion verdict rubric ({met | on_track | at_risk | no_evidence | needs_external_metric}) rides `assessment_guidance` + the tool description for the operator (its own LLM turn) to apply. Measurable criteria (counts, %, revenue) are flagged `needs_external_metric` so the real number is verified against the external platform, never hallucinated; `at_risk`/`no_evidence` criteria direct the operator to act (decompose via `hand_off`, re-brief, or ask the team).

Resilient: each sub-read is guarded independently — a failure degrades to a partial bundle + a note and never raises. Untrusted worker text is sanitized at the tool boundary. `team_outputs` now also surfaces `result_summary` (already stored on the task row) so completed work is real evidence, not just titles.

Registration: `tool_groups.py` (goals_review), `cli/config.py` `_OPERATOR_ALLOWED_TOOLS`, `loop.py` `_READ_ONLY_TOOLS`, `app.js` `verbForTool` (dashboard UI completeness gate), and one guidance line in the fleet-monitoring operator playbook.

## Tests

New coverage in `tests/test_operator_tools.py`: composition of criteria + completed-work evidence + counts; `since` forwarding; unknown team; graceful degradation on outputs/summary read failure; no-criteria case; no-mesh-client; non-operator rejection.

Gate (`.env`-leak protocol, `LITELLM_MODE=PRODUCTION`): `test_operator_tools.py`, `test_dashboard_ui.py`, `test_operator_playbooks.py`, `test_grouped_tools.py`, `test_operator_product_tools.py` → 482 passed, 3 skipped. `test_loop.py` read-only subset → 6 passed. `ruff check` clean on all touched `.py`.