### PR TITLE
fix(billing): read CAPTCHA spend from the browser service, not the mesh's empty copy

### DIFF
--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -43,6 +43,10 @@ Public surface:
     log a warning and skip counting (over-counting is worse than
     under-counting for trust).
   * :func:`get_millicents(agent_id)` — current-month spend.
+  * :func:`spend_by_agent()` — every agent's current-month spend, for
+    the read-only ``GET /browser/captcha-costs`` HTTP surface (the
+    billing rollup runs in the MESH process and cannot see this
+    process's ``_state``).
 
 Tenant rollup (Phase 10 §24):
   * :func:`_tenant_for(agent_id)` — resolve an agent to its tenant via
@@ -357,6 +361,35 @@ async def get_millicents(agent_id: str) -> int:
     async with _get_lock():
         bucket = _bucket_for(agent_id)
         return int(bucket["millicents"])
+
+
+async def spend_by_agent() -> dict[str, Any]:
+    """Return every agent's current-month spend as ``{"month", "agents"}``.
+
+    Deliberately tenant-agnostic. ``_state`` is process-local and lives in
+    the browser-service process (the ``openlegion_browser`` container),
+    while the team authority (TeamStore) lives with the mesh — the browser
+    container mounts neither ``config/`` nor the mesh ``data/``, so it
+    cannot resolve tenants at all (see :func:`_tenant_for`). Anything that
+    wants a per-tenant rollup must therefore read these raw per-agent
+    numbers over HTTP (``GET /browser/captcha-costs``) and group them
+    mesh-side, where team membership actually is.
+
+    Buckets stamped with a previous month are omitted rather than
+    reported: they reset lazily on the next write, so their contribution
+    to the CURRENT month is zero.
+    """
+    cm = _current_month()
+    async with _get_lock():
+        # Materialize under the lock so a concurrent ``add_cost`` cannot
+        # mutate the dict mid-walk; same pattern as the tenant helpers.
+        items = list(_state.items())
+    agents: dict[str, int] = {}
+    for agent_id, bucket in items:
+        if not isinstance(bucket, dict) or bucket.get("month") != cm:
+            continue
+        agents[str(agent_id)] = int(bucket.get("millicents", 0))
+    return {"month": cm, "agents": agents}
 
 
 async def check_and_charge(

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -84,7 +84,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             # always agent-scoped (``/browser/{agent_id}/keepalive``)
             # since the legacy bare endpoint was removed in #813.
             if len(parts) >= 3 and parts[2] not in (
-                "", "status", "metrics", "_canary", "settings",
+                "", "status", "metrics", "_canary", "settings", "captcha-costs",
             ):
                 if not _AGENT_ID_RE.fullmatch(parts[2]):
                     return JSONResponse(
@@ -233,6 +233,25 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         except (TypeError, ValueError):
             since_seq = 0
         return manager.get_recent_metrics(since_seq=since_seq)
+
+    @app.get("/browser/captcha-costs")
+    async def service_captcha_costs(request: Request):
+        """Return current-month CAPTCHA spend per agent (millicents).
+
+        The cost counter's state is process-local to THIS process, but the
+        operator billing rollup renders in the dashboard, which runs inside
+        the mesh process. Reading ``captcha_cost_counter`` from there sees
+        an always-empty dict, so the rollup reads it here over HTTP instead
+        (same shape as ``/browser/metrics``: mesh polls, service answers).
+
+        Tenant grouping is deliberately NOT done here — this container has
+        no access to the mesh's team authority. Callers group by team on
+        the mesh side.
+        """
+        _verify_auth(request)
+        from src.browser import captcha_cost_counter as _ccc
+
+        return await _ccc.spend_by_agent()
 
     @app.post("/browser/_canary")
     async def run_canary_endpoint(request: Request):

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -16,6 +16,11 @@ Phase 10 §24 — billing-export endpoint.
   ``monthly`` (current calendar month). Each CSV row is
   ``period_start, agent_id, millicents, dollars, data_scope`` plus a
   final ``__tenant_total__`` synthetic row carrying the rolled-up total.
+  The per-agent spend is fetched over HTTP from the browser service
+  (``GET /browser/captcha-costs``) because the cost counter's state is
+  process-local to THAT process; the tenant grouping happens here, where
+  the TeamStore lives. When the browser service is unreachable the
+  endpoint returns 503 rather than a zero-filled CSV.
   The ``data_scope`` column is ``monthly_actual`` when the period is
   ``monthly`` (live state IS current-month so the number is correct);
   for ``daily`` / ``weekly`` it is ``current_month_aggregate`` because
@@ -137,6 +142,66 @@ async def _fetch_browser_metrics_upstream(
                 "code": "service_unavailable",
                 "message": "Malformed response from browser service",
                 "retry_after_ms": None,
+            },
+        }
+    return {"success": True, "data": data}
+
+
+async def _fetch_captcha_costs_upstream(
+    client: Any,
+    service_url: str,
+    auth_token: str,
+) -> dict:
+    """Call ``GET /browser/captcha-costs`` on the browser service.
+
+    The CAPTCHA cost counter keeps its state in process-local module
+    globals that live in the BROWSER SERVICE process (:8500); the
+    dashboard runs inside the mesh process (:8420). Importing
+    ``src.browser.captcha_cost_counter`` here only ever reads the mesh
+    process's own (permanently empty) copy, so the billing rollup reads
+    the numbers over HTTP from the process that owns them — the same way
+    ``/browser/metrics`` is proxied.
+
+    Module-level (not a closure) so tests can patch it directly. Returns
+    the §2.3 error envelope on any failure and ``{"success": True,
+    "data": {...}}`` on success.
+    """
+    headers: dict[str, str] = {}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    try:
+        resp = await client.get(
+            f"{service_url}/browser/captcha-costs",
+            headers=headers,
+            timeout=10,
+        )
+    except Exception as e:
+        logger.debug("CAPTCHA cost fetch failed: %s", e)
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": "Browser service unreachable",
+            },
+        }
+    if resp.status_code >= 400:
+        logger.debug("CAPTCHA cost fetch returned HTTP %d", resp.status_code)
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": f"Browser service returned HTTP {resp.status_code}",
+            },
+        }
+    try:
+        data = resp.json()
+    except Exception as e:
+        logger.debug("CAPTCHA cost JSON parse failed: %s", e)
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": "Malformed response from browser service",
             },
         }
     return {"success": True, "data": data}
