### PR TITLE
Operator tool polish: goal-timing note + summarize_team_progress consolidation

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2297,7 +2297,12 @@ async def update_team_brief(
 @tool(
     name="set_team_goal",
     operator_only=True,
-    description="Set a team's north star + success criteria.",
+    description=(
+        "Set a team's north star + success criteria. Mirrors into TEAM.md "
+        "and live-pushes to running members, but takes effect on each "
+        "member's next turn — an in-flight task finishes under its current "
+        "context, not mid-run."
+    ),
     parameters={
         "team_name": {"type": "string", "description": "Team name"},
         "north_star": {
@@ -2367,7 +2372,13 @@ async def set_team_goal(
 @tool(
     name="summarize_team_progress",
     operator_only=True,
-    description="Synthesised progress summary for a team.",
+    description=(
+        "Raw task-count rollup for a team (active/blocked/done tallies + "
+        "narrative status_text). Not operator-callable — for a real "
+        "goal-vs-evidence judgement (met / on_track / at_risk / no_evidence "
+        "/ needs_external_metric per success criterion), use "
+        "assess_team_progress instead."
+    ),
     parameters={
         "team_id": {"type": "string", "description": "Team id"},
     },
@@ -2378,7 +2389,13 @@ async def summarize_team_progress(
     mesh_client=None,
     **_kw,
 ) -> dict:
-    """Synthesized progress summary for a team."""
+    """Synthesized task-count progress summary for a team.
+
+    Kept registered (directly callable in Python, e.g. by tests) but
+    removed from the operator's callable surface (``_OPERATOR_ALLOWED_TOOLS``
+    in ``src/cli/config.py``) — ``assess_team_progress`` supersedes it for
+    the operator's actual goal-vs-evidence judgement.
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1748,7 +1748,11 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "inspect_team_spend",
     "list_agent_queue",
     "get_team_outputs",
-    "summarize_team_progress",
+    # NOTE: ``summarize_team_progress`` (raw task-count rollup) is
+    # deliberately NOT on this allowlist — it's a thin, easily-confused
+    # near-duplicate of ``assess_team_progress`` below (goal-vs-evidence
+    # judgement). The tool stays registered (directly callable in
+    # Python / tests) but is no longer offered to the operator LLM.
     # Goal-progress assessment (Tier-3) — composes the team's north_star +
     # success_criteria with real completed-work evidence + task counts +
     # blockers so the operator can judge each criterion (met / on_track /

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -430,7 +430,6 @@ class TestOperatorConstants:
         for tool in (
             "inspect_teams", "inspect_agents",
             "list_agent_queue", "get_team_outputs",
-            "summarize_team_progress",
             "manage_team", "manage_agent", "manage_task",
             # PR 5 — north-star setter is no-confirmation meta-config.
             "set_team_goal",
@@ -456,6 +455,12 @@ class TestOperatorConstants:
             "create_project", "add_agents_to_project",
             "remove_agents_from_project", "update_project_context",
             "set_project_goal", "manage_project",
+            # Consolidation cleanup: ``summarize_team_progress`` (thin
+            # task-count wrapper) is a confusingly-named near-duplicate of
+            # ``assess_team_progress`` (goal-vs-evidence judgement). It
+            # remains registered (directly callable in Python / tests) but
+            # is no longer on the operator's callable surface.
+            "summarize_team_progress",
         ):
             assert tool not in _OPERATOR_ALLOWED_TOOLS
 


### PR DESCRIPTION
## Summary
- `set_team_goal` description now states goal changes take effect on each member's next turn (system prompt rebuilds per-turn), not mid-run, even though the goal mirrors into TEAM.md and live-pushes to running members (#1268).
- `summarize_team_progress` (thin task-count wrapper) and `assess_team_progress` (#1272, rich goal-vs-evidence bundle) had confusingly similar names/purposes. Removed `summarize_team_progress` from the operator's callable surface (`_OPERATOR_ALLOWED_TOOLS` in `src/cli/config.py`) since it was an ungrouped leftover (not in any tool group, not playbook-referenced); the function itself stays registered (still directly callable in Python / by tests) with its description redirecting to `assess_team_progress`.

## Test plan
- [x] `PYTHONPATH=$PWD LITELLM_MODE=PRODUCTION python -m pytest tests/test_operator_tools.py tests/test_dashboard_ui.py tests/test_operator_playbooks.py tests/test_grouped_tools.py -q` — 425 passed, 3 skipped
- [x] Also ran `tests/test_operator_config.py tests/test_operator_product_tools.py tests/test_team_goal.py` — 544 passed, 3 skipped total
- [x] `ruff check` on touched files — all checks passed