### PR TITLE
Close team-membership join-context and lead-orphan lifecycle seams

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6968,6 +6968,26 @@ def create_mesh_app(
         if old and old != team_name:
             _remove_team_blackboard_permissions(agent, old)
             _purge_departed_team_signals(agent, old)
+            # Lead-orphan seam on the DEPARTURE side of a move: ``add_member``
+            # evicts the agent from ``old`` and clears ``old``'s lead pointer
+            # in-transaction when the mover WAS that team's lead — but nothing
+            # re-appoints, so the team it LEFT sits leaderless until the next
+            # reboot's backfill. Same mirror as the remove/offboard paths: if
+            # ``old`` now has no lead and still >=2 real members, appoint the
+            # first remaining real member + wire its standup. The mover is
+            # already gone from ``old``'s membership (moved to ``team_name``),
+            # so it can't be re-picked. Best-effort — must not fail the move.
+            try:
+                _old_team = teams_store.get_team(old) or {}
+                _old_real = [m for m in _old_team.get("members", []) if m != "operator"]
+                if len(_old_real) >= 2 and not (_old_team.get("lead_agent_id") or "").strip():
+                    try:
+                        teams_store.set_lead(old, _old_real[0])
+                        _sync_standup_job_on_lead_change(old, _old_real[0])
+                    except (TeamNotFound, ValueError) as e:
+                        logger.warning("move auto-appoint lead for team %s failed: %s", old, e)
+            except Exception as e:
+                logger.warning("move auto-appoint check for team %s failed: %s", old, e)
         _add_team_blackboard_permissions(agent, team_name)
         permissions.reload()
         # Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
@@ -6999,6 +7019,23 @@ def create_mesh_app(
                     logger.warning("auto-appoint lead for team %s failed: %s", team_name, e)
         except Exception as e:
             logger.warning("auto-appoint lead check for team %s failed: %s", team_name, e)
+        # Join-context seam (docs/plans/2026-07-16-autonomous-team-delivery.md
+        # §1): a worker container is started at create_agent BEFORE it joins,
+        # so its ``/data/workspace/TEAM.md`` is empty/stale — yet the onboarding
+        # intro tells it to "Read TEAM.md for team context." Nothing pushed the
+        # team's shared brief on JOIN (only the goal/context/brief writers push,
+        # or a container restart), so the new hire couldn't see shared context
+        # until some later edit. Push the team's CURRENT TEAM.md to running
+        # members now, reusing the same closure those writers use — the new
+        # member (if running) is included since it's now in ``members``. Best-
+        # effort: a push hiccup must not fail the add-member response; no
+        # team.md / a solo team with no running peers no-ops cleanly.
+        try:
+            _team_md_path = teams_store.team_md_path(team_name)
+            if _team_md_path is not None and _team_md_path.exists():
+                await _push_team_md(team_name, _team_md_path.read_text(errors="replace"))
+        except Exception as e:
+            logger.warning("TEAM.md push on join for team %s failed: %s", team_name, e)
         _schedule_onboarding_wake(agent, team_name)
         return {"added": True, "team_id": team_name, "team_name": team_name, "agent": agent}
 
@@ -7016,6 +7053,30 @@ def create_mesh_app(
         _remove_team_blackboard_permissions(agent, team_name)
         _purge_departed_team_signals(agent, team_name)
         permissions.reload()
+        # Lead-orphan seam (docs/plans/2026-07-16-autonomous-team-delivery.md
+        # §1/§3) — mirror of the ADD-side auto-appoint. ``remove_member``
+        # clears ``lead_agent_id`` in-transaction when the DEPARTING member was
+        # the lead, but nothing re-appoints, so a team that loses its lead sits
+        # LEADERLESS (stewardship — standup, goal-coverage probe, blocked-task
+        # escalation, drive-review verdicts — dormant) until the next mesh
+        # reboot's backfill. If the team now has NO lead AND still has >=2 real
+        # (non-operator) members, appoint the first remaining real member as
+        # lead + wire its standup cron live. Removing a NON-lead leaves the
+        # surviving lead intact (the ``lead_agent_id`` guard); dropping below 2
+        # real members appoints nobody (a solo team self-leads); NEVER the
+        # operator (``set_lead`` re-checks). Best-effort: a failure here must
+        # not fail the remove response; the boot backfill catches any drift.
+        try:
+            _team = teams_store.get_team(team_name) or {}
+            _real_members = [m for m in _team.get("members", []) if m != "operator"]
+            if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
+                try:
+                    teams_store.set_lead(team_name, _real_members[0])
+                    _sync_standup_job_on_lead_change(team_name, _real_members[0])
+                except (TeamNotFound, ValueError) as e:
+                    logger.warning("auto-appoint lead for team %s failed: %s", team_name, e)
+        except Exception as e:
+            logger.warning("auto-appoint lead check for team %s failed: %s", team_name, e)
         return {"removed": True, "team_id": team_name, "team_name": team_name, "agent": agent}
 
     @app.delete("/mesh/teams/{team_name}")
@@ -11623,6 +11684,35 @@ def create_mesh_app(
                 logger.warning(
                     "offboard clear-lead for team %s failed: %s", led_team_id, e,
                 )
+            # Lead-orphan seam (docs/plans/2026-07-16-autonomous-team-
+            # delivery.md §1/§3) — mirror of the ADD-side auto-appoint on the
+            # OFFBOARD departure path: clearing the departing lead above leaves
+            # the team leaderless (stewardship dormant) until the next reboot's
+            # backfill. Re-appoint a remaining real member. CRUCIAL difference
+            # from the remove-member path: offboard ARCHIVES the agent but does
+            # NOT drop its ``team_members`` row, so the departing agent is still
+            # in ``members`` — it is EXCLUDED here so it can never be re-picked
+            # as its own successor. If >=2 OTHER real (non-operator) members
+            # remain and there's no lead, appoint the first + wire its standup.
+            # Best-effort; the boot backfill catches any drift.
+            try:
+                _team = teams_store.get_team(led_team_id) or {}
+                _real_members = [
+                    m for m in _team.get("members", [])
+                    if m != "operator" and m != agent_id
+                ]
+                if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
+                    try:
+                        teams_store.set_lead(led_team_id, _real_members[0])
+                        _sync_standup_job_on_lead_change(led_team_id, _real_members[0])
+                    except (TeamNotFound, ValueError) as e:
+                        logger.warning(
+                            "offboard auto-appoint lead for team %s failed: %s", led_team_id, e,
+                        )
+            except Exception as e:
+                logger.warning(
+                    "offboard auto-appoint check for team %s failed: %s", led_team_id, e,
+                )
         archive_result = await _archive_agent_core(agent_id)
         return {"offboarded": True, "manifest": manifest, **archive_result}
 
@@ -12110,6 +12200,17 @@ def create_mesh_app(
                         target_id,
                         e,
                     )
+            # Lead-orphan seam on the DELETE departure path: capture the team
+            # this agent LEADS (if any) BEFORE ``_remove_agent`` drops its
+            # membership and clears ``lead_agent_id`` in-transaction. A deleted
+            # lead's team would otherwise sit leaderless until the next reboot's
+            # backfill (plain archive keeps the lead pointer, so a lead survives
+            # archive intact and is only orphaned here at delete time).
+            _deleted_led_team = None
+            try:
+                _deleted_led_team = teams_store.led_team(target_id)
+            except Exception as e:
+                logger.warning("delete lead lookup for %s failed: %s", target_id, e)
             try:
                 _remove_agent(target_id, stop_container=False)
             except Exception as e:
@@ -12129,6 +12230,26 @@ def create_mesh_app(
                     health_monitor.unregister(target_id)
                 except Exception:
                     pass
+            # Re-appoint a remaining real member as lead for the deleted lead's
+            # team (mirror of the remove/offboard/move paths). ``_remove_agent``
+            # already removed the deleted agent from ``team_members``, so it
+            # can't be re-picked. Best-effort — must not fail the delete.
+            if _deleted_led_team:
+                try:
+                    _team = teams_store.get_team(_deleted_led_team) or {}
+                    _real_members = [m for m in _team.get("members", []) if m != "operator"]
+                    if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
+                        try:
+                            teams_store.set_lead(_deleted_led_team, _real_members[0])
+                            _sync_standup_job_on_lead_change(_deleted_led_team, _real_members[0])
+                        except (TeamNotFound, ValueError) as e:
+                            logger.warning(
+                                "delete auto-appoint lead for team %s failed: %s", _deleted_led_team, e,
+                            )
+                except Exception as e:
+                    logger.warning(
+                        "delete auto-appoint check for team %s failed: %s", _deleted_led_team, e,
+                    )
             blackboard.log_audit(
                 action="delete_agent",
                 target=target_id,

--- a/tests/test_cron_standup.py
+++ b/tests/test_cron_standup.py
@@ -508,6 +508,104 @@ class TestAddMemberAutoAppointWiresStandup:
             importlib.reload(server_module)
 
 
+class TestRemoveLeadReappointWiresStandup:
+    """Lead-orphan seam (docs/plans/2026-07-16-autonomous-team-delivery.md
+    §1/§3): removing the lead must re-appoint a remaining member AND rewire
+    ITS standup cron LIVE — the mirror of the add-side auto-appoint, so
+    stewardship isn't dormant until the next reboot's reconcile."""
+
+    @pytest.mark.asyncio
+    async def test_remove_lead_reappoints_and_rewires_standup_job(self, tmp_path, monkeypatch):
+        import importlib
+        import json as _json
+
+        import yaml as _yaml
+        from httpx import ASGITransport, AsyncClient
+
+        monkeypatch.chdir(tmp_path)
+        import src.cli.config as cli_cfg
+
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(
+            _json.dumps(
+                {
+                    "permissions": {
+                        "agent1": {"blackboard_read": [], "blackboard_write": []},
+                        "agent2": {"blackboard_read": [], "blackboard_write": []},
+                        "agent3": {"blackboard_read": [], "blackboard_write": []},
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", perms_file)
+        agents_file = tmp_path / "agents.yaml"
+        agents_file.write_text(
+            _yaml.dump(
+                {
+                    "agents": {
+                        "agent1": {"role": "a"},
+                        "agent2": {"role": "b"},
+                        "agent3": {"role": "c"},
+                        "operator": {"role": "operator"},
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(cli_cfg, "AGENTS_FILE", agents_file)
+
+        import src.host.server as server_module
+
+        importlib.reload(server_module)
+        from src.host.cron import CronScheduler
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.teams import TeamStore
+
+        permissions = PermissionMatrix()
+        router = MessageRouter(
+            permissions,
+            {
+                "operator": "http://op:8400",
+                "agent1": "http://a1:8400",
+                "agent2": "http://a2:8400",
+                "agent3": "http://a3:8400",
+            },
+        )
+        blackboard = Blackboard(str(tmp_path / "bb.db"))
+        cron_scheduler = CronScheduler(config_path=str(tmp_path / "cron.json"))
+        teams_store = TeamStore(db_path=str(tmp_path / "teams.db"), teams_dir=tmp_path / "teams")
+        teams_store.create_team("squad")
+        app = server_module.create_mesh_app(
+            blackboard=blackboard,
+            pubsub=PubSub(),
+            router=router,
+            permissions=permissions,
+            teams_store=teams_store,
+            cron_scheduler=cron_scheduler,
+            auth_tokens={"operator": "op-token"},
+        )
+        hdr = {"Authorization": "Bearer op-token", "X-Agent-ID": "operator"}
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                for agent in ("agent1", "agent2", "agent3"):
+                    r = await c.post("/mesh/teams/squad/members", json={"agent": agent}, headers=hdr)
+                    assert r.status_code == 200, r.text
+                # agent1 auto-appointed on crossing to two + standup wired.
+                assert teams_store.get_team("squad")["lead_agent_id"] == "agent1"
+                assert cron_scheduler.find_standup_job("squad").agent == "agent1"
+                # Remove the LEAD → first remaining member re-appointed + standup rewired.
+                r = await c.delete("/mesh/teams/squad/members/agent1", headers=hdr)
+                assert r.status_code == 200, r.text
+            assert teams_store.get_team("squad")["lead_agent_id"] == "agent2"
+            job = cron_scheduler.find_standup_job("squad")
+            assert job is not None
+            assert job.agent == "agent2"
+            assert job.post_to_channel == "squad"
+        finally:
+            blackboard.close()
+            importlib.reload(server_module)
+
+
 # ── Boot reconcile (cli/runtime.RuntimeContext._reconcile_standup_jobs) ──
 
 

--- a/tests/test_offboarding.py
+++ b/tests/test_offboarding.py
@@ -420,6 +420,151 @@ class TestOffboardEndpoint:
             bb.close()
 
 
+# ── Lead-orphan seam: departure re-appoint (offboard + delete) ──────
+#
+# Mirror of the ADD-side auto-appoint (docs/plans/2026-07-16-autonomous-
+# team-delivery.md §1/§3): a departing lead must not leave the team
+# leaderless until the next reboot's backfill.
+
+
+class TestOffboardLeadReappoint:
+    @pytest.mark.asyncio
+    async def test_offboard_lead_reappoints_remaining_and_wires_standup(self, tmp_path, monkeypatch):
+        """Offboarding the lead re-appoints the first OTHER real member and
+        rewires the standup cron. The offboarded agent is archived but still
+        in ``team_members`` — it is EXCLUDED from candidates (never re-picked
+        as its own successor)."""
+        from src.host.cron import CronScheduler
+
+        cron = CronScheduler(config_path=str(tmp_path / "cron.json"))
+        lane = _RecordingLaneManager(reply="Handover text.")
+        app, bb, store, _ = _build_app(
+            tmp_path, monkeypatch, lane_manager=lane, cron_scheduler=cron,
+            extra_agents={"analyst": {"role": "a"}, "editor": {"role": "e"}},
+        )
+        # research already has scout; add two more real members, scout leads.
+        store.add_member("research", "analyst")
+        store.add_member("research", "editor")
+        store.set_lead("research", "scout")
+        cron.ensure_standup_job("research", "scout")
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r = await c.post("/mesh/agents/scout/offboard", headers=_op_headers())
+            assert r.status_code == 200, r.text
+        finally:
+            bb.close()
+        # scout excluded → the first OTHER real member (analyst) re-appointed.
+        assert store.get_team("research")["lead_agent_id"] == "analyst"
+        job = cron.find_standup_job("research")
+        assert job is not None
+        assert job.agent == "analyst"
+
+    @pytest.mark.asyncio
+    async def test_offboard_lead_down_to_one_leaves_no_lead(self, tmp_path, monkeypatch):
+        """Offboarding a lead when only one OTHER real member remains leaves
+        the team leaderless (the solo remainder self-leads)."""
+        lane = _RecordingLaneManager(reply="Handover text.")
+        app, bb, store, _ = _build_app(
+            tmp_path, monkeypatch, lane_manager=lane,
+            extra_agents={"analyst": {"role": "a"}},
+        )
+        store.add_member("research", "analyst")  # research = {scout, analyst}
+        store.set_lead("research", "scout")
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r = await c.post("/mesh/agents/scout/offboard", headers=_op_headers())
+            assert r.status_code == 200, r.text
+        finally:
+            bb.close()
+        assert store.get_team("research")["lead_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_offboard_non_lead_leaves_lead_unchanged(self, tmp_path, monkeypatch):
+        """Offboarding a NON-lead member never touches the surviving lead."""
+        lane = _RecordingLaneManager(reply="Handover text.")
+        app, bb, store, _ = _build_app(
+            tmp_path, monkeypatch, lane_manager=lane,
+            extra_agents={"analyst": {"role": "a"}, "editor": {"role": "e"}},
+        )
+        store.add_member("research", "analyst")
+        store.add_member("research", "editor")
+        store.set_lead("research", "analyst")  # analyst leads; offboard scout
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r = await c.post("/mesh/agents/scout/offboard", headers=_op_headers())
+            assert r.status_code == 200, r.text
+        finally:
+            bb.close()
+        assert store.get_team("research")["lead_agent_id"] == "analyst"
+
+    @pytest.mark.asyncio
+    async def test_offboard_reappoint_failure_does_not_fail_offboard(self, tmp_path, monkeypatch):
+        """Best-effort: a ``set_lead`` failure during the departure re-appoint
+        must never fail the offboard response."""
+        from unittest.mock import patch
+
+        lane = _RecordingLaneManager(reply="Handover text.")
+        app, bb, store, _ = _build_app(
+            tmp_path, monkeypatch, lane_manager=lane,
+            extra_agents={"analyst": {"role": "a"}, "editor": {"role": "e"}},
+        )
+        store.add_member("research", "analyst")
+        store.add_member("research", "editor")
+        store.set_lead("research", "scout")
+        try:
+            with patch.object(store, "set_lead", side_effect=ValueError("boom")):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                    r = await c.post("/mesh/agents/scout/offboard", headers=_op_headers())
+            assert r.status_code == 200, r.text
+            assert r.json()["offboarded"] is True
+        finally:
+            bb.close()
+
+
+class TestDeleteLeadReappoint:
+    @pytest.mark.asyncio
+    async def test_delete_lead_reappoints_remaining_member(self, tmp_path, monkeypatch):
+        """Deleting a lead (archive → propose-delete → confirm) re-appoints
+        the first remaining real member for its former team — the delete path
+        clears the lead via ``remove_agent`` and would otherwise orphan it."""
+        # ``_remove_agent`` opens its OWN TeamStore handle via
+        # ``_open_teams_store()`` (``OPENLEGION_TEAMS_DB``); point it at the
+        # SAME file the app's store uses so the delete's membership write is
+        # visible to the endpoint's re-appoint (in production both resolve to
+        # one ``data/teams.db``).
+        monkeypatch.setenv("OPENLEGION_TEAMS_DB", str(tmp_path / "teams.db"))
+        lane = _RecordingLaneManager(reply="Handover text.")
+        container_manager = MagicMock()
+        app, bb, store, _ = _build_app(
+            tmp_path, monkeypatch, lane_manager=lane, container_manager=container_manager,
+            extra_agents={"analyst": {"role": "a"}, "editor": {"role": "e"}},
+        )
+        store.add_member("research", "analyst")
+        store.add_member("research", "editor")
+        store.set_lead("research", "scout")  # scout leads; archive keeps the pointer
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r = await c.post("/mesh/agents/scout/archive", headers=_op_headers())
+                assert r.status_code == 200, r.text
+                r = await c.post(
+                    "/mesh/agents/scout/propose-delete", headers=_human_origin_headers(),
+                )
+                assert r.status_code == 200, r.text
+                nonce = r.json()["change_id"]
+                digest = r.json()["payload_digest"]
+                r = await c.post(
+                    "/mesh/config/confirm",
+                    json={"change_id": nonce, "payload_digest": digest},
+                    headers=_human_origin_headers(),
+                )
+                assert r.status_code == 200, r.text
+                assert r.json()["deleted"] == "agent"
+        finally:
+            bb.close()
+        assert store.team_of("scout") is None
+        assert store.get_team("research")["lead_agent_id"] == "analyst"
+
+
 # ── ORDER PROOF: mesh delete-confirm chain ──────────────────────────
 
 

--- a/tests/test_team_brief.py
+++ b/tests/test_team_brief.py
@@ -226,6 +226,136 @@ async def test_team_context_update_now_pushes(brief_app):
     assert "fresh shared context" in project_md.read_text()
 
 
+# ── join-context push (add-member → TEAM.md to running members) ────
+
+
+@pytest.fixture
+def join_app(tmp_path, monkeypatch):
+    """Mesh app for the JOIN-context seam: the add-member endpoint's
+    operator gate needs ``auth_tokens`` configured (dev-mode resolves the
+    caller to "" and 403s), a FakeTransport to observe the push, a team
+    with an on-disk team.md, and one RUNNING member (in the registry)."""
+    monkeypatch.setenv(
+        "OPENLEGION_ORCHESTRATION_TASKS_DB", str(tmp_path / "tasks.db"),
+    )
+    import json as _json
+
+    import yaml as _yaml
+
+    import src.cli.config as config_module
+    import src.host.server as server_module
+    from src.host.teams import TeamStore
+
+    importlib.reload(server_module)
+    agents_file = tmp_path / "agents.yaml"
+    agents_file.write_text(
+        _yaml.dump(
+            {
+                "agents": {
+                    "scout": {"role": "a"},
+                    "analyst": {"role": "b"},
+                    "operator": {"role": "operator"},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(config_module, "AGENTS_FILE", agents_file)
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(
+        _json.dumps(
+            {
+                "permissions": {
+                    "scout": {"blackboard_read": [], "blackboard_write": []},
+                    "analyst": {"blackboard_read": [], "blackboard_write": []},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(config_module, "PERMISSIONS_FILE", perms_file)
+    teams_dir = tmp_path / "teams"
+    monkeypatch.setattr(config_module, "TEAMS_DIR", teams_dir)
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    permissions = PermissionMatrix()
+    router = MessageRouter(
+        permissions,
+        {
+            "scout": "http://scout:8400",  # RUNNING (in registry)
+            "operator": "http://operator:8400",
+            # analyst is a member but NOT running (absent from the registry).
+        },
+    )
+    fake_transport = _FakeTransport()
+    teams_store = TeamStore(db_path=str(tmp_path / "teams.db"), teams_dir=teams_dir)
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=PubSub(),
+        router=router,
+        permissions=permissions,
+        teams_store=teams_store,
+        transport=fake_transport,  # type: ignore[arg-type]
+        auth_tokens={"operator": "op-token"},
+    )
+    teams_store.create_team("research")
+    team_md = teams_dir / "research" / "team.md"
+    team_md.write_text("# research\n\nShared mission: ship the widget.\n")
+    yield app, fake_transport, teams_store, team_md
+    blackboard.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+def _op_bearer() -> dict:
+    return {"Authorization": "Bearer op-token", "X-Agent-ID": "operator"}
+
+
+@pytest.mark.asyncio
+async def test_add_member_pushes_current_team_md_to_running_members(join_app):
+    """Join-context seam: adding an agent pushes the team's CURRENT TEAM.md
+    to running members so a new hire's onboarding "Read TEAM.md" is not
+    stale until the next goal/context/brief edit or a container restart.
+    The newly-added RUNNING member (scout) receives the push; a non-running
+    member does not."""
+    app, transport, store, team_md = join_app
+    # A prior (non-running) member so the roster crosses to two; then add the
+    # RUNNING member (scout) via the endpoint.
+    store.add_member("research", "analyst")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.post(
+            "/mesh/teams/research/members",
+            json={"agent": "scout"},
+            headers=_op_bearer(),
+        )
+    assert r.status_code == 200, r.text
+    team_pushes = [call for call in transport.calls if call["path"] == "/team"]
+    assert team_pushes, "join should have pushed TEAM.md to running members"
+    # Only the running member got the push (scout), not the non-running one.
+    assert {call["agent_id"] for call in team_pushes} == {"scout"}
+    # The pushed content is the team's CURRENT on-disk TEAM.md.
+    assert team_pushes[0]["json"]["content"] == team_md.read_text()
+
+
+@pytest.mark.asyncio
+async def test_add_member_no_team_md_on_disk_no_ops_cleanly(join_app):
+    """Best-effort: with no team.md on disk the join push is a clean no-op —
+    the add still succeeds and nothing is pushed."""
+    app, transport, store, team_md = join_app
+    team_md.unlink()  # remove the scaffolded brief
+    store.add_member("research", "analyst")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.post(
+            "/mesh/teams/research/members",
+            json={"agent": "scout"},
+            headers=_op_bearer(),
+        )
+    assert r.status_code == 200, r.text
+    assert [call for call in transport.calls if call["path"] == "/team"] == []
+
+
 # ── outcomes_window on team summary ───────────────────────────────
 
 

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -457,6 +457,88 @@ class TestMeshTeamEndpoints:
         assert r.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_remove_lead_reappoints_first_remaining_member(self, team_app):
+        """Lead-orphan seam (docs/plans/2026-07-16-autonomous-team-delivery.md
+        §1/§3), mirror of the ADD-side auto-appoint: removing the LEAD from a
+        >=3-member team re-appoints the first remaining real member so
+        stewardship never goes dormant until the next reboot's backfill."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        store.add_member("proj1", "agent1")
+        store.add_member("proj1", "agent2")
+        store.add_member("proj1", "agent3")
+        store.set_lead("proj1", "agent1")
+        r = await _delete(app, "/mesh/teams/proj1/members/agent1")
+        assert r.status_code == 200
+        assert store.members("proj1") == ["agent2", "agent3"]
+        # First remaining real member (by join order) is re-appointed.
+        assert store.get_team("proj1")["lead_agent_id"] == "agent2"
+
+    @pytest.mark.asyncio
+    async def test_remove_non_lead_leaves_lead_unchanged(self, team_app):
+        """Never re-appoint over a surviving lead: removing a NON-lead member
+        leaves the existing lead intact."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        store.add_member("proj1", "agent1")
+        store.add_member("proj1", "agent2")
+        store.add_member("proj1", "agent3")
+        store.set_lead("proj1", "agent2")  # lead is agent2
+        r = await _delete(app, "/mesh/teams/proj1/members/agent3")  # remove non-lead
+        assert r.status_code == 200
+        assert store.get_team("proj1")["lead_agent_id"] == "agent2"
+
+    @pytest.mark.asyncio
+    async def test_remove_lead_down_to_one_leaves_no_lead(self, team_app):
+        """Dropping below two real members appoints nobody — the solo
+        remainder self-leads (no lead row)."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        store.add_member("proj1", "agent1")
+        store.add_member("proj1", "agent2")
+        store.set_lead("proj1", "agent1")
+        r = await _delete(app, "/mesh/teams/proj1/members/agent1")
+        assert r.status_code == 200
+        assert store.members("proj1") == ["agent2"]
+        assert store.get_team("proj1")["lead_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_remove_lead_reappoint_failure_does_not_fail_remove(self, team_app):
+        """Best-effort: a ``set_lead`` failure during re-appoint must not fail
+        the remove response — the member is still removed, the lead stays
+        cleared, and the boot backfill catches the drift."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        store.add_member("proj1", "agent1")
+        store.add_member("proj1", "agent2")
+        store.add_member("proj1", "agent3")
+        store.set_lead("proj1", "agent1")
+        with patch.object(store, "set_lead", side_effect=ValueError("boom")):
+            r = await _delete(app, "/mesh/teams/proj1/members/agent1")
+        assert r.status_code == 200
+        assert store.team_of("agent1") is None
+        assert store.get_team("proj1")["lead_agent_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_move_lead_reappoints_old_team(self, team_app):
+        """Move departure side: moving a team's LEAD to another team orphans
+        the old team's lead (``add_member`` eviction clears it) — the add
+        endpoint re-appoints a remaining old-team member."""
+        app, store, _, _ = team_app
+        store.create_team("proj1")
+        store.create_team("proj2")
+        store.add_member("proj1", "agent1")
+        store.add_member("proj1", "agent2")
+        store.add_member("proj1", "agent3")
+        store.set_lead("proj1", "agent1")  # agent1 leads proj1
+        r = await _post(app, "/mesh/teams/proj2/members", {"agent": "agent1"})
+        assert r.status_code == 200
+        assert store.team_of("agent1") == "proj2"
+        # proj1 lost its lead on the move → first remaining member re-appointed.
+        assert store.members("proj1") == ["agent2", "agent3"]
+        assert store.get_team("proj1")["lead_agent_id"] == "agent2"
+
+    @pytest.mark.asyncio
     async def test_delete_team_strips_all_member_permissions(self, team_app):
         app, store, perms_file, tmp_path = team_app
         await _post(


### PR DESCRIPTION
## Summary

Two mesh seams in the operator↔team lifecycle (design doc: `docs/plans/2026-07-16-autonomous-team-delivery.md` §1/§3) left team state stale or dormant until the next mesh reboot's backfill. This closes both.

### Seam A — joining a team never pushed TEAM.md to the new member
A worker container is started (at `create_agent`) **before** it joins, so its `/data/workspace/TEAM.md` stays empty/stale — yet onboarding tells it to "Read TEAM.md for team context." `mesh_add_team_member` now pushes the team's **current** TEAM.md to running members right after the join, reusing the same `_push_team_md` closure the goal/context/brief writers use. Best-effort; no `team.md` / a solo team no-ops cleanly.

### Seam B — removing/offboarding the lead never re-appointed
The store clears `lead_agent_id` in the departure transaction, but only the boot backfill re-appointed — the mirror of the gap PR #1270 fixed on the ADD side. So a team that lost its lead sat leaderless (standup, goal-coverage probe, blocked-task escalation, drive-review verdicts dormant) until the next restart.

Every member-departure mesh path that can orphan the lead now re-appoints the first remaining real member (and rewires its standup cron) when the team is left with **no lead and ≥2 real members** — never the operator, never over a surviving lead:

- **`mesh_remove_team_member`** (explicit remove) — named target.
- **`offboard_agent_endpoint`** — named target; the archived departing agent is still in `team_members`, so it's **excluded** from candidates (never re-picked as its own successor).
- **`mesh_add_team_member` move-eviction** — moving a team's lead to another team clears the OLD team's lead; the old team is re-appointed.
- **delete-confirm agent path** (`_apply_pending_delete`) — `remove_agent` clears the lead; the former team is re-appointed.

All best-effort — a hiccup must never fail the add/remove/offboard/delete response; the boot backfill still catches any drift. Reuses existing helpers (`set_lead`, `_sync_standup_job_on_lead_change`, `_push_team_md`).

## Tests
- `test_team_brief.py` — add-member pushes current TEAM.md to running members; no-team.md no-ops.
- `test_teams.py` — remove-lead re-appoints; remove non-lead unchanged; remove down to <2 leaves no lead; best-effort survival on appoint failure; move-lead re-appoints old team.
- `test_cron_standup.py` — remove-lead re-appoint rewires the standup cron.
- `test_offboarding.py` — offboard-lead re-appoints + wires standup; down-to-one leaves no lead; non-lead unchanged; best-effort survival; delete-lead re-appoints.

Gate (`.env`-leak protocol, `LITELLM_MODE=PRODUCTION`): **403 passed, 3 skipped** across `test_teams.py test_cron_standup.py test_team_brief.py test_dashboard_ui.py test_offboarding.py`. `ruff check` clean on all touched files.