### PR TITLE
fix(cli): declare chain_watcher in RuntimeContext.__init__ so shutdown can't mask boot errors

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -311,6 +311,13 @@ class RuntimeContext:
         self.lifecycle_store = None
         self.teams_store = None
         self.thread_store = None
+        # Chain watcher (delegate-and-subscribe terminal delivery) — wired in
+        # ``_start_background`` once the mesh app's ``tasks_store`` exists.
+        # Declared here (not only in ``_create_components``) because
+        # ``shutdown()`` dereferences it: ``main.py`` runs ``ctx.shutdown()``
+        # in a ``finally``, so a boot failure BEFORE ``_create_components``
+        # must not turn into an AttributeError that masks the real error.
+        self.chain_watcher = None
         # Idle-agent hibernation sweep (plan §8 #24) — the mesh app builds
         # it inside ``create_mesh_app`` (it needs ``lane_manager``/
         # ``tasks_store``/``ask_broker``, all resolved there); wired here

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3401,3 +3401,82 @@ class TestUtilityModelEnv:
 
         monkeypatch.setattr("src.cli.config._load_config", _boom)
         assert backend._utility_model_from_config() == ""
+
+
+# ── RuntimeContext.shutdown() before start() ──────────────────
+#
+# ``cli/main.py`` wraps ``ctx.start()`` in ``try/finally: ctx.shutdown()``.
+# A boot failure BEFORE ``_create_components`` runs (e.g. ``_validate_prereqs``
+# calling ``sys.exit(1)`` because Docker is down) therefore still runs the
+# teardown against a context where nothing is wired. Every attribute
+# ``shutdown()`` dereferences must exist from ``__init__`` — otherwise the
+# AttributeError propagates out of the ``finally`` and REPLACES the real boot
+# error, so the operator sees a traceback instead of "Docker is not running".
+
+
+def _bare_runtime_context(monkeypatch, tmp_path):
+    """A RuntimeContext built through the real ``__init__``, nothing started."""
+    from src.cli import runtime as runtime_mod
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "_load_config",
+        lambda *a, **k: {
+            "mesh": {"host": "127.0.0.1", "port": 8420},
+            "llm": {},
+            "agents": {},
+        },
+    )
+    return runtime_mod.RuntimeContext(str(tmp_path / "mesh.yaml"))
+
+
+class TestShutdownBeforeStart:
+    def test_shutdown_without_start_does_not_raise(self, monkeypatch, tmp_path):
+        ctx = _bare_runtime_context(monkeypatch, tmp_path)
+        # Every component guard is falsy, so this walks the whole teardown
+        # body and dereferences each attribute exactly as a failed boot would.
+        ctx.shutdown()
+        assert ctx._shutting_down is True
+
+    def test_chain_watcher_is_declared_by_init(self, monkeypatch, tmp_path):
+        # Pins the specific regression: ``chain_watcher`` used to be assigned
+        # only in ``_create_components``, which a failed boot never reaches.
+        ctx = _bare_runtime_context(monkeypatch, tmp_path)
+        assert ctx.chain_watcher is None
+
+    def test_no_component_attribute_is_late_bound_only(self):
+        """Static guard for the whole class of bug, incl. code paths the
+        no-op teardown above skips (the ``_dispatch_loop`` close closure).
+
+        Every non-method ``self.X`` that ``shutdown()`` reads must be assigned
+        in ``__init__``.
+        """
+        import ast
+        import inspect
+
+        from src.cli import runtime as runtime_mod
+
+        tree = ast.parse(inspect.getsource(runtime_mod))
+        cls = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "RuntimeContext")
+        methods = {f.name for f in cls.body if isinstance(f, (ast.FunctionDef, ast.AsyncFunctionDef))}
+
+        def self_attrs(node, ctx_type):
+            return {
+                n.attr
+                for n in ast.walk(node)
+                if isinstance(n, ast.Attribute)
+                and isinstance(n.value, ast.Name)
+                and n.value.id == "self"
+                and isinstance(n.ctx, ctx_type)
+            }
+
+        init = next(f for f in cls.body if getattr(f, "name", None) == "__init__")
+        shutdown = next(f for f in cls.body if getattr(f, "name", None) == "shutdown")
+
+        declared = self_attrs(init, ast.Store)
+        touched = {a for a in self_attrs(shutdown, ast.Load) if a not in methods}
+        assert not (touched - declared), (
+            "shutdown() dereferences attributes that __init__ never declares — "
+            "a boot failure before they are wired would mask the real error: "
+            f"{sorted(touched - declared)}"
+        )


### PR DESCRIPTION
## Problem

`RuntimeContext.shutdown()` dereferences `self.chain_watcher` as its first component teardown (`src/cli/runtime.py:382`), but the attribute was assigned **only** in `_create_components()` (line ~750). It was absent from `__init__` (lines 291–354).

