### PR TITLE
fix(security): close deep_redact's blind spots and the ReDoS behind them

### DIFF
--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -108,20 +108,24 @@ def _redact_bearer(text: str) -> str:
 # the string stays diagnostically useful. Anchored on the ``scheme://`` prefix;
 # the userinfo run excludes ``/@`` so it can't cross past the authority.
 #
-# Every quantifier here is BOUNDED, and that is load-bearing rather than
-# cosmetic. With an unbounded scheme class the engine matches
-# ``[A-Za-z][A-Za-z0-9+.\-]*`` greedily from EVERY position in the subject,
-# consuming the rest of the string before failing to find ``://`` and
-# backtracking over every length — O(n^2) in the subject, on a sanitizer that
-# runs over agent-supplied pubsub payloads and blocker notes on the mesh event
-# loop. A 200 KB string shaped like ``https://host/?q=<200k chars>`` took ~93
-# SECONDS. Bounding the scheme to 31 chars (RFC 3986 schemes are short; the
-# longest registered one is well under that) makes the work per start position
-# constant, and the run is linear again — 64 KB went from 9.6 s to 11 ms. The
-# userinfo halves are bounded for the same reason.
+# The SCHEME class is BOUNDED, and that is load-bearing rather than cosmetic.
+# Unbounded, the engine matches ``[A-Za-z][A-Za-z0-9+.\-]*`` greedily from
+# EVERY position in the subject, consuming the rest of the string before
+# failing to find ``://`` and backtracking over every length — O(n^2) in the
+# subject, on a sanitizer that runs over agent-supplied payloads on the mesh
+# event loop. 128 KB took ~39.6 SECONDS; bounded, 23 ms.
+#
+# Only the scheme is bounded. The userinfo runs are deliberately left
+# UNBOUNDED: they are negated classes that stop at the authority delimiters, so
+# they cannot drive the same every-position rescan — and capping them silently
+# STOPS REDACTING long credentials. A 900-char password (the shape of an AWS
+# IAM database-auth token, which is used directly as a DSN password and
+# documented at ~1 KiB) matches with the run unbounded and is MISSED under a
+# ``{1,256}`` cap. Verified linear with the userinfo unbounded, including on an
+# adversarial ``scheme://<128 KB>:<128 KB>`` subject containing no ``@`` at all.
 _CONN_USERINFO_RE = re.compile(
-    r"([A-Za-z][A-Za-z0-9+.\-]{0,31}://)"   # scheme://
-    r"[^/\s:@]{1,256}:[^/\s@]{1,256}@",     # user:password@
+    r"([A-Za-z][A-Za-z0-9+.\-]{0,31}://)"   # scheme:// (bounded: see above)
+    r"[^/\s:@]+:[^/\s@]+@",                 # user:password@ (unbounded on purpose)
 )
 
 
@@ -262,16 +266,29 @@ def redact_url(url: str) -> str:
     if not url:
         return url
 
-    # We structurally-parse any input that looks like either:
-    #   * an absolute web URL (``scheme://host/…?q``), or
-    #   * a relative URL with a query string (``/cb?code=TOKEN&state=…``).
-    # Logged redirects, OAuth callback paths, and copy-pasted URL
-    # fragments commonly arrive without a scheme; the query-string part
-    # is still the highest-leak component we need to strip. Fall through
-    # to pattern-only redaction only for strings that are neither.
+    # We structurally-parse any input that looks like:
+    #   * an absolute URL (``scheme://host/…``),
+    #   * a network-path reference (``//host/…``) — no scheme, but the
+    #     authority (and therefore any ``user:pass@``) is still present, or
+    #   * a relative URL carrying a query or a fragment (``/cb?code=…``,
+    #     ``/cb#access_token=…``).
+    # Logged redirects, OAuth callback paths and copy-pasted URL fragments
+    # commonly arrive without a scheme; the query and fragment are the
+    # highest-leak components and the authority carries userinfo. Anything
+    # else falls through to pattern-only redaction.
+    #
+    # A plain path with neither query nor fragment (``/etc/passwd``,
+    # ``/var/log/app``) is deliberately NOT parsed — there is nothing
+    # structural to strip and parsing would only risk reshaping it.
     has_scheme = "://" in url