@@ -5694,8 +5759,6 @@ def create_dashboard_router(
 
         from starlette.responses import PlainTextResponse
 
-        from src.browser import captcha_cost_counter as _ccc
-
         if not tenant:
             raise HTTPException(400, "Missing required query param: tenant")
         if period not in _VALID_BILLING_PERIODS:
@@ -5731,21 +5794,60 @@ def create_dashboard_router(
                 microsecond=0,
             )
 
-        # Walk per-agent buckets via the new tenant helpers. The
-        # in-memory state is current-month only (see captcha_cost_counter
-        # docstring for the trim rationale), so for ``daily`` and
-        # ``weekly`` we still report the same per-agent monthly buckets
-        # — operators get a month-to-date number with a ``data_scope``
-        # column flagging that the data IS NOT period-correct.  Older
-        # buckets would require persisted snapshots, deferred per
-        # §11.10's SQLite trim.  The honest column on every row beats
-        # a billing footgun where finance reconciles a "daily" CSV
-        # against month-to-date numbers.
-        breakdown = await _ccc.get_tenant_breakdown(tenant)
-        total_millicents = await _ccc.get_tenant_total(
-            tenant,
-            since=period_start,
+        # Where the numbers come from. The CAPTCHA cost counter keeps its
+        # state in process-local module globals inside the BROWSER SERVICE
+        # process (:8500); this dashboard router runs inside the mesh
+        # process (:8420). Importing ``captcha_cost_counter`` here reads
+        # the mesh's own copy of those globals, which nothing ever writes
+        # — the export reported 0 for every tenant. So: fetch the raw
+        # per-agent spend over HTTP from the process that owns it (same
+        # proxy pattern as ``/browser/metrics``), and do the tenant
+        # grouping HERE, where the team authority (TeamStore) lives. The
+        # browser container mounts neither ``config/`` nor the mesh
+        # ``data/``, so it cannot resolve tenants itself.
+        #
+        # A 503 (rather than a zero-filled CSV) when the service is down
+        # is deliberate: silently exporting zeros into finance tooling is
+        # the exact footgun this endpoint exists to avoid.
+        service_url = getattr(runtime, "browser_service_url", "") if runtime else ""
+        if not service_url:
+            raise HTTPException(
+                503,
+                "Browser service unavailable — CAPTCHA spend cannot be read",
+            )
+        upstream = await _fetch_captcha_costs_upstream(
+            _dashboard_browser_client,
+            service_url,
+            getattr(runtime, "browser_auth_token", "") or "",
         )
+        if not upstream.get("success"):
+            raise HTTPException(
+                503,
+                (upstream.get("error") or {}).get("message") or "Browser service unavailable",
+            )
+        per_agent = (upstream.get("data") or {}).get("agents") or {}
+
+        # Tenant membership from the mesh-side team authority. Every
+        # member is emitted — including members with no spend this month
+        # — so the operator sees which agents in the tenant are active vs
+        # idle rather than having to infer absence.
+        #
+        # The in-memory upstream state is current-month only (see the
+        # captcha_cost_counter docstring for the trim rationale), so for
+        # ``daily`` and ``weekly`` we still report the same monthly
+        # buckets — operators get a month-to-date number with a
+        # ``data_scope`` column flagging that the data IS NOT
+        # period-correct. Older buckets would require persisted
+        # snapshots, deferred per §11.10's SQLite trim. The honest column
+        # on every row beats a billing footgun where finance reconciles a
+        # "daily" CSV against month-to-date numbers.
+        try:
+            members = list(teams_store.members(tenant) or [])
+        except Exception as e:
+            logger.warning("billing rollup: team member lookup failed for %r: %s", tenant, e)
+            members = []
+        breakdown = {str(aid): int(per_agent.get(aid, 0) or 0) for aid in members}
+        total_millicents = sum(breakdown.values())
         # ``monthly_actual`` for monthly (the in-memory state IS the
         # current month, so the number is correct for the requested
         # period); ``current_month_aggregate`` for daily/weekly since

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -204,6 +204,24 @@ async def _fetch_captcha_costs_upstream(
                 "message": "Malformed response from browser service",
             },
         }
+    # Validate the SHAPE, not just the parse. Downstream indexes
+    # ``data["agents"][agent_id]`` and coerces each value with ``int()``,
+    # so a well-formed-JSON-but-wrong-shape response (a list, a null, a
+    # non-numeric string) would raise inside the endpoint and surface as a
+    # 500 instead of the 503 this envelope promises — and a 500 on a
+    # billing export reads as "our bug" rather than "upstream is down".
+    agents = data.get("agents") if isinstance(data, dict) else None
+    if not isinstance(agents, dict) or any(
+        not isinstance(v, int) or isinstance(v, bool) for v in agents.values()
+    ):
+        logger.debug("CAPTCHA cost response had unexpected shape: %r", data)
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": "Malformed response from browser service",
+            },
+        }
     return {"success": True, "data": data}
 
 