`src/cli/main.py` wraps the boot in `try/finally`:

```python
ctx = RuntimeContext(config_path, use_sandbox=sandbox, port_override=port)
try:
    ctx.start()
    ...
finally:
    ctx.shutdown()
```

and `start()` runs `_validate_prereqs()` → `_select_backend()` → `_create_components()` in that order. So any boot failure in the first two steps unwinds into the `finally`, where `shutdown()` raises:

```
AttributeError: 'RuntimeContext' object has no attribute 'chain_watcher'
```

An exception raised inside a `finally` **replaces** the in-flight exception. The most common trigger is the friendliest error the CLI has: `_validate_prereqs()` prints `"Docker is not running. Please start Docker first."` and calls `sys.exit(1)`. The `SystemExit` is swallowed by the AttributeError, so the operator gets an internal-attribute traceback instead of the actionable message. The same masking applies to anything `_select_backend()` raises (e.g. `_ensure_docker_image()`).

## Fix

One line: initialize `self.chain_watcher = None` in `__init__`, alongside the other late-bound components (`hibernation_sweeper`, `offboard_agent`, `cleanup_agent`) which already follow exactly this declare-in-`__init__`, wire-later pattern — with a comment in the same house style noting *why* it must be declared here.

The existing assignment in `_create_components()` is deliberately kept: it re-arms the attribute on a re-init, and removing it would risk leaving a stale watcher behind.

## Audit of the rest of `shutdown()`

Every other attribute `shutdown()` dereferences was checked (via an AST pass over the class, not by eye) and **all were already declared in `__init__`**: `_shutting_down`, `channel_manager`, `health_monitor`, `cron_scheduler`, `hibernation_sweeper`, `runtime`, `cost_tracker`, `trace_store`, `intent_store`, `lifecycle_store`, `pubsub`, `blackboard`, `_dispatch_loop`, `transport`, `router`, `credential_vault`, `_server`. `chain_watcher` was the only gap — so this PR is a single-line source change.

A wider sweep found other attributes assigned only outside `__init__` (`_app`, `_is_sandbox`, `_backend_label`, `connector_store`, `ask_broker`, `mcp_gateway`, `_tasks_store_ref`, `_pending_chain_pushes`, `_api_key_manager`, `_wallet_ref`, `_pending_actions_ref`). None of them are read by `shutdown()`, and every bare-dereference site sits in a method that runs strictly *after* its assigning method in `start()`'s fixed sequence — so none is a live bug. They are left alone rather than pre-emptively declared, to keep this change minimal.

## Verification

Reproduced on `origin/main` before fixing:

```
hasattr chain_watcher: False
  Stopping OpenLegion...REPRO AttributeError: 'RuntimeContext' object has no attribute 'chain_watcher'
```

Three tests added in `tests/test_runtime.py::TestShutdownBeforeStart`:

1. `test_shutdown_without_start_does_not_raise` — builds a `RuntimeContext` through the real `__init__` and calls `shutdown()` with no `start()`. Because every guard is falsy, this walks the entire teardown body and dereferences each attribute exactly as a failed boot does.
2. `test_chain_watcher_is_declared_by_init` — pins the specific regression.
3. `test_no_component_attribute_is_late_bound_only` — static AST guard asserting no attribute `shutdown()` reads is missing from `__init__`, which also covers the `_dispatch_loop` close closure (`transport`/`router`/`credential_vault`) that the no-op teardown skips at runtime.

All three **fail** on the unpatched source (`git stash` of the source hunk) and pass with it:

```
FAILED tests/test_runtime.py::TestShutdownBeforeStart::test_shutdown_without_start_does_not_raise
FAILED tests/test_runtime.py::TestShutdownBeforeStart::test_chain_watcher_is_declared_by_init
FAILED tests/test_runtime.py::TestShutdownBeforeStart::test_no_component_attribute_is_late_bound_only
AssertionError: shutdown() dereferences attributes that __init__ never declares — ['chain_watcher']
```

Targeted suites run locally, all green:

- `tests/test_runtime.py tests/test_cli_commands.py tests/test_repl_remove.py tests/test_cli_remove_review_fix.py` — 308 passed
- `tests/test_hibernation.py tests/test_boot_archived_skip.py tests/test_cron_heartbeats_reconcile.py tests/test_cron_standup.py tests/test_cron_work_summaries.py tests/test_lanes.py` — 214 passed
- `ruff check src/ tests/` — clean; `tests/test_runtime.py` is `ruff format` clean.

`src/cli/runtime.py` has pre-existing `ruff format` drift on `main`; the added lines are not inside any of the hunks `ruff format` wants, and the file was deliberately not reformatted to avoid an unrelated diff.

Diff is purely additive: 7 lines of source, 79 of tests. No behavior change on a successful boot — `_create_components()` sets the same value it always did. CLAUDE.md is untouched (no `tests/test_dashboard_ui.py` impact).