### PR TITLE
fix(teams): unify lead lifecycle — no dead-lead, no orphaned standup (PR-B)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -2807,19 +2807,44 @@ class RuntimeContext:
         except Exception as e:
             logger.warning("team-lead backfill failed to load teams: %s", e)
             return
+        # Agent status by id (same source as ``_reconcile_standup_jobs``) so
+        # an ARCHIVED member can never be appointed — or an archived
+        # dead-lead pointer left in place — as a team's lead.
+        try:
+            agent_statuses = {
+                aid: (acfg or {}).get("status", "active")
+                for aid, acfg in (_load_config().get("agents", {}) or {}).items()
+            }
+        except Exception as e:
+            logger.warning("team-lead backfill failed to load agent statuses: %s", e)
+            agent_statuses = {}
         for name, meta in teams.items():
             if (meta.get("status") or "active") == "archived":
                 continue
-            if meta.get("lead_agent_id"):
-                continue
+            current = (meta.get("lead_agent_id") or "").strip()
             members = [m for m in (meta.get("members") or []) if m != "operator"]
-            if len(members) < 2:
-                # Solo / team-of-one self-leads — no lead row.
+            active_members = [
+                m for m in members if agent_statuses.get(m, "active") == "active"
+            ]
+            # A current lead that is still active + a member is authoritative;
+            # an archived (dead) lead pointer is treated as vacant so it heals.
+            if current and current in members and agent_statuses.get(current, "active") == "active":
+                continue
+            if len(active_members) < 2:
+                # Solo / no active pair self-leads. Clear a stale dead-lead
+                # pointer so the Team Room + the standup reconcile below see no
+                # lead (which prunes the orphaned standup cron).
+                if current:
+                    try:
+                        self.teams_store.set_lead(name, None)
+                        logger.info("cleared dead lead %s for team %s", current, name)
+                    except Exception as e:
+                        logger.warning("team-lead backfill clear for %s failed: %s", name, e)
                 continue
             try:
-                self.teams_store.set_lead(name, members[0])
+                self.teams_store.set_lead(name, active_members[0])
                 logger.info(
-                    "backfilled lead %s for leaderless team %s", members[0], name
+                    "backfilled lead %s for team %s", active_members[0], name
                 )
             except Exception as e:
                 logger.warning("team-lead backfill for team %s failed: %s", name, e)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6732,10 +6732,12 @@ def create_mesh_app(
                 teams_store.create_team(name, description=description)
             except (TeamExists, ValueError) as e:
                 raise HTTPException(400, str(e))
+            _evicted_old_teams: set[str] = set()
             for agent in members:
                 old = teams_store.add_member(name, agent)
                 if old and old != name:
                     _remove_team_blackboard_permissions(agent, old)
+                    _evicted_old_teams.add(old)
                 _add_team_blackboard_permissions(agent, name)
             if members:
                 # ACL writes land on disk; refresh the LIVE matrix so the
@@ -6754,19 +6756,15 @@ def create_mesh_app(
         # refuses the operator. A solo/one-member team self-leads — no lead
         # row (nobody to coordinate). Best-effort: a failure here must not
         # fail team creation; the boot backfill catches any drift.
-        lead_id: str | None = None
-        _real_members = [m for m in members if m != "operator"]
-        if len(_real_members) >= 2:
-            try:
-                teams_store.set_lead(name, _real_members[0])
-                lead_id = _real_members[0]
-            except (TeamNotFound, ValueError) as e:
-                logger.warning("auto-appoint lead for team %s failed: %s", name, e)
-        if lead_id is not None:
-            # Wire the new lead's standup cron immediately (same helper the
-            # dedicated lead endpoint uses) so stewardship starts now, not at
-            # the next mesh restart. No-op when cron_scheduler is unwired.
-            _sync_standup_job_on_lead_change(name, lead_id)
+        # Appoint an active lead for a non-solo team + wire its standup (the
+        # helper filters archived members and self-heals a stale pointer). A
+        # solo/one-member team self-leads — no lead row.
+        _ensure_team_lead(name)
+        # A create can pull members OUT of other teams (add_member move); a
+        # team that lost its lead to this create must be re-evaluated too, or
+        # it sits leaderless until the next reboot's backfill.
+        for _old_team in _evicted_old_teams:
+            _ensure_team_lead(_old_team)
         # Team channel thread (Phase-2 Team Threads): create the durable
         # channel and point the team row at it. Best-effort — a thread
         # hiccup must not fail team creation; the boot backfill catches
@@ -6984,25 +6982,10 @@ def create_mesh_app(
             _remove_team_blackboard_permissions(agent, old)
             _purge_departed_team_signals(agent, old)
             # Lead-orphan seam on the DEPARTURE side of a move: ``add_member``
-            # evicts the agent from ``old`` and clears ``old``'s lead pointer
-            # in-transaction when the mover WAS that team's lead — but nothing
-            # re-appoints, so the team it LEFT sits leaderless until the next
-            # reboot's backfill. Same mirror as the remove/offboard paths: if
-            # ``old`` now has no lead and still >=2 real members, appoint the
-            # first remaining real member + wire its standup. The mover is
-            # already gone from ``old``'s membership (moved to ``team_name``),
-            # so it can't be re-picked. Best-effort — must not fail the move.
-            try:
-                _old_team = teams_store.get_team(old) or {}
-                _old_real = [m for m in _old_team.get("members", []) if m != "operator"]
-                if len(_old_real) >= 2 and not (_old_team.get("lead_agent_id") or "").strip():
-                    try:
-                        teams_store.set_lead(old, _old_real[0])
-                        _sync_standup_job_on_lead_change(old, _old_real[0])
-                    except (TeamNotFound, ValueError) as e:
-                        logger.warning("move auto-appoint lead for team %s failed: %s", old, e)
-            except Exception as e:
-                logger.warning("move auto-appoint check for team %s failed: %s", old, e)
+            # evicts the mover from ``old`` and clears ``old``'s lead pointer
+            # in-transaction when the mover WAS its lead. Re-evaluate ``old`` so
+            # it doesn't sit leaderless until the next reboot's backfill.
+            _ensure_team_lead(old)
         _add_team_blackboard_permissions(agent, team_name)
         permissions.reload()
         # Phase-1 leadership loop (docs/plans/2026-07-16-autonomous-team-
@@ -7020,20 +7003,10 @@ def create_mesh_app(
         # operator). A solo/one-member team self-leads (no lead row). Best-
         # effort: a failure here must not fail the add-members response; the
         # boot backfill catches any drift.
-        try:
-            _team = teams_store.get_team(team_name) or {}
-            _real_members = [m for m in _team.get("members", []) if m != "operator"]
-            if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
-                try:
-                    teams_store.set_lead(team_name, _real_members[0])
-                    # Wire the new lead's standup cron immediately (same helper
-                    # the dedicated lead endpoint uses) so stewardship starts
-                    # now, not at the next mesh restart.
-                    _sync_standup_job_on_lead_change(team_name, _real_members[0])
-                except (TeamNotFound, ValueError) as e:
-                    logger.warning("auto-appoint lead for team %s failed: %s", team_name, e)
-        except Exception as e:
-            logger.warning("auto-appoint lead check for team %s failed: %s", team_name, e)
+        # Appoint an active lead once the roster reaches >=2 active members
+        # (mirrors the create path; the helper self-heals a stale pointer and
+        # a solo/one-member team self-leads with no lead row).
+        _ensure_team_lead(team_name)
         # Join-context seam (docs/plans/2026-07-16-autonomous-team-delivery.md
         # §1): a worker container is started at create_agent BEFORE it joins,
         # so its ``/data/workspace/TEAM.md`` is empty/stale — yet the onboarding
@@ -7081,17 +7054,10 @@ def create_mesh_app(
         # real members appoints nobody (a solo team self-leads); NEVER the
         # operator (``set_lead`` re-checks). Best-effort: a failure here must
         # not fail the remove response; the boot backfill catches any drift.
-        try:
-            _team = teams_store.get_team(team_name) or {}
-            _real_members = [m for m in _team.get("members", []) if m != "operator"]
-            if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
-                try:
-                    teams_store.set_lead(team_name, _real_members[0])
-                    _sync_standup_job_on_lead_change(team_name, _real_members[0])
-                except (TeamNotFound, ValueError) as e:
-                    logger.warning("auto-appoint lead for team %s failed: %s", team_name, e)
-        except Exception as e:
-            logger.warning("auto-appoint lead check for team %s failed: %s", team_name, e)
+        # Re-evaluate the team's lead after a departure: re-appoint an active
+        # member, or clear the lead + retire the standup when it drops to solo
+        # (fixes the orphaned standup cron + stuck dead-lead on removal).
+        _ensure_team_lead(team_name)
         return {"removed": True, "team_id": team_name, "team_name": team_name, "agent": agent}
 
     @app.delete("/mesh/teams/{team_name}")
@@ -8349,6 +8315,57 @@ def create_mesh_app(
             "north_star": north_star,
             "success_criteria": success_criteria,
         }
+
+    def _active_real_members(members: list[str]) -> list[str]:
+        """Members eligible to lead: non-operator AND active. Excludes
+        archived/hibernated agents (``_status_overrides`` is kept in sync on
+        archive/hibernate/offboard and defaults ``"active"``) so a departed-
+        but-still-in-``team_members`` agent can never be appointed — or boot-
+        backfilled — as a dead lead. Preserves stored (rowid) order.
+        """
+        return [
+            m for m in (members or [])
+            if m != "operator" and _status_overrides.get(m, "active") == "active"
+        ]
+
+    def _ensure_team_lead(team_name: str) -> None:
+        """Idempotently keep a non-solo team led by an ACTIVE member; retire
+        the lead + standup when it can't be.
+
+        The single entry point every membership-mutation path calls (create /
+        add / remove / move-eviction / offboard / delete / unarchive / agent-
+        archive). Appointment filters by active status; a current lead that is
+        no longer active or no longer a member is treated as vacant (so a
+        stuck dead-lead self-heals on the next mutation); a team that drops
+        below two active members has its lead cleared and its standup cron
+        retired. Best-effort — never raises into the caller.
+        """
+        try:
+            team = teams_store.get_team(team_name)
+        except Exception as e:  # noqa: BLE001 - best-effort stewardship
+            logger.warning("ensure-lead: get_team(%s) failed: %s", team_name, e)
+            return
+        if not team or (team.get("status") or "active") == "archived":
+            return
+        current = (team.get("lead_agent_id") or "").strip()
+        active = _active_real_members(team.get("members", []))
+        if current and current in active:
+            return  # a still-active current lead is authoritative
+        if len(active) >= 2:
+            try:
+                teams_store.set_lead(team_name, active[0])
+                _sync_standup_job_on_lead_change(team_name, active[0])
+            except (TeamNotFound, ValueError) as e:
+                logger.warning("ensure-lead: appoint for %s failed: %s", team_name, e)
+        else:
+            # Solo / no active pair → no lead. Clear a stale (e.g. now-archived)
+            # pointer and retire the standup so it stops firing on a non-lead.
+            if current:
+                try:
+                    teams_store.set_lead(team_name, None)
+                except (TeamNotFound, ValueError) as e:
+                    logger.warning("ensure-lead: clear for %s failed: %s", team_name, e)
+            _sync_standup_job_on_lead_change(team_name, None)
 
     def _sync_standup_job_on_lead_change(team_name: str, lead_agent_id: str | None) -> None:
         """Live cron sync for a lead assign/unassign (plan §8 #14).
@@ -10832,6 +10849,10 @@ def create_mesh_app(
                     team_name,
                     e,
                 )
+        # Restore the daily STANDUP cron too (archive tore it down). The helper
+        # re-validates/appoints the lead and re-wires its standup — symmetric to
+        # the summary-job restore above.
+        _ensure_team_lead(team_name)
         _emit_team_event(event_bus, "team_unarchived", agent="operator", name=team_name)
         return {
             "archived": False,
@@ -11309,6 +11330,16 @@ def create_mesh_app(
         # the stale pre-archive entry — "active" or "hibernated" — from
         # the cache and either no-op or attempt a wake).
         _status_overrides[agent_id] = "archived"
+        # If the archived agent was a team's lead, its stewardship would go
+        # dormant (a stopped agent's heartbeat never ticks). Re-evaluate that
+        # team so an active member takes over — or the lead is cleared and the
+        # standup retired when none remain. Best-effort.
+        try:
+            _led_team = teams_store.led_team(agent_id)
+            if _led_team:
+                _ensure_team_lead(_led_team)
+        except Exception as e:
+            logger.warning("archive: re-evaluate lead for %s failed: %s", agent_id, e)
         # Stop scheduling: drop heartbeat and any cron jobs the agent owns.
         if cron_scheduler is not None:
             try:
@@ -11743,24 +11774,13 @@ def create_mesh_app(
             # as its own successor. If >=2 OTHER real (non-operator) members
             # remain and there's no lead, appoint the first + wire its standup.
             # Best-effort; the boot backfill catches any drift.
-            try:
-                _team = teams_store.get_team(led_team_id) or {}
-                _real_members = [
-                    m for m in _team.get("members", [])
-                    if m != "operator" and m != agent_id
-                ]
-                if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
-                    try:
-                        teams_store.set_lead(led_team_id, _real_members[0])
-                        _sync_standup_job_on_lead_change(led_team_id, _real_members[0])
-                    except (TeamNotFound, ValueError) as e:
-                        logger.warning(
-                            "offboard auto-appoint lead for team %s failed: %s", led_team_id, e,
-                        )
-            except Exception as e:
-                logger.warning(
-                    "offboard auto-appoint check for team %s failed: %s", led_team_id, e,
-                )
+            # Offboard archives the agent but KEEPS its team_members row, and
+            # ``_archive_agent_core`` (which marks it archived) runs below — so
+            # mark it archived HERE first, then re-evaluate, so the helper's
+            # active-member filter can't re-pick the departing agent as its own
+            # successor.
+            _status_overrides[agent_id] = "archived"
+            _ensure_team_lead(led_team_id)
         archive_result = await _archive_agent_core(agent_id)
         return {"offboarded": True, "manifest": manifest, **archive_result}
 
@@ -12282,22 +12302,11 @@ def create_mesh_app(
             # team (mirror of the remove/offboard/move paths). ``_remove_agent``
             # already removed the deleted agent from ``team_members``, so it
             # can't be re-picked. Best-effort — must not fail the delete.
+            # ``_remove_agent`` above already dropped the deleted agent from
+            # team_members, so it can't be re-picked. Re-evaluate the team it
+            # led so it doesn't sit leaderless until the next reboot's backfill.
             if _deleted_led_team:
-                try:
-                    _team = teams_store.get_team(_deleted_led_team) or {}
-                    _real_members = [m for m in _team.get("members", []) if m != "operator"]
-                    if len(_real_members) >= 2 and not (_team.get("lead_agent_id") or "").strip():
-                        try:
-                            teams_store.set_lead(_deleted_led_team, _real_members[0])
-                            _sync_standup_job_on_lead_change(_deleted_led_team, _real_members[0])
-                        except (TeamNotFound, ValueError) as e:
-                            logger.warning(
-                                "delete auto-appoint lead for team %s failed: %s", _deleted_led_team, e,
-                            )
-                except Exception as e:
-                    logger.warning(
-                        "delete auto-appoint check for team %s failed: %s", _deleted_led_team, e,
-                    )
+                _ensure_team_lead(_deleted_led_team)
             blackboard.log_audit(
                 action="delete_agent",
                 target=target_id,

--- a/tests/test_cron_standup.py
+++ b/tests/test_cron_standup.py
@@ -605,6 +605,67 @@ class TestRemoveLeadReappointWiresStandup:
             blackboard.close()
             importlib.reload(server_module)
 
+    @pytest.mark.asyncio
+    async def test_remove_lead_to_solo_clears_lead_and_retires_standup(self, tmp_path, monkeypatch):
+        """Removing the LEAD of a two-member team drops it to solo — the lead
+        pointer is cleared and its standup cron retired (previously the standup
+        kept firing daily on the departed lead)."""
+        import importlib
+        import json as _json
+
+        import yaml as _yaml
+        from httpx import ASGITransport, AsyncClient
+
+        monkeypatch.chdir(tmp_path)
+        import src.cli.config as cli_cfg
+
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(_json.dumps({"permissions": {
+            "agent1": {"blackboard_read": [], "blackboard_write": []},
+            "agent2": {"blackboard_read": [], "blackboard_write": []},
+        }}))
+        monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", perms_file)
+        agents_file = tmp_path / "agents.yaml"
+        agents_file.write_text(_yaml.dump({"agents": {
+            "agent1": {"role": "a"}, "agent2": {"role": "b"}, "operator": {"role": "operator"},
+        }}))
+        monkeypatch.setattr(cli_cfg, "AGENTS_FILE", agents_file)
+
+        import src.host.server as server_module
+        importlib.reload(server_module)
+        from src.host.cron import CronScheduler
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.teams import TeamStore
+
+        blackboard = Blackboard(str(tmp_path / "bb.db"))
+        permissions = PermissionMatrix()
+        router = MessageRouter(permissions, {"operator": "http://op:8400"})
+        teams_store = TeamStore(db_path=str(tmp_path / "teams.db"))
+        teams_store.create_team("squad")
+        cron_scheduler = CronScheduler()
+        app = server_module.create_mesh_app(
+            blackboard=blackboard, pubsub=PubSub(), router=router,
+            permissions=permissions, teams_store=teams_store,
+            cron_scheduler=cron_scheduler, auth_tokens={"operator": "op-token"},
+        )
+        hdr = {"Authorization": "Bearer op-token", "X-Agent-ID": "operator"}
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                for agent in ("agent1", "agent2"):
+                    r = await c.post("/mesh/teams/squad/members", json={"agent": agent}, headers=hdr)
+                    assert r.status_code == 200, r.text
+                assert teams_store.get_team("squad")["lead_agent_id"] == "agent1"
+                assert cron_scheduler.find_standup_job("squad") is not None
+                # Remove the LEAD → team is now solo {agent2}: no lead, no standup.
+                r = await c.delete("/mesh/teams/squad/members/agent1", headers=hdr)
+                assert r.status_code == 200, r.text
+            assert teams_store.get_team("squad")["lead_agent_id"] is None
+            assert cron_scheduler.find_standup_job("squad") is None
+        finally:
+            blackboard.close()
+            importlib.reload(server_module)
+
 
 # ── Boot reconcile (cli/runtime.RuntimeContext._reconcile_standup_jobs) ──
 
@@ -904,6 +965,66 @@ class TestBackfillTeamLeads:
         RuntimeContext._backfill_team_leads(self._stub(store))
 
         assert store.get_team("old")["lead_agent_id"] is None
+
+    def test_backfill_excludes_archived_member_and_appoints_first_active(self, tmp_path, monkeypatch):
+        """A leaderless team whose first-rowid member is ARCHIVED gets the
+        first ACTIVE member as lead — never the archived one (the dead-lead
+        bug: appointment used to filter only ``!= operator``, not status)."""
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob", "cid"])  # ada first by rowid
+        import src.cli.runtime as rt
+        monkeypatch.setattr(rt, "_load_config", lambda *a, **k: {
+            "agents": {
+                "ada": {"status": "archived"},
+                "bob": {"status": "active"},
+                "cid": {"status": "active"},
+            }
+        })
+        rt.RuntimeContext._backfill_team_leads(self._stub(store))
+        assert store.get_team("alpha")["lead_agent_id"] == "bob"
+
+    def test_backfill_effectively_solo_when_only_one_active_member(self, tmp_path, monkeypatch):
+        """A 2-row team with only ONE active member is effectively solo — no
+        lead is appointed (the archived row doesn't make it a real pair)."""
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob"])
+        import src.cli.runtime as rt
+        monkeypatch.setattr(rt, "_load_config", lambda *a, **k: {
+            "agents": {"ada": {"status": "archived"}, "bob": {"status": "active"}}
+        })
+        rt.RuntimeContext._backfill_team_leads(self._stub(store))
+        assert store.get_team("alpha")["lead_agent_id"] is None
+
+    def test_backfill_heals_dead_archived_lead(self, tmp_path, monkeypatch):
+        """A team whose lead pointer references an ARCHIVED agent (a stuck
+        dead lead) is re-appointed to the first active member at boot — the
+        non-empty ``lead_agent_id`` guard no longer blocks the self-heal."""
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob", "cid"])
+        store.set_lead("alpha", "ada")  # ada leads...
+        import src.cli.runtime as rt
+        monkeypatch.setattr(rt, "_load_config", lambda *a, **k: {
+            "agents": {
+                "ada": {"status": "archived"},  # ...but ada is archived
+                "bob": {"status": "active"},
+                "cid": {"status": "active"},
+            }
+        })
+        rt.RuntimeContext._backfill_team_leads(self._stub(store))
+        assert store.get_team("alpha")["lead_agent_id"] == "bob"
+
+    def test_backfill_clears_dead_lead_when_no_active_pair(self, tmp_path, monkeypatch):
+        """A dead (archived) lead with fewer than two active members is
+        CLEARED so the Team Room + the standup reconcile see no lead."""
+        store = _team_store(tmp_path)
+        _seed_team(store, "alpha", ["ada", "bob"])
+        store.set_lead("alpha", "ada")
+        import src.cli.runtime as rt
+        monkeypatch.setattr(rt, "_load_config", lambda *a, **k: {
+            "agents": {"ada": {"status": "archived"}, "bob": {"status": "active"}}
+        })
+        rt.RuntimeContext._backfill_team_leads(self._stub(store))
+        assert store.get_team("alpha")["lead_agent_id"] is None
 
     def test_backfill_then_standup_reconcile_creates_job(self, tmp_path):
         """End-to-end: a leaderless multi-member team gets a lead at boot,


### PR DESCRIPTION
**PR-B of the teams-loop remediation.** Fixes the lead-lifecycle cluster (review findings A-F1/F2/F3/F4/F6 = Codex #3/#4/#5/#14).

## Root cause
Appointment + boot backfill filtered members only by `!= "operator"`, never active status; archived agents stay in `team_members`; and a non-empty `lead_agent_id` blocked re-appointment. So a departed/archived agent could become a permanent **dead lead** (stewardship dormant, no self-heal), and standup crons orphaned on departed leads.

## Fix — one unified helper at every mutation path
`_ensure_team_lead(team)` (+ `_active_real_members`) replaces the six ad-hoc appointment blocks:
- Appointment **filters by active status** (`_status_overrides`, kept in sync on archive/hibernate/offboard) → an archived member is never appointed.
- A current lead that's no longer active/a member is treated as **vacant** → a stuck dead-lead **self-heals** on the next mutation or boot.
- A team below two active members has its **lead cleared and standup cron retired** → no orphaned daily standup.

Applied at: create (+ re-ensure any team a moved member was **evicted** from — Codex #3), add, add-member move-eviction, remove, offboard (mark departing archived first so it can't re-pick itself), confirmed delete, **agent-archive** (re-evaluate the archived agent's led team — A-F4), **team unarchive** (rebuild the standup archive tore down — A-F3). Boot backfill filters by active status and clears dead-lead pointers.

## Out of scope (tracked follow-ups)
Busy-lead heartbeat starvation (A-F5); dashboard team-mutation paths (Codex #2).

## Tests
- Backfill: excludes archived member + appoints first active; effectively-solo (1 active) → no lead; heals a dead archived-lead; clears when no active pair.
- Endpoint: removing the lead of a 2-member team → lead cleared + standup retired.
- Full `test_offboarding` / `test_teams_store` / `test_journey_e2e` / `test_cron` / `test_cron_standup` / `test_team_budget` green locally (323+ passed); `ruff check` clean.