### PR TITLE
fix(teams): make update_team_context section-scoped so it stops clobbering goal/brief

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -8114,16 +8114,35 @@ def create_mesh_app(
         except TeamNotFound:
             raise HTTPException(404, f"Team '{team_name}' not found")
 
-        # Update team.md in place (store teams_dir first — see the brief
-        # endpoint's path note; mkdir covers a failed create scaffold).
+        # Section-scoped update of the shared TEAM.md's reserved ``##
+        # Context`` block (store teams_dir first — see the brief endpoint's
+        # path note; mkdir covers a failed create scaffold). This writer
+        # used to FULL-OVERWRITE the file (``# {team}\n\n{context}\n``),
+        # which silently wiped every OTHER section other tools now own — the
+        # ``## Goal`` block (set_team_goal, #1268) and ``## User
+        # Preferences`` / other brief blocks (update_team_brief). Read the
+        # existing file (seed ``# {team}\n`` when absent) and replace ONLY
+        # the ``## Context`` section, reusing the SAME section-scoped write
+        # (``replace_markdown_section``) + concurrent live-push
+        # (``_push_team_md``) the goal mirror and brief endpoint use, so
+        # goal/context/brief compose without clobbering each other (design
+        # doc ``docs/plans/2026-07-16-autonomous-team-delivery.md`` — closes
+        # the sibling of the §1-finding-4 goal seam).
         team_md_path = teams_store.team_md_path(team_name) or (TEAMS_DIR / team_name / "team.md")
         team_md_path.parent.mkdir(parents=True, exist_ok=True)
-        new_content = f"# {team_name}\n\n{context}\n"
+        existing = (
+            team_md_path.read_text(errors="replace")
+            if team_md_path.exists()
+            else f"# {team_name}\n"
+        )
+        new_content = replace_markdown_section(existing, "Context", context)
         team_md_path.write_text(new_content)
         # P2 gap fix: this writer previously never pushed to running
         # members (only the dashboard's PUT /api/team did), so an
-        # operator-tool context update was invisible to agents until
-        # their next restart.
+        # operator-tool context update was invisible to agents until their
+        # next restart. Best-effort — ``_push_team_md`` swallows per-target
+        # failures, so a push hiccup never fails the context write, and a
+        # solo/memberless team pushes to nobody (clean no-op).
         pushed = await _push_team_md(team_name, new_content)
 
         _emit_team_event(

--- a/tests/test_team_brief.py
+++ b/tests/test_team_brief.py
@@ -226,6 +226,122 @@ async def test_team_context_update_now_pushes(brief_app):
     assert "fresh shared context" in project_md.read_text()
 
 
+@pytest.mark.asyncio
+async def test_context_update_preserves_goal_and_prefs_sections(brief_app):
+    """Core regression: the context writer used to FULL-OVERWRITE TEAM.md,
+    silently wiping the ``## Goal`` (set_team_goal, #1268) and ``## User
+    Preferences`` (update_team_brief) sections. It is now section-scoped
+    into a reserved ``## Context`` block, so every sibling section
+    survives."""
+    app, transport, project_md = brief_app
+    project_md.write_text(
+        "# research\n\n"
+        "## Goal\n\nShip the launch\n\n"
+        "## User Preferences\n\n- Formal tone\n\n"
+        "## Workflow\n\nscout -> analyst\n"
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.put(
+            "/mesh/teams/research/context",
+            json={"context": "Team ships weekly."},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    # Pushed to the running member only (scout, not the stopped analyst).
+    assert r.json()["pushed"] == {"scout": True}
+    on_disk = project_md.read_text()
+    # New Context section written into its own reserved block...
+    assert "## Context" in on_disk
+    assert "Team ships weekly." in on_disk
+    assert on_disk.count("## Context") == 1
+    # ...and every pre-existing section survived (the seam that regressed).
+    assert "## Goal" in on_disk and "Ship the launch" in on_disk
+    assert "## User Preferences" in on_disk and "- Formal tone" in on_disk
+    assert "scout -> analyst" in on_disk
+    # The push carries the full composed file.
+    assert transport.calls[0]["json"]["content"] == on_disk
+
+
+@pytest.mark.asyncio
+async def test_context_update_replaces_only_context_on_rewrite(brief_app):
+    """A second context update replaces the ``## Context`` block in place —
+    never a duplicate, never touching sibling sections."""
+    app, _transport, project_md = brief_app
+    project_md.write_text("# research\n\n## Goal\n\nkeep me\n")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        await c.put(
+            "/mesh/teams/research/context",
+            json={"context": "v1 context"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        await c.put(
+            "/mesh/teams/research/context",
+            json={"context": "v2 context"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    on_disk = project_md.read_text()
+    assert "v2 context" in on_disk
+    assert "v1 context" not in on_disk
+    assert on_disk.count("## Context") == 1
+    assert "keep me" in on_disk  # goal untouched across both writes
+
+
+@pytest.mark.asyncio
+async def test_context_update_survives_push_failure(brief_app, monkeypatch):
+    """A push that raises must NOT fail the context write (best-effort):
+    the file is still written and sibling sections preserved."""
+    app, transport, project_md = brief_app
+    project_md.write_text("# research\n\n## Goal\n\nnorth star\n")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("member unreachable")
+
+    monkeypatch.setattr(transport, "request", _boom)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.put(
+            "/mesh/teams/research/context",
+            json={"context": "resilient context"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    # Push attempted against the running member, recorded as failed.
+    assert r.json()["pushed"] == {"scout": False}
+    on_disk = project_md.read_text()
+    assert "resilient context" in on_disk and "## Context" in on_disk
+    assert "north star" in on_disk  # goal preserved despite the push failure
+
+
+@pytest.mark.asyncio
+async def test_context_update_memberless_team_no_ops_push_and_seeds_file(brief_app):
+    """A team with no running members pushes to nobody (clean no-op) and,
+    when TEAM.md is absent, seeds ``# {team}`` + the ``## Context`` block."""
+    import src.cli.config as config_module
+
+    app, transport, _ = brief_app
+    app.teams_store.create_team("solo")  # pure-DB store: no scaffold, no members
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.put(
+            "/mesh/teams/solo/context",
+            json={"context": "seeded context"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["pushed"] == {}  # nobody to push to — clean no-op
+    assert transport.calls == []  # no push attempted at all
+    seeded = config_module.TEAMS_DIR / "solo" / "team.md"
+    text = seeded.read_text()
+    assert text.startswith("# solo")
+    assert "## Context" in text and "seeded context" in text
+
+
 # ── outcomes_window on team summary ───────────────────────────────
 
 

--- a/tests/test_team_goal.py
+++ b/tests/test_team_goal.py
@@ -482,6 +482,38 @@ async def test_endpoint_set_goal_mirrors_into_team_md_and_pushes(goal_push_app):
 
 
 @pytest.mark.asyncio
+async def test_context_update_preserves_goal_section(goal_push_app):
+    """Cross-writer composition against a REAL disk scaffold: setting a
+    goal then updating context leaves BOTH the ``## Goal`` and ``##
+    Context`` sections (plus the scaffold preamble) intact. The context
+    endpoint used to full-overwrite TEAM.md and wipe the goal — this is
+    the clobber seam the section-scoped write closes."""
+    app, _teams_store, transport, team_md = goal_push_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        rg = await c.post(
+            "/mesh/teams/growth/goal",
+            json={"north_star": "Reach 1k signups", "success_criteria": ["launch"]},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert rg.status_code == 200, rg.text
+        rc = await c.put(
+            "/mesh/teams/growth/context",
+            json={"context": "Focus on retention."},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert rc.status_code == 200, rc.text
+    # Context pushed to the running member only (writer, not stopped editor).
+    assert rc.json()["pushed"] == {"writer": True}
+    on_disk = team_md.read_text()
+    # Goal survived the context write (the regression).
+    assert "## Goal" in on_disk and "Reach 1k signups" in on_disk
+    # Context landed in its own reserved section.
+    assert "## Context" in on_disk and "Focus on retention." in on_disk
+    # Scaffold preamble description still present.
+    assert "growth project" in on_disk
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("goal_push_app", [True], indirect=True)
 async def test_endpoint_set_goal_survives_push_failure(goal_push_app):
     """A push that raises must NOT fail the goal write (best-effort): the


### PR DESCRIPTION
The mesh context writer (`PUT /mesh/teams/{name}/context`, the `update_team_context` operator tool) wrote TEAM.md by **full overwrite** — `team_md_path.write_text(f"# {team}\n\n{context}\n")`. But TEAM.md now holds multiple sibling sections written by other tools: `set_team_goal` writes a reserved `## Goal` block (#1268) and `update_team_brief` writes named blocks like `## User Preferences`. So calling `update_team_context` after a goal or brief existed **silently wiped them** — a data-loss seam.

## Fix

Make the context write section-scoped like its siblings: read the existing file (seed `# {team}\n` when absent), replace **only** the reserved `## Context` section via `replace_markdown_section`, write it back, and live-push to running members via `_push_team_md` — the exact pattern the goal mirror and the brief endpoint already use. `## Goal`, `## User Preferences`, and any other sections now survive a context update, so goal/context/brief compose without clobbering each other.

- Push stays best-effort (`_push_team_md` swallows per-target failures, so a push hiccup never fails the context write); a solo/memberless team pushes to nobody (clean no-op).
- **Scaffold untouched:** `_scaffold_files` writes the description into the H1 preamble (not a `## Context` section), so the appended `## Context` block sits alongside it exactly as the `## Goal` mirror already sits alongside the same preamble (asserted in `test_team_goal.py`). No collision among the four writers (scaffold preamble, `## Goal`, `## Context`, brief-named sections).

Closes the sibling of the §1-finding-4 "ghost goal" seam in `docs/plans/2026-07-16-autonomous-team-delivery.md`.

## Tests

- `test_context_update_preserves_goal_and_prefs_sections` — core regression (unit, `brief_app`)
- `test_context_update_preserves_goal_section` — cross-endpoint composition against a real disk scaffold (`goal_push_app`: POST goal then PUT context)
- `test_context_update_replaces_only_context_on_rewrite` — idempotent in-place replace, goal untouched
- `test_context_update_survives_push_failure` — best-effort push
- `test_context_update_memberless_team_no_ops_push_and_seeds_file` — no-op push + file seed

Gate: `tests/test_team_brief.py tests/test_team_goal.py tests/test_teams.py tests/test_dashboard_ui.py` → **349 passed, 3 skipped**. `ruff check` clean on touched files.