### PR TITLE
fix(dashboard): call showToast, not the non-existent _showToast

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -8295,14 +8295,14 @@ function dashboard() {
           this.captchaSolverProvider = data.provider || '';
           this.captchaSolverKeyMasked = data.key_masked || '';
           if (keyInput) keyInput.value = '';
-          this._showToast('CAPTCHA solver settings saved');
+          this.showToast('CAPTCHA solver settings saved');
         } else {
           const err = await resp.json().catch(() => ({}));
-          this._showToast(err.detail || 'Failed to save', 'error');
+          this.showToast(err.detail || 'Failed to save');
         }
       } catch (e) {
         console.warn('saveCaptchaSolver failed:', e);
-        this._showToast('Failed to save CAPTCHA solver settings', 'error');
+        this.showToast('Failed to save CAPTCHA solver settings');
       }
       this.captchaSolverSaving = false;
     },
@@ -8317,7 +8317,7 @@ function dashboard() {
         if (resp.ok) {
           this.captchaSolverProvider = '';
           this.captchaSolverKeyMasked = '';
-          this._showToast('CAPTCHA solver removed');
+          this.showToast('CAPTCHA solver removed');
         }
       } catch (e) { console.warn('removeCaptchaSolver failed:', e); }
       this.captchaSolverSaving = false;

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -3069,3 +3069,58 @@ class TestAutonomyLogUI:
         # tab body rather than declared at the top-nav bar.
         preceding = _INDEX_HTML[:idx]
         assert preceding.count("Sticky \"Needs you\" panel") >= 1
+
+
+# ── Toast helper call sites ────────────────────────────────────────────
+#
+# Regression guard for the CAPTCHA-solver settings handlers, which called
+# a helper that does not exist. See ``TestToastHelperCallSites``.
+
+
+class TestToastHelperCallSites:
+    """``showToast(msg, duration)`` is the component's only toast helper.
+
+    Two contracts are asserted here, both of which the CAPTCHA-solver
+    settings handlers used to violate:
+
+    1. The method is ``showToast`` — there is no ``_showToast``. Calling
+       the underscore-prefixed name is a plain ``TypeError``. In
+       ``saveCaptchaSolver`` the success-branch TypeError was swallowed by
+       the surrounding ``catch``, whose handler called ``this._showToast``
+       *again*; that second TypeError escaped the function, so the
+       ``captchaSolverSaving = false`` line after the try/catch never ran
+       and the Save button stayed stuck spinning.
+
+    2. The second argument is a millisecond duration fed straight to
+       ``setTimeout`` — not a severity. A string such as ``'error'``
+       coerces to ``NaN``, which ``setTimeout`` clamps to ``0``, so the
+       toast would be dropped on the next tick instead of shown. The
+       toast template renders only ``t.msg`` and has no severity styling.
+    """
+
+    def test_no_underscore_prefixed_toast_helper(self):
+        assert "_showToast" not in _APP_JS_TEXT, (
+            "app.js references this._showToast(...), but the method is "
+            "showToast(...) — every such call site throws TypeError"
+        )
+
+    def test_toast_helper_defined_exactly_once(self):
+        assert len(re.findall(r"^\s{4}showToast\(", _APP_JS_TEXT, re.M)) == 1
+
+    def test_no_string_literal_passed_as_duration(self):
+        bad = re.findall(
+            r"showToast\([^\n]*,\s*['\"][A-Za-z_]+['\"]\s*,?\s*\)", _APP_JS_TEXT
+        )
+        assert not bad, (
+            "showToast()'s second argument is a setTimeout duration; a bare "
+            f"word literal silently makes the toast invisible: {bad}"
+        )
+
+    def test_captcha_solver_handlers_use_the_real_helper(self):
+        start = _APP_JS_TEXT.index("async saveCaptchaSolver()")
+        end = _APP_JS_TEXT.index("// ── Network / Proxy")
+        block = _APP_JS_TEXT[start:end]
+        # Two calls in saveCaptchaSolver's try, one in its catch, one in
+        # removeCaptchaSolver.
+        assert block.count("this.showToast(") == 4
+        assert "_showToast" not in block


