### PR TITLE
fix(browser): point persistence sidecars at the mounted /data volume

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,7 +220,7 @@ All persistent state is SQLite (WAL mode, `busy_timeout=30000` except `traces` w
 |---|---|---|
 | `data/costs.db` | Per-agent + per-team LLM cost ledger | `src/host/costs.py` |
 | `data/wallet.db` | Agent wallet index, addresses, derivation metadata | `src/host/wallet.py` |
-| `data/captcha_costs.json` | CAPTCHA cost ledger in millicents (1/100,000 USD) | `src/browser/captcha_cost_counter.py` |
+| `/data/captcha_costs.json` (browser container volume `openlegion_browser_data`) | CAPTCHA cost ledger in millicents (1/100,000 USD) | `src/browser/captcha_cost_counter.py` |
 | Mesh-side blackboard / pubsub / audit-log SQLite | Inter-agent state, atomic CAS, undo/archive | `src/host/mesh.py` |
 | `data/traces.db` | Request traces (lower `busy_timeout=5000`) | `src/host/traces.py` |
 | `data/dashboard.db` | Telemetry | `src/dashboard/telemetry.py` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ OpenLegion uses YAML and JSON files in the `config/` directory. Config files are
 | `config/teams/` | Directory | Per-team data (`team.md`, members). |
 | `config/settings.json` | JSON | Dashboard-managed runtime settings: browser speed/delay/timeout, execution limits (`max_iterations`, `chat_max_tool_rounds`, etc.), default budgets, and a `browser_flags` dict that overrides any flag in [`src/browser/flags.py:KNOWN_FLAGS`](../src/browser/flags.py) (precedence sits between per-agent overrides and env vars). Read by the browser service via `src/browser/flags.py`. The dashboard also bridges the CAPTCHA solver provider/key fields into the host process env (via `os.environ[…]` in `src/host/runtime.py`) so the browser container picks them up. **The four `_ENV_ONLY_FLAGS` (`CAPTCHA_SOLVER_KEY`, `CAPTCHA_SOLVER_KEY_SECONDARY`, `CAPTCHA_SOLVER_PROXY_LOGIN`, `CAPTCHA_SOLVER_PROXY_PASSWORD`) are stripped from this file at load with a one-time warning that names the stripped keys** — settings.json is plaintext on disk with no chmod / encryption, so solver secrets must come from env vars only. See [Browser Flag Precedence](#browser-flag-precedence). |
 | `config/api_keys.json` | JSON | Named API keys for mesh authentication. Shape: `{"keys": {key_id: {name, key_hash, created_at, last_used_at}}}`. Key IDs are `"ak_" + token_hex(6)`; the raw key is returned **once** at creation (`POST /api/api-keys`) and never persisted — only the salted SHA-256 hash (`sha256(key_id + raw_key)`) is stored. Name capped at 128 chars. The legacy `OPENLEGION_API_KEY` env var (single key) is also accepted as a back-compat fallback. |
-| `data/captcha_costs.json` | JSON | Runtime CAPTCHA spend ledger (chmod `0o600`). Per-agent monthly buckets in millicents (1/100,000 USD); persisted as a periodic snapshot from in-memory state on the 60s metrics tick. Override path with `CAPTCHA_COST_COUNTER_PATH`. State is current-month only — older windows defer to the planned SQLite snapshots. Restart loses at most one tick of spend. |
+| `/data/captcha_costs.json` | JSON | Runtime CAPTCHA spend ledger (chmod `0o600`), on the browser container's `openlegion_browser_data` volume. Per-agent monthly buckets in millicents (1/100,000 USD); persisted as a periodic snapshot from in-memory state on the 60s metrics tick. Override path with `CAPTCHA_COST_COUNTER_PATH`. State is current-month only — older windows defer to the planned SQLite snapshots. Restart loses at most one tick of spend. |
 | `config/network.yaml` | YAML | Network settings (`no_proxy` exclusion list for proxy mode). |
 | `.env` | dotenv | API keys and credentials |
 
@@ -451,7 +451,7 @@ Cost caps are **opt-in** — unset = no cap. All amounts are USD; the runtime le
 |---|---|---|
 | `CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH` | -- (no cap when unset) | Per-agent monthly USD cap. When exceeded, solver short-circuits with `skipped="cost_cap"`. |
 | `CAPTCHA_COST_LIMIT_USD_PER_TENANT_MONTH` | -- (no cap when unset) | Per-tenant monthly USD cap (tenant = team membership from `config/teams/`). Drives 50/80/100% threshold alerts. |
-| `CAPTCHA_COST_COUNTER_PATH` | `data/captcha_costs.json` | Path to the persisted cost counter snapshot. chmod `0o600`. |
+| `CAPTCHA_COST_COUNTER_PATH` | `/data/captcha_costs.json` | Path to the persisted cost counter snapshot. chmod `0o600`. |
 | `OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS` | -- | Comma-separated; force normal solver flow on hosts otherwise classified `unsolvable` by `src/browser/captcha_policy.py` (e.g. `challenges.cloudflare.com`, `humansecurity.com`, `captcha-delivery.com`). Read once at module import — restart browser service to apply changes. |
 | `OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS` | -- | Comma-separated; force escalation-only on hosts the solver would otherwise attempt. Read once at module import — restart browser service to apply changes. |
 | `BROWSER_CAPTCHA_REDETECT_ENABLED` | `true` | Gate the MutationObserver-based post-action captcha re-detection on `click` / `type` / `press_key` / `fill_form`. |
@@ -505,7 +505,7 @@ Opt-in persistence of `BrowserContext.storage_state()` across container restarts
 |---|---|---|
 | `BROWSER_SESSION_PERSISTENCE_ENABLED` | `false` | **Opt-in.** Enable per-agent storage_state snapshots. |
 | `BROWSER_SESSION_PERIODIC_SNAPSHOT_S` | `300` | Periodic snapshot interval in seconds (range 60–3600). Snapshots run on the 60s metrics tick when this elapsed. Lower = better RPO at the cost of disk writes. |
-| `BROWSER_SESSION_DIR` | `data/sessions` | Directory for per-agent sidecars (`<agent_id>.json`, chmod `0o600`). |
+| `BROWSER_SESSION_DIR` | `/data/sessions` | Directory for per-agent sidecars (`<agent_id>.json`, chmod `0o600`). |
 
 ### Mobile / Device Profile
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -484,7 +484,7 @@ Tenant lookup is by `_tenant_for(agent_id)` reverse-mapping `config/teams/`; age
 
 When a cap is configured but the solver provider name or the (provider, kind) price is unknown, the solve **fails closed** with `solver_outcome="provider_missing"` or `"price_missing"` rather than letting an untrackable charge slip past. Reset by configuring the provider, waiting for next month, or explicitly disabling the cap.
 
-The on-disk counter file (`data/captcha_costs.json` by default; override via `CAPTCHA_COST_COUNTER_PATH`) is in-memory + JSON snapshot — restart loses at most one tick's worth of recorded spend.
+The on-disk counter file (`/data/captcha_costs.json` by default — the browser container's durable volume; override via `CAPTCHA_COST_COUNTER_PATH`) is in-memory + JSON snapshot — restart loses at most one tick's worth of recorded spend.
 
 ### Fingerprint Burn Detection
 

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -78,9 +78,13 @@ from src.shared.utils import setup_logging
 logger = setup_logging("browser.captcha_cost")
 
 
-# Persistence path. Lives under ``data/`` (NOT a SQLite ``.db`` — see module
+# Persistence path. Lives under ``/data/`` (NOT a SQLite ``.db`` — see module
 # docstring for the deferred-rationale; the trim spec is explicit on this).
-_DEFAULT_PATH = "data/captcha_costs.json"
+# ABSOLUTE on purpose: the browser container's WORKDIR is ``/app`` and only
+# ``/data`` is the mounted ``openlegion_browser_data`` volume, so a relative
+# ``data/...`` would put the spend ledger in the ephemeral write layer and
+# every container recreation would silently reset the month's counted spend.
+_DEFAULT_PATH = "/data/captcha_costs.json"
 
 
 def _state_path() -> Path:

--- a/src/browser/fingerprint_state.py
+++ b/src/browser/fingerprint_state.py
@@ -49,7 +49,7 @@ On-disk schema::
       "binding_signatures": {"<agent_id>": "<16-hex>", ...}
     }
 
-Default path ``data/fingerprint_state.json``; env override
+Default path ``/data/fingerprint_state.json``; env override
 ``FINGERPRINT_STATE_PATH`` (consistent with ``CAPTCHA_COST_COUNTER_PATH``).
 """
 
@@ -68,10 +68,14 @@ from src.shared.utils import setup_logging
 logger = setup_logging("browser.fingerprint_state")
 
 
-# Persistence path. Lives under ``data/`` alongside the captcha-cost
-# counter sidecar so all browser-service persistence stays under one
-# parent. Override-able via env for tests + custom deployments.
-_DEFAULT_PATH = "data/fingerprint_state.json"
+# Persistence path. Lives under ``/data/`` alongside the captcha-cost
+# counter sidecar so all browser-service persistence stays on the one
+# durable volume. ABSOLUTE on purpose: the browser container's WORKDIR is
+# ``/app`` and only ``/data`` is the mounted ``openlegion_browser_data``
+# volume, so a relative ``data/...`` would land in the ephemeral write
+# layer and the burn/binding state would not actually survive a restart.
+# Override-able via env for tests + custom deployments.
+_DEFAULT_PATH = "/data/fingerprint_state.json"
 _SCHEMA_VERSION = 1
 # Default rolling-window bound. Mirrors ``service._FINGERPRINT_WINDOW_SIZE``
 # but kept as a local default so this module has NO import cycle back into

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -158,7 +158,7 @@ KNOWN_FLAGS: dict[str, str] = {
         "true | false (DEFAULT FALSE) — opt-in persistence of "
         "BrowserContext.storage_state() across container restarts. "
         "Stores cookies + localStorage + sessionStorage + IndexedDB at "
-        "data/sessions/<agent_id>.json with chmod 0o600. Default-off "
+        "/data/sessions/<agent_id>.json with chmod 0o600. Default-off "
         "because the sidecar contains live session tokens; if leaked, "
         "those tokens grant account takeover on whatever sites the "
         "agent was logged into. Operators must opt in deliberately and "
@@ -173,7 +173,7 @@ KNOWN_FLAGS: dict[str, str] = {
         "more disk writes; higher = fewer writes but more state lost "
         "on a hard kill.",
     "BROWSER_SESSION_DIR":
-        "directory for per-agent session sidecars (default data/sessions). "
+        "directory for per-agent session sidecars (default /data/sessions). "
         "Override for tests / custom volume layouts.",
     # ── Observability ─────────────────────────────────────────────────────
     "BROWSER_RECORD_BEHAVIOR": "1 to enable behavior recorder (§5.3)",

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -1003,7 +1003,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
     #
     # Read-only summary + operator clear endpoint. Mounted on the browser
     # service so the per-agent JSON sidecar lives next to the rest of the
-    # browser-state files (``data/sessions/<agent_id>.json``). The dashboard
+    # browser-state files (``/data/sessions/<agent_id>.json``). The dashboard
     # router calls these via ``runtime.browser_service_url`` and forwards
     # the privacy-safe shape to the operator panel.
     #

--- a/src/browser/session_persistence.py
+++ b/src/browser/session_persistence.py
@@ -7,7 +7,7 @@ than one task either re-authenticates (slow, often blocked by 2FA /
 captcha) or stops working entirely.
 
 This module captures Playwright's ``BrowserContext.storage_state()``
-to a per-agent JSON sidecar at ``data/sessions/<agent_id>.json``,
+to a per-agent JSON sidecar at ``/data/sessions/<agent_id>.json``,
 restores it on next launch, and exposes an operator-controlled clear
 path. Lifecycle wiring lives in ``src/browser/service.py``; the flag
 gate lives in ``src/browser/flags.py``.
@@ -76,10 +76,21 @@ from src.shared.utils import setup_logging
 logger = setup_logging("browser.session_persistence")
 
 
-# Default storage location. Override-able via env for tests + custom
-# deployments. The directory is created lazily on first snapshot;
-# missing dir on restore is a non-fatal no-op (returns None).
-_DEFAULT_DIR = "data/sessions"
+# Default storage location. ABSOLUTE on purpose: the browser service runs
+# with ``WORKDIR /app`` (Dockerfile.browser) and the ONLY durable mount is
+# the ``openlegion_browser_data`` volume at ``/data`` (src/host/runtime.py
+# ``start_browser_service``). A relative ``data/sessions`` resolves to
+# ``/app/data/sessions`` — the container's ephemeral write layer, which is
+# discarded every time the engine recreates the container (runtime.py
+# force-removes the stale ``openlegion_browser`` container on each start),
+# so the across-restart durability this module exists to provide would
+# silently not hold. ``/data`` matches the defaults already used by
+# ``service.BrowserManager.profiles_dir`` (``/data/profiles``),
+# ``canary`` (``/data/canary``) and ``recorder`` (``/data/debug``).
+# Override-able via env for tests + custom deployments. The directory is
+# created lazily on first snapshot; missing dir on restore is a non-fatal
+# no-op (returns None).
+_DEFAULT_DIR = "/data/sessions"
 _SCHEMA_VERSION = 1
 # Hard cap on serialized snapshot size. localStorage can be ~5 MiB per
 # origin under spec; a malicious site can inflate one origin's quota by
@@ -140,8 +151,8 @@ def _sessions_dir() -> Path:
     """Return the per-service sessions directory.
 
     Resolved lazily so tests can monkeypatch the env var between
-    cases. A ``data/`` sibling of the captcha-cost counter sidecar
-    keeps all browser-service persistence under one parent.
+    cases. A ``/data/`` sibling of the captcha-cost counter sidecar
+    keeps all browser-service persistence on the one durable volume.
     """
     return Path(os.environ.get("BROWSER_SESSION_DIR", _DEFAULT_DIR))
 

--- a/tests/test_browser_data_volume_paths.py
+++ b/tests/test_browser_data_volume_paths.py
@@ -1,0 +1,71 @@
+"""Browser-service persistence defaults must live on the mounted volume.
+
+``Dockerfile.browser`` sets ``WORKDIR /app`` and the only durable mount the
+browser container gets is the ``openlegion_browser_data`` Docker volume at
+``/data`` (``src/host/runtime.py`` ``_start_browser_container``). Any
+persistence default expressed as a RELATIVE path therefore resolves to
+``/app/<path>`` — the container's ephemeral write layer, which is discarded
+whenever the engine recreates the container (runtime force-removes the stale
+``openlegion_browser`` container on every start).
+
+Three sidecars regressed on exactly that: session storage_state, fingerprint
+burn/binding state, and the CAPTCHA spend ledger. Their writes succeeded
+(``/app`` is chown'd to the browser user, so nothing errored) and the data
+silently evaporated on restart — defeating the whole point of each module.
+
+This file pins the invariant for all three: with no env override set, the
+resolved default is absolute and lives under ``/data``, matching the
+convention already used by ``service.BrowserManager.profiles_dir``
+(``/data/profiles``), ``canary`` (``/data/canary``) and ``recorder``
+(``/data/debug``). The env overrides remain the escape hatch for tests and
+custom volume layouts, so those are pinned too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.browser import captcha_cost_counter as ccc
+from src.browser import fingerprint_state as fp
+from src.browser import session_persistence as sp
+
+# (env var, zero-arg resolver) for every browser-service persistence sidecar.
+_SIDECARS = [
+    pytest.param("BROWSER_SESSION_DIR", sp._sessions_dir, id="sessions"),
+    pytest.param("FINGERPRINT_STATE_PATH", fp._state_path, id="fingerprint"),
+    pytest.param("CAPTCHA_COST_COUNTER_PATH", ccc._state_path, id="captcha_costs"),
+]
+
+# The browser container's durable mount point (Dockerfile.browser ``VOLUME
+# /data``; runtime.py binds ``openlegion_browser_data`` here).
+_VOLUME = Path("/data")
+
+
+class TestDefaultsLandOnTheVolume:
+    @pytest.mark.parametrize(("env_var", "resolver"), _SIDECARS)
+    def test_default_is_under_data_volume(self, env_var, resolver, monkeypatch):
+        monkeypatch.delenv(env_var, raising=False)
+        resolved = resolver()
+        assert resolved.is_absolute(), (
+            f"{env_var} default {resolved} is relative — it would resolve "
+            f"under the container's WORKDIR (/app), not the /data volume."
+        )
+        assert resolved == _VOLUME or _VOLUME in resolved.parents, (
+            f"{env_var} default {resolved} is not on the {_VOLUME} volume — "
+            f"it would not survive a container restart."
+        )
+
+    @pytest.mark.parametrize(("env_var", "resolver"), _SIDECARS)
+    def test_env_override_still_wins(self, env_var, resolver, tmp_path, monkeypatch):
+        target = tmp_path / "custom"
+        monkeypatch.setenv(env_var, str(target))
+        assert resolver() == target
+
+
+class TestSessionPathUsesTheVolume:
+    def test_per_agent_sidecar_path(self, monkeypatch):
+        """The public path builder inherits the volume default."""
+        monkeypatch.delenv("BROWSER_SESSION_DIR", raising=False)
+        assert sp.session_path("agent-a") == Path("/data/sessions/agent-a.json")


### PR DESCRIPTION
## Problem

The browser container runs with `WORKDIR /app` (`Dockerfile.browser`) and the only durable mount it gets is the `openlegion_browser_data` Docker volume bound at `/data` (`src/host/runtime.py:872`, `start_browser_service`). Three persistence sidecars defaulted to **relative** paths, so they resolved under `/app`:

| module | default before | resolved to |
|---|---|---|
| `src/browser/session_persistence.py` | `data/sessions` | `/app/data/sessions` |
| `src/browser/fingerprint_state.py` | `data/fingerprint_state.json` | `/app/data/fingerprint_state.json` |
| `src/browser/captcha_cost_counter.py` | `data/captcha_costs.json` | `/app/data/captcha_costs.json` |

`Dockerfile.browser` runs `chown -R browser:browser /app`, so every write **succeeded** and nothing logged an error — the data simply landed in the container's ephemeral write layer, which is discarded on the next engine start (`runtime.py` force-removes the stale `openlegion_browser` container before recreating it).

Consequences, each defeating the stated purpose of the module:

- **Sessions** — agents lose cookies / `localStorage` / IndexedDB on every restart, so `BROWSER_SESSION_PERSISTENCE_ENABLED` buys nothing and every restart forces a re-login (often into 2FA or a captcha).
- **Fingerprint state** — burn flags and binding signatures reset, so a fingerprint an anti-bot vendor already burned gets reused as if it were clean.
- **CAPTCHA costs** — the monthly spend ledger resets mid-billing-month, weakening `CAPTCHA_COST_LIMIT_USD_PER_{AGENT,TENANT}_MONTH` (the cap only ever sees spend since the last restart).

## Fix

Point the three defaults at absolute `/data` paths. This is the convention the rest of the browser package already follows for the same volume — `BrowserManager.profiles_dir` = `/data/profiles` (`service.py:3473`), `canary._DEFAULT_STATE_PATH` = `/data/canary/state.json`, `recorder._DEFAULT_DUMP_DIR` = `/data/debug`. The three sidecars were the outliers.

No new env var and no new helper: the existing overrides (`BROWSER_SESSION_DIR`, `FINGERPRINT_STATE_PATH`, `CAPTCHA_COST_COUNTER_PATH`) are untouched and still win, which is what tests and custom volume layouts use.

Deliberately **not** changed: `captcha_cost_counter._tenant_for`'s `OPENLEGION_TEAMS_DB` default (`data/teams.db`). That one is host-relative on purpose — the browser container mounts neither `config/` nor the mesh `data/`, and its own docstring documents the missing-file no-op.

Docs and `flags.KNOWN_FLAGS` descriptions that quoted the old relative defaults are updated to match (`docs/configuration.md`, `docs/architecture.md`, `docs/security.md`).

## Verification

- New `tests/test_browser_data_volume_paths.py` parametrizes over all three sidecars and asserts (a) with the env override unset the resolved default is absolute and under `/data`, (b) the env override still wins, (c) `session_path()` inherits the volume default. Confirmed it **fails on `main`** (4 failures, e.g. `PosixPath('data/sessions/agent-a.json') != PosixPath('/data/sessions/agent-a.json')`) and passes with this change.
- Targeted suites green (532 passed): `test_session_persistence`, `test_fingerprint_state`, `test_captcha_cost_counter`, `test_captcha_cost_tenant`, `test_browser_flags`, `test_dashboard_browser_metrics`, `test_binding_cookie_coherence`, `test_fingerprint_health`, `test_browser_metrics`, `test_browser_solve_captcha`, `test_check_captcha_metered`, `test_check_captcha_policy`, `test_browser_captcha_redetect`, `test_captcha_validation_harness`, `test_antibot_task_types`, `test_captcha_solver_proxy`, `test_browser_proxy_hardening`.
- `ruff check src/browser tests/test_browser_data_volume_paths.py` clean.
- Full suite runs in CI; not merging until it is green.

## Notes for review

- Existing sidecars written under `/app/data/...` are not migrated — by definition they never survived a restart, so there is nothing durable to migrate.
- `tests/conftest.py` already redirects `FINGERPRINT_STATE_PATH` to a per-pid temp file for the whole session, so no test writes to the new default.