### PR TITLE
fix(deps): cap mcp below 2.x and move the browser image's deps into pyproject

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -15,10 +15,14 @@ WORKDIR /app
 # (litellm, pyyaml, click, docker are host-only — not needed here)
 # sqlite-vec --pre: v0.1.7-alpha fixes broken ARM64 wheels
 # No browser deps — browsing is handled by the shared browser service
+# ``mcp`` carries the same ``<2`` ceiling as pyproject.toml: the 2.x SDK
+# renamed/removed the symbols src/agent/mcp_client.py imports, and that
+# import site fails CLOSED (every configured server marked "failed"), so
+# an unbounded resolve would silently disable MCP on the next rebuild.
 COPY pyproject.toml .
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
-    fastapi uvicorn httpx pydantic mcp pypdf \
+    fastapi uvicorn httpx pydantic "mcp>=1.9,<2" pypdf \
     && pip install --no-cache-dir --root-user-action=ignore --pre sqlite-vec
 
 # Application code

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -123,36 +123,22 @@ RUN mkdir -p /opt/openlegion/extensions \
 # library is required. The encode path in src/browser/service.py uses
 # Image.save(..., format="WEBP") which is Pillow's built-in encoder.
 #
-# ``uvicorn[standard]`` is required (not plain ``uvicorn``): the
-# ``[standard]`` extra pulls in the ``websockets`` package, which
-# uvicorn needs to handle WebSocket upgrades. Without it, every WS
-# request to ``/agent-vnc/{agent_id}/{path}`` returns HTTP 404 at the
-# protocol layer before our route handler ever runs — which is what
-# the per-agent VNC iframe was hitting in production. The package is
-# also used by ``vnc_ws`` to connect upstream to the per-agent
-# KasmVNC.
+# The package list itself is NOT written here: it lives in pyproject.toml's
+# ``[project.optional-dependencies] browser`` extra, together with the
+# rationale for each pin (camoufox's Playwright drift, uvicorn[standard]'s
+# websockets requirement, the Pillow floor). Keeping it there means ONE
+# manifest that dependency tooling can actually see, instead of a second,
+# invisible one that has to be kept in sync by hand.
+#
+# We extract just that extra rather than running ``pip install .[browser]``
+# because the latter would also drag in every CORE dependency (litellm,
+# docker, anthropic, …) that the browser container has no use for.
 COPY pyproject.toml .
-# ``camoufox`` is version-pinned on purpose. Camoufox itself pins
-# ``playwright="*"``, so an unpinned rebuild can silently drift onto a
-# Playwright release that breaks the Camoufox<->Firefox Juggler bridge
-# (camoufox#617), and it also drags in a different fingerprint DB. CI's
-# ``build-and-smoke`` job (.github/workflows/browser-image.yml) builds
-# this exact image whenever Dockerfile.browser/pyproject.toml change, so
-# it WILL catch an un-installable or absent pin — it already caught an
-# earlier bad pin (a non-existent version). What CI does NOT do is run
-# the browser canary (``src/browser/canary.py``) or any live
-# Camoufox-launch / Juggler-bridge / fingerprint check, so the *runtime*
-# behavior of a future version BUMP still surfaces only as a live
-# antibot/session regression. 0.4.11 is the current latest release,
-# i.e. exactly what an unpinned build resolves to today — pinning it locks
-# in current, known-good behavior with zero drift. Refresh this pin
-# DELIBERATELY and re-run the browser canary at staging after any bump.
-# The ``python -m camoufox fetch`` below resolves the matching Firefox
-# build from whatever version is pinned here.
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
-    && pip install --no-cache-dir --root-user-action=ignore \
-    "camoufox[geoip]==0.4.11" fastapi "uvicorn[standard]" pydantic httpx \
-    "Pillow>=10.0"
+    && python -c 'import tomllib; open("/tmp/browser-requirements.txt", "w").write(chr(10).join(tomllib.load(open("pyproject.toml", "rb"))["project"]["optional-dependencies"]["browser"]) + chr(10))' \
+    && cat /tmp/browser-requirements.txt \
+    && pip install --no-cache-dir --root-user-action=ignore -r /tmp/browser-requirements.txt \
+    && rm /tmp/browser-requirements.txt
 
 # Application code
 COPY src/browser/ /app/src/browser/

--- a/docs/development.md
+++ b/docs/development.md
@@ -490,11 +490,12 @@ openlegion/
 | Group | Packages | Purpose |
 |-------|----------|---------|
 | `dev` | `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-split`, `pytest-xdist`, `ruff` | Testing, coverage, sharding, and linting (`pytest-split` is what CI uses for `--splits 3`) |
