### PR TITLE
fix(operator): wire the monitor playbook to monitoring tools (PR-D)

### DIFF
--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -669,6 +669,14 @@ _TOOL_PLAYBOOK_MAP: dict[str, str] = {
     "undo_change": "edit",
     "request_credential": "credentials",
     "request_browser_login": "credentials",
+    # Monitoring: inspecting a team / its spend / its goal-vs-evidence is the
+    # signal the operator is reviewing the fleet — surface the monitor
+    # playbook so it ACTS on what it finds (rate_delivery / set_agent_goals /
+    # manage_task) instead of merely observing. Without a trigger here the
+    # monitor playbook was unreachable dead code.
+    "inspect_teams": "monitor",
+    "inspect_team_spend": "monitor",
+    "assess_team_progress": "monitor",
 }
 
 # ── Playbook content map ─────────────────────────────────────

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -69,6 +69,19 @@ class TestExtractTriggeredPlaybooks:
         ]
         assert extract_triggered_playbooks(msgs) == set()
 
+    def test_monitoring_tools_trigger_monitor_playbook(self):
+        """A monitoring read surfaces the (previously unreachable) monitor
+        playbook so the operator acts on what it finds."""
+        for tool in ("inspect_teams", "inspect_team_spend", "assess_team_progress"):
+            msgs = [
+                {"role": "assistant", "tool_calls": [
+                    {"function": {"name": tool}, "id": "t", "type": "function"},
+                ]},
+            ]
+            assert extract_triggered_playbooks(msgs) == {"monitor"}, tool
+            # The triggered content is the real monitor playbook.
+            assert "Monitoring" in get_playbook_content(["monitor"])
+
     def test_all_playbook_triggers(self):
         """Every tool in _TOOL_PLAYBOOK_MAP triggers the expected playbook."""
         for tool_name, expected_pb in _TOOL_PLAYBOOK_MAP.items():


### PR DESCRIPTION
**PR-D of the teams-loop remediation** — the orphaned monitor playbook (D-F1 / Codex #20).

The operator's *Fleet Monitoring & Improvement* playbook (`_PLAYBOOK_MONITOR`) existed in the content table but **no tool mapped to `"monitor"`** in `_TOOL_PLAYBOOK_MAP` — and `extract_triggered_playbooks` only returns values found in that map. So the playbook was **unreachable dead code**: the operator inspecting a team never got the nudge to *act* (`rate_delivery` / `set_agent_goals` / `manage_task`) instead of merely observe. The gap was masked by tests that exercised the content directly rather than the trigger.

**Fix:** map the monitoring reads — `inspect_teams`, `inspect_team_spend`, `assess_team_progress` — to the monitor playbook, so reviewing the fleet surfaces its improvement-lever guidance. (`list_agents` / `get_system_status` stay unmapped — general reads, not a monitoring-intent signal.)

Test: each monitoring tool now triggers the monitor playbook and returns its real content. `test_operator_playbooks` green (28 passed); ruff clean.