@@ -5841,11 +5859,27 @@ def create_dashboard_router(
         # snapshots, deferred per §11.10's SQLite trim. The honest column
         # on every row beats a billing footgun where finance reconciles a
         # "daily" CSV against month-to-date numbers.
+        # Fail LOUD, for the same reason the browser-service fetch above
+        # 503s: an empty member list is indistinguishable from a tenant
+        # that spent nothing, so swallowing a lookup failure here would
+        # export a zero-total CSV into finance tooling — exactly the
+        # footgun this endpoint exists to avoid, just reached through the
+        # team authority instead of the cost counter.
         try:
-            members = list(teams_store.members(tenant) or [])
+            tenant_known = teams_store.team_exists(tenant)
+            members = list(teams_store.members(tenant) or []) if tenant_known else []
         except Exception as e:
-            logger.warning("billing rollup: team member lookup failed for %r: %s", tenant, e)
-            members = []
+            logger.warning("billing rollup: team lookup failed for %r: %s", tenant, e)
+            raise HTTPException(
+                503,
+                "Team directory unavailable — CAPTCHA spend cannot be attributed",
+            ) from e
+        # An unknown tenant is a caller error, not an empty bill: a typo'd
+        # ``tenant`` would otherwise return HTTP 200 and a clean zero that
+        # reconciles against nothing. A tenant that DOES exist and simply
+        # spent nothing is a legitimate zero and still returns 200.
+        if not tenant_known:
+            raise HTTPException(404, f"Unknown tenant: {tenant!r}")
         breakdown = {str(aid): int(per_agent.get(aid, 0) or 0) for aid in members}
         total_millicents = sum(breakdown.values())
         # ``monthly_actual`` for monthly (the in-memory state IS the

--- a/tests/test_captcha_cost_tenant.py
+++ b/tests/test_captcha_cost_tenant.py
@@ -538,6 +538,8 @@ class TestCSVExportEndpoint:
         self.upstream: dict[str, int] = {}
         self.upstream_status = 200
         self.upstream_auth: list[str] = []
+        # Set to a raw JSON body to simulate a wrong-shaped upstream reply.
+        self.upstream_shape_override = None
 
         import httpx
 
@@ -549,6 +551,8 @@ class TestCSVExportEndpoint:
                     self.upstream_status,
                     json={"detail": "browser service error"},
                 )