### PR DESCRIPTION
## Problem

`src/dashboard/static/js/app.js` called `this._showToast(...)` in four places, but the Alpine component's toast helper is `showToast(msg, duration)` (defined once, at line 4599). There is no `_showToast` anywhere in the codebase, so all four call sites were guaranteed `TypeError`s.

All four sit in the CAPTCHA-solver settings handlers, and in `saveCaptchaSolver` the failure compounded:

```js
if (resp.ok) {
  ...
  this._showToast('CAPTCHA solver settings saved');   // throws
} else {
  this._showToast(err.detail || 'Failed to save', 'error');
}
} catch (e) {
  console.warn('saveCaptchaSolver failed:', e);
  this._showToast('Failed to save CAPTCHA solver settings', 'error');  // throws AGAIN
}
this.captchaSolverSaving = false;   // never reached
```

The success-branch `TypeError` was swallowed by the surrounding `catch`, whose handler threw a second `TypeError` that escaped the function entirely. The line after the try/catch never ran.

**User-visible symptom:** saving a CAPTCHA solver key silently persisted server-side, but the operator saw no confirmation toast and the Save button stayed stuck in its spinner state (`captchaSolverSaving` pinned to `true`) until a full page reload.

There was a second, quieter bug in the same lines: two calls passed `'error'` as a second argument. That parameter is a millisecond duration handed straight to `setTimeout`, not a severity — `Number('error')` is `NaN`, which `setTimeout` clamps to `0`. A naive rename would have traded the `TypeError` for a toast that disappeared on the next tick.

## Fix

Four call sites renamed to `showToast`, and the bogus `'error'` argument dropped rather than reinterpreted:

- The toast template (`index.html`, the `x-for="t in toastQueue"` block) renders only `t.msg`. There is no severity styling to route to, so the argument was never meaningful.
- Every other error path in this file conveys severity through the message text itself (`Save failed: …`, `Cancel failed: …`). Both messages here already read as failures unchanged.
- The only legitimate second-argument uses in the file pass a real number (`8000`, at the fingerprint-drift toasts).

Net diff is 4 lines of `app.js`. No behavior outside these two handlers is touched.

## Verification

- **Reproduced the control flow** in Node against a faithful mirror of the pre-fix code: the `catch` observes `TypeError - this._showToast is not a function`, a second `TypeError` escapes the call, and `saving` remains stuck at `true`. Confirmed `Number('error') === NaN` → clamped to `0`.
- **`node --check src/dashboard/static/js/app.js`** passes (no build step in this SPA, so parse validity is the real gate).
- **Grepped the whole repo** for `_showToast` — the only remaining hits are two prose references in `docs/plans/` describing this very bug. No template, Python handler, or other JS references the underscore-prefixed name.
- **New tests** in `tests/test_dashboard_ui.py::TestToastHelperCallSites`, following that file's existing string-level-assertion convention. Verified they fail on the pre-fix file (3 of 4 fail; the "defined exactly once" case is a both-ways invariant guard) and pass after:

```
FAILED ...::test_no_underscore_prefixed_toast_helper
FAILED ...::test_no_string_literal_passed_as_duration
FAILED ...::test_captcha_solver_handlers_use_the_real_helper
3 failed, 1 passed
```

- **Suites run green:** `tests/test_dashboard_ui.py` + `tests/test_dashboard_telemetry.py` (281 passed, 3 skipped) and `tests/test_dashboard.py::TestDashboardCaptchaHelpSpaWiring` (3 passed). `ruff check` clean on the changed test file.
- The duration-guard regex was validated empirically against both revisions: 2 matches before, 0 after, with no false positives across the file's ~300 other `showToast` calls.

Full `make test` is left to CI.
