### PR TITLE
ci(browser): trigger the image build on the code the image actually contains

### DIFF
--- a/.github/workflows/browser-image.yml
+++ b/.github/workflows/browser-image.yml
@@ -8,24 +8,39 @@ name: Browser image smoke
 # Dockerfile *requests* the right packages; this workflow confirms pip
 # can actually *resolve* and *install* them in a fresh container.
 #
-# Path-filtered so it only runs when the build inputs change. PRs that
-# don't touch Dockerfile.browser or pyproject.toml (the dep declarations)
-# don't pay the ~5 minute build cost.
+# Path-filtered so it only runs when the build inputs change. "Build
+# inputs" means everything Dockerfile.browser COPYs into the image, not
+# just the dependency declarations: the image embeds src/browser/,
+# src/shared/ and docker/, so a change to any of them produces a
+# different image and must be re-verified here. Directory-wide globs
+# (rather than an enumeration of the files browser happens to import
+# today) keep the filter fail-closed — an enumeration goes silently
+# stale the first time a new import is added. PRs that touch none of
+# these don't pay the build cost.
+#
+# tests/test_dockerfile_browser_deps.py::TestBuildTriggerCoverage pins
+# the filter against the Dockerfile's COPY list so the two can't drift.
 
 on:
   push:
     branches: [main]
     paths:
       - "Dockerfile.browser"
-      - "docker/browser-entrypoint.sh"
+      - "docker/**"
       - "pyproject.toml"
+      - "src/__init__.py"
+      - "src/browser/**"
+      - "src/shared/**"
       - ".github/workflows/browser-image.yml"
   pull_request:
     branches: [main]
     paths:
       - "Dockerfile.browser"
-      - "docker/browser-entrypoint.sh"
+      - "docker/**"
       - "pyproject.toml"
+      - "src/__init__.py"
+      - "src/browser/**"
+      - "src/shared/**"
       - ".github/workflows/browser-image.yml"
 
 jobs:
@@ -79,6 +94,73 @@ jobs:
                   print(pkg + ": MISSING (" + str(e) + ")", file=sys.stderr)
                   missing.append(pkg)
           if missing:
+              sys.exit(1)
+          '
+
+      - name: Verify application code imports
+        # Without this step the source-path triggers above would be
+        # vacuous: a change under src/browser/ or src/shared/ can never
+        # fail a COPY, and nothing else in this job loads the copied
+        # code. This turns "the image was rebuilt" into "every module in
+        # the image still imports" — which is weaker than "the image
+        # starts": ``__main__`` is imported by name, so its
+        # ``if __name__ == "__main__"`` guard means ``main()`` never runs
+        # here, and lazily-imported deps stay out of reach (below).
+        #
+        # The concrete regression it catches: src/browser gains a new
+        # module-level third-party import, the author adds the package
+        # to pyproject.toml (so the test workflow, which installs
+        # ".[dev]", stays green) and does NOT add it to the hard-coded
+        # pip install list in Dockerfile.browser. The container then
+        # dies on boot in production with ModuleNotFoundError.
+        #
+        # Walked rather than a fixed module list so new modules —
+        # including ones in new subpackages — are covered automatically.
+        # ``__main__`` is imported by name, so
+        # its ``if __name__ == "__main__"`` guard keeps ``main()`` from
+        # running. Lazily-imported deps (camoufox, playwright,
+        # browserforge) are deliberately out of reach here — they are
+        # imported inside functions and only a live launch exercises
+        # them.
+        run: |
+          docker run --rm --entrypoint python3 openlegion-browser:ci -c '
+          import importlib
+          import pathlib
+          import sys
+          sys.path.insert(0, "/app")
+          failed = []
+          root = pathlib.Path("/app/src/browser")
+          modules = ["src.browser"]
+          # rglob, not glob: a shallow scan misses every subpackage, so a
+          # new nested module could ship an unsatisfied import even though
+          # this step "passed". Directories contribute their package name
+          # via __init__.py; other files contribute their own.
+          for path in sorted(root.rglob("*.py")):
+              rel = path.relative_to(root)
+              parts = list(rel.parts[:-1]) + ([] if rel.stem == "__init__" else [rel.stem])
+              if not parts:
+                  continue
+              modules.append("src.browser." + ".".join(parts))
+          modules = sorted(set(modules))
+          for name in modules:
+              try:
+                  importlib.import_module(name)
+                  print(name + ": ok")
+              except Exception as exc:
+                  print(
+                      name + ": FAILED (" + type(exc).__name__ + ": " + str(exc) + ")",
+                      file=sys.stderr,
+                  )
+                  failed.append(name)
+          if failed:
+              print(
+                  "Modules that do not import inside the browser image: "
+                  + ", ".join(failed)
+                  + " — the image is missing a dependency that "
+                  "Dockerfile.browser must install, or the module has a "
+                  "broken import.",
+                  file=sys.stderr,
+              )
               sys.exit(1)
           '
 