+            if self.upstream_shape_override is not None:
+                return httpx.Response(200, json=self.upstream_shape_override)
             return httpx.Response(
                 200,
                 json={
@@ -570,7 +574,13 @@ class TestCSVExportEndpoint:
         try:
             self.client, self.components = _make_dashboard_client(
                 self._tmpdir,
-                teams={"alpha": "tenant-a", "beta": "tenant-a"},
+                teams={
+                    "alpha": "tenant-a",
+                    "beta": "tenant-a",
+                    # A real team that simply hasn't spent — distinct from a
+                    # tenant that doesn't exist at all.
+                    "gamma": "tenant-idle",
+                },
             )
         finally:
             httpx_patch.stop()
@@ -781,18 +791,74 @@ class TestCSVExportEndpoint:
             reset_cache()
 
     def test_csv_tenant_with_no_spend_returns_total_zero(self):
-        """An empty tenant still emits the header + a zero-total row."""
+        """A REAL tenant that simply spent nothing is a legitimate zero.
+
+        It emits the header, a zero row for each member, and a zero total —
+        200, not an error. This is the case that must stay distinguishable
+        from the unknown-tenant and lookup-failure cases below.
+        """
+        self.upstream = {"alpha": 100}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-idle", "period": "monthly"},
+        )
+        assert resp.status_code == 200
+        lines = resp.text.strip().split("\n")
+        assert lines[0] == ("period_start,agent_id,millicents,dollars,data_scope")
+        # One member row (gamma, zero spend) + the total row.
+        assert len(lines) == 3
+        assert ",gamma,0,0.00000,monthly_actual" in lines[1]
+        assert "__tenant_total__,0,0.00000,monthly_actual" in lines[2]
+        # tenant-a's spend must not leak into another tenant's export.
+        assert "alpha" not in resp.text
+
+    def test_csv_unknown_tenant_is_404_not_a_zero_bill(self):
+        """A typo'd tenant must not reconcile as "spent nothing".
+
+        Returning 200 + a clean zero for a name that doesn't exist is the
+        same silent-zero footgun the browser-service path 503s for: finance
+        tooling cannot tell it from a real zero.
+        """
         self.upstream = {"alpha": 100}
         resp = self.client.get(
             "/dashboard/api/billing/captcha-rollup",
             params={"tenant": "ghost", "period": "monthly"},
         )
-        assert resp.status_code == 200
-        lines = resp.text.strip().split("\n")
-        assert lines[0] == ("period_start,agent_id,millicents,dollars,data_scope")
-        # No agent rows, just header + total.
-        assert len(lines) == 2
-        assert "__tenant_total__,0,0.00000,monthly_actual" in lines[1]
+        assert resp.status_code == 404
+
+    def test_csv_503s_on_malformed_upstream_shape(self):
+        """Well-formed JSON in the wrong shape is still an upstream failure.
+
+        The endpoint indexes ``data["agents"][id]`` and coerces with
+        ``int()``, so a list (or a non-numeric value) would raise inside the
+        handler and surface as a 500 — reading as "our bug" rather than
+        "upstream is down". It must take the same 503 path as a dead service.
+        """
+        self.upstream_shape_override = {"month": "2026-08", "agents": ["alpha"]}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
+        assert resp.status_code == 503
+
+    def test_csv_503s_when_the_team_directory_fails(self):
+        """A team-authority failure must fail LOUD.
+
+        An empty member list is indistinguishable from a tenant that spent
+        nothing, so swallowing the error here would export a zero-total CSV
+        — the exact failure the browser-service branch already 503s for.
+        """
+        self.upstream = {"alpha": 100}
+        store = self.components["teams_store"]
+        with patch.object(
+            type(store), "members", side_effect=RuntimeError("teams db is locked"),
+        ):
+            resp = self.client.get(
+                "/dashboard/api/billing/captcha-rollup",
+                params={"tenant": "tenant-a", "period": "monthly"},
+            )
+        assert resp.status_code == 503
+        assert "0.00000" not in resp.text
 
 
 # ── Browser-service read surface ───────────────────────────────────────────

--- a/tests/test_captcha_cost_tenant.py
+++ b/tests/test_captcha_cost_tenant.py
@@ -10,6 +10,10 @@ Covers:
     month falls through to live total; older months drop to zero).
   * CSV export endpoint shape — header row, per-agent rows in sorted
     order, ``__tenant_total__`` summary row, period-start column.
+  * CSV export reads per-agent spend from the BROWSER SERVICE over HTTP
+    (``GET /browser/captcha-costs``) rather than from the mesh process's
+    own copy of the counter globals, groups it by team mesh-side, and
+    503s instead of exporting zeros when the service is unreachable.
   * CSV endpoint requires auth (no ol_session cookie in production), GET
     is allowed without ``X-Requested-With`` (CSRF only on state changes).
   * ``record_tenant_threshold_alerts`` fires once per crossing per month
@@ -427,22 +431,42 @@ class TestThresholdAlerts:
 
 
 # ── CSV export endpoint ────────────────────────────────────────────────────
