### PR TITLE
fix(teams): atomic + per-team-locked TEAM.md writes; surface goal push result (PR-C2)

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -79,6 +79,7 @@ from src.shared.types import (
     NotifyRequest,
 )
 from src.shared.utils import (
+    atomic_write_text,
     dumps_safe,
     replace_markdown_section,
     sanitize_for_prompt,
@@ -8039,6 +8040,20 @@ def create_mesh_app(
             encoding = "base64"
         return {"path": safe_path, "ref": safe_ref, "content": text, "encoding": encoding, "size": len(data)}
 
+    _team_md_locks: dict[str, asyncio.Lock] = {}
+
+    def _team_md_lock(team_name: str) -> asyncio.Lock:
+        """Per-team lock serializing read-modify-write-push of the shared
+        ``team.md``. Without it, concurrent section writers (goal / context /
+        brief) each read the same base, replace their own section, and the
+        last plain write wins — silently dropping the others; the async push
+        could also deliver an older snapshot after a newer one."""
+        lock = _team_md_locks.get(team_name)
+        if lock is None:
+            lock = asyncio.Lock()
+            _team_md_locks[team_name] = lock
+        return lock
+
     async def _push_team_md(team_name: str, content: str) -> dict[str, bool]:
         """Push updated TEAM.md content to running team members.
 
@@ -8126,10 +8141,15 @@ def create_mesh_app(
         # the source of truth for existence, not the dir).
         team_md_path = teams_store.team_md_path(team_name) or (TEAMS_DIR / team_name / "team.md")
         team_md_path.parent.mkdir(parents=True, exist_ok=True)
-        existing = team_md_path.read_text(errors="replace") if team_md_path.exists() else f"# {team_name}\n"
-        updated = replace_markdown_section(existing, section, content)
-        team_md_path.write_text(updated)
-        pushed = await _push_team_md(team_name, updated)
+        # Serialize read-modify-write-push per team so concurrent section
+        # writers (goal / context / brief) can't lost-update the shared file
+        # or deliver an older snapshot after a newer one; atomic write so a
+        # concurrent reader never sees a torn file.
+        async with _team_md_lock(team_name):
+            existing = team_md_path.read_text(errors="replace") if team_md_path.exists() else f"# {team_name}\n"
+            updated = replace_markdown_section(existing, section, content)
+            atomic_write_text(team_md_path, updated)
+            pushed = await _push_team_md(team_name, updated)
         _emit_team_event(
             event_bus,
             "team_updated",
@@ -8183,20 +8203,24 @@ def create_mesh_app(
         # the sibling of the §1-finding-4 goal seam).
         team_md_path = teams_store.team_md_path(team_name) or (TEAMS_DIR / team_name / "team.md")
         team_md_path.parent.mkdir(parents=True, exist_ok=True)
-        existing = (
-            team_md_path.read_text(errors="replace")
-            if team_md_path.exists()
-            else f"# {team_name}\n"
-        )
-        new_content = replace_markdown_section(existing, "Context", context)
-        team_md_path.write_text(new_content)
-        # P2 gap fix: this writer previously never pushed to running
-        # members (only the dashboard's PUT /api/team did), so an
-        # operator-tool context update was invisible to agents until their
-        # next restart. Best-effort — ``_push_team_md`` swallows per-target
-        # failures, so a push hiccup never fails the context write, and a
-        # solo/memberless team pushes to nobody (clean no-op).
-        pushed = await _push_team_md(team_name, new_content)
+        # Serialize + atomic (see the brief endpoint): concurrent section
+        # writers must not lost-update or deliver an older snapshot after a
+        # newer one.
+        async with _team_md_lock(team_name):
+            existing = (
+                team_md_path.read_text(errors="replace")
+                if team_md_path.exists()
+                else f"# {team_name}\n"
+            )
+            new_content = replace_markdown_section(existing, "Context", context)
+            atomic_write_text(team_md_path, new_content)
+            # P2 gap fix: this writer previously never pushed to running
+            # members (only the dashboard's PUT /api/team did), so an
+            # operator-tool context update was invisible to agents until their
+            # next restart. Best-effort — ``_push_team_md`` swallows per-target
+            # failures, so a push hiccup never fails the context write, and a
+            # solo/memberless team pushes to nobody (clean no-op).
+            pushed = await _push_team_md(team_name, new_content)
 
         _emit_team_event(
             event_bus,
@@ -8287,6 +8311,8 @@ def create_mesh_app(
         # (the persisted row above is the source of truth), and a team
         # with no shared TEAM.md (pure-DB store / solo team-of-one with no
         # scaffold) no-ops cleanly.
+        pushed: dict[str, bool] = {}
+        mirror_ok = True
         try:
             team_md_path = teams_store.team_md_path(team_name)
             if team_md_path is not None:
@@ -8304,15 +8330,20 @@ def create_mesh_app(
                 # a section when given empty content).
                 goal_md = "\n".join(goal_lines)
                 team_md_path.parent.mkdir(parents=True, exist_ok=True)
-                existing = (
-                    team_md_path.read_text(errors="replace")
-                    if team_md_path.exists()
-                    else f"# {team_name}\n"
-                )
-                updated = replace_markdown_section(existing, "Goal", goal_md)
-                team_md_path.write_text(updated)
-                await _push_team_md(team_name, updated)
+                # Serialize + atomic read-modify-write-push per team (same as
+                # the context/brief writers) so a concurrent write can't
+                # lost-update or reorder the delivered snapshot.
+                async with _team_md_lock(team_name):
+                    existing = (
+                        team_md_path.read_text(errors="replace")
+                        if team_md_path.exists()
+                        else f"# {team_name}\n"
+                    )
+                    updated = replace_markdown_section(existing, "Goal", goal_md)
+                    atomic_write_text(team_md_path, updated)
+                    pushed = await _push_team_md(team_name, updated)
         except Exception as e:  # noqa: BLE001 — best-effort mirror, never fail the write
+            mirror_ok = False
             logger.warning("goal mirror/push for team %s failed: %s", team_name, e)
 
         _emit_team_event(
@@ -8329,6 +8360,13 @@ def create_mesh_app(
             "team_id": team_name,
             "north_star": north_star,
             "success_criteria": success_criteria,
+            # Propagation status, distinct from the DB persist (the source of
+            # truth, which already succeeded). ``mirror_ok=False`` means the
+            # TEAM.md mirror/push failed and running members may not see the
+            # new goal until their next restart; ``pushed`` is the per-member
+            # delivery result.
+            "mirror_ok": mirror_ok,
+            "pushed": pushed,
         }
 
     def _active_real_members(members: list[str]) -> list[str]:

--- a/tests/test_team_brief.py
+++ b/tests/test_team_brief.py
@@ -252,6 +252,29 @@ async def test_brief_update_validation(brief_app):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_section_writes_compose(brief_app):
+    """Context and brief writes to the same team, fired concurrently, must
+    BOTH land — neither clobbers the other and the pre-existing Workflow
+    section survives (per-team lock + atomic write)."""
+    import asyncio as _asyncio
+
+    app, _transport, project_md = brief_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        hdr = {"X-Agent-ID": "operator"}
+        results = await _asyncio.gather(
+            c.put("/mesh/teams/research/context",
+                  json={"context": "audience founders"}, headers=hdr),
+            c.put("/mesh/teams/research/brief",
+                  json={"section": "Rituals", "content": "daily standup"}, headers=hdr),
+        )
+    assert all(r.status_code == 200 for r in results), [r.text for r in results]
+    final = project_md.read_text()
+    assert "## Context" in final and "audience founders" in final
+    assert "## Rituals" in final and "daily standup" in final
+    assert "## Workflow" in final  # pre-existing section untouched
+
+
+@pytest.mark.asyncio
 async def test_team_context_update_now_pushes(brief_app):
     """P2 gap fix: the mesh-side context writer pushes to members."""
     app, transport, project_md = brief_app

--- a/tests/test_team_goal.py
+++ b/tests/test_team_goal.py
@@ -227,6 +227,10 @@ async def test_endpoint_set_goal_persists(goal_app):
     assert body["team_name"] == "growth"
     assert body["north_star"] == "Ship $10k MRR landing page in 2 weeks"
     assert body["success_criteria"] == ["100 visits/day", "5 demo bookings/wk"]
+    # Propagation status is surfaced distinctly from the DB persist so a
+    # silent mirror/push failure is visible to the operator (B-F3).
+    assert body["mirror_ok"] is True
+    assert isinstance(body["pushed"], dict)
 
     # Round-trip via the store so the dashboard would see the same.
     team = teams_store.get_team("growth")


### PR DESCRIPTION
**PR-C2 of the teams-loop remediation** — TEAM.md write durability.

- **Atomic writes (B-F4 / Codex #17):** goal / context / brief writers used plain `write_text`, so a concurrent reader (dashboard, `_push_team_md`) could see a torn file. All three now use `atomic_write_text` (tempfile + `os.replace`).
- **Per-team write lock (B-F4 / Codex #17):** each writer's read-modify-write-push runs under a per-team `asyncio.Lock`, so concurrent section writers can't lost-update the shared file and pushes go out in write order (no older snapshot delivered after a newer one).
- **Surface goal propagation status (B-F3 / Codex #7):** the goal endpoint discarded `_push_team_md`'s result and returned unqualified success even when the mirror/push failed silently. It now returns `mirror_ok` + the per-member `pushed` map, distinct from the DB persist (source of truth) — a silent propagation failure is now visible.

Deferred follow-up: goal-preserving prompt truncation (B-F5).

## Tests
Goal response carries `mirror_ok` + `pushed`; concurrent context+brief writes both land and leave the pre-existing section intact. `test_team_brief` + `test_team_goal` + `test_journey_e2e` green (49 passed); ruff clean.