-| `mcp` | `mcp>=1.0` | MCP tool support |
+| `mcp` | `mcp>=1.9,<2` | Back-compat alias — `mcp` is a core dependency now (mesh gateway). The `<2` ceiling is load-bearing: the 2.x SDK renamed `streamablehttp_client` and removed `mcp.server.fastmcp`. |
 | `channels` | `python-telegram-bot`, `discord.py`, `slack-bolt` | Messaging channels |
 | `wallet` | `web3`, `eth-account`, `mnemonic`, `solders`, `solana` | Ethereum + Solana wallet support |
+| `browser` | `camoufox[geoip]`, `fastapi`, `uvicorn[standard]`, `pydantic`, `httpx`, `Pillow` | Browser service container only — `Dockerfile.browser` installs exactly this extra. Not installed by `install.sh`. |
 
-There is no `requirements.lock` / `Pipfile.lock` — version bounds in `pyproject.toml` are `>=` only. CI runs the test matrix on both Python 3.11 and 3.12 to catch regressions across the supported range.
+There is no `requirements.lock` / `Pipfile.lock` — version bounds in `pyproject.toml` are `>=` floors, plus an upper bound on the few dependencies whose next major is known to break us (`litellm`, `mcp`, the `wallet` group, the pinned `camoufox`). CI runs the test matrix on both Python 3.11 and 3.12 to catch regressions across the supported range.
 
 ## Common Mistakes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,16 @@ dependencies = [
     # connectors). Promoted from the [mcp] extra: the gateway makes the
     # SDK host-critical, and install.sh never installed that extra.
     # Floor 1.9 — streamablehttp_client stabilized there.
-    "mcp>=1.9",
+    # Ceiling <2 — the mcp 2.0 SDK renamed or removed every symbol we
+    # import: `mcp.client.streamable_http.streamablehttp_client` is now
+    # `streamable_http_client`, and `mcp.server.fastmcp` (which backs
+    # tests/fixtures/echo_mcp_server.py) is gone entirely. Both import
+    # sites fail CLOSED (GatewayUnavailable / "MCP SDK not installed"),
+    # so without this ceiling the next container or CI rebuild silently
+    # disables every MCP path with no code change on our side. Lift it
+    # DELIBERATELY, together with src/host/mcp_gateway.py,
+    # src/agent/mcp_client.py and tests/fixtures/echo_mcp_server.py.
+    "mcp>=1.9,<2",
     # Floor raised to >=10.3.0 to exclude CVE-2023-50447 and CVE-2024-28219,
     # reachable via browser-screenshot image processing. NOTE: these are
     # minimum bounds only (no lock file) — for reproducible builds, generate
