### PR TITLE
fix(cron): retain a strong reference to in-flight cron job dispatches

### DIFF
--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -234,6 +234,15 @@ class CronScheduler:
         # never persisted across restarts; ``get_last_plate`` is the only
         # reader (the dashboard's Team Room panel).
         self._last_plate: dict[str, dict] = {}
+        # Strong references to in-flight job dispatches. The asyncio event
+        # loop only holds WEAK references to tasks, so a bare
+        # ``create_task(self._execute_job(job))`` can be garbage-collected
+        # mid-flight (a heartbeat / standup / daily summary vanishing with
+        # no log). Same discipline as ``LaneManager._forward_tasks`` /
+        # ``_rehydrate_tasks``: hold the task for its lifetime, discard it
+        # in a done-callback that also retrieves the result so a raise
+        # outside ``_execute_job``'s own ``except`` is surfaced.
+        self._job_tasks: set[asyncio.Task] = set()
         self._load()
 
     def set_health_monitor(self, health_monitor: Any) -> None:
@@ -638,13 +647,29 @@ class CronScheduler:
                 if not job.enabled:
                     continue
                 if self._is_due(job, now):
-                    asyncio.create_task(self._execute_job(job))
+                    task = asyncio.create_task(self._execute_job(job))
+                    self._job_tasks.add(task)
+                    task.add_done_callback(self._on_job_task_done)
             except Exception:
                 logger.error(
                     "Cron tick: job %s raised during scheduling — skipping",
                     getattr(job, "id", "<unknown>"), exc_info=True,
                 )
                 continue
+
+    def _on_job_task_done(self, task: asyncio.Task) -> None:
+        """Drop a finished job dispatch and surface any error.
+
+        Retrieving the result is what keeps an exception raised OUTSIDE
+        ``_execute_job``'s own ``except Exception`` (its pre-lock guards)
+        from being swallowed silently.
+        """
+        self._job_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("Cron tick: job dispatch failed: %s", exc, exc_info=exc)
 
     def _stamp_activity(self, agent: str) -> None:
         """Stamp the idle-sweep's last-activity clock for ``agent`` (plan

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import gc
+import logging
 import shutil
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -2099,6 +2102,79 @@ class TestSchedulerResilience:
         ):
             # Must swallow the raise rather than propagate out of the loop.
             await sched._tick()
+
+
+class TestTickTaskReferences:
+    """A fired job dispatch must be strongly referenced for its lifetime.
+
+    The asyncio event loop only holds WEAK references to tasks, so a bare
+    ``create_task(self._execute_job(job))`` can be garbage-collected
+    mid-flight — a heartbeat / standup / daily summary vanishing with no
+    log. Mirrors ``LaneManager._forward_tasks`` / ``_rehydrate_tasks``.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _due_scheduler(self, **kwargs) -> CronScheduler:
+        sched = CronScheduler(config_path=self.config_path, **kwargs)
+        job = sched.add_job(agent="a", schedule="every 1s", message="x")
+        job.last_run = None
+        return sched
+
+    @pytest.mark.asyncio
+    async def test_tick_holds_reference_until_dispatch_completes(self):
+        """The in-flight dispatch survives a GC pass and still finishes."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+        completed: list[str] = []
+
+        async def dispatch(agent, message):
+            started.set()
+            await release.wait()
+            completed.append(agent)
+            return "done"
+
+        sched = self._due_scheduler(dispatch_fn=dispatch)
+        await sched._tick()
+        await asyncio.wait_for(started.wait(), timeout=5)
+        # The scheduler — not just the loop's weak set — owns the task.
+        assert len(sched._job_tasks) == 1
+        gc.collect()
+        release.set()
+        await asyncio.wait_for(
+            asyncio.gather(*list(sched._job_tasks)), timeout=5,
+        )
+        assert completed == ["a"]
+        # Done-callback discards, so the set can't grow without bound.
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if not sched._job_tasks:
+                break
+        assert sched._job_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_raise_outside_execute_job_is_logged(self, caplog):
+        """``_execute_job``'s pre-lock guards sit OUTSIDE its own
+        ``except Exception`` — a raise there must still surface."""
+        health = MagicMock()
+        health.is_quarantined.side_effect = RuntimeError("health probe exploded")
+        sched = self._due_scheduler(
+            dispatch_fn=AsyncMock(return_value="ok"), health_monitor=health,
+        )
+        with caplog.at_level(logging.ERROR, logger="host.cron"):
+            await sched._tick()
+            for _ in range(5):
+                await asyncio.sleep(0)
+                if not sched._job_tasks:
+                    break
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "health probe exploded" in joined
+        assert sched._job_tasks == set()
 
 
 class TestPerAgentCronCap:


### PR DESCRIPTION
## Problem

`CronScheduler._tick` fired every due job with a bare
`asyncio.create_task(self._execute_job(job))` and retained no reference:

```python
if self._is_due(job, now):
    asyncio.create_task(self._execute_job(job))
```

Two defects follow from that:

1. **The dispatch can vanish mid-flight.** The event loop keeps only *weak*
   references to tasks (documented caveat on `asyncio.create_task`). A
   heartbeat, standup or daily-summary turn could be garbage-collected while
   awaiting the agent — with no log and no retry. Worse, `_execute_job` has
   already advanced `last_run`/`next_run` and persisted them by then, so the
   tick looks like it succeeded and the job simply waits for its next slot.
2. **Exceptions were swallowed.** The task result was never retrieved. Most of
   `_execute_job` runs under its own `except Exception`, but its pre-lock
   guards — `self._job_locks[job.id]` and the health-monitor quarantine probe —
   sit *outside* it. A raise there surfaced only if and when the interpreter
   collected the task, as asyncio's generic "Task exception was never
   retrieved", never through the `host.cron` logger.

## Fix

Hold each dispatch in a `_job_tasks` set for its lifetime and discard it in a
done-callback that retrieves the result and logs any exception.

This is not a new pattern: `LaneManager` in the same package already does
exactly this for its own fire-and-forget work (`_forward_tasks` /
`_rehydrate_tasks` + `_on_rehydrate_done`), and the two host-side paths called
out in CLAUDE.md — `_schedule_onboarding_wake` and the auto-merge consumer —
were already retaining their tasks the same way. `cron.py` was the outlier;
this brings it in line so the host package has one discipline.

Behaviour is otherwise unchanged: the H8 poison-job containment wrapper, the
manual `run_job` path and `_execute_job` itself are untouched. Nothing awaits
the dispatch, so tick cadence is identical.

## Verification

Two regression tests in `tests/test_cron.py::TestTickTaskReferences`:

- `test_tick_holds_reference_until_dispatch_completes` — a due job with a
  dispatch parked on an `asyncio.Event`; asserts the scheduler owns the task,
  forces a `gc.collect()`, releases, and asserts the dispatch still ran to
  completion and the set was cleaned up afterwards.
- `test_dispatch_raise_outside_execute_job_is_logged` — a health monitor whose
  `is_quarantined` raises (a real unguarded pre-lock path); asserts the error
  reaches the `host.cron` logger.

Both fail on `main` (`AttributeError: 'CronScheduler' object has no attribute
'_job_tasks'`, and on the second test asyncio's "Task exception was never
retrieved" appears in captured stderr while the `host.cron` logger stays
silent) and pass with the fix.

```
pytest tests/test_cron.py tests/test_cron_standup.py \
       tests/test_cron_heartbeats_reconcile.py tests/test_cron_work_summaries.py \
       tests/test_hibernation.py
302 passed
```

`ruff check src/host/cron.py tests/test_cron.py` clean.