### PR TITLE
dashboard: give operator team tools friendly activity verbs

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -11482,6 +11482,17 @@ function dashboard() {
         recommend_pending_action: 'recommending on a held action',
         allocate_member_budget: 'allocating a teammate\'s budget',
         set_team_lead: 'appointing a team lead',
+        create_team: 'creating a team',
+        add_agents_to_team: 'adding teammates to a team',
+        remove_agents_from_team: 'removing teammates from a team',
+        set_team_goal: 'setting the team goal',
+        update_team_context: 'updating team context',
+        inspect_teams: 'reviewing teams',
+        get_team_outputs: 'reviewing team outputs',
+        manage_team: 'managing a team',
+        manage_task: 'managing a task',
+        manage_agent: 'managing a teammate',
+        manage_goals: 'updating the goals board',
       };
       if (map[toolName]) return map[toolName];
       // Fallback: humanise the snake_case tool name.

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1972,7 +1972,6 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     # Introspection / mesh-internal — fallback "using X" reads fine.
     "get_system_status",
     "get_agent_profile",
-    "get_team_outputs",
     "list_agent_queue",
     "list_blackboard",
     "list_files",
@@ -1999,16 +1998,8 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "cancel_pending_action",
     "archive_audit_before",
     "undo_change",
-    "manage_agent",
-    "manage_goals",
-    "manage_team",
-    "manage_task",
-    "create_team",
-    "add_agents_to_team",
-    "remove_agents_from_team",
-    "set_team_goal",
-    "update_team_context",
-    "inspect_teams",
+    # summarize_team_progress: removed from the operator surface (#1275) but
+    # still a registered @tool, so it stays on the fallback allowlist.
     "summarize_team_progress",
     # Vault / credentials.
     "vault_generate_secret",


### PR DESCRIPTION
## What
Operator team-management actions rendered in the dashboard activity feed as the raw `using <snake_case>` fallback (`set_team_goal`, `inspect_teams`, `manage_team`, `create_team`, …), even though sibling tools (`set_team_lead`, `inspect_team_spend`, `set_agent_goals`, `update_team_brief`) already had proper verbs. This closes that sibling split so the operator's work reads cleanly at a glance.

## Changes
- **`app.js`** — added `verbForTool` entries for the review-relevant operator team tools: `create_team`, `add_agents_to_team`, `remove_agents_from_team`, `set_team_goal`, `update_team_context`, `inspect_teams`, `get_team_outputs`, `manage_team`, `manage_task`, `manage_agent`, `manage_goals`.
- **`test_dashboard_ui.py`** — removed those 11 from `_VERB_FOR_TOOL_FALLBACK_OK`, so `TestVerbForToolCompleteness` now **requires** a verb for each (prevents future drift where a new sibling lands without a label). `summarize_team_progress` (off the operator surface since #1275, still a registered `@tool`) stays on the allowlist.

## Verification
- `TestVerbForToolCompleteness` + `TestActivityVerbs` + full `test_dashboard_ui.py` green locally (250 passed, 3 pre-existing skips).
- `ruff check` clean; `node --check app.js` OK.

Cosmetic/observability only — no behavior change. Follow-up to the docs pass in #1277.