-    has_relative_query = (not has_scheme) and ("?" in url) and url.startswith("/")
-    if not (has_scheme or has_relative_query):
+    has_authority = (not has_scheme) and url.startswith("//")
+    has_relative_marker = (
+        (not has_scheme)
+        and (not has_authority)
+        and url.startswith("/")
+        and ("?" in url or "#" in url)
+    )
+    if not (has_scheme or has_authority or has_relative_marker):
         return redact_string(url)
 
     try:
@@ -424,8 +441,18 @@ _TRUNCATED_ARGS_RE = re.compile(
 # A contentless exception note — ``exception:``, ``exception: Error:``,
 # ``Error:`` — carries no signal. Collapse to a stable code so the UI never
 # shows a blank "failed" reason.
+# Each optional group owns its OWN trailing ``\s*``. The previous spelling,
+# ``^(exception:)?\s*(error:?)?\s*$``, put two ``\s*`` runs on either side of an
+# optional group that can match empty, so on a long whitespace run the engine
+# tried every split between them — quadratic. The blocker note is
+# agent-controlled (task status POST) and ``normalize_blocker_note`` runs
+# synchronously on the mesh loop BEFORE the 500-char truncation, so this was
+# reachable: "exception:" + 80k spaces + "x" took 34 SECONDS, now 4.5 ms.
+# Equivalent on every input production can produce — ``normalize_blocker_note``
+# strips first, and the two spellings agree on all 777 stripped combinations of
+# the tokens this classifies.
 _EMPTY_EXCEPTION_RE = re.compile(
-    r"^(exception:)?\s*(error:?)?\s*$", re.IGNORECASE,
+    r"^\s*(?:exception:\s*)?(?:error:?\s*)?$", re.IGNORECASE,
 )
 
 
@@ -470,9 +497,15 @@ def normalize_blocker_note(note: str | None) -> str | None:
 def deep_redact(obj):
     """Recursively redact secrets from any JSON-serializable value.
 
-    Guards the audit log, trace store, lifecycle log, intent log and the
-    pubsub payload path (``src/host/mesh.py``), so anything it declines to
-    walk is a value that reaches durable storage unredacted. It therefore
+    Guards the trace store, lifecycle log, intent log and the durable DM
+    thread record (``src/host/mesh.py`` — delivery keeps the original
+    payload; only the stored copy is redacted), so anything it declines to
+    walk is a value that reaches durable storage unredacted.
+
+    NOTE it does NOT guard ``Blackboard.log_audit``, which writes
+    ``before_value`` / ``after_value`` verbatim. That is a real, separate
+    gap — do not assume audit rows are sanitized because this function
+    exists. It therefore
     walks EVERY position a string can occupy, and treats an unrecognised
     container as something to recurse into rather than something to return
     untouched.

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -107,9 +107,21 @@ def _redact_bearer(text: str) -> str:
 # (the username alone can leak account ownership), keeping the scheme + host so
 # the string stays diagnostically useful. Anchored on the ``scheme://`` prefix;
 # the userinfo run excludes ``/@`` so it can't cross past the authority.
+#
+# Every quantifier here is BOUNDED, and that is load-bearing rather than
+# cosmetic. With an unbounded scheme class the engine matches
+# ``[A-Za-z][A-Za-z0-9+.\-]*`` greedily from EVERY position in the subject,
+# consuming the rest of the string before failing to find ``://`` and
+# backtracking over every length — O(n^2) in the subject, on a sanitizer that
+# runs over agent-supplied pubsub payloads and blocker notes on the mesh event
+# loop. A 200 KB string shaped like ``https://host/?q=<200k chars>`` took ~93
+# SECONDS. Bounding the scheme to 31 chars (RFC 3986 schemes are short; the
+# longest registered one is well under that) makes the work per start position
+# constant, and the run is linear again — 64 KB went from 9.6 s to 11 ms. The
+# userinfo halves are bounded for the same reason.
 _CONN_USERINFO_RE = re.compile(
-    r"([A-Za-z][A-Za-z0-9+.\-]*://)"   # scheme://
-    r"[^/\s:@]+:[^/\s@]+@",            # user:password@
+    r"([A-Za-z][A-Za-z0-9+.\-]{0,31}://)"   # scheme://
+    r"[^/\s:@]{1,256}:[^/\s@]{1,256}@",     # user:password@
 )
 
 
@@ -455,33 +467,56 @@ def normalize_blocker_note(note: str | None) -> str | None:
 # ── Deep recursion over JSON-shaped structures ──────────────────────────────
 
 
-def _looks_like_url(s: str) -> bool:
-    """Heuristic: bare-minimum check to avoid running urlsplit on plain text.
-
-    Accepts strings with an explicit ``://`` scheme marker. Conservative
-    on purpose — false negatives fall back to pattern-only redaction which
-    is still safe.
-    """
-    return "://" in s and len(s) < 4096
-
-
 def deep_redact(obj):
     """Recursively redact secrets from any JSON-serializable value.
 
-    - Strings flow through :func:`redact_url` if they look like URLs, else
-      :func:`redact_string`.
-    - Dicts and lists recurse.
-    - Tuples are supported but returned as tuples.
-    - Other values (int, bool, None, float) pass through unchanged.
+    Guards the audit log, trace store, lifecycle log, intent log and the
+    pubsub payload path (``src/host/mesh.py``), so anything it declines to
+    walk is a value that reaches durable storage unredacted. It therefore
+    walks EVERY position a string can occupy, and treats an unrecognised
+    container as something to recurse into rather than something to return
+    untouched.
+
+    - Strings flow through :func:`redact_url`, which redacts URL structure
+      (userinfo, sensitive query params, fragment, JWT path segments) when
+      the string parses as one and otherwise falls back to
+      :func:`redact_string` internally.
+    - Dict KEYS are redacted as well as values — a secret is a secret
+      wherever it sits, and callers do put them in keys (a captured header
+      map, a ``{token: metadata}`` index).
+    - Dicts, lists, tuples, sets and frozensets recurse and keep their type.
+    - Other scalars (int, bool, None, float) pass through unchanged.
+
+    Three blind spots this closes, each of which leaked a live secret into
+    durable storage before:
+
+    1. **Dict keys.** ``{k: deep_redact(v) ...}`` never touched ``k``.
+    2. **Unhandled containers.** ``set`` / ``frozenset`` fell through to
+       ``return obj`` and were emitted verbatim.
+    3. **The URL gate.** ``_looks_like_url`` required ``"://"``, but
+       :func:`redact_url` itself also accepts a relative URL carrying a
+       query string (``/cb?code=…``). The gate was STRICTER than the
+       function it guarded, so those took the pattern-only path and kept
+       their structural secrets — ``//user:pass@host/cb?token=…`` retained
+       ``user:pass``. The gate is gone: ``redact_url`` is documented safe on
+       non-URLs and does its own cheap check before parsing, so there is
+       nothing left for a second, divergent heuristic to get wrong.
+
+    Key collisions: if two distinct keys redact to the same string, the last
+    value wins, exactly as a dict literal would. That only happens when both
+    keys contained secrets, where losing one is strictly better than
+    emitting either.
     """
     if isinstance(obj, str):
-        if _looks_like_url(obj):
-            return redact_url(obj)
-        return redact_string(obj)
+        return redact_url(obj)
     if isinstance(obj, dict):
-        return {k: deep_redact(v) for k, v in obj.items()}
+        return {deep_redact(k): deep_redact(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [deep_redact(item) for item in obj]
     if isinstance(obj, tuple):
         return tuple(deep_redact(item) for item in obj)
+    if isinstance(obj, frozenset):
+        return frozenset(deep_redact(item) for item in obj)
+    if isinstance(obj, set):
+        return {deep_redact(item) for item in obj}
     return obj

--- a/tests/test_deep_redact_blind_spots.py
+++ b/tests/test_deep_redact_blind_spots.py
@@ -1,8 +1,10 @@
 """``deep_redact`` must walk every position a string can occupy.
 
-It guards the audit log, trace store, lifecycle log, intent log and the pubsub
-payload path (``src/host/mesh.py:930``), so anything it declines to walk is a
-value that reaches durable storage unredacted. Three positions were skipped,
+It guards the trace store, lifecycle log, intent log and the durable DM thread
+record (``src/host/mesh.py:930`` — delivery keeps the original payload), so
+anything it declines to walk reaches durable storage unredacted. It does NOT
+guard ``Blackboard.log_audit``, which writes values verbatim; that is a
+separate, still-open gap. Three positions were skipped,
 each demonstrated below against the pre-fix implementation:
 
   1. Dict KEYS — ``{k: deep_redact(v) ...}`` never touched ``k``.
@@ -75,12 +77,38 @@ class TestUrlGate:
         """The gate's sharpest edge: NO ``://``, so URL structure was skipped.
 
         Pattern matching still caught the token, but ``user:hunter2`` in the
-        userinfo is only reachable by parsing the URL — which the gate
-        prevented.
+        userinfo is only reachable by parsing the URL.
         """
         out = deep_redact(f"//user:hunter2@example.com/cb?token={SECRET}")
         assert "hunter2" not in out, f"userinfo survived: {out!r}"
         assert not _leaks(out)
+
+    def test_network_path_userinfo_without_a_query(self):
+        """Independent of query handling.
+
+        ``redact_url``'s own gate accepted a relative ref only when it began
+        with ``/`` AND contained ``?``, so a network-path reference carrying
+        userinfo but no query fell through to pattern-only redaction.
+        """
+        out = deep_redact("//user:hunter2@example.com/cb")
+        assert "hunter2" not in out, f"userinfo survived: {out!r}"
+
+    def test_relative_url_fragment_is_dropped(self):
+        """Fragments carry OAuth implicit tokens (``#access_token=…``).
+
+        They were already dropped for absolute URLs; a relative ref with a
+        fragment and no query was not parsed at all.
+        """
+        out = deep_redact("/cb#access_token=opaque-token-value")
+        assert "opaque-token-value" not in out, f"fragment survived: {out!r}"
+
+    @pytest.mark.parametrize(
+        "path", ["/etc/passwd", "/var/log/app.log", "a/b/c", "C:\\path\\file"],
+    )
+    def test_plain_paths_are_not_reshaped(self, path: str):
+        """A path with neither query nor fragment has nothing structural to
+        strip, so it must pass through byte-identical."""
+        assert deep_redact(path) == path
 
     def test_absolute_url_still_redacted(self):
         out = deep_redact(f"https://example.com/cb?token={SECRET}")
@@ -137,3 +165,73 @@ class TestRedactionIsLinear:
             f"4x input grew cost {large / small:.1f}x ({small:.1f} -> "
             f"{large:.1f} ms) — that is superlinear, i.e. backtracking."
         )
