### PR TITLE
fix(teams): clear fail-closed budget message + dedup credential requests (PR-E)

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1550,6 +1550,18 @@ class CredentialVault:
                     # reservation to close that race is a tracked follow-up.
                     envelope = self.cost_tracker.team_envelope_check(bill_agent, model)
                     if not envelope["allowed"]:
+                        if envelope.get("reason") == "envelope_check_unavailable":
+                            # Fail-closed on a budget-store outage — the block
+                            # is real but ``team``/limits are null, so the
+                            # normal render would read "team 'None' … unlimited".
+                            return APIProxyResponse(
+                                success=False,
+                                error=(
+                                    "Team budget governor temporarily "
+                                    "unavailable (budget store unreachable) — "
+                                    "spend paused until it recovers (fail-closed)."
+                                ),
+                            )
                         _d = envelope.get("daily_limit")
                         _m = envelope.get("monthly_limit")
                         return APIProxyResponse(
@@ -4132,6 +4144,14 @@ class CredentialVault:
                 # shape the sync fork yields at 1546-1562.
                 envelope = self.cost_tracker.team_envelope_check(bill_agent, requested_model)
                 if not envelope["allowed"]:
+                    if envelope.get("reason") == "envelope_check_unavailable":
+                        _un = (
+                            "Team budget governor temporarily unavailable "
+                            "(budget store unreachable) — spend paused until "
+                            "it recovers (fail-closed)."
+                        )
+                        yield f"data: {json.dumps({'error': _un})}\n\n"
+                        return
                     _d = envelope.get("daily_limit")
                     _m = envelope.get("monthly_limit")
                     _msg = (

--- a/src/host/help_requests.py
+++ b/src/host/help_requests.py
@@ -144,14 +144,28 @@ class HelpRequests:
         now = time.time()
         payload = payload or {}
         self._safe_reap()
+        name_key = payload.get("name")
         with self._conn() as conn:
+            # Dedup (at-least-once safety): an identical OPEN request — same
+            # kind + agent + name — means a prior attempt was recorded but its
+            # HTTP response may have been lost and the caller retried. Return
+            # the existing id instead of opening a duplicate "Needs you" card.
+            if name_key is not None:
+                existing = conn.execute(
+                    "SELECT request_id FROM help_requests "
+                    "WHERE kind = ? AND agent_id = ? AND name = ? "
+                    "AND status = 'open' LIMIT 1",
+                    (kind, agent_id, name_key),
+                ).fetchone()
+                if existing is not None:
+                    return existing[0]
             conn.execute(
                 f"INSERT INTO help_requests ({self._COLS}) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open')",
                 (
                     request_id, kind, agent_id,
                     payload.get("service"),
-                    payload.get("name"),
+                    name_key,
                     payload.get("description"),
                     payload.get("url"),
                     dumps_safe(payload), now,

--- a/tests/test_help_requests.py
+++ b/tests/test_help_requests.py
@@ -37,6 +37,26 @@ def test_list_open_orders_oldest_first(tmp_path):
     assert ids == [a, b]
 
 
+def test_record_dedups_identical_open_request(tmp_path):
+    """A retry of the same open request (same kind + agent + name) returns
+    the existing id instead of opening a duplicate 'Needs you' card — the
+    server records BEFORE responding, so a lost response + retry would
+    otherwise double the request (C-F5)."""
+    store = HelpRequests(db_path=str(tmp_path / "hr.db"))
+    a = store.record("credential_request", "scout", {"name": "stripe_key"})
+    b = store.record("credential_request", "scout", {"name": "stripe_key"})
+    assert a == b
+    assert len(store.list_open()) == 1
+    # A different name is a distinct request.
+    c = store.record("credential_request", "scout", {"name": "other_key"})
+    assert c != a
+    assert len(store.list_open()) == 2
+    # A different agent asking for the same name is also distinct.
+    d = store.record("credential_request", "analyst", {"name": "stripe_key"})
+    assert d != a
+    assert len(store.list_open()) == 3
+
+
 def test_resolve_pops_and_is_idempotent(tmp_path):
     store = HelpRequests(db_path=str(tmp_path / "hr.db"))
     rid = store.record("credential_request", "a", {"name": "x"})

--- a/tests/test_team_budget.py
+++ b/tests/test_team_budget.py
@@ -286,6 +286,25 @@ class TestProxyEnvelopeBlock:
         tracker.close()
 
     @pytest.mark.asyncio
+    async def test_fail_closed_envelope_renders_clear_message(self, tmp_path, monkeypatch):
+        """When the envelope check fails closed (budget-store outage) the
+        block is real but team/limits are null — the render must say the
+        governor is unavailable, not the confusing 'team None … unlimited'
+        (C-F7)."""
+        vault, tracker, store = self._vault_and_tracker(tmp_path, monkeypatch)
+        store.set_budget("alpha", 10.0, None)
+        monkeypatch.setattr(tracker, "team_envelope_check", lambda *a, **k: {
+            "allowed": False, "reason": "envelope_check_unavailable",
+            "team": None, "daily_used": 0.0, "daily_limit": None,
+            "monthly_used": 0.0, "monthly_limit": None, "estimated_cost": 0.0,
+        })
+        result = await vault.execute_api_call(self._chat_request(), agent_id="worker")
+        assert result.success is False
+        assert "governor temporarily unavailable" in result.error
+        assert "'None'" not in result.error  # not the confusing team 'None' render
+        tracker.close()
+
+    @pytest.mark.asyncio
     async def test_zero_envelope_does_not_block(self, tmp_path, monkeypatch):
         """B4 pinned at the proxy: 0 envelope = unlimited; the call reaches
         the provider handler."""


### PR DESCRIPTION
**PR-E of the teams-loop remediation** — two contained hygiene fixes.

- **Fail-closed budget message (C-F7):** when the team-envelope check fails closed on a budget-store outage, the block is real but `team`/limits are null, so the render read *"Team budget exceeded for team 'None': $0.00/unlimited …"*. Now detects `reason == "envelope_check_unavailable"` on both the sync and streaming transports and renders *"governor temporarily unavailable … spend paused (fail-closed)"*.
- **Credential-request dedup (C-F5):** `HelpRequests.record` did an unconditional INSERT, so a lost HTTP response + client retry (which `request_credential`'s recovery hint suggests) opened a duplicate "Needs you" card. Now dedups an identical OPEN request (same kind + agent + name) — returns the existing id. Distinct name/agent/resolved-prior are still fresh.

**Deferred (separate follow-ups):** exec-time operator-allowlist recheck for de-advertised tools (Codex #24 — LOW/read-only, hot-path); dashboard-mutation lead bypass (Codex #2); embedding + interrupted-stream accounting (Codex #10/#19); goal-preserving truncation (B-F5); busy-lead starvation (A-F5).

## Tests
Fail-closed render says "governor temporarily unavailable" (not "team 'None'"); a repeated credential request returns the same id. `test_help_requests` + `test_team_budget` + `test_credential_request_cancel` green (46 passed); ruff clean.