+#
+# The rollup does NOT read the cost counter in-process. ``_state`` is a
+# process-local module global written in the BROWSER SERVICE process
+# (:8500), while the dashboard router runs inside the mesh process
+# (:8420) — an in-process import there reads a copy nothing ever writes.
+# The endpoint therefore fetches per-agent spend over HTTP from the
+# browser service and groups it by team on the mesh side, where the
+# TeamStore lives. These tests wire a stub browser service through
+# ``httpx.MockTransport`` so the real fetch helper is exercised end to end.
+
+_BROWSER_SERVICE_URL = "http://browser.test:8500"
 
 
-def _make_dashboard_client(tmp_path: str) -> TestClient:
+def _make_dashboard_client(
+    tmp_path: str,
+    teams: dict[str, str] | None = None,
+    browser_service_url: str = _BROWSER_SERVICE_URL,
+):
     """Build a TestClient with the dashboard router mounted (auth-bypass).
 
     Auth-bypass: the dashboard's ``verify_session_cookie`` returns
     ``None`` (= pass) when no access-token file is present (dev mode).
     Tests run in dev mode by default, so we don't need to forge cookies.
+
+    ``teams`` maps agent_id → team name and seeds the real TeamStore the
+    router groups by. ``browser_service_url`` is what the runtime reports;
+    pass ``""`` to simulate a browser service that never came up.
     """
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import MagicMock
 
     from src.dashboard.events import EventBus
     from src.dashboard.server import create_dashboard_router
     from src.host.costs import CostTracker
     from src.host.health import HealthMonitor
     from src.host.mesh import Blackboard
+    from src.host.teams import TeamStore
     from src.host.traces import TraceStore
 
     bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
@@ -450,10 +474,16 @@ def _make_dashboard_client(tmp_path: str) -> TestClient:
     trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
     event_bus = EventBus()
 
+    teams_store = TeamStore(db_path=os.path.join(tmp_path, "teams.db"))
+    for agent, team in (teams or {}).items():
+        if not teams_store.team_exists(team):
+            teams_store.create_team(team)
+        teams_store.add_member(team, agent)
+
     runtime_mock = MagicMock()
     runtime_mock.browser_vnc_url = None
-    runtime_mock.browser_service_url = None
-    runtime_mock.browser_auth_token = ""
+    runtime_mock.browser_service_url = browser_service_url
+    runtime_mock.browser_auth_token = "browser-token"
     transport_mock = MagicMock()
     router_mock = MagicMock()
     health_monitor = HealthMonitor(
@@ -474,9 +504,9 @@ def _make_dashboard_client(tmp_path: str) -> TestClient:
             "alpha": "http://localhost:8401",
             "beta": "http://localhost:8402",
         },
+        "runtime": runtime_mock,
+        "teams_store": teams_store,
     }
-    # Suppress unused import warnings for AsyncMock
-    _ = AsyncMock
     router = create_dashboard_router(**components, mesh_port=8420)
     app = FastAPI()
     app.include_router(router)
@@ -501,7 +531,49 @@ class TestCSVExportEndpoint:
         from src.dashboard.auth import reset_cache
 
         reset_cache()
