### PR TITLE
fix(dashboard): Team Room degrades on sub-source failure + health-aware dot (PR-G)

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6241,11 +6241,22 @@ def create_dashboard_router(
         if team is None:
             raise HTTPException(status_code=404, detail=f"Team '{team_name}' not found")
 
-        lane_status = lane_manager.get_status() if lane_manager else {}
+        # Every live sub-source is BOTH None-guarded AND exception-guarded so
+        # a failing (not just absent) source degrades to empty/null fields
+        # rather than 500-ing the whole panel — honoring the docstring above.
+        lane_status: dict = {}
+        if lane_manager is not None:
+            try:
+                lane_status = lane_manager.get_status()
+            except Exception as e:  # noqa: BLE001 - degrade, never 500
+                logger.warning("Team Room %s: lane status failed: %s", team_name, e)
 
         health_map: dict[str, str] = {}
         if health_monitor is not None:
-            health_map = {h["agent"]: h.get("status") for h in health_monitor.get_status()}
+            try:
+                health_map = {h["agent"]: h.get("status") for h in health_monitor.get_status()}
+            except Exception as e:  # noqa: BLE001 - degrade, never 500
+                logger.warning("Team Room %s: health lookup failed: %s", team_name, e)
 
         # Current task per member: the (at most one, by design — B1
         # single-lane) "working" task, plus any "blocked" task. Without
@@ -6276,7 +6287,14 @@ def create_dashboard_router(
         members = []
         for agent_id in team.get("members", []):
             status = lane_status.get(agent_id, {})
-            plate = cron_scheduler.get_last_plate(agent_id) if cron_scheduler else None
+            plate = None
+            if cron_scheduler is not None:
+                try:
+                    plate = cron_scheduler.get_last_plate(agent_id)
+                except Exception as e:  # noqa: BLE001 - degrade, never 500
+                    logger.warning(
+                        "Team Room %s: plate for %s failed: %s", team_name, agent_id, e,
+                    )
             members.append({
                 "agent_id": agent_id,
                 "is_lead": agent_id == team.get("lead_agent_id"),

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1809,8 +1809,8 @@
                               <img :src="agentAvatarUrl(m.agent_id)" :alt="m.agent_id">
                             </div>
                             <span class="w-2 h-2 rounded-full flex-shrink-0"
-                              :class="m.blocked_task ? 'bg-red-400' : (m.busy ? 'bg-amber-400' : 'bg-emerald-400')"
-                              :title="m.blocked_task ? 'Blocked' : (m.busy ? 'Busy' : 'Idle')"></span>
+                              :class="m.blocked_task ? 'bg-red-400' : ((m.health && m.health !== 'healthy') ? 'bg-gray-400' : (m.busy ? 'bg-amber-400' : 'bg-emerald-400'))"
+                              :title="m.blocked_task ? 'Blocked' : ((m.health && m.health !== 'healthy') ? ('Unhealthy: ' + m.health) : (m.busy ? 'Busy' : 'Idle'))"></span>
                             <span class="text-xs text-gray-300 truncate" x-text="m.agent_id"></span>
                             <span x-show="m.is_lead"
                               class="text-[11px] px-1.5 py-0.5 rounded bg-amber-900/30 text-amber-400 border border-amber-800/40 flex-shrink-0"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3549,6 +3549,28 @@ class TestTeamRoomEndpoint:
         resp = self.client.get("/dashboard/api/teams/ghost/room")
         assert resp.status_code == 404
 
+    def test_room_degrades_when_subsources_raise(self):
+        """A live-but-FAILING sub-source (lane / health / plate) must degrade
+        to empty/null fields, not 500 the whole panel (Codex #23)."""
+        from unittest.mock import MagicMock
+
+        teams_store = self.components["teams_store"]
+        teams_store.create_team("team")
+        teams_store.add_member("team", "alpha")
+        teams_store.add_member("team", "beta")
+        self.components["lane_manager"].get_status.side_effect = RuntimeError("boom")
+        self.components["cron_scheduler"].get_last_plate.side_effect = RuntimeError("boom")
+        self.components["health_monitor"].get_status = MagicMock(
+            side_effect=RuntimeError("boom"),
+        )
+        resp = self.client.get("/dashboard/api/teams/team/room")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data["members"]) == 2
+        assert all(m["busy"] is False for m in data["members"])
+        assert all(m["plate"] is None for m in data["members"])
+        assert all(m["health"] is None for m in data["members"])
+
     def test_composed_payload_busy_task_plate_lead_threads(self):
         teams_store = self.components["teams_store"]
         teams_store.create_team("team", description="desc")

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2840,6 +2840,8 @@ class TestTeamRoomSubTab:
         assert "m.busy ? 'bg-amber-400' : 'bg-emerald-400'" in block
         assert "m.current_task" in block
         assert "m.plate" in block
+        # Health-aware: a failed/unhealthy member is not shown as green "Idle".
+        assert "m.health && m.health !== 'healthy'" in block
 
     def test_plate_line_shows_count_and_last_checked_or_unknown(self):
         idx = _INDEX_HTML.index('data-testid="team-room-plate-line"')


### PR DESCRIPTION
**PR-G of the teams-loop remediation** — Team Room robustness.

- **Degraded-read (Codex #23):** `api_team_room`'s docstring promises "a missing source degrades to empty/null fields, never a 500", but `lane_status`, `health_map`, and the per-member `plate` reads were only *None*-guarded, not *exception*-guarded — a live-but-failing sub-source 500'd the whole panel. All three are now `try/except`-guarded.
- **Health-aware status dot (Codex #22):** the member dot branched only on blocked/busy, so a **failed/unhealthy agent with an empty lane rendered as a green "Idle" dot** — telling the operator it was healthy and free. Added a health branch (blocked > unhealthy > busy > idle): `m.health !== 'healthy'` now shows a gray "Unhealthy: <status>" dot.

**Deferred (LOW, client-side races):** rapid Team-Room switch (Codex #21); stale full-document editor overwriting a freshly-propagated goal (Codex #8).

## Tests
Room endpoint returns a partial 200 (not 500) when lane/health/plate all raise; the member-card dot markup branches on `m.health`. Room server + UI tests green (23 passed); ruff clean.