+
+
+class TestLongCredentialsAreStillRedacted:
+    """The ReDoS fix must not cap the userinfo runs.
+
+    Bounding them to ``{1,256}`` fixed the ReDoS equally well but silently
+    STOPPED redacting long credentials: a 900-char password matched with the
+    run unbounded and was MISSED under the cap. That shape is real — AWS
+    documents IAM database-auth tokens at roughly 1 KiB, and they are used
+    directly as the password in a DSN.
+
+    Only the SCHEME is bounded; see the comment on ``_CONN_USERINFO_RE``.
+    """
+
+    @pytest.mark.parametrize("length", [10, 256, 257, 900, 4000])
+    def test_dsn_password_of_any_length_is_redacted(self, length: int):
+        password = "p" * length
+        out = deep_redact(f"postgres://dbuser:{password}@db.internal:5432/main")
+        assert password not in out, (
+            f"{length}-char DSN password survived — check for a capped "
+            f"quantifier on the userinfo run: {out[:120]!r}"
+        )
+
+    @pytest.mark.parametrize("length", [256, 257, 900])
+    def test_dsn_username_of_any_length_is_redacted(self, length: int):
+        user = "u" * length
+        out = deep_redact(f"postgres://{user}:pw@db/main")
+        assert user not in out, f"{length}-char DSN username survived"
+
+
+class TestBlockerNoteIsLinear:
+    """``normalize_blocker_note`` runs on agent-controlled text, on the loop.
+
+    ``_EMPTY_EXCEPTION_RE`` was ``^(exception:)?\\s*(error:?)?\\s*$`` — two
+    ``\\s*`` runs either side of an optional group that can match empty, so on
+    a long whitespace run the engine tried every split between them. The
+    blocker note arrives on a task-status POST and is normalized synchronously
+    BEFORE the 500-char truncation, so an agent could stall the mesh:
+    "exception:" + 80k spaces took 34 SECONDS.
+    """
+
+    def test_long_whitespace_note_is_fast(self):
+        from src.shared.redaction import normalize_blocker_note
+
+        subject = "exception:" + " " * 80_000 + "x"
+        start = time.perf_counter()
+        normalize_blocker_note(subject)
+        elapsed = (time.perf_counter() - start) * 1000
+        assert elapsed < 1000, (
+            f"normalize_blocker_note took {elapsed:.0f} ms on 80k spaces "
+            "(was ~34,000 ms) — check for ambiguous adjacent \\s* runs."
+        )
+
+    @pytest.mark.parametrize(
+        ("note", "expected"),
+        [
+            ("exception:", "internal_error"),
+            ("Exception: Error:", "internal_error"),
+            ("Error:", "internal_error"),
+            ("error", "internal_error"),
+            ("", None),
+            ("   ", None),
+            ("exception: boom", "exception: boom"),
+        ],
+    )
+    def test_classification_unchanged(self, note, expected):
+        """The rewrite must classify exactly as before."""
+        from src.shared.redaction import normalize_blocker_note
+
+        assert normalize_blocker_note(note) == expected