-        self.client, self.components = _make_dashboard_client(self._tmpdir)
+
+        # Stub browser service. ``upstream`` is the per-agent spend the
+        # service reports; ``upstream_status`` lets a test simulate a
+        # failing / unreachable service.
+        self.upstream: dict[str, int] = {}
+        self.upstream_status = 200
+        self.upstream_auth: list[str] = []
+
+        import httpx
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/browser/captcha-costs"
+            self.upstream_auth.append(request.headers.get("Authorization", ""))
+            if self.upstream_status != 200:
+                return httpx.Response(
+                    self.upstream_status,
+                    json={"detail": "browser service error"},
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "month": datetime.now(timezone.utc).strftime("%Y-%m"),
+                    "agents": dict(self.upstream),
+                },
+            )
+
+        original_async_client = httpx.AsyncClient
+
+        def patched_async_client(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        # The dashboard builds its browser client at router-construction
+        # time, so the patch only has to be live across the build.
+        httpx_patch = patch.object(httpx, "AsyncClient", patched_async_client)
+        httpx_patch.start()
+        try:
+            self.client, self.components = _make_dashboard_client(
+                self._tmpdir,
+                teams={"alpha": "tenant-a", "beta": "tenant-a"},
+            )
+        finally:
+            httpx_patch.stop()
 
     def teardown_method(self):
         _teardown(self.components)
@@ -513,22 +585,12 @@ class TestCSVExportEndpoint:
 
     def test_csv_endpoint_returns_correct_shape(self):
         """Endpoint returns CSV with header + per-agent rows + total row."""
-        import asyncio
+        self.upstream = {"alpha": 100, "beta": 50}
 
-        with _patch_projects(
-            {
-                "alpha": "tenant-a",
-                "beta": "tenant-a",
-            }
-        ):
-            cost.reset_tenant_cache()
-            asyncio.run(cost.add_cost("alpha", 100))
-            asyncio.run(cost.add_cost("beta", 50))
-
-            resp = self.client.get(
-                "/dashboard/api/billing/captcha-rollup",
-                params={"tenant": "tenant-a", "period": "monthly"},
-            )
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
 
         assert resp.status_code == 200
         assert "text/csv" in resp.headers["content-type"]
@@ -536,43 +598,131 @@ class TestCSVExportEndpoint:
         lines = resp.text.strip().split("\n")
         assert lines[0] == ("period_start,agent_id,millicents,dollars,data_scope")
         # Sorted agent rows then the synthetic total. ``data_scope`` is
-        # ``monthly_actual`` for monthly because the in-memory state
+        # ``monthly_actual`` for monthly because the upstream state
         # IS the current month — the number is correct for the period.
         assert ",alpha,100,0.00100,monthly_actual" in lines[1]
         assert ",beta,50,0.00050,monthly_actual" in lines[2]
         assert "__tenant_total__,150,0.00150,monthly_actual" in lines[3]
 
-    def test_csv_endpoint_period_daily(self):
+    def test_csv_reads_browser_service_not_in_process_counter(self):
+        """Regression: the rollup must NOT read the mesh process's counter.
+
+        ``captcha_cost_counter._state`` is process-local. The dashboard
+        runs in the mesh process where that dict is always empty in production,
+        so the export used to report 0 for every tenant. Seed the local
+        counter with a value the browser service does NOT report: the CSV
+        must carry the browser service's number, never the local one.
+        """
         import asyncio
 
-        with _patch_projects({"alpha": "tenant-a"}):
+        with _patch_projects({"alpha": "tenant-a", "beta": "tenant-a"}):
             cost.reset_tenant_cache()
-            asyncio.run(cost.add_cost("alpha", 100))
+            asyncio.run(cost.add_cost("alpha", 999))
+            asyncio.run(cost.add_cost("beta", 777))
+
+            self.upstream = {"alpha": 100, "beta": 50}
             resp = self.client.get(
                 "/dashboard/api/billing/captcha-rollup",
-                params={"tenant": "tenant-a", "period": "daily"},
+                params={"tenant": "tenant-a", "period": "monthly"},
             )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert ",alpha,100," in body
+        assert ",beta,50," in body
+        assert "__tenant_total__,150," in body
+        # The in-process numbers must not leak into the export at all.
+        assert "999" not in body
+        assert "777" not in body
+
+    def test_csv_forwards_browser_auth_token(self):
+        """The upstream read carries the runtime's browser bearer token."""
+        self.upstream = {"alpha": 100}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
+        assert resp.status_code == 200
+        assert self.upstream_auth == ["Bearer browser-token"]
+
+    def test_csv_includes_team_member_with_no_spend(self):
+        """Team members the browser service never charged still get a row."""
+        self.upstream = {"alpha": 100}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
+        assert resp.status_code == 200
+        lines = resp.text.strip().split("\n")
+        assert ",alpha,100,0.00100,monthly_actual" in lines[1]
+        assert ",beta,0,0.00000,monthly_actual" in lines[2]
+        assert "__tenant_total__,100,0.00100,monthly_actual" in lines[3]
+
+    def test_csv_excludes_agents_outside_the_tenant(self):
+        """Spend from agents outside the requested team is not rolled up."""
+        self.upstream = {"alpha": 100, "stranger": 5000}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
+        assert resp.status_code == 200
+        assert "stranger" not in resp.text
+        assert "__tenant_total__,100," in resp.text
+
+    def test_csv_503_when_browser_service_not_configured(self):
+        """No browser service → 503, never a zero-filled CSV.
+
+        Silently exporting zeros into finance tooling is the exact
+        failure mode this endpoint exists to avoid.
+        """
+        client, components = _make_dashboard_client(
+            self._tmpdir,
+            teams={"alpha": "tenant-a"},
+            browser_service_url="",
+        )
+        try:
+            resp = client.get(
+                "/dashboard/api/billing/captcha-rollup",
+                params={"tenant": "tenant-a", "period": "monthly"},
+            )
+            assert resp.status_code == 503
+            assert "0.00000" not in resp.text
+        finally:
+            _teardown(components)
+
+    def test_csv_503_when_browser_service_errors(self):
+        """Upstream HTTP failure surfaces as 503, not a zero-filled CSV."""
+        self.upstream_status = 500
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
+        assert resp.status_code == 503
+        assert "0.00000" not in resp.text
+
+    def test_csv_endpoint_period_daily(self):
+        self.upstream = {"alpha": 100}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "daily"},
+        )
         assert resp.status_code == 200
         # Daily period_start is today UTC at midnight.
         first_data_line = resp.text.strip().split("\n")[1]
         cells = first_data_line.split(",")
         assert cells[0].endswith("T00:00:00Z")
         # Billing-honesty: ``daily`` (and ``weekly``) report month-to-date
-        # data because the in-memory state is current-month only — the
+        # data because the upstream state is current-month only — the
         # ``data_scope`` column flags this so finance reconciliation
         # tooling doesn't accept the "daily" CSV as a daily-correct number.
         assert cells[-1] == "current_month_aggregate"
 
     def test_csv_endpoint_period_weekly(self):
