### PR TITLE
fix(teams): fence-aware TEAM.md section parser + reserved-name guard (PR-C)

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -8100,6 +8100,17 @@ def create_mesh_app(
                 400,
                 "Invalid section name (letters/digits/spaces/_-/&, max 64 chars)",
             )
+        # ``## Goal`` and ``## Context`` are OWNED by set_team_goal /
+        # update_team_context and carry DB backing (north_star / description).
+        # A generic brief write to those names would silently diverge TEAM.md
+        # from the store (workers follow the brief while inspect_teams /
+        # assess_team_progress report the stale DB value). Reject them.
+        if section.strip().lower() in ("goal", "context"):
+            raise HTTPException(
+                400,
+                f"'{section}' is a reserved section — use set_team_goal / "
+                "update_team_context so the store stays in sync.",
+            )
         if not content:
             raise HTTPException(400, "content is required")
         if len(content) > 2000:
@@ -8287,7 +8298,11 @@ def create_mesh_app(
                         goal_lines.append("")
                     goal_lines.append("Success criteria:")
                     goal_lines.extend(f"- {sc}" for sc in success_criteria)
-                goal_md = "\n".join(goal_lines) or "_No goal set._"
+                # Empty goal (both cleared) → remove the ``## Goal`` section
+                # entirely rather than leave a ``_No goal set._`` placeholder
+                # riding every member's prompt (replace_markdown_section drops
+                # a section when given empty content).
+                goal_md = "\n".join(goal_lines)
                 team_md_path.parent.mkdir(parents=True, exist_ok=True)
                 existing = (
                     team_md_path.read_text(errors="replace")

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -103,29 +103,62 @@ def format_dict(d: dict) -> str:
 
 
 def replace_markdown_section(text: str, section: str, content: str) -> str:
-    """Replace (or append) one level-2 ``## {section}`` block in markdown.
+    """Replace, append, or remove one level-2 ``## {section}`` block.
 
-    The block spans from its heading to the next ``## `` heading or EOF.
-    When the section is absent, it is appended at the end. Used for
-    section-scoped TEAM.md brief updates so an operator-written section
-    (e.g. ``## User Preferences``) never clobbers the rest of the
-    document — last-writer-wins is limited to one section.
+    Fence-aware LINE parser: lines inside ``` / ~~~ fenced code blocks are
+    NEVER treated as headings, so a ``## Goal`` example inside a fenced block
+    (or a multi-line body) can't be mistaken for the real section boundary.
+    The prior regex treated ANY ``## ``-prefixed line as a boundary and could
+    delete a section's content — and everything after it — to EOF.
+
+    The heading is matched exactly (case-insensitively on the name, trailing
+    whitespace tolerated); the FIRST matching section is replaced, spanning to
+    the next real (non-fenced) ``## `` heading or EOF. When the section is
+    absent it is appended. An empty ``content`` REMOVES the section, so
+    clearing a reserved section (Goal/Context) leaves no placeholder.
+    Content is inserted literally (no regex substitution), so backslashes in
+    the body are preserved verbatim.
     """
-    import re as _re
+    def _is_h2(line: str) -> bool:
+        return line.startswith("## ") and not line.startswith("### ")
 
-    block = f"## {section}\n\n{content.strip()}\n"
-    pattern = _re.compile(
-        rf"^## {_re.escape(section)}[ \t]*\n.*?(?=^## |\Z)",
-        _re.DOTALL | _re.MULTILINE,
-    )
-    if pattern.search(text):
-        # Function repl so backslashes in content can't act as group refs.
-        updated = pattern.sub(lambda _m: block + "\n", text, count=1)
-        return updated.rstrip("\n") + "\n"
+    lines = text.split("\n")
+    target = section.strip().lower()
+    fence: str | None = None
+    start: int | None = None
+    end = len(lines)
+    for i, line in enumerate(lines):
+        marker = line.lstrip()
+        if fence is None:
+            if marker.startswith("```") or marker.startswith("~~~"):
+                fence = marker[:3]
+                continue
+        else:
+            if marker.startswith(fence):
+                fence = None
+            continue  # inside a fence — never a heading boundary
+        if start is None:
+            if _is_h2(line) and line[3:].strip().lower() == target:
+                start = i
+        elif _is_h2(line):
+            end = i
+            break
+
+    new_body = content.strip()
+    if start is not None:
+        before = lines[:start]
+        after = lines[end:]
+        if not new_body:
+            merged = "\n".join(before + after)
+            return merged.rstrip("\n") + "\n" if merged.strip() else ""
+        rebuilt = before + [f"## {section}", "", new_body, ""] + after
+        return "\n".join(rebuilt).rstrip("\n") + "\n"
+
+    if not new_body:
+        return text  # nothing to append or remove — unchanged
     base = text.rstrip("\n")
-    if base:
-        return f"{base}\n\n{block}"
-    return block
+    block = f"## {section}\n\n{new_body}\n"
+    return f"{base}\n\n{block}" if base else block
 
 
 # ── Prompt injection sanitization ────────────────────────────

--- a/tests/test_team_brief.py
+++ b/tests/test_team_brief.py
@@ -61,6 +61,38 @@ class TestReplaceMarkdownSection:
         out = replace_markdown_section("", "User Preferences", "prefs")
         assert out == "## User Preferences\n\nprefs\n"
 
+    def test_fenced_heading_is_not_a_boundary(self):
+        """A ``## Goal`` inside a code fence must NOT be treated as a real
+        heading — replacing another section must not eat the fenced example
+        or the content after it (the old regex deleted to EOF)."""
+        fence = "```"
+        text = (
+            "# t\n\n## Context\n\n"
+            f"{fence}\n## Goal\nexample\n{fence}\n\nmore ctx\n\n"
+            "## Goal\n\nreal goal\n"
+        )
+        out = replace_markdown_section(text, "Goal", "NEW")
+        assert "more ctx" in out          # content after the fence survives
+        assert "## Context" in out
+        assert "NEW" in out and "real goal" not in out
+        # The fenced example heading is preserved; the real Goal is replaced.
+        assert out.count("## Goal") == 2
+
+    def test_empty_content_removes_section(self):
+        text = "# t\n\n## Goal\n\nG\n\n## Context\n\nC\n"
+        out = replace_markdown_section(text, "Goal", "")
+        assert "## Goal" not in out
+        assert "## Context" in out and "C" in out
+
+    def test_empty_content_absent_section_is_noop(self):
+        text = "# t\n\nintro\n"
+        assert replace_markdown_section(text, "Goal", "") == text
+
+    def test_heading_match_is_case_insensitive_and_trims_ws(self):
+        out = replace_markdown_section("# t\n\n## Goal   \n\nold\n", "Goal", "new")
+        assert "new" in out and "old" not in out
+        assert out.count("## Goal") == 1
+
 
 # ── mesh endpoint ─────────────────────────────────────────────────
 
@@ -193,6 +225,16 @@ async def test_brief_update_validation(brief_app):
             headers={"X-Agent-ID": "operator"},
         )
         assert r.status_code == 400
+        # Reserved section names (owned by set_team_goal /
+        # update_team_context, DB-backed) are rejected so a brief can't
+        # silently diverge TEAM.md from the store.
+        for reserved in ("Goal", "Context", "goal", " context "):
+            r = await c.put(
+                "/mesh/teams/research/brief",
+                json={"section": reserved, "content": "y"},
+                headers={"X-Agent-ID": "operator"},
+            )
+            assert r.status_code == 400, reserved
         # Oversized content.
         r = await c.put(
             "/mesh/teams/research/brief",


### PR DESCRIPTION
**PR-C of the teams-loop remediation** — TEAM.md section-integrity.

## `replace_markdown_section` rewrite (B-F1 / Codex #16)
The old regex treated **any** `## `-prefixed line as a section boundary — including one inside a fenced code block or a multi-line body — so replacing one section could delete a fenced example and everything after it **to EOF**. Rewritten as a **fence-aware line parser**: lines inside ` ``` `/`~~~` fences are never boundaries; headings match exactly (case-insensitive name, trailing whitespace tolerated); the first match is replaced, spanning to the next real `## ` heading or EOF; content inserted literally. All five existing shape-contract tests still pass.

## Empty content removes a section (B-F6)
Clearing a goal/context now **drops** the `## Goal` / `## Context` block instead of leaving a `_No goal set._` / empty-header placeholder in every member's prompt.

## Reserved-name guard (B-F2 / Codex #15)
`update_team_brief` rejects section names `Goal`/`Context` (case-insensitive) — they're owned by `set_team_goal`/`update_team_context` with DB backing, so a generic brief write would silently diverge TEAM.md from the store.

## Deferred to PR-C2 (TEAM.md durability)
Atomic+locked writes (B-F4), surfaced goal-push result (B-F3), goal-preserving prompt truncation (B-F5).

## Tests
Fenced `## Goal` example is not a boundary (content after it survives); empty content removes / no-op when absent; case-insensitive trimmed heading match; brief rejects reserved names. `test_team_brief` + `test_team_goal` + `test_journey_e2e` + `test_stable_prefix` green (57 passed); ruff clean.