--- a/tests/test_deep_redact_blind_spots.py
+++ b/tests/test_deep_redact_blind_spots.py
@@ -1,0 +1,139 @@
+"""``deep_redact`` must walk every position a string can occupy.
+
+It guards the audit log, trace store, lifecycle log, intent log and the pubsub
+payload path (``src/host/mesh.py:930``), so anything it declines to walk is a
+value that reaches durable storage unredacted. Three positions were skipped,
+each demonstrated below against the pre-fix implementation:
+
+  1. Dict KEYS — ``{k: deep_redact(v) ...}`` never touched ``k``.
+  2. ``set`` / ``frozenset`` — fell through to ``return obj``, emitted verbatim.
+  3. The URL gate — ``_looks_like_url`` required ``"://"``, but ``redact_url``
+     itself also accepts a relative URL carrying a query string. The gate was
+     stricter than the function it guarded, so those strings took the
+     pattern-only path and kept their structural secrets.
+
+``TestRedactionIsLinear`` covers the ReDoS that removing the gate's incidental
+length cap exposed — see that class for why the bound is load-bearing.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from src.shared.redaction import deep_redact
+
+# Shaped like a real key so SECRET_PATTERNS matches it.
+SECRET = "sk-ant-api03-REALSECRETVALUE1234567890abcdefghijklmnop"
+
+
+def _leaks(value) -> bool:
+    return SECRET in repr(value)
+
+
+class TestSecretsInDictKeys:
+    def test_secret_in_a_key_is_redacted(self):
+        out = deep_redact({f"token={SECRET}": "v"})
+        assert not _leaks(out), f"secret survived in a dict key: {out!r}"
+
+    def test_secret_in_a_nested_key_is_redacted(self):
+        out = deep_redact({"outer": [{f"{SECRET}": 1}]})
+        assert not _leaks(out)
+
+    def test_ordinary_keys_are_untouched(self):
+        """Only secret-SHAPED keys change — the log stays readable."""
+        assert deep_redact({"api_key_name": "x", "user_id": 7}) == {
+            "api_key_name": "x",
+            "user_id": 7,
+        }
+
+    def test_non_string_keys_survive(self):
+        assert deep_redact({1: "a", (2, 3): "b"}) == {1: "a", (2, 3): "b"}
+
+
+class TestUnhandledContainers:
+    @pytest.mark.parametrize("factory", [set, frozenset, list, tuple])
+    def test_container_contents_are_redacted(self, factory):
+        out = deep_redact({"c": factory([SECRET])})
+        assert not _leaks(out), f"secret survived inside a {factory.__name__}"
+
+    @pytest.mark.parametrize(
+        ("factory", "expected"),
+        [(set, set), (frozenset, frozenset), (list, list), (tuple, tuple)],
+    )
+    def test_container_type_is_preserved(self, factory, expected):
+        assert isinstance(deep_redact(factory(["plain"])), expected)
+
+
+class TestUrlGate:
+    def test_relative_url_with_query_gets_structural_redaction(self):
+        out = deep_redact(f"/cb?code={SECRET}&state=ok")
+        assert not _leaks(out)
+
+    def test_scheme_relative_url_userinfo_is_stripped(self):
+        """The gate's sharpest edge: NO ``://``, so URL structure was skipped.
+
+        Pattern matching still caught the token, but ``user:hunter2`` in the
+        userinfo is only reachable by parsing the URL — which the gate
+        prevented.
+        """
+        out = deep_redact(f"//user:hunter2@example.com/cb?token={SECRET}")
+        assert "hunter2" not in out, f"userinfo survived: {out!r}"
+        assert not _leaks(out)
+
+    def test_absolute_url_still_redacted(self):
+        out = deep_redact(f"https://example.com/cb?token={SECRET}")
+        assert not _leaks(out)
+
+    def test_plain_text_passes_through(self):
+        assert deep_redact("just a routine status line") == (
+            "just a routine status line"
+        )
+
+
+class TestScalarsPassThrough:
+    @pytest.mark.parametrize("value", [1, 1.5, True, False, None])
+    def test_scalar_unchanged(self, value):
+        assert deep_redact(value) is value
+
+
+class TestRedactionIsLinear:
+    """The sanitizer must not be a DoS vector.
+
+    ``_CONN_USERINFO_RE`` used an UNBOUNDED scheme class
+    (``[A-Za-z][A-Za-z0-9+.-]*://``). The engine matched it greedily from every
+    position in the subject, consuming the rest of the string before failing to
+    find ``://`` and backtracking over every length — quadratic in the subject
+    length, on a sanitizer that runs over agent-supplied pubsub payloads and
+    blocker notes on the mesh event loop. A 200 KB URL-shaped string took ~93
+    SECONDS; an agent could stall the mesh by publishing one.
+
+    ``deep_redact`` previously skipped URL parsing above 4096 chars, which
+    incidentally hid part of this. That cap is gone (it was also what made the
+    gate diverge from ``redact_url``), so the bound has to be real.
+    """
+
+    @staticmethod
+    def _elapsed_ms(n: int) -> float:
+        subject = "https://example.com/?q=" + "x" * n
+        start = time.perf_counter()
+        deep_redact(subject)
+        return (time.perf_counter() - start) * 1000
+
+    def test_large_url_shaped_string_is_fast(self):
+        elapsed = self._elapsed_ms(200_000)
+        assert elapsed < 2000, (
+            f"deep_redact took {elapsed:.0f} ms on a 200 KB URL-shaped string. "
+            "Before the scheme class was bounded this was ~93,000 ms — check "
+            "for an unbounded quantifier in the redaction patterns."
+        )
+
+    def test_cost_grows_linearly_not_quadratically(self):
+        """4x the input must not cost anything like 16x the time."""
+        small = max(self._elapsed_ms(25_000), 0.5)
+        large = self._elapsed_ms(100_000)
+        assert large / small < 8, (
+            f"4x input grew cost {large / small:.1f}x ({small:.1f} -> "
+            f"{large:.1f} ms) — that is superlinear, i.e. backtracking."
+        )


### PR DESCRIPTION
Roadmap Phase 1, item **1d** — plus a denial-of-service found while fixing it.

`deep_redact` guards the audit log, trace store, lifecycle log, intent log and the pubsub payload path (`src/host/mesh.py:930`). Anything it declines to walk reaches durable storage unredacted.

## Three skipped positions

Verified against `main` with a live-shaped key:

```
LEAKS   secret in a dict KEY
LEAKS   secret inside a set
LEAKS   secret inside a frozenset
LEAKS   URL with no :// (userinfo)
```

1. **Dict keys** — `{k: deep_redact(v) ...}` never touched `k`. Secrets do end up in keys: a captured header map, a `{token: metadata}` index.
2. **`set` / `frozenset`** — fell through to `return obj` and were emitted verbatim.
3. **The URL gate** — `_looks_like_url` required `"://"`, but `redact_url` *itself* also accepts a relative URL carrying a query string. The gate was **stricter than the function it guarded**, so those strings took the pattern-only path and kept their structural secrets. `//user:hunter2@example.com/cb?token=…` had the token caught by pattern matching but retained `user:hunter2`, which is only reachable by parsing the URL.

The gate is deleted rather than widened — `redact_url` is documented safe on non-URLs and does its own cheap check before parsing, so there's nothing left for a second, divergent heuristic to get wrong.

## The ReDoS the gate was hiding

That gate also carried `len(s) < 4096`. Removing it exposed why it was really there. `_CONN_USERINFO_RE` used an unbounded scheme class:

```
([A-Za-z][A-Za-z0-9+.\-]*://)[^/\s:@]+:[^/\s@]+@
```

The engine matches that class greedily from **every** position in the subject, consumes the rest of the string, fails to find `://`, and backtracks over every length — quadratic in subject length, on a sanitizer that runs over **agent-supplied payloads on the mesh event loop**.

```
len=  8000   current     147.0 ms    bounded    1.35 ms
len= 16000   current     595.3 ms    bounded    2.80 ms
len= 32000   current    2397.9 ms    bounded    5.84 ms
len= 64000   current    9633.0 ms    bounded   11.19 ms
```

A 200 KB string shaped like `https://host/?q=<200k chars>` took **93 seconds**. An agent could stall the mesh by publishing one. **This is reachable on `main` independently of this PR**, via `redact_string` and `redact_text_with_urls` — the 4096 cap only ever covered the `deep_redact` entry point.

Bounding the scheme to 31 chars (RFC 3986 schemes are short) makes the work per start position constant: 200 KB goes **93,500 ms → 50 ms**. The userinfo halves are bounded for the same reason. Behavior is byte-identical on every connection-string shape in the existing tests. Bounded quantifiers rather than atomic groups because `requires-python = ">=3.10"` and `(?>...)` landed in 3.11.

## Tests

23 new. `TestRedactionIsLinear` asserts the scaling directly, and I checked it fails against the old pattern rather than passing vacuously — **23,741 ms** on a 100 KB subject against a 2,000 ms threshold.

Non-secret keys stay untouched so logs remain readable; container types are preserved. `737 passed` across redaction and every consumer (traces, lifecycle, intent, credentials); `563 passed` across redaction/mesh/pubsub/blocker.