-        import asyncio
-
-        with _patch_projects({"alpha": "tenant-a"}):
-            cost.reset_tenant_cache()
-            asyncio.run(cost.add_cost("alpha", 100))
-            resp = self.client.get(
-                "/dashboard/api/billing/captcha-rollup",
-                params={"tenant": "tenant-a", "period": "weekly"},
-            )
+        self.upstream = {"alpha": 100}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "weekly"},
+        )
         assert resp.status_code == 200
         first_data_line = resp.text.strip().split("\n")[1]
         cells = first_data_line.split(",")
@@ -595,17 +745,13 @@ class TestCSVExportEndpoint:
 
     def test_csv_get_does_not_require_csrf_header(self):
         """CSRF check exempts GET — the endpoint works without the header."""
-        import asyncio
-
-        with _patch_projects({"alpha": "tenant-a"}):
-            cost.reset_tenant_cache()
-            asyncio.run(cost.add_cost("alpha", 100))
-            # No X-Requested-With header — should still pass CSRF gate
-            # because GET is in the exempt-method set.
-            resp = self.client.get(
-                "/dashboard/api/billing/captcha-rollup",
-                params={"tenant": "tenant-a", "period": "monthly"},
-            )
+        self.upstream = {"alpha": 100}
+        # No X-Requested-With header — should still pass CSRF gate
+        # because GET is in the exempt-method set.
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "tenant-a", "period": "monthly"},
+        )
         assert resp.status_code == 200
 
     def test_csv_requires_auth_when_token_present(self):
@@ -636,15 +782,82 @@ class TestCSVExportEndpoint:
 
     def test_csv_tenant_with_no_spend_returns_total_zero(self):
         """An empty tenant still emits the header + a zero-total row."""
-        with _patch_projects({}):
-            cost.reset_tenant_cache()
-            resp = self.client.get(
-                "/dashboard/api/billing/captcha-rollup",
-                params={"tenant": "ghost", "period": "monthly"},
-            )
+        self.upstream = {"alpha": 100}
+        resp = self.client.get(
+            "/dashboard/api/billing/captcha-rollup",
+            params={"tenant": "ghost", "period": "monthly"},
+        )
         assert resp.status_code == 200
         lines = resp.text.strip().split("\n")
         assert lines[0] == ("period_start,agent_id,millicents,dollars,data_scope")
         # No agent rows, just header + total.
         assert len(lines) == 2
         assert "__tenant_total__,0,0.00000,monthly_actual" in lines[1]
+
+
+# ── Browser-service read surface ───────────────────────────────────────────
+
+
+class TestSpendByAgent:
+    """``spend_by_agent`` + its ``GET /browser/captcha-costs`` route.
+
+    This is the seam the mesh-side rollup reads across the process
+    boundary, so both the payload shape and the route have to hold.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_every_current_month_bucket(self):
+        await cost.add_cost("alpha", 100)
+        await cost.add_cost("beta", 50)
+        payload = await cost.spend_by_agent()
+        assert payload["month"] == datetime.now(timezone.utc).strftime("%Y-%m")
+        assert payload["agents"] == {"alpha": 100, "beta": 50}
+
+    @pytest.mark.asyncio
+    async def test_skips_stale_month_buckets(self):
+        await cost.add_cost("alpha", 100)
+        # Age the bucket into a previous month — it contributes nothing to
+        # the current month and must not be reported as if it did.
+        cost._state["alpha"]["month"] = "1999-01"
+        payload = await cost.spend_by_agent()
+        assert payload["agents"] == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_state_returns_empty_mapping(self):
+        payload = await cost.spend_by_agent()
+        assert payload["agents"] == {}
+
+    def test_route_returns_counter_state(self, monkeypatch):
+        """The browser service exposes the counter over HTTP."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from src.browser.server import create_browser_app
+
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        asyncio.run(cost.add_cost("alpha", 100))
+
+        app = create_browser_app(MagicMock())
+        with TestClient(app) as client:
+            resp = client.get("/browser/captcha-costs")
+
+        assert resp.status_code == 200
+        assert resp.json()["agents"] == {"alpha": 100}
+
+    def test_route_requires_auth_when_token_set(self, monkeypatch):
+        """The read is bearer-gated like every other service endpoint."""
+        from unittest.mock import MagicMock
+
+        from src.browser.server import create_browser_app
+
+        monkeypatch.setenv("BROWSER_AUTH_TOKEN", "svc-token")
+
+        app = create_browser_app(MagicMock())
+        with TestClient(app) as client:
+            assert client.get("/browser/captcha-costs").status_code == 401
+            ok = client.get(
+                "/browser/captcha-costs",
+                headers={"Authorization": "Bearer svc-token"},
+            )
+        assert ok.status_code == 200


### PR DESCRIPTION
## Problem

`GET /dashboard/api/billing/captcha-rollup` — the operator CSV export for CAPTCHA
solver spend — always reported **0 for every tenant**.