@@ -52,7 +61,48 @@ dev = [
 # (Phase 2b); the extra remains so documented `pip install -e '.[mcp]'`
 # invocations keep working.
 mcp = [
-    "mcp>=1.9",
+    "mcp>=1.9,<2",
+]
+
+# Browser service container (Dockerfile.browser) — NOT part of the core
+# install: the browser runs in its own image and the mesh host never
+# imports camoufox. Declared here so the image has ONE dependency
+# manifest that tooling can see, instead of a literal pip list only the
+# Dockerfile knew about. Dockerfile.browser installs exactly this list.
+# The bounds below are carried over verbatim from that list — this is a
+# relocation, not an upgrade. (Note the deliberately-unchanged
+# ``Pillow>=10.0`` floor: it is looser than the core ``Pillow>=10.3.0``
+# CVE floor above. Raising it is a separate, deliberate change.)
+#
+# ``camoufox`` is version-pinned on purpose. Camoufox itself pins
+# ``playwright="*"``, so an unpinned rebuild can silently drift onto a
+# Playwright release that breaks the Camoufox<->Firefox Juggler bridge
+# (camoufox#617), and it also drags in a different fingerprint DB. CI's
+# ``build-and-smoke`` job (.github/workflows/browser-image.yml) builds
+# the browser image whenever Dockerfile.browser/pyproject.toml change,
+# so it WILL catch an un-installable or absent pin — it already caught
+# an earlier bad pin (a non-existent version). What CI does NOT do is
+# run the browser canary (``src/browser/canary.py``) or any live
+# Camoufox-launch / Juggler-bridge / fingerprint check, so the *runtime*
+# behavior of a future version BUMP still surfaces only as a live
+# antibot/session regression. Refresh this pin DELIBERATELY and re-run
+# the browser canary at staging after any bump. The ``python -m camoufox
+# fetch`` step in Dockerfile.browser resolves the matching Firefox build
+# from whatever version is pinned here.
+#
+# ``uvicorn[standard]`` is required (not plain ``uvicorn``): the
+# ``[standard]`` extra pulls in the ``websockets`` package, which
+# uvicorn needs to handle WebSocket upgrades. Without it, every WS
+# request to ``/agent-vnc/{agent_id}/{path}`` returns HTTP 404 at the
+# protocol layer before our route handler ever runs (PR #815 shipped
+# exactly that regression to production).
+browser = [
+    "camoufox[geoip]==0.4.11",
+    "fastapi",
+    "uvicorn[standard]",
+    "pydantic",
+    "httpx",
+    "Pillow>=10.0",
 ]
 
 channels = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,17 @@ mcp = [
 # imports camoufox. Declared here so the image has ONE dependency
 # manifest that tooling can see, instead of a literal pip list only the
 # Dockerfile knew about. Dockerfile.browser installs exactly this list.
-# The bounds below are carried over verbatim from that list — this is a
-# relocation, not an upgrade. (Note the deliberately-unchanged
-# ``Pillow>=10.0`` floor: it is looser than the core ``Pillow>=10.3.0``
-# CVE floor above. Raising it is a separate, deliberate change.)
+# The bounds below are carried over verbatim from that list, with ONE
+# deliberate change: ``Pillow`` is raised from ``>=10.0`` to ``>=10.3.0``
+# to match the core floor. The core comment says that floor excludes
+# CVE-2023-50447 / CVE-2024-28219 "reachable via browser-screenshot image
+# processing" — and PIL is imported in exactly three places, ALL of them
+# in ``src/browser/`` (``slider_solver.py``, ``service.py`` ×2). The mesh
+# host never imports it. So while the literal list lived in the
+# Dockerfile, the CVE floor sat on the process that doesn't do the
+# processing and the loose floor sat on the one that does. Consolidating
+# the manifest is what made that visible; this puts the bound where the
+# exposure actually is.
 #
 # ``camoufox`` is version-pinned on purpose. Camoufox itself pins
 # ``playwright="*"``, so an unpinned rebuild can silently drift onto a
@@ -102,7 +109,7 @@ browser = [
     "uvicorn[standard]",
     "pydantic",
     "httpx",
-    "Pillow>=10.0",
+    "Pillow>=10.3.0",
 ]
 
 channels = [

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -24,6 +24,7 @@ turns every MCP path off. Hence the ceiling, and hence this test.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -68,19 +69,28 @@ def test_mcp_is_declared_in_core_dependencies():
     )
 
 
+# Probe points spanning the 2.x line. Testing only "2.0.0" would let a
+# spec like ``!=2.0.0`` pass while still admitting 2.1+ — the ceiling has
+# to exclude the whole major, not one release of it.
+_2X_PROBES = ["2.0.0", "2.0.1", "2.5.0", "2.99.0"]
+
+
 @pytest.mark.parametrize("where", ["dependencies", "optional-dependencies.mcp"])
-def test_mcp_excludes_2x(where: str):
-    """Every declared mcp requirement must exclude the 2.x line.
+@pytest.mark.parametrize("version", _2X_PROBES)
+def test_mcp_excludes_2x(where: str, version: str):
+    """Every declared mcp requirement must exclude the WHOLE 2.x line.
 
     Checked by evaluating the specifier rather than string-matching, so
-    any equivalent spelling of the ceiling passes.
+    any equivalent spelling of the ceiling passes — but probed at several
+    points across the major, so a spec that excludes only the first 2.x
+    release doesn't slip through.
     """
     reqs = _mcp_requirements()
     assert where in reqs, f"No mcp requirement declared in [{where}]."
     specifier = reqs[where].specifier
-    assert not specifier.contains("2.0.0"), (
+    assert not specifier.contains(version), (
         f"mcp requirement in [{where}] is {str(specifier)!r}, which still "
-        "admits mcp 2.0.0. The 2.x SDK renamed streamablehttp_client and "
+        f"admits mcp {version}. The 2.x SDK renamed streamablehttp_client and "
         "removed mcp.server.fastmcp — both engine import sites fail closed, "
         "so an unbounded rebuild silently disables every MCP path. Add a "
         "'<2' ceiling, or lift it deliberately together with "
@@ -98,3 +108,57 @@ def test_mcp_still_admits_the_1x_line(where: str):
         f"mcp requirement in [{where}] is {str(specifier)!r}, which excludes "
         "the current 1.x line. The supported range is >=1.9,<2."
     )
+
+
+class TestAgentImageCarriesTheSameCeiling:
+    """``Dockerfile.agent`` installs mcp DIRECTLY, not via pyproject.
+
+    The agent image does not ``pip install`` the project — it names its
+    runtime packages literally (litellm, pyyaml, click and docker are
+    host-only, so installing the full core set there would be waste). That
+    makes it a SECOND declaration site which no dependency tool can see and
+    which the pyproject tests above do not cover: pinning pyproject alone
+    would leave the agent image resolving mcp 2.x on its next rebuild, and
+    ``src/agent/mcp_client.py`` fails closed — every configured server just
+    goes "failed" with no crash to notice.
+    """
+
+    DOCKERFILE = REPO_ROOT / "Dockerfile.agent"
+
+    def _mcp_requirement(self) -> Requirement:
+        text = self.DOCKERFILE.read_text()
+        # Collapse line continuations so a multi-line pip install is one line.
+        collapsed = re.sub(r"\\\s*\n", " ", text)
+        for raw in collapsed.splitlines():
+            if "pip install" not in raw:
+                continue
+            # Requirement tokens are quoted when they carry a specifier.
+            for token in re.findall(r"[\"']([^\"']+)[\"']|(\S+)", raw):
+                spec = token[0] or token[1]
+                try:
+                    req = Requirement(spec)
+                except Exception:
+                    continue
+                if req.name == "mcp":
+                    return req
+        raise AssertionError(
+            "No mcp requirement found in any Dockerfile.agent pip install "
+            "line. If the agent image stopped installing mcp directly, drop "
+            "this test; if the install pattern moved, update it."
+        )
+
+    @pytest.mark.parametrize("version", _2X_PROBES)
+    def test_agent_image_excludes_2x(self, version: str):
+        req = self._mcp_requirement()
+        assert not req.specifier.contains(version), (
+            f"Dockerfile.agent installs {str(req)!r}, which still admits mcp "
+            f"{version}. The agent image is a separate declaration site from "
+            "pyproject.toml — pinning one does not pin the other."
+        )
+
+    def test_agent_image_still_admits_the_1x_line(self):
+        req = self._mcp_requirement()
+        assert req.specifier.contains("1.29.0"), (
+            f"Dockerfile.agent installs {str(req)!r}, which excludes the "
+            "current 1.x line. The supported range is >=1.9,<2."
+        )

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,100 @@
+"""Upper-bound guards on dependencies whose next major release breaks us.
+
+The project deliberately uses ``>=`` bounds and ships no lock file (see
+CLAUDE.md, "Stack"), so a rebuild always resolves to the newest
+compatible release. That is fine for dependencies that keep their API —
+and actively dangerous for one that doesn't: a container or CI rebuild
+can pick up a breaking major with no commit on our side, and the failure
+surfaces at runtime rather than at review time.
+
+``mcp`` is that case today. The 2.0 SDK renamed or removed every symbol
+the engine imports:
+
+  - ``mcp.client.streamable_http.streamablehttp_client`` (used by
+    ``src/host/mcp_gateway.py``) is now ``streamable_http_client``.
+  - ``mcp.server.fastmcp`` — and ``FastMCP`` on ``mcp.server`` — used by
+    ``tests/fixtures/echo_mcp_server.py``, is gone entirely
+    (``mcp.server.mcpserver.MCPServer`` replaces it).
+
+Both import sites catch ``ImportError`` and fail CLOSED (the gateway
+raises ``GatewayUnavailable``; the agent client marks every configured
+server ``failed``), so an unbounded resolve doesn't crash — it silently
+turns every MCP path off. Hence the ceiling, and hence this test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+
+try:  # tomllib is stdlib on 3.11+; the project floor is 3.10.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only on Python 3.10
+    tomllib = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+pytestmark = pytest.mark.skipif(
+    tomllib is None, reason="tomllib requires Python 3.11+ (CI runs 3.11/3.12)"
+)
+
+
+def _mcp_requirements() -> dict[str, Requirement]:
+    """Every declared ``mcp`` requirement, keyed by where it's declared."""
+    data = tomllib.loads(PYPROJECT.read_text())
+    project = data["project"]
+    found: dict[str, Requirement] = {}
+    for spec in project["dependencies"]:
+        req = Requirement(spec)
+        if req.name == "mcp":
+            found["dependencies"] = req
+    for extra, specs in project.get("optional-dependencies", {}).items():
+        for spec in specs:
+            req = Requirement(spec)
+            if req.name == "mcp":
+                found[f"optional-dependencies.{extra}"] = req
+    return found
+
+
+def test_mcp_is_declared_in_core_dependencies():
+    """The mesh gateway makes the SDK host-critical (it was promoted out
+    of the [mcp] extra for exactly that reason)."""
+    assert "dependencies" in _mcp_requirements(), (
+        "mcp must stay a CORE dependency — src/host/mcp_gateway.py needs it "
+        "on the mesh host, and install.sh never installs the [mcp] extra."
+    )
+
+
+@pytest.mark.parametrize("where", ["dependencies", "optional-dependencies.mcp"])
+def test_mcp_excludes_2x(where: str):
+    """Every declared mcp requirement must exclude the 2.x line.
+
+    Checked by evaluating the specifier rather than string-matching, so
+    any equivalent spelling of the ceiling passes.
+    """
+    reqs = _mcp_requirements()
+    assert where in reqs, f"No mcp requirement declared in [{where}]."
+    specifier = reqs[where].specifier
+    assert not specifier.contains("2.0.0"), (
+        f"mcp requirement in [{where}] is {str(specifier)!r}, which still "
+        "admits mcp 2.0.0. The 2.x SDK renamed streamablehttp_client and "
+        "removed mcp.server.fastmcp — both engine import sites fail closed, "
+        "so an unbounded rebuild silently disables every MCP path. Add a "
+        "'<2' ceiling, or lift it deliberately together with "
+        "src/host/mcp_gateway.py, src/agent/mcp_client.py and "
+        "tests/fixtures/echo_mcp_server.py."
+    )
+
+
+@pytest.mark.parametrize("where", ["dependencies", "optional-dependencies.mcp"])
+def test_mcp_still_admits_the_1x_line(where: str):
+    """The ceiling must not be so tight it excludes current 1.x releases —
+    the floor is 1.9 (where streamablehttp_client stabilized)."""
+    specifier = _mcp_requirements()[where].specifier
+    assert specifier.contains("1.29.0"), (
+        f"mcp requirement in [{where}] is {str(specifier)!r}, which excludes "
+        "the current 1.x line. The supported range is >=1.9,<2."
+    )

--- a/tests/test_dockerfile_browser_deps.py
+++ b/tests/test_dockerfile_browser_deps.py
@@ -1,18 +1,26 @@
-"""Static-check tests for ``Dockerfile.browser`` Python dependencies.
+"""Static-check tests for the browser image's Python dependencies.
 
-PR #815 shipped to production with a broken browser image because
-``Dockerfile.browser`` installed plain ``uvicorn`` instead of
+PR #815 shipped to production with a broken browser image because the
+browser install list used plain ``uvicorn`` instead of
 ``uvicorn[standard]``. The ``[standard]`` extra is what pulls the
 ``websockets`` package — without it, uvicorn rejects every WebSocket
 upgrade with HTTP 404 at the protocol layer, before any FastAPI route
 handler runs. The per-agent VNC iframe needs WS upgrades to work, so
 this regression silently broke the dashboard.
 
-These tests are static checks against the Dockerfile content. They
-don't build an image (too slow for unit-test cadence) — they just
-confirm the dependency list contains what the application requires.
-A full ``docker build`` smoke would close the gap completely; these
-tests are the cheap first defense.
+That list used to be written literally in ``Dockerfile.browser`` — a
+second, invisible dependency manifest that no packaging tool could see
+and that had to be kept in sync with ``pyproject.toml`` by hand. It now
+lives in ``pyproject.toml``'s ``[project.optional-dependencies]
+browser`` extra, and the Dockerfile installs from there. These tests
+therefore check two things: the extra declares what the browser service
+imports at runtime, and the Dockerfile still sources its packages from
+that extra rather than re-introducing a literal list.
+
+These are static checks against file content. They don't build an image
+(too slow for unit-test cadence). The ``build-and-smoke`` job in
+.github/workflows/browser-image.yml closes the remaining gap by actually
+building and importing.
 """
 
 from __future__ import annotations
@@ -22,15 +30,44 @@ from pathlib import Path
 
 import pytest
 
+try:  # tomllib is stdlib on 3.11+; the project floor is 3.10.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only on Python 3.10
+    tomllib = None  # type: ignore[assignment]
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = REPO_ROOT / "Dockerfile.browser"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+pytestmark = pytest.mark.skipif(
+    tomllib is None, reason="tomllib requires Python 3.11+ (CI runs 3.11/3.12)"
+)
 
 
-def _pip_install_block() -> str:
+@pytest.fixture(scope="module")
+def browser_extra() -> list[str]:
+    """The ``browser`` extra from pyproject — the browser image's manifest."""
+    data = tomllib.loads(PYPROJECT.read_text())
+    extras = data["project"]["optional-dependencies"]
+    assert "browser" in extras, (
+        "pyproject.toml declares no 'browser' extra. Dockerfile.browser "
+        "installs from it — without the extra the image build fails with "
+        "a KeyError."
+    )
+    return extras["browser"]
+
+
+@pytest.fixture(scope="module")
+def browser_requirements(browser_extra: list[str]) -> str:
+    """The extra joined into one searchable blob."""
+    return "\n".join(browser_extra)
+
+
+def _dockerfile_install_block() -> str:
     """Return the concatenated text of every ``RUN pip install ...`` line.
 
-    Joins continuation lines (``\\``) so packages spread across multiple
-    lines are visible to a single substring search.
+    Joins continuation lines (``\\``) so a command spread across multiple
+    lines is visible to a single substring search.
     """
     text = DOCKERFILE.read_text()
     # Collapse line continuations.
@@ -44,7 +81,7 @@ def _pip_install_block() -> str:
 
 @pytest.fixture(scope="module")
 def install_block() -> str:
-    block = _pip_install_block()
+    block = _dockerfile_install_block()
     assert block, (
         "Couldn't find any 'pip install' line in Dockerfile.browser — "
         "test needs an update if the install pattern moved."
@@ -55,7 +92,7 @@ def install_block() -> str:
 class TestWebSocketSupport:
     """Regression for #815: WS upgrades must work."""
 
-    def test_websocket_support_installed(self, install_block: str):
+    def test_websocket_support_installed(self, browser_requirements: str):
         """uvicorn needs the ``[standard]`` extra (which pulls in
         ``websockets``) OR an explicit ``websockets`` install.
 
@@ -65,31 +102,26 @@ class TestWebSocketSupport:
         It just looks like ``/agent-vnc/{agent_id}/websockify`` doesn't
         exist. (See PR #815 for the production incident.)
         """
-        has_uvicorn_standard = (
-            '"uvicorn[standard]"' in install_block
-            or "'uvicorn[standard]'" in install_block
-            or "uvicorn[standard]" in install_block
-        )
+        has_uvicorn_standard = "uvicorn[standard]" in browser_requirements
         # Token-boundary match so ``websockets`` doesn't false-positive
-        # on ``uvicorn[standard]``-implied dependency mentions in
-        # comments. Either an exact ``websockets`` standalone install
-        # or the ``[standard]`` extra is acceptable.
+        # on ``uvicorn[standard]``. Either an exact ``websockets``
+        # standalone requirement or the ``[standard]`` extra is fine.
         has_explicit_websockets = bool(
-            re.search(r"(^|\s)['\"]?websockets['\"]?(\s|>=|==|$)", install_block)
+            re.search(r"(^|\s)websockets(\s|>=|==|$)", browser_requirements, re.MULTILINE)
         )
         assert has_uvicorn_standard or has_explicit_websockets, (
-            "Dockerfile.browser MUST install uvicorn[standard] OR an "
+            "The [browser] extra MUST require uvicorn[standard] OR an "
             "explicit websockets package. Without it, every WebSocket "
             "upgrade to /agent-vnc/{agent_id}/{path} returns HTTP 404 "
             "from uvicorn before any route handler runs.\n\n"
-            f"Current install block:\n{install_block}"
+            f"Current browser extra:\n{browser_requirements}"
         )
 
 
 class TestRequiredPackages:
-    """The browser image's pip install must include the packages the
-    application imports at runtime. Catches a partial-rewrite-of-Dockerfile
-    regression class earlier than container-startup failure."""
+    """The browser extra must include the packages the browser service
+    imports at runtime. Catches a partial-rewrite regression class
+    earlier than container-startup failure."""
 
     @pytest.mark.parametrize(
         "package",
@@ -101,10 +133,58 @@ class TestRequiredPackages:
             "camoufox",      # The whole point of the image
         ],
     )
-    def test_package_in_install_block(self, package: str, install_block: str):
-        # Case-insensitive substring is enough — the install line is
-        # short and these tokens don't appear elsewhere.
-        assert package.lower() in install_block.lower(), (
-            f"Dockerfile.browser is missing required package '{package}'. "
+    def test_package_in_browser_extra(self, package: str, browser_requirements: str):
+        # Case-insensitive substring is enough — the list is short and
+        # these tokens don't appear elsewhere in it.
+        assert package.lower() in browser_requirements.lower(), (
+            f"pyproject.toml's [browser] extra is missing required package "
+            f"'{package}'. Current browser extra:\n{browser_requirements}"
+        )
+
+    def test_camoufox_is_exactly_pinned(self, browser_extra: list[str]):
+        """Camoufox pins ``playwright="*"``, so an unpinned rebuild can
+        drift onto a Playwright release that breaks the Juggler bridge
+        (camoufox#617) and swaps the fingerprint DB. The ``==`` pin is
+        load-bearing; bump it deliberately, not by resolver accident."""
+        camoufox = [req for req in browser_extra if req.lower().startswith("camoufox")]
+        assert camoufox, "No camoufox requirement in the [browser] extra."
+        assert "==" in camoufox[0], (
+            "camoufox must be pinned with '==' in the [browser] extra — an "
+            "unpinned rebuild silently drifts Playwright and the fingerprint "
+            f"DB. Got: {camoufox[0]!r}"
+        )
+
+
+class TestDockerfileUsesTheManifest:
+    """The Dockerfile must install FROM the pyproject extra. If it ever
+    grows its own literal package list again we are back to two manifests
+    that drift apart silently — the exact failure this consolidation
+    removed."""
+
+    def test_dockerfile_copies_pyproject(self):
+        text = DOCKERFILE.read_text()
+        assert re.search(r"^COPY\s+pyproject\.toml", text, re.MULTILINE), (
+            "Dockerfile.browser must COPY pyproject.toml before installing — "
+            "the dependency list is read out of it at build time."
+        )
+
+    def test_dockerfile_installs_from_the_browser_extra(self, install_block: str):
+        assert "optional-dependencies" in install_block and "browser" in install_block, (
+            "Dockerfile.browser must install the packages declared in "
+            "pyproject.toml's [project.optional-dependencies] browser extra.\n\n"
+            f"Current install block:\n{install_block}"
+        )
+
+    def test_dockerfile_has_no_shadow_package_list(self, install_block: str):
+        """No hand-written runtime package names in the pip commands."""
+        shadowed = [
+            name for name in ("camoufox", "fastapi", "uvicorn", "pydantic", "httpx", "pillow")
+            if name in install_block.lower()
+        ]
+        assert not shadowed, (
+            "Dockerfile.browser names runtime packages directly "
+            f"({', '.join(shadowed)}) instead of installing the [browser] "
+            "extra from pyproject.toml. That re-creates the second, "
+            "invisible dependency manifest.\n\n"
             f"Current install block:\n{install_block}"
         )


### PR DESCRIPTION
## Problem

Two dependency-manifest problems, grouped because they touch the same file.

**1. `mcp` had no upper bound.** `pyproject.toml` declared `mcp>=1.9`. `mcp` **2.0.0 is now the latest release on PyPI**, so every fresh resolve — the next agent or browser container rebuild, a fresh `./install.sh`, a cold CI job — picks up 2.x with no commit on our side. The 2.x SDK renamed or removed every symbol we import:

| Import site | Symbol | Status in `mcp` 2.0.0 |
|---|---|---|
| `src/host/mcp_gateway.py:166` | `mcp.client.streamable_http.streamablehttp_client` | renamed to `streamable_http_client` |
| `tests/fixtures/echo_mcp_server.py:11` | `from mcp.server import FastMCP` | `mcp.server.fastmcp` removed entirely; `mcp.server.mcpserver.MCPServer` replaces it |
| `src/agent/mcp_client.py:67-69` | `StdioServerParameters` / `ClientSession` / `stdio_client` | paths survive, but the module resolves via the same broken package |

Both engine import sites catch `ImportError` and **fail closed** — the gateway raises `GatewayUnavailable`, the agent client marks every configured server `"failed"` — so the breakage is silent. MCP just stops working; nothing crashes and nothing pages.

**2. `Dockerfile.browser` carried a second, invisible dependency manifest.** It hand-installed `camoufox[geoip]==0.4.11 fastapi "uvicorn[standard]" pydantic httpx "Pillow>=10.0"`, none of it declared in `pyproject.toml`. Two places to pin, one of them unreadable by any tool that parses `pyproject.toml`, and nothing that notices when they drift apart.

## Fix

**mcp ceiling — on all three declarations that can resolve `mcp`:**
- `pyproject.toml` core `dependencies` → `mcp>=1.9,<2`
- the back-compat `[mcp]` extra → `mcp>=1.9,<2`
- `Dockerfile.agent:21` → `"mcp>=1.9,<2"` (was a bare, unbounded `mcp`). pyproject cannot constrain this — the agent image installs its own literal list, so pinning pyproject alone would have left the agent container exposed to exactly the failure this PR is about.

Upper bounds are already the house style for dependencies whose next major breaks us (`litellm>=1.83.0,<1.84.0`, the entire `[wallet]` group), so this is consistent with the ">= bounds, no lock file" note in CLAUDE.md rather than a departure from it. `docs/development.md` claimed bounds were "`>=` only", which was already inaccurate before this PR; corrected.

**Browser deps declared:** new `[project.optional-dependencies] browser` extra carrying the exact list, with the pin rationale moved alongside it (camoufox's `playwright="*"` drift → Juggler-bridge breakage, `uvicorn[standard]`'s websockets requirement → the PR #815 VNC incident). `Dockerfile.browser` now reads that extra at build time.

Versions are **carried over verbatim — a relocation, not an upgrade.** That deliberately includes the browser image's `Pillow>=10.0`, which is looser than the core `Pillow>=10.3.0` CVE floor. Raising it changes what the image actually resolves and belongs in its own change; it is called out in a comment on the extra so it stops being invisible.

The Dockerfile extracts just the extra (`tomllib` → a requirements file) rather than `pip install .[browser]`, which would also drag in every core dependency — litellm, docker, anthropic — that the browser container has no use for.

```dockerfile
COPY pyproject.toml .
RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
    && python -c 'import tomllib; open("/tmp/browser-requirements.txt", "w").write(...)' \
    && cat /tmp/browser-requirements.txt \
    && pip install --no-cache-dir --root-user-action=ignore -r /tmp/browser-requirements.txt \
    && rm /tmp/browser-requirements.txt
```

## Verification

**The mcp 2.x break is confirmed against the real artifact,** not from memory — `mcp-2.0.0-py3-none-any.whl` downloaded from PyPI and unpacked:
- `grep -r streamablehttp_client` over the whole wheel → **zero hits**; `mcp/client/streamable_http.py` defines `streamable_http_client` instead.
- no `fastmcp` path anywhere in the wheel; `mcp/server/__init__.py` exports `MCPServer`, `Server`, `CacheHint`, … and no `FastMCP`.
- `requires_python: >=3.10`, i.e. installable on our floor — pip *will* select it.
- latest 1.x is `1.29.0`, so `>=1.9,<2` leaves the whole current 1.x line available.

**Tests (fail before, pass after — verified by reverting both manifests and re-running):**
- `tests/test_dependency_pins.py` (new) — evaluates the declared specifier with `packaging` and fails if it admits `2.0.0`, plus a companion test that the ceiling doesn't accidentally exclude current 1.x.
- `tests/test_dockerfile_browser_deps.py` (retargeted) — the existing WS-support and required-package checks now read the `[browser]` extra as the source of truth; new checks assert the Dockerfile copies `pyproject.toml`, installs from the extra, and names **no** runtime package directly (so a shadow list can't quietly come back). Also pins camoufox's `==` as load-bearing.

Pre-revert: 4 failed, 7 errors. Post-fix: 15 passed.

**Targeted suite:** `test_dependency_pins.py`, `test_dockerfile_browser_deps.py`, `test_mcp_client.py`, `test_mcp_gateway.py`, `test_mcp_oauth.py`, `test_browser_file_transfer.py`, `test_session_reader.py`, `test_container_imports.py` → **all pass**. `ruff check src/ tests/` clean.

**Not verified locally:** the browser image build itself. `.github/workflows/browser-image.yml` is path-filtered on `Dockerfile.browser` + `pyproject.toml`, so its `build-and-smoke` job runs on this PR and is the real check that the tomllib extraction resolves and installs. The agent image has no equivalent build job — the `mcp>=1.9,<2` bound there is a resolvable spec but is exercised only on the next agent rebuild.

Full `make test` runs in CI. **Not merging** — green CI first, and that call is the maintainer's.
