### PR TITLE
fix(teams): surface the enforced (work-only) team spend, not just the total (PR-H)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1055,11 +1055,14 @@ async def get_team_outputs(
     name="inspect_team_spend",
     operator_only=True,
     description=(
-        "Read a team's aggregate spend: total cost + tokens for the "
-        "period, its daily/monthly budget envelope (null = unlimited), "
-        "and a per-member cost/token breakdown. Use this to answer "
-        "'how much has this team spent' or 'who on the team is burning "
-        "the most budget' without fanning out inspect_agents per member."
+        "Read a team's aggregate spend: total_cost + tokens for the period, "
+        "its daily/monthly budget envelope (null = unlimited), and a "
+        "per-member cost/token breakdown. NOTE: work_cost is the figure the "
+        "envelope actually ENFORCES (kind='work'); total_cost is inclusive "
+        "of coordination_cost (utility-model traffic, capped separately), so "
+        "compare work_cost — not total_cost — against the limits. Use this "
+        "to answer 'how much has this team spent' or 'who is burning the "
+        "most budget' without fanning out inspect_agents per member."
     ),
     parameters={
         "team_name": {

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -579,11 +579,25 @@ class CostTracker:
             })
         daily_env = trow.get("budget_daily_usd") or 0.0
         monthly_env = trow.get("budget_monthly_usd") or 0.0
+        # ENFORCED figure: ``team_envelope_check`` counts only kind='work',
+        # but ``total_cost`` above is spend-INCLUSIVE (work + coordination).
+        # Surface ``work_cost`` — the number that actually trips the
+        # daily/monthly limit — so the operator isn't misled by a total that
+        # sits above the enforced amount.
+        try:
+            work_cost, _work_tokens = self._members_spend_totals(
+                members, _period_to_since(period),
+            )
+        except Exception as e:  # noqa: BLE001 - display degrades to the total
+            logger.warning("get_team_spend: work-total read failed: %s", e)
+            work_cost = total_cost
         return {
             "team": team,
             "period": period,
             "total_cost": round(total_cost, 4),
             "total_tokens": total_tokens,
+            "work_cost": round(work_cost, 4),
+            "coordination_cost": round(max(0.0, total_cost - work_cost), 4),
             "daily_limit": daily_env if daily_env > 0 else None,
             "monthly_limit": monthly_env if monthly_env > 0 else None,
             "agents": agent_breakdown,

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -384,6 +384,24 @@ class TestTeamCostAggregation:
         assert alice_spend["tokens"] == 1500
         assert bob_spend["tokens"] == 3000
 
+    def test_team_spend_separates_enforced_work_from_coordination(self):
+        """work_cost is the ENFORCED figure (envelope counts kind='work');
+        total_cost is inclusive of coordination — so work_cost < total_cost
+        when coordination spend exists, and the operator can compare the
+        right number against the limit (C-F3)."""
+        self.store.create_team("teamA")
+        self.store.add_member("teamA", "alice")
+        self.tracker.track("alice", "openai/gpt-4o-mini", 1000, 500, kind="work")
+        self.tracker.track("alice", "openai/gpt-4o-mini", 2000, 1000, kind="coordination")
+
+        result = self.tracker.get_team_spend("teamA", "today")
+        assert result["total_cost"] > result["work_cost"] > 0
+        assert result["coordination_cost"] > 0
+        # coordination_cost is the non-enforced remainder (within 4-dp rounding).
+        assert abs(
+            result["coordination_cost"] - (result["total_cost"] - result["work_cost"])
+        ) <= 2e-4
+
     def test_team_spend_unknown_team_errors(self):
         """get_team_spend keeps the historical error-dict contract for an
         unknown team (introspect guards on ``"error" not in``)."""


### PR DESCRIPTION
**PR-H of the teams-loop remediation** — displayed-vs-enforced spend (C-F3).

`get_team_spend` summed each member's spend **inclusive of coordination** (utility-model) traffic and displayed that `total_cost` next to the daily/monthly limits — but the envelope enforces only `kind='work'` (`_members_spend_totals`). An operator watching the displayed total approach the limit was misled: the shown number is higher than what actually trips the cap.

**Fix:** add `work_cost` (the enforced figure) + `coordination_cost` (the non-enforced remainder) alongside the existing inclusive `total_cost`, and update `inspect_team_spend`'s description to compare `work_cost` — not `total_cost` — against the limits.

**Deferred (documented residual):** no team-level aggregate cap on coordination; embedding + interrupted-stream cost recording (Codex #10/#19); per-usage-row team attribution (Codex #12 — a schema change).

## Tests
With both work and coordination spend, `work_cost < total_cost` and `coordination_cost` is the remainder. `test_costs` + `test_team_budget` + `test_operator_metrics` green (113 passed); ruff clean.