--- a/tests/test_dockerfile_browser_deps.py
+++ b/tests/test_dockerfile_browser_deps.py
@@ -21,6 +21,12 @@ These are static checks against file content. They don't build an image
 (too slow for unit-test cadence). The ``build-and-smoke`` job in
 .github/workflows/browser-image.yml closes the remaining gap by actually
 building and importing.
+
+``TestBuildTriggerCoverage`` covers the other half of that gap: the
+``build-and-smoke`` job is path-filtered, so it only defends the paths it
+watches. Those tests pin the filter against the Dockerfile's own ``COPY``
+list, so adding a ``COPY`` without widening the trigger fails here rather
+than shipping unbuilt.
 """
 
 from __future__ import annotations
@@ -29,6 +35,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 try:  # tomllib is stdlib on 3.11+; the project floor is 3.10.
     import tomllib
@@ -37,6 +44,7 @@ except ModuleNotFoundError:  # pragma: no cover - only on Python 3.10
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = REPO_ROOT / "Dockerfile.browser"
+WORKFLOW = REPO_ROOT / ".github/workflows/browser-image.yml"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 
 pytestmark = pytest.mark.skipif(
@@ -188,3 +196,112 @@ class TestDockerfileUsesTheManifest:
             "invisible dependency manifest.\n\n"
             f"Current install block:\n{install_block}"
         )
+
+
+class TestBuildTriggerCoverage:
+    """The image-build workflow must actually run when the image changes.
+
+    ``.github/workflows/browser-image.yml`` is path-filtered, and its
+    filter used to watch only ``Dockerfile.browser``,
+    ``docker/browser-entrypoint.sh`` and ``pyproject.toml``. But the
+    Dockerfile also ``COPY``s ``src/browser/``, ``src/shared/``,
+    ``src/__init__.py`` and the fontconfig alias file into the image —
+    so a change to any of those produced a different image that the
+    only automated build-and-smoke gate never rebuilt.
+
+    These tests derive the expectation from the Dockerfile itself
+    rather than restating a list, so adding a new ``COPY`` without
+    widening the trigger fails here instead of silently shipping.
+    """
+
+    @staticmethod
+    def _copy_sources() -> list[str]:
+        """Return every build-context path ``Dockerfile.browser`` COPYs in."""
+        sources: list[str] = []
+        for raw in DOCKERFILE.read_text().splitlines():
+            line = raw.strip()
+            if not line.upper().startswith("COPY "):
+                continue
+            args = [a for a in line.split()[1:] if not a.startswith("--")]
+            # Last arg is the destination inside the image.
+            sources.extend(args[:-1])
+        return sources
+
+    @staticmethod
+    def _matches(pattern: str, path: str) -> bool:
+        """Match one path against a GitHub ``paths:`` pattern.
+
+        NOT ``fnmatch``: Python's ``*`` crosses ``/``, GitHub's does not.
+        Using fnmatch directly would accept ``src/browser/*`` as covering
+        ``src/browser/nested/new_file.py`` — the exact shallow-filter gap
+        these tests exist to catch — so the check would pass while the
+        build trigger stayed blind to new subpackages.
+        """
+        if pattern.endswith("/**"):
+            prefix = pattern[: -len("/**")]
+            return path == prefix or path.startswith(prefix + "/")
+        # Translate the remaining wildcards segment-wise: ``**`` spans
+        # separators, a single ``*`` (and ``?``) never does.
+        parts = []
+        i = 0
+        while i < len(pattern):
+            c = pattern[i]
+            if pattern.startswith("**", i):
+                parts.append(".*")
+                i += 2
+            elif c == "*":
+                parts.append("[^/]*")
+                i += 1
+            elif c == "?":
+                parts.append("[^/]")
+                i += 1
+            else:
+                parts.append(re.escape(c))
+                i += 1
+        return re.fullmatch("".join(parts), path) is not None
+
+    @pytest.fixture(scope="class")
+    def triggers(self) -> dict[str, list[str]]:
+        workflow = yaml.safe_load(WORKFLOW.read_text())
+        # ``on`` is parsed as the boolean True by YAML 1.1.
+        on = workflow.get("on", workflow.get(True))
+        assert on, "browser-image.yml has no trigger block"
+        return {event: cfg.get("paths", []) for event, cfg in on.items()}
+
+    def test_push_and_pull_request_filters_agree(self, triggers: dict[str, list[str]]):
+        """A filter that fires on one event but not the other means main
+        and PRs are gated differently — the gap just moves rather than
+        closing."""
+        assert triggers["push"] == triggers["pull_request"], (
+            "browser-image.yml's push and pull_request paths filters have "
+            f"drifted:\npush: {triggers['push']}\npull_request: {triggers['pull_request']}"
+        )
+
+    def test_every_copied_path_triggers_a_rebuild(self, triggers: dict[str, list[str]]):
+        """Everything baked into the image must be watched by the filter."""
+        patterns = triggers["pull_request"]
+        uncovered = []
+        for source in self._copy_sources():
+            cleaned = source.rstrip("/")
+            if (REPO_ROOT / cleaned).is_dir():
+                # A directory COPY bakes in the whole subtree, so a
+                # shallow pattern (``src/browser/*.py``) is not enough.
+                probe = f"{cleaned}/nested/new_file.py"
+            else:
+                probe = cleaned
+            if not any(self._matches(p, probe) for p in patterns):
+                uncovered.append(source)
+        assert not uncovered, (
+            "Dockerfile.browser COPYs these paths into the image, but "
+            "browser-image.yml's paths filter does not watch them — a change "
+            f"to any of them ships without a build-and-smoke run: {uncovered}\n"
+            f"Current filter: {patterns}"
+        )
+
+    def test_build_definition_files_trigger_a_rebuild(self, triggers: dict[str, list[str]]):
+        """The Dockerfile and the workflow itself are build inputs too."""
+        patterns = triggers["pull_request"]
+        for required in ("Dockerfile.browser", ".github/workflows/browser-image.yml"):
+            assert any(self._matches(p, required) for p in patterns), (
+                f"browser-image.yml's paths filter does not watch '{required}'. Current filter: {patterns}"
+            )


### PR DESCRIPTION
## Problem

`.github/workflows/browser-image.yml` is the only automated check that builds `Dockerfile.browser` end-to-end and verifies the resulting image can start. It is path-filtered, and the filter watched three things:

```yaml
- "Dockerfile.browser"
- "docker/browser-entrypoint.sh"
- "pyproject.toml"
```

But `Dockerfile.browser` bakes in more than that:

```dockerfile
COPY docker/fontconfig-windows-aliases.conf /etc/fonts/conf.d/99-openlegion-windows-fonts.conf
COPY pyproject.toml .
COPY src/browser/ /app/src/browser/
COPY src/shared/ /app/src/shared/
COPY src/__init__.py /app/src/__init__.py
COPY docker/browser-entrypoint.sh /usr/local/bin/browser-entrypoint.sh
```

So a change to any of the 25,401 lines under `src/browser/`, to anything under `src/shared/`, to `src/__init__.py`, or to the fontconfig alias file produced a **different image** that this job never rebuilt. The fontconfig file is the sharpest case: the build asserts on it (`fc-match "Segoe UI"` must resolve to Carlito, `exit 1` otherwise), so editing it could hard-fail the build with no CI run to say so.

## Fix

**1. Widen the filter to everything the Dockerfile COPYs.**

```yaml
- "Dockerfile.browser"
- "docker/**"
- "pyproject.toml"
- "src/__init__.py"
- "src/browser/**"
- "src/shared/**"
- ".github/workflows/browser-image.yml"
```

**Why `src/shared/**` and not the five files browser imports.** The verified import set today is `utils.py`, `redaction.py`, `types.py`, `trace.py`, `paths.py` (confirmed by AST-walking the module-level import closure of `src.browser.__main__`, which is what the entrypoint runs). Enumerating those five is more precise and would skip roughly a third of `src/shared` commits — the ones touching `operator_playbooks.py`, `limits.py`, `models.py`, etc. that browser never imports.

I chose the glob anyway, for three reasons:

- **It fails closed.** An enumeration encodes today's import graph. The first `from src.shared.limits import ...` added to `src/browser` silently reopens exactly the hole this PR closes, and nothing tells anyone. A stale enumeration *is* the bug being fixed here — reintroducing one in slow motion is the wrong trade.
- **The whole directory is literally a build input.** `COPY src/shared/` copies all 14 files; the image bytes change with any of them, imported or not. The glob describes the Dockerfile as written; the five-file list describes an inference about it.
- **It is simpler to read and to keep true.** Two globs and a file, versus nine lines that must be re-derived every time an import changes.

`docker/**` is the same argument at smaller scale: it covers both files in `docker/` (both COPY'd, both build inputs) without needing an update when a third arrives.

**2. Make the new triggers non-vacuous.**

Widening the filter alone would have added CI cost and bought nothing: a change under `src/browser/` cannot fail a `COPY`, and no step in this job loaded the copied code. The build would have gone green without ever touching the changed lines.

So this PR adds one step that imports every module under `/app/src/browser` **inside the built image**. The concrete regression it catches:

> `src/browser` gains a new module-level third-party import. The author adds the package to `pyproject.toml`, so the `Tests` workflow (which installs `.[dev]`) stays green. They do not add it to the hard-coded pip install list in `Dockerfile.browser` — which does not read `pyproject.toml`; it installs a literal list of six packages. The browser container then dies on boot in production with `ModuleNotFoundError`.

Nothing in the repo catches that today. It is the same shape as the PR #815 incident this workflow was built for (a dependency the image is missing, failing only at runtime), which is why it belongs in this job rather than a new one.

The module list is globbed, not fixed, so new modules are covered automatically. `__main__` is imported by name, so its `if __name__ == "__main__"` guard keeps `main()` from running. Lazily-imported deps (`camoufox`, `playwright`, `browserforge` — all imported inside functions) are deliberately out of reach; only a live launch exercises those.

**3. Pin the invariant in the fast suite.**

`tests/test_dockerfile_browser_deps.py::TestBuildTriggerCoverage` derives the expectation from the Dockerfile rather than restating a list: every `COPY` source must be matched by the paths filter, and the `push` and `pull_request` filters must not drift apart (a filter that fires on one but not the other just relocates the gap). A future `COPY` that nobody adds to the filter now fails in `make test` instead of shipping.

## Verification

- **Test fails before, passes after.** Against the pre-fix workflow the new test names exactly the four uncovered paths:
  ```
  AssertionError: Dockerfile.browser COPYs these paths into the image, but browser-image.yml's
  paths filter does not watch them — a change to any of them ships without a build-and-smoke run:
  ['docker/fontconfig-windows-aliases.conf', 'src/browser/', 'src/shared/', 'src/__init__.py']
  ```
  With the widened filter: `9 passed`.
- **The new CI step was executed, not just written.** Its Python program was extracted from the YAML and run against the working tree with `/app` rewritten to the checkout: all 20 `src.browser.*` modules import, exit 0. The local environment is a strict *subset* of the image's (it lacks `camoufox`, `browserforge` and `websockets`, all of which the image has and none of which are imported at module level), so a local pass implies an in-image pass.
- Workflow YAML re-parsed with `yaml.safe_load` after editing; step order and both trigger blocks confirmed.
- `ruff check src/ tests/` clean. (`ruff format` reports three pre-existing hunks in this test file that are present on `main` — untouched, no drive-by reformat.)

## Cost

`src/shared/types.py` alone appears in ~47% of the last 200 commits, so this job will now run on a meaningful share of PRs. Two notes for the reviewer:

- The source `COPY` layers sit *before* `RUN python -m camoufox fetch`, so a source-only change invalidates the Firefox download layer and pays a near-cold build (minutes, well inside the 20-minute timeout). Moving the three source `COPY`s below the fetch — they only need to precede `RUN chown -R browser:browser /app` — would make these builds warm-cache cheap. That is a Dockerfile layer-ordering change with its own risk, so it is deliberately **not** in this PR.
- Nothing here changes the image contents or the runtime; the diff is the trigger, one verification step, comments, and tests.

## Other workflows

`.github/workflows/test.yml` is the only other workflow and has **no** paths filter at all — it runs on every push and PR, so it cannot have this bug. Checked, nothing to fix there.