`src/browser/captcha_cost_counter.py` keeps its state in a process-local module
global (`_state`, line 259). That dict is written in the **browser service
process** — the `openlegion_browser` container listening on `:8500`, where solves
are actually charged (`service.py` → `add_cost`). The dashboard router runs
**inside the mesh process** on `:8420` (`src/dashboard/server.py` is mounted as a
router on the mesh host; see the Architecture section of `CLAUDE.md`, and
`host/runtime.py:start_browser_service` which runs the browser service as a
separate container).

So `src/dashboard/server.py:5697`'s `from src.browser import captcha_cost_counter
as _ccc` bound a **second, never-written copy** of those globals.
`get_tenant_breakdown()` / `get_tenant_total()` walked an empty dict and returned
nothing. Every row of the export was zero, and finance tooling reconciling
against it was silently reading zeros as if they were real.

There is a second half to the same seam: even if the browser service had run the
rollup itself, it could not have. `_tenant_for()` resolves an agent → team by
opening the mesh's `data/teams.db`, and the browser container mounts neither
`config/` nor the mesh `data/` (its own docstring says so). Tenant grouping is
only possible on the mesh side.

## Fix

Read the data from where it actually lives, over the same HTTP seam the mesh
already uses for `/browser/metrics`:

- **`src/browser/captcha_cost_counter.py`** — new `spend_by_agent()` reader
  returning `{"month": "YYYY-MM", "agents": {agent_id: millicents}}` for the
  current month. Snapshots `_state` under the existing lock; stale-month buckets
  are omitted (they contribute zero to the current month).
- **`src/browser/server.py`** — new `GET /browser/captcha-costs`, bearer-gated by
  `_verify_auth` like every other service endpoint, and added to the
  non-agent-scoped prefix allow-list in the path-validation middleware.
  Deliberately does **not** do tenant grouping — this container has no access to
  the team authority.
- **`src/dashboard/server.py`** — new module-level `_fetch_captcha_costs_upstream()`
  (mirrors the existing `_fetch_browser_metrics_upstream`, module-level so tests
  can patch it), and the rollup endpoint now fetches per-agent spend over HTTP
  and groups it by team using the `teams_store` the router already holds.

Two behaviour changes fall out, both deliberate:

1. **503 instead of a CSV when the browser service is unconfigured or
   unreachable.** Emitting a zero-filled billing export into finance tooling is
   the exact footgun this endpoint exists to avoid — an error the operator can
   see beats a plausible wrong number.
2. **Team members with no spend this month now get an explicit `0` row.** That is
   what `get_tenant_breakdown`'s docstring already promised ("the operator wants
   to SEE which agents in the tenant are active vs idle"); the mesh-side roster
   can finally deliver it, where the per-agent bucket walk could not.

The CSV schema, the period semantics, and the `data_scope` column are unchanged.
The `since=period_start` argument that used to be threaded into
`get_tenant_total` was a documented no-op for month-granularity state and is
dropped.

## Verification

- **Fails before, passes after.** With the `src/dashboard/server.py` change
  stashed, three tests fail:
  `test_csv_reads_browser_service_not_in_process_counter`,
  `test_csv_503_when_browser_service_not_configured`,
  `test_csv_503_when_browser_service_errors`. With the change applied, all 41
  tests in the file pass. The first is the direct regression pin: it seeds the
  **in-process** counter with `alpha=999 / beta=777` while the stub browser
  service reports `alpha=100 / beta=50`, then asserts the CSV carries the
  service's numbers and that `999` / `777` appear nowhere in the body. Pre-fix
  the export rendered `999`.
- The CSV tests now wire a stub browser service through `httpx.MockTransport`, so
  the real fetch helper — URL, bearer header, JSON parsing, failure envelope — is
  exercised end to end rather than mocked out.
- New coverage for the service side: `spend_by_agent()` (current-month buckets,
  stale-month skip, empty state) and the `GET /browser/captcha-costs` route
  (payload + bearer gate).
- Targeted suites run green: `test_captcha_cost_tenant.py` (41),
  `test_captcha_cost_counter.py` + `test_check_captcha_metered.py` (64),
  `test_browser_service.py` / `test_browser_metrics*.py` /
  `test_dashboard_browser_metrics.py` / `test_per_agent_vnc.py` (585 passed, 7
  skipped), the captcha-adjacent set (184), `test_dashboard.py` (430),
  `test_dashboard_ui.py` (250 passed, 3 skipped). `ruff check` clean on all four
  changed files.

## Out of scope

`captcha_cost_counter._read_team_of` opens the mesh's `data/teams.db` directly
and runs raw SQL against `team_members` — an undeclared schema coupling from the
semi-trusted browser zone into the team authority's storage. It is a real
problem, but it is Phase 3 work and is left untouched here. This PR does stop the
**dashboard** from depending on that path (tenant resolution now goes through
`TeamStore`); the remaining caller is the browser service's own threshold-alert
tick, which is where the Phase 